### PR TITLE
T/135 Fix problem with manual tests containing dots in file names

### DIFF
--- a/packages/ckeditor5-dev-tests/lib/utils/manual-tests/compilehtmlfiles.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/manual-tests/compilehtmlfiles.js
@@ -29,7 +29,7 @@ module.exports = function compileHtmlFiles( buildDir, manualTestPattern ) {
 	const sourceFilePathBases = sourceMDFiles.map( ( mdFile ) => getFilePathWithoutExtension( mdFile ) );
 	const staticFiles = _.flatten( sourceDirs.map( sourceDir => {
 		return globSync( path.join( sourceDir, '**', '*.!(js|html|md)' ) );
-	} ) );
+	} ) ).filter( file => !file.match( /\.(js|html|md)$/ ) );
 
 	fs.ensureDirSync( buildDir );
 

--- a/packages/ckeditor5-dev-tests/tests/utils/manual-tests/compilehtmlfiles.js
+++ b/packages/ckeditor5-dev-tests/tests/utils/manual-tests/compilehtmlfiles.js
@@ -168,6 +168,7 @@ describe( 'compileHtmlFiles', () => {
 			[ path.join( 'manualTestPattern', '*.js' ) ]: [ path.join( 'path', 'to', 'manual', 'file.js' ) ],
 			[ path.join( 'anotherPattern', '*.js' ) ]: [ path.join( 'path', 'to', 'another', 'manual', 'file.js' ) ],
 			[ path.join( 'path', 'to', 'manual', '**', '*.!(js|html|md)' ) ]: [ 'static-file.png' ],
+			[ path.join( 'path', 'to', 'another', 'manual', '**', '*.!(js|html|md)' ) ]: [],
 		};
 
 		compileHtmlFiles( 'buildDir', [
@@ -181,7 +182,7 @@ describe( 'compileHtmlFiles', () => {
 		sinon.assert.calledWithExactly( stubs.chokidar.watch, path.join( 'path', 'to', 'another', 'manual', 'file.html' ) );
 	} );
 
-	it( 'compiles only manual test files', () => {
+	it( 'should compile only manual test files', () => {
 		files = {
 			[ path.join( fakeDirname, 'template.html' ) ]: '<div>template html content</div>',
 			[ path.join( 'path', 'to', 'manual', 'file.md' ) ]: '## Markdown header',
@@ -205,5 +206,36 @@ describe( 'compileHtmlFiles', () => {
 		sinon.assert.calledWithExactly( stubs.chokidar.watch, path.join( 'path', 'to', 'manual', 'file.html' ) );
 		sinon.assert.neverCalledWith( stubs.chokidar.watch, path.join( 'path', 'to', 'another', 'file.html' ) );
 		sinon.assert.neverCalledWith( stubs.chokidar.watch, path.join( 'path', 'to', 'another', 'file.html' ) );
+	} );
+
+	it( 'should not copy md files containing dots in their file names', () => {
+		files = {
+			[ path.join( fakeDirname, 'template.html' ) ]: '<div>template html content</div>',
+			[ path.join( 'path', 'to', 'manual', 'file.md' ) ]: '## Markdown header',
+			[ path.join( 'path', 'to', 'manual', 'file.html' ) ]: '<div>html file content</div>'
+		};
+
+		patternFiles = {
+			[ path.join( 'manualTestPattern', '*.js' ) ]: [ path.join( 'path', 'to', 'manual', 'file.js' ) ],
+			// glob pattern have problem with file names containing dots.
+			[ path.join( 'path', 'to', 'manual', '**', '*.!(js|html|md)' ) ]: [ 'some.file.md' ],
+		};
+
+		compileHtmlFiles( 'buildDir', [ path.join( 'manualTestPattern', '*.js' ) ] );
+
+		sinon.assert.calledWithExactly( stubs.commonmark.parse, '## Markdown header' );
+		sinon.assert.calledWithExactly( stubs.fs.ensureDirSync, 'buildDir' );
+		sinon.assert.calledWithExactly(
+			stubs.fs.outputFileSync,
+			path.join( 'buildDir', 'path', 'to', 'manual', 'file.html' ), [
+				'<div>template html content</div>',
+				'<div class="manual-test-sidebar"><h2>Markdown header</h2></div>',
+				'<div>html file content</div>',
+				`<body class="manual-test-container"><script src="${ path.sep + path.join( 'path', 'to', 'manual', 'file.js' ) }"></script></body>`
+			].join( '\n' )
+		);
+		sinon.assert.calledWithExactly( stubs.chokidar.watch, path.join( 'path', 'to', 'manual', 'file.md' ) );
+		sinon.assert.calledWithExactly( stubs.chokidar.watch, path.join( 'path', 'to', 'manual', 'file.html' ) );
+		sinon.assert.neverCalledWith( stubs.fs.copySync, 'some.file.md', path.join( 'buildDir', 'some.file.md' ) );
 	} );
 } );

--- a/packages/ckeditor5-dev-tests/tests/utils/manual-tests/compilehtmlfiles.js
+++ b/packages/ckeditor5-dev-tests/tests/utils/manual-tests/compilehtmlfiles.js
@@ -217,7 +217,7 @@ describe( 'compileHtmlFiles', () => {
 
 		patternFiles = {
 			[ path.join( 'manualTestPattern', '*.js' ) ]: [ path.join( 'path', 'to', 'manual', 'file.js' ) ],
-			// glob pattern have problem with file names containing dots.
+			// Glob pattern has problem with file names containing dots.
 			[ path.join( 'path', 'to', 'manual', '**', '*.!(js|html|md)' ) ]: [ 'some.file.md' ],
 		};
 


### PR DESCRIPTION
Fixes https://github.com/ckeditor/ckeditor5-dev/issues/135.

The glob pattern `globSync( path.join( sourceDir, '**', '*.!(js|html|md)' )` matches e.g. `someDir/ckeditor.es6.md`. It's hard for me to figure out the correct glob pattern for this match so I added the regexp exclusion.
