### PR TITLE
Fix typo in `replaceTranslationCallsForOneLanguage`

### DIFF
--- a/packages/ckeditor5-dev-webpack-plugin/lib/index.js
+++ b/packages/ckeditor5-dev-webpack-plugin/lib/index.js
@@ -5,7 +5,7 @@
 
 'use strict';
 
-const replaceTranslationCallsForOneLangauge = require( './replacetranslationcallsforonelanguage' );
+const replaceTranslationCallsForOneLanguage = require( './replacetranslationcallsforonelanguage' );
 
 module.exports = class CKEditorWebpackPlugin {
 	/**
@@ -21,7 +21,7 @@ module.exports = class CKEditorWebpackPlugin {
 		const { languages } = this.options;
 
 		if ( languages && languages.length == 1 ) {
-			replaceTranslationCallsForOneLangauge( compiler, languages[ 0 ] );
+			replaceTranslationCallsForOneLanguage( compiler, languages[ 0 ] );
 		} else {
 			console.error( 'Multi-language support is not implemented yet.' );
 		}

--- a/packages/ckeditor5-dev-webpack-plugin/lib/replaceTranslationCallsForOneLanguage.js
+++ b/packages/ckeditor5-dev-webpack-plugin/lib/replaceTranslationCallsForOneLanguage.js
@@ -14,7 +14,7 @@ const {	TranslationService } = require( '@ckeditor/ckeditor5-dev-utils' ).transl
  * @param {Object} compiler Webpack compiler.
  * @param {String} language Language code, e.g en_US.
  */
-module.exports = function replaceTranslationCallsForOneLangauge( compiler, language ) {
+module.exports = function replaceTranslationCallsForOneLanguage( compiler, language ) {
 	const translationService = new TranslationService( language );
 
 	compiler.options.translateSource = ( source ) => translationService.translateSource( source );


### PR DESCRIPTION
Fixes https://github.com/ckeditor/ckeditor5-dev/issues/141.