### PR TITLE
Added support for the --server option

### DIFF
--- a/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getkarmaconfig.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getkarmaconfig.js
@@ -42,18 +42,6 @@ module.exports = function getKarmaConfig( options ) {
 		}
 	}
 
-	let browsers = [];
-
-	if ( options.browsers ) {
-		browsers = options.browsers.map( ( browser ) => {
-			if ( browser === 'Chrome' ) {
-				return 'CHROME_LOCAL';
-			}
-
-			return browser;
-		} );
-	}
-
 	const karmaConfig = {
 		// Base path that will be used to resolve all patterns (eg. files, exclude).
 		basePath: process.cwd(),
@@ -106,7 +94,7 @@ module.exports = function getKarmaConfig( options ) {
 
 		// Start these browsers.
 		// Available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
-		browsers: browsers,
+		browsers: getBrowsers( options ),
 
 		customLaunchers: {
 			CHROME_TRAVIS_CI: {
@@ -134,11 +122,7 @@ module.exports = function getKarmaConfig( options ) {
 		}
 	};
 
-	if ( process.env.TRAVIS ) {
-		karmaConfig.browsers = [ 'CHROME_TRAVIS_CI' ];
-	}
-
-	if ( options.watch ) {
+	if ( options.watch || options.server ) {
 		// Enable/Disable watching file and executing tests whenever any file changes.
 		karmaConfig.autoWatch = true;
 		karmaConfig.singleRun = false;
@@ -174,3 +158,22 @@ module.exports = function getKarmaConfig( options ) {
 	return karmaConfig;
 };
 
+// Returns the value of Karma's browser option.
+// @returns {Array|null}
+function getBrowsers( options ) {
+	if ( process.env.TRAVIS ) {
+		return [ 'CHROME_TRAVIS_CI' ];
+	}
+
+	if ( options.server || !options.browsers ) {
+		return null;
+	}
+
+	return options.browsers.map( ( browser ) => {
+		if ( browser === 'Chrome' ) {
+			return 'CHROME_LOCAL';
+		}
+
+		return browser;
+	} );
+}

--- a/packages/ckeditor5-dev-tests/lib/utils/automated-tests/parsearguments.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/automated-tests/parsearguments.js
@@ -23,7 +23,8 @@ module.exports = function parseArguments( args ) {
 			'watch',
 			'coverage',
 			'source-map',
-			'verbose'
+			'verbose',
+			'server'
 		],
 
 		alias: {
@@ -40,7 +41,8 @@ module.exports = function parseArguments( args ) {
 			watch: false,
 			coverage: false,
 			verbose: false,
-			'source-map': false
+			'source-map': false,
+			server: false
 		}
 	} );
 

--- a/packages/ckeditor5-dev-tests/tests/utils/automated-tests/getkarmaconfig.js
+++ b/packages/ckeditor5-dev-tests/tests/utils/automated-tests/getkarmaconfig.js
@@ -183,6 +183,31 @@ describe( 'getKarmaConfig', () => {
 		} );
 	} );
 
+	it( 'should return karma config for options.server=true', () => {
+		const karmaConfig = getKarmaConfig( {
+			files: [ '/' ],
+			reporter: 'mocha',
+			server: true
+		} );
+
+		expect( karmaConfig.browsers ).to.equal( null );
+		expect( karmaConfig.autoWatch ).to.equal( true );
+		expect( karmaConfig.singleRun ).to.equal( false );
+	} );
+
+	it( 'should return karma config for options.watch=true', () => {
+		const karmaConfig = getKarmaConfig( {
+			files: [ '/' ],
+			reporter: 'mocha',
+			watch: true,
+			browsers: [ 'Chrome' ]
+		} );
+
+		expect( karmaConfig.browsers ).to.deep.equal( [ 'CHROME_LOCAL' ] );
+		expect( karmaConfig.autoWatch ).to.equal( true );
+		expect( karmaConfig.singleRun ).to.equal( false );
+	} );
+
 	it( 'should throw an error if no files are provided', () => {
 		const spy = sandbox.spy( getKarmaConfig );
 


### PR DESCRIPTION
Feature: Added support for the `--server` option to the automated tests runner. Closes #165.
