### PR TITLE
T/88: Disable background throttling in Chrome

### DIFF
--- a/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getkarmaconfig.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getkarmaconfig.js
@@ -99,7 +99,7 @@ module.exports = function getKarmaConfig( options ) {
 		customLaunchers: {
 			CHROME_TRAVIS_CI: {
 				base: 'Chrome',
-				flags: [ '--no-sandbox' ]
+				flags: [ '--no-sandbox', '--disable-background-timer-throttling' ]
 			}
 		},
 

--- a/packages/ckeditor5-dev-tests/tests/utils/automated-tests/getkarmaconfig.js
+++ b/packages/ckeditor5-dev-tests/tests/utils/automated-tests/getkarmaconfig.js
@@ -85,7 +85,7 @@ describe( 'getKarmaConfig', () => {
 			customLaunchers: {
 				CHROME_TRAVIS_CI: {
 					base: 'Chrome',
-					flags: [ '--no-sandbox' ]
+					flags: [ '--no-sandbox', '--disable-background-timer-throttling' ]
 				}
 			},
 			singleRun: true,


### PR DESCRIPTION
Internal: Disabled background timer throttling for automated tests. Closes #88.