### PR TITLE
T/113: Release task fails when CHANGELOG contains entry generated for the first time

### DIFF
--- a/packages/ckeditor5-dev-env/lib/release-tools/utils/changelog.js
+++ b/packages/ckeditor5-dev-env/lib/release-tools/utils/changelog.js
@@ -28,9 +28,8 @@ const utils = {
 	getChangesForVersion( version ) {
 		version = version.replace( /^v/, '' );
 
-		let changelog = utils.getChangelog().replace( utils.changelogHeader, '\n' );
-
-		const match = changelog.match( new RegExp( `\\n(## \\[${ version }\\][\\s\\S]+?)(?:\\n## \\[|$)` ) );
+		const changelog = utils.getChangelog().replace( utils.changelogHeader, '\n' );
+		const match = changelog.match( new RegExp( `\\n(## \\[?${ version }\\]?[\\s\\S]+?)(?:\\n## \\[?|$)` ) );
 
 		if ( !match || !match[ 1 ] ) {
 			throw new Error( `Cannot find changelog entries for ${ version }.` );
@@ -55,7 +54,7 @@ const utils = {
 		const changelogFile = path.resolve( utils.changelogFile );
 
 		fs.writeFileSync( changelogFile, content, 'utf-8' );
-	},
+	}
 };
 
 module.exports = utils;

--- a/packages/ckeditor5-dev-env/lib/release-tools/utils/versions.js
+++ b/packages/ckeditor5-dev-env/lib/release-tools/utils/versions.js
@@ -17,7 +17,7 @@ const versions = {
 	 */
 	getLastFromChangelog() {
 		const changelog = changelogUtils.getChangelog();
-		const regexp = /\n## \[?([^\]]+)/;
+		const regexp = /\n## \[?([^\]| ]+)/;
 
 		const matches = changelog.match( regexp );
 

--- a/packages/ckeditor5-dev-env/tests/release-tools/utils/changelog.js
+++ b/packages/ckeditor5-dev-env/tests/release-tools/utils/changelog.js
@@ -40,7 +40,7 @@ describe( 'dev-env/release-tools/utils', () => {
 				].join( '\n' );
 
 				const changelog =
-`## [0.1.0](https://github.com) (2017-01-13)
+`## 0.1.0 (2017-01-13)
 
 ${ expectedChangelog }`;
 
@@ -68,7 +68,7 @@ ${ expectedChangelog }`;
 
 ${ expectedChangelog }
 
-## [0.1.0](https://github.com) (2017-01-13)
+## 0.1.0 (2017-01-13)
 
 ### Features
 

--- a/packages/ckeditor5-dev-env/tests/release-tools/utils/versions.js
+++ b/packages/ckeditor5-dev-env/tests/release-tools/utils/versions.js
@@ -47,52 +47,112 @@ describe( 'dev-env/release-tools/utils', () => {
 		} );
 
 		describe( 'getLastFromChangelog()', () => {
-			it( 'returns version from changelog #1', () => {
-				changelogStub.returns( `\n## [1.0.0]\n\n## 0.0.1` );
+			describe( 'changelog generated for the first time', () => {
+				it( 'returns version from changelog #1', () => {
+					const expectedVersion = '1.0.0';
 
-				expect( version.getLastFromChangelog() ).to.equal( '1.0.0' );
+					changelogStub.returns( [
+						'Changelog',
+						'=========',
+						'',
+						`## ${ expectedVersion } (2017-03-08)`
+					].join( '\n' ) );
+
+					expect( version.getLastFromChangelog() ).to.equal( expectedVersion );
+				} );
+
+				it( 'returns version from changelog #2', () => {
+					const expectedVersion = '1.0.0-alpha';
+
+					changelogStub.returns( [
+						'Changelog',
+						'=========',
+						'',
+						`## ${ expectedVersion } (2017-03-08)`
+					].join( '\n' ) );
+
+					expect( version.getLastFromChangelog() ).to.equal( expectedVersion );
+				} );
+
+				it( 'returns version from changelog #3', () => {
+					const expectedVersion = '1.0.0-alpha+001';
+
+					changelogStub.returns( [
+						'Changelog',
+						'=========',
+						'',
+						`## ${ expectedVersion } (2017-03-08)`
+					].join( '\n' ) );
+
+					expect( version.getLastFromChangelog() ).to.equal( expectedVersion );
+				} );
+
+				it( 'returns version from changelog #4', () => {
+					const expectedVersion = '1.0.0-beta.2';
+
+					changelogStub.returns( [
+						'Changelog',
+						'=========',
+						'',
+						`## ${ expectedVersion } (2017-03-08)`
+					].join( '\n' ) );
+
+					expect( version.getLastFromChangelog() ).to.equal( expectedVersion );
+				} );
 			} );
 
-			it( 'returns version from changelog #2', () => {
-				changelogStub.returns( `\n## 1.0.0` );
+			describe( 'changelog contains URLs which compare the versions', () => {
+				it( 'returns version from changelog #1', () => {
+					const expectedVersion = '1.0.0';
 
-				expect( version.getLastFromChangelog() ).to.equal( '1.0.0' );
-			} );
+					changelogStub.returns( [
+						'Changelog',
+						'=========',
+						'',
+						`## [${ expectedVersion }](https://github.com/ckeditor/ckeditor5-dev/compare/v0.1.0...${ expectedVersion }) (2017-03-08)`
+					].join( '\n' ) );
 
-			it( 'returns version from changelog #3', () => {
-				changelogStub.returns( `\n## [1.0.0-alpha]\n\n## 0.0.1` );
+					expect( version.getLastFromChangelog() ).to.equal( expectedVersion );
+				} );
 
-				expect( version.getLastFromChangelog() ).to.equal( '1.0.0-alpha' );
-			} );
+				it( 'returns version from changelog #2', () => {
+					const expectedVersion = '1.0.0-alpha';
 
-			it( 'returns version from changelog #4', () => {
-				changelogStub.returns( `\n## 1.0.0-alpha` );
+					changelogStub.returns( [
+						'Changelog',
+						'=========',
+						'',
+						`## [${ expectedVersion }](https://github.com/ckeditor/ckeditor5-dev/compare/v0.1.0...${ expectedVersion }) (2017-03-08)`
+					].join( '\n' ) );
 
-				expect( version.getLastFromChangelog() ).to.equal( '1.0.0-alpha' );
-			} );
+					expect( version.getLastFromChangelog() ).to.equal( expectedVersion );
+				} );
 
-			it( 'returns version from changelog #5', () => {
-				changelogStub.returns( `\n## [1.0.0-alpha+001]\n\n## 0.0.1` );
+				it( 'returns version from changelog #3', () => {
+					const expectedVersion = '1.0.0-alpha+001';
 
-				expect( version.getLastFromChangelog() ).to.equal( '1.0.0-alpha+001' );
-			} );
+					changelogStub.returns( [
+						'Changelog',
+						'=========',
+						'',
+						`## [${ expectedVersion }](https://github.com/ckeditor/ckeditor5-dev/compare/v0.1.0...${ expectedVersion }) (2017-03-08)`
+					].join( '\n' ) );
 
-			it( 'returns version from changelog #6', () => {
-				changelogStub.returns( `\n## 1.0.0-alpha+001` );
+					expect( version.getLastFromChangelog() ).to.equal( expectedVersion );
+				} );
 
-				expect( version.getLastFromChangelog() ).to.equal( '1.0.0-alpha+001' );
-			} );
+				it( 'returns version from changelog #4', () => {
+					const expectedVersion = '1.0.0-beta.2';
 
-			it( 'returns version from changelog #7', () => {
-				changelogStub.returns( `\n## [1.0.0-beta.2]\n\n## 0.0.1` );
+					changelogStub.returns( [
+						'Changelog',
+						'=========',
+						'',
+						`## [${ expectedVersion }](https://github.com/ckeditor/ckeditor5-dev/compare/v0.1.0...${ expectedVersion }) (2017-03-08)`
+					].join( '\n' ) );
 
-				expect( version.getLastFromChangelog() ).to.equal( '1.0.0-beta.2' );
-			} );
-
-			it( 'returns version from changelog #8', () => {
-				changelogStub.returns( `\n## 1.0.0-beta.2` );
-
-				expect( version.getLastFromChangelog() ).to.equal( '1.0.0-beta.2' );
+					expect( version.getLastFromChangelog() ).to.equal( expectedVersion );
+				} );
 			} );
 
 			it( 'returns null for empty changelog', () => {


### PR DESCRIPTION
Fix: Changelog utils do not work properly with changelog generated for the first time. Closes #113.