### PR TITLE
T/88: Disable background throttling in Chrome (2)

### DIFF
--- a/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getkarmaconfig.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getkarmaconfig.js
@@ -42,6 +42,18 @@ module.exports = function getKarmaConfig( options ) {
 		}
 	}
 
+	let browsers = [];
+
+	if ( options.browsers ) {
+		browsers = options.browsers.map( ( browser ) => {
+			if ( browser === 'Chrome' ) {
+				return 'CHROME_LOCAL';
+			}
+
+			return browser;
+		} );
+	}
+
 	const karmaConfig = {
 		// Base path that will be used to resolve all patterns (eg. files, exclude).
 		basePath: process.cwd(),
@@ -94,13 +106,17 @@ module.exports = function getKarmaConfig( options ) {
 
 		// Start these browsers.
 		// Available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
-		browsers: options.browsers,
+		browsers: browsers,
 
 		customLaunchers: {
 			CHROME_TRAVIS_CI: {
 				base: 'Chrome',
 				flags: [ '--no-sandbox', '--disable-background-timer-throttling' ]
-			}
+			},
+			CHROME_LOCAL: {
+				base: 'Chrome',
+				flags: [ '--disable-background-timer-throttling' ]
+			},
 		},
 
 		// Continuous Integration mode. If true, Karma captures browsers, runs the tests and exits.

--- a/packages/ckeditor5-dev-tests/tests/utils/automated-tests/getkarmaconfig.js
+++ b/packages/ckeditor5-dev-tests/tests/utils/automated-tests/getkarmaconfig.js
@@ -48,7 +48,7 @@ describe( 'getKarmaConfig', () => {
 			reporter: 'mocha',
 			sourceMap: false,
 			coverage: false,
-			browsers: 'Chrome',
+			browsers: [ 'Chrome' ],
 			watch: false,
 			verbose: false
 		} );
@@ -81,12 +81,16 @@ describe( 'getKarmaConfig', () => {
 			port: 9876,
 			colors: true,
 			logLevel: 'INFO',
-			browsers: 'Chrome',
+			browsers: [ 'CHROME_LOCAL' ],
 			customLaunchers: {
 				CHROME_TRAVIS_CI: {
 					base: 'Chrome',
 					flags: [ '--no-sandbox', '--disable-background-timer-throttling' ]
-				}
+				},
+				CHROME_LOCAL: {
+					base: 'Chrome',
+					flags: [ '--disable-background-timer-throttling' ]
+				},
 			},
 			singleRun: true,
 			concurrency: Infinity,


### PR DESCRIPTION
Internal: Added `CHROME_LOCAL` browser which uses `--disable-background-timer-throttling` option for local environments. Fixes #88.

`CHROME_LOCAL` is used instead of `Chrome`.

---

The previous merge introduced the option only for CI. 