### PR TITLE
T/156b Increase code coverage in translation scripts. part 2.

### DIFF
--- a/packages/ckeditor5-dev-utils/lib/translations/translationservice.js
+++ b/packages/ckeditor5-dev-utils/lib/translations/translationservice.js
@@ -11,6 +11,7 @@ const createDictionaryFromPoFileContent = require( './createdictionaryfrompofile
 const acorn = require( 'acorn' );
 const walk = require( 'acorn/dist/walk' );
 const escodegen = require( 'escodegen' );
+const logger = require( '../logger' )();
 
 /**
  *
@@ -68,7 +69,7 @@ module.exports = class TranslationService {
 				}
 
 				if ( node.arguments[ 0 ].type !== 'Literal' ) {
-					console.error( 'First t() call argument should be a string literal.' );
+					logger.error( 'First t() call argument should be a string literal.' );
 
 					return;
 				}
@@ -84,7 +85,9 @@ module.exports = class TranslationService {
 		}
 
 		escodegen.attachComments( ast, comments, tokens );
-		const output = escodegen.generate( ast, { comment: true } );
+		const output = escodegen.generate( ast, {
+			comment: true
+		} );
 
 		return output;
 	}
@@ -108,7 +111,7 @@ module.exports = class TranslationService {
 		let translation = this.dictionary.get( originalString );
 
 		if ( !translation ) {
-			console.error( `Missing translation for: ${ originalString }.` );
+			logger.error( `Missing translation for: ${ originalString }.` );
 
 			translation = originalString;
 		}

--- a/packages/ckeditor5-dev-utils/tests/translations/createdictionaryfrompofilecontent.js
+++ b/packages/ckeditor5-dev-utils/tests/translations/createdictionaryfrompofilecontent.js
@@ -31,5 +31,16 @@ describe( 'translations', () => {
 				Cancel: 'Anuluj'
 			} );
 		} );
+
+		it( 'should skip the objects that do not contain msgstr property', () => {
+			const result = createDicitionaryFromPoFileContent( [
+				`msgctxt "Label for the Save button."`,
+				`msgid "Save"`,
+				`msgstr ""`,
+				``,
+			].join( '\n' ) );
+
+			expect( result ).to.deep.equal( {} );
+		} );
 	} );
 } );


### PR DESCRIPTION
Continuation of the https://github.com/ckeditor/ckeditor5-dev/pull/157 PR.
Closes #156

Provides 100% CC for the `ckeditor5-dev-utils/lib/translations/` and `ckeditor5-dev-env/lib/translations/` directories.