### PR TITLE
Minor improvements for parsing commits function.

### DIFF
--- a/packages/ckeditor5-dev-env/lib/release-tools/changelog/parser-options.js
+++ b/packages/ckeditor5-dev-env/lib/release-tools/changelog/parser-options.js
@@ -11,7 +11,8 @@ module.exports = {
 		'type',
 		'subject'
 	],
-	noteKeywords: [ 'BREAKING CHANGE', 'NOTE' ],
+	// 'BREAKING CHANGE' and 'BREAKING CHANGES' will be grouped as 'BREAKING CHANGES'.
+	noteKeywords: [ 'BREAKING CHANGE', 'BREAKING CHANGES', 'NOTE' ],
 	revertPattern: /^Revert:\s([\s\S]*?)\s*This reverts commit (\w*)\./,
 	revertCorrespondence: [ 'header', 'hash' ],
 	referenceActions: [

--- a/packages/ckeditor5-dev-env/lib/release-tools/changelog/writer-options.js
+++ b/packages/ckeditor5-dev-env/lib/release-tools/changelog/writer-options.js
@@ -63,14 +63,17 @@ function transformCommit( commit ) {
 		commit.hash = commit.hash.substring( 0, 7 );
 	}
 
+	const hasCorrectType = availableTypes.has( commit.type );
 	const isCommitIncluded = availableTypes.get( commit.type );
 
 	let logMessage = `* ${ commit.hash } "${ commit.header }" `;
 
-	if ( isCommitIncluded ) {
+	if ( hasCorrectType && isCommitIncluded ) {
 		logMessage += chalk.green( 'INCLUDED' );
+	} else if ( hasCorrectType && !isCommitIncluded ) {
+		logMessage += chalk.grey( 'SKIPPED' );
 	} else {
-		logMessage += chalk.red( 'SKIPPED' );
+		logMessage += chalk.red( 'INVALID' );
 	}
 
 	log.info( logMessage );
@@ -92,6 +95,9 @@ function transformCommit( commit ) {
 	}
 
 	for ( const note of commit.notes ) {
+		if ( note.title === 'BREAKING CHANGE' ) {
+			note.title = 'BREAKING CHANGES';
+		}
 		note.text = linkGithubIssues( linkGithubUsers( note.text ) );
 	}
 

--- a/packages/ckeditor5-dev-env/tests/release-tools/changelog/transformcommit.js
+++ b/packages/ckeditor5-dev-env/tests/release-tools/changelog/transformcommit.js
@@ -1,0 +1,137 @@
+/**
+ * @license Copyright (c) 2003-2017, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/* jshint mocha:true */
+
+'use strict';
+
+const expect = require( 'chai' ).expect;
+const sinon = require( 'sinon' );
+const mockery = require( 'mockery' );
+
+describe( 'dev-env/release-tools/changelog/writer-options', () => {
+	describe( 'transform()', () => {
+		let transformCommit, sandbox, stubs;
+
+		beforeEach( () => {
+			sandbox = sinon.sandbox.create();
+
+			mockery.enable( {
+				useCleanCache: true,
+				warnOnReplace: false,
+				warnOnUnregistered: false
+			} );
+
+			stubs = {
+				logger: {
+					info: sandbox.spy(),
+					warning: sandbox.spy(),
+					error: sandbox.spy()
+				},
+				chalk: {
+					red: sandbox.stub().returnsArg( 0 ),
+					grey: sandbox.stub().returnsArg( 0 ),
+					green: sandbox.stub().returnsArg( 0 )
+				}
+			};
+
+			mockery.registerMock( '@ckeditor/ckeditor5-dev-utils', {
+				logger() {
+					return stubs.logger;
+				}
+			} );
+
+			mockery.registerMock( 'chalk', stubs.chalk );
+
+			transformCommit = require( '../../../lib/release-tools/changelog/writer-options' ).transform;
+		} );
+
+		afterEach( () => {
+			sandbox.restore();
+			mockery.disable();
+		} );
+
+		it( 'groups "BREAKING CHANGES" and "BREAKING CHANGE" as a single group', () => {
+			const commit = {
+				hash: '684997d0eb2eca76b9e058fb1c3fa00b50059cdc',
+				header: 'Fix: Simple fix.',
+				type: 'Fix',
+				subject: 'Simple fix.',
+				body: null,
+				footer: null,
+				notes: [
+					{ title: 'BREAKING CHANGE', text: 'Note 1.' },
+					{ title: 'BREAKING CHANGES', text: 'Note 2.' }
+				],
+				references: []
+			};
+
+			transformCommit( commit );
+
+			expect( commit.notes[ 0 ].title ).to.equal( 'BREAKING CHANGES' );
+			expect( commit.notes[ 1 ].title ).to.equal( 'BREAKING CHANGES' );
+		} );
+
+		it( 'attaches valid "external" commit to the changelog', () => {
+			const commit = {
+				hash: '684997d0eb2eca76b9e058fb1c3fa00b50059cdc',
+				header: 'Fix: Simple fix.',
+				type: 'Fix',
+				subject: 'Simple fix.',
+				body: null,
+				footer: null,
+				notes: [],
+				references: []
+			};
+
+			transformCommit( commit );
+
+			expect( stubs.logger.info.calledOnce ).to.equal( true );
+			expect( stubs.logger.info.firstCall.args[ 0 ] ).to.match( /\* 684997d "Fix: Simple fix\." INCLUDED/ );
+			expect( stubs.chalk.green.calledOnce ).to.equal( true );
+			expect( stubs.chalk.green.firstCall.args[ 0 ] ).to.equal( 'INCLUDED' );
+		} );
+
+		it( 'does not attach valid "internal" commit to the changelog', () => {
+			const commit = {
+				hash: '684997d0eb2eca76b9e058fb1c3fa00b50059cdc',
+				header: 'Docs: README.',
+				type: 'Docs',
+				subject: 'README.',
+				body: null,
+				footer: null,
+				notes: [],
+				references: []
+			};
+
+			transformCommit( commit );
+
+			expect( stubs.logger.info.calledOnce ).to.equal( true );
+			expect( stubs.logger.info.firstCall.args[ 0 ] ).to.match( /\* 684997d "Docs: README\." SKIPPED/ );
+			expect( stubs.chalk.grey.calledOnce ).to.equal( true );
+			expect( stubs.chalk.grey.firstCall.args[ 0 ] ).to.equal( 'SKIPPED' );
+		} );
+
+		it( 'does not attach invalid commit to the changelog', () => {
+			const commit = {
+				hash: '684997d0eb2eca76b9e058fb1c3fa00b50059cdc',
+				header: 'Invalid commit.',
+				type: null,
+				subject: null,
+				body: null,
+				footer: null,
+				notes: [],
+				references: []
+			};
+
+			transformCommit( commit );
+
+			expect( stubs.logger.info.calledOnce ).to.equal( true );
+			expect( stubs.logger.info.firstCall.args[ 0 ] ).to.match( /\* 684997d "Invalid commit\." INVALID/ );
+			expect( stubs.chalk.red.calledOnce ).to.equal( true );
+			expect( stubs.chalk.red.firstCall.args[ 0 ] ).to.equal( 'INVALID' );
+		} );
+	} );
+} );


### PR DESCRIPTION
Fix: Improvements for the changelog generator.

NOTE: During parsing the commits, the logger will inform about 3 statuses of the commit. Closes: #71.
NOTE: `'BREAKING CHANGE'` and `'BREAKING CHANGES'` will be grouped as `'BREAKING CHANGES'`. Closes: #73.