### PR TITLE
T127: The save-revision script could log a link to a commit that it's made

### DIFF
--- a/packages/ckeditor5-dev-tests/bin/save-revision.js
+++ b/packages/ckeditor5-dev-tests/bin/save-revision.js
@@ -37,7 +37,9 @@ exec( 'mgit bootstrap --recursive --resolver-url-template="https://github.com/\\
 // Save hashes from all dependencies.
 exec( 'mgit save-hashes' );
 
-const commitMessage = `[${ process.env.TRAVIS_REPO_SLUG }] Updated hashes.`;
+const repository = process.env.TRAVIS_REPO_SLUG;
+const commit = process.env.TRAVIS_COMMIT;
+const commitMessage = `Revision: https://github.com/${ repository }/commit/${ commit }`;
 
 // Check whether the mgit.json has changed. It might not have changed if, e.g., a build was restarted.
 if ( exec( 'git diff --name-only mgit.json' ).trim().length ) {

--- a/packages/ckeditor5-dev-tests/bin/save-revision.js
+++ b/packages/ckeditor5-dev-tests/bin/save-revision.js
@@ -17,10 +17,11 @@ if ( branch !== 'master' ) {
 const path = require( 'path' );
 const { tools } = require( '@ckeditor/ckeditor5-dev-utils' );
 
+const mainRepoUrl = 'https://github.com/ckeditor/ckeditor5';
 const revisionBranch = `${ branch }-revisions`;
 
 // Clone the repository.
-exec( `git clone -b ${ revisionBranch } https://github.com/ckeditor/ckeditor5.git` );
+exec( `git clone -b ${ revisionBranch } ${ mainRepoUrl }.git` );
 
 // Change current dir to cloned repository.
 process.chdir( path.join( process.cwd(), 'ckeditor5' ) );
@@ -49,6 +50,9 @@ if ( exec( 'git diff --name-only mgit.json' ).trim().length ) {
 	exec( 'git config credential.helper "store --file=.git/credentials"' );
 
 	exec( `git push origin ${ revisionBranch } --quiet` );
+
+	const lastCommit = exec( 'git log -1 --format="%h"' );
+	console.log( `Successfully saved the revision under ${ mainRepoUrl }/commit/${ lastCommit }` );
 }
 
 function exec( command ) {


### PR DESCRIPTION
Internal: Changed commit message for commits made by script for saving revisions. Closes #127.