### PR TITLE
T/79: Use deps hoisting to speed up installation time on CI 

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,5 +3,7 @@
   "packages": [
     "packages/*"
   ],
+  "hoist": true,
+  "nohoist": "guppy-pre-commit",
   "version": "independent"
 }


### PR DESCRIPTION
Internal: Added `hoist` option to `lerna.json` in order to improve the speed of installing packages on CI. Closes #79.