### PR TITLE
T/79: Use deps hoisting to speed up installation time on CI (2)

### DIFF
--- a/packages/ckeditor5-dev-tests/bin/create-lerna-json.js
+++ b/packages/ckeditor5-dev-tests/bin/create-lerna-json.js
@@ -20,8 +20,7 @@ let json = {
 		'.'
 	],
 	'version': '0.0.0',
-	'hoist': true,
-	'nohoist': 'guppy-pre-commit',
+	'hoist': true
 };
 
 fs.writeFileSync( lerna, JSON.stringify( json, null, 2 ) + '\n', 'utf-8' );

--- a/packages/ckeditor5-dev-tests/bin/create-lerna-json.js
+++ b/packages/ckeditor5-dev-tests/bin/create-lerna-json.js
@@ -19,7 +19,9 @@ let json = {
 		'packages/*',
 		'.'
 	],
-	'version': '0.0.0'
+	'version': '0.0.0',
+	'hoist': true,
+	'nohoist': 'guppy-pre-commit',
 };
 
 fs.writeFileSync( lerna, JSON.stringify( json, null, 2 ) + '\n', 'utf-8' );


### PR DESCRIPTION
Internal: Use Lerna `hoist` option in order to improve the speed of installing packages on CI for ckeditor5-* packages. Closes #79.