### PR TITLE
T/125: Use a more secure way to access GitHub on Travis

### DIFF
--- a/packages/ckeditor5-dev-tests/bin/save-revision.js
+++ b/packages/ckeditor5-dev-tests/bin/save-revision.js
@@ -19,11 +19,10 @@ const { tools } = require( '@ckeditor/ckeditor5-dev-utils' );
 
 const revisionBranch = `${ branch }-revisions`;
 
+exec( `echo "https://${ process.env.GITHUB_TOKEN }:@github.com" > .git/credentials 2> /dev/null` );
+
 // Clone the repository.
-exec(
-	`git clone -b ${ revisionBranch } ` +
-	`https://${ process.env.GITHUB_USER }:${ process.env.GITHUB_PASSWORD }@github.com/ckeditor/ckeditor5.git`
-);
+exec( `git clone -b ${ revisionBranch } https://github.com/ckeditor/ckeditor5.git` );
 
 // Change current dir to cloned repository.
 process.chdir( path.join( process.cwd(), 'ckeditor5' ) );

--- a/packages/ckeditor5-dev-tests/bin/save-revision.js
+++ b/packages/ckeditor5-dev-tests/bin/save-revision.js
@@ -44,7 +44,7 @@ const commitMessage = `[${ process.env.TRAVIS_REPO_SLUG }] Updated hashes.`;
 // Check whether the mgit.json has changed. It might not have changed if, e.g., a build was restarted.
 if ( exec( 'git diff --name-only mgit.json' ).trim().length ) {
 	exec( `git add mgit.json && git commit -m "${ commitMessage }"` );
-	exec( `git push origin ${ revisionBranch }` );
+	exec( `git push origin ${ revisionBranch } --quiet` );
 }
 
 function exec( command ) {

--- a/packages/ckeditor5-dev-tests/bin/save-revision.js
+++ b/packages/ckeditor5-dev-tests/bin/save-revision.js
@@ -22,7 +22,7 @@ const revisionBranch = `${ branch }-revisions`;
 exec( `echo "https://${ process.env.GITHUB_TOKEN }:@github.com" > .git/credentials 2> /dev/null` );
 
 // Clone the repository.
-exec( `git clone -b ${ revisionBranch } https://github.com/ckeditor/ckeditor5.git` );
+exec( `git clone -b ${ revisionBranch } https://github.com/ckeditor/ckeditor5.git --quiet` );
 
 // Change current dir to cloned repository.
 process.chdir( path.join( process.cwd(), 'ckeditor5' ) );


### PR DESCRIPTION
Fix: Script for saving revision was not safe. Closes #125.

If git failed, the credentials data was printed to the public logs.

