### PR TITLE
T/135 Fix problem with manual tests containing periods

### DIFF
--- a/packages/ckeditor5-dev-tests/lib/utils/manual-tests/compilehtmlfiles.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/manual-tests/compilehtmlfiles.js
@@ -48,9 +48,9 @@ module.exports = function compileHtmlFiles( buildDir, manualTestPattern ) {
 
 function compileHtmlFile( buildDir, sourceFilePathBase, viewTemplate ) {
 	const log = logger();
-	const sourceMDFilePath = setExtension( sourceFilePathBase, 'md' );
-	const sourceHtmlFilePath = setExtension( sourceFilePathBase, 'html' );
-	const sourceJSFilePath = setExtension( sourceFilePathBase, 'js' );
+	const sourceMDFilePath = sourceFilePathBase + '.md';
+	const sourceHtmlFilePath = sourceFilePathBase + '.html';
+	const sourceJSFilePath = sourceFilePathBase + '.js';
 
 	const absoluteHtmlFilePath = getRelativeFilePath( sourceHtmlFilePath );
 	const absoluteJSFilePath = getRelativeFilePath( sourceJSFilePath );


### PR DESCRIPTION
Fix: Manual tests containing period in file name should not crash. Closes #135.