### PR TITLE
T/172: Merge commits are ignored when releasing sub packages

### DIFF
--- a/packages/ckeditor5-dev-env/lib/release-tools/utils/transform-commit/getchangedfilesforcommit.js
+++ b/packages/ckeditor5-dev-env/lib/release-tools/utils/transform-commit/getchangedfilesforcommit.js
@@ -14,7 +14,7 @@ const { tools } = require( '@ckeditor/ckeditor5-dev-utils' );
  * @returns {Array.<String>}
  */
 module.exports = function getChangedFilesForCommit( commitId ) {
-	const gitCommand = `git log -m -1 --name-only --pretty="format:" ${ commitId }`;
+	const gitCommand = `git diff --name-only ${ commitId }~..${ commitId }`;
 	const changedFiles = tools.shExec( gitCommand, { verbosity: 'error' } ).trim();
 
 	if ( !changedFiles ) {

--- a/packages/ckeditor5-dev-env/lib/release-tools/utils/transform-commit/getchangedfilesforcommit.js
+++ b/packages/ckeditor5-dev-env/lib/release-tools/utils/transform-commit/getchangedfilesforcommit.js
@@ -14,7 +14,7 @@ const { tools } = require( '@ckeditor/ckeditor5-dev-utils' );
  * @returns {Array.<String>}
  */
 module.exports = function getChangedFilesForCommit( commitId ) {
-	const gitCommand = `git show --pretty="" --name-only ${ commitId }`;
+	const gitCommand = `git log -m -1 --name-only --pretty="format:" ${ commitId }`;
 	const changedFiles = tools.shExec( gitCommand, { verbosity: 'error' } ).trim();
 
 	if ( !changedFiles ) {

--- a/packages/ckeditor5-dev-env/lib/release-tools/utils/transform-commit/transformcommitforsubpackage.js
+++ b/packages/ckeditor5-dev-env/lib/release-tools/utils/transform-commit/transformcommitforsubpackage.js
@@ -11,7 +11,7 @@ const getChangedFilesForCommit = require( './getchangedfilesforcommit' );
 /**
  * Parses a single commit for package which is located in multi-package repository.
  *
- * The commit will be parsed only if its files are located in current processing package.
+ * The commit will be parsed only if its at least one file is located in current processing package.
  *
  * @param {Commit} commit
  * @param {Object} context
@@ -36,12 +36,8 @@ module.exports = function transformCommitForSubPackage( commit, context ) {
 };
 
 function isValidCommit( files, packageName ) {
-	for ( const filePath of files ) {
-		// Reject if given file is not a part of current processed package.
-		if ( !filePath.startsWith( `packages/${ packageName}` ) ) {
-			return false;
-		}
-	}
-
-	return true;
+	// Commit is valid for the package if at least one file in the package was changed.
+	return files.some( ( filePath ) => {
+		return filePath.startsWith( `packages/${ packageName }` );
+	} );
 }

--- a/packages/ckeditor5-dev-env/tests/release-tools/utils/transform-commit/getchangedfilesforcommit.js
+++ b/packages/ckeditor5-dev-env/tests/release-tools/utils/transform-commit/getchangedfilesforcommit.js
@@ -55,14 +55,21 @@ packages/ckeditor5-dev-env/tests/index.js` );
 				'packages/ckeditor5-dev-env/tests/index.js'
 			] );
 
-			expect( shExecStub.firstCall.args[ 0 ] ).to.equal( 'git log -m -1 --name-only --pretty="format:" a1b2c3d' );
+			expect( shExecStub.firstCall.args[ 0 ] ).to.equal( 'git diff --name-only a1b2c3d~..a1b2c3d' );
 		} );
 
-		it( 'should not use "git show" command for collecting changed files', () => {
+		it( 'should not use "git show" command because it does not work for merge commits', () => {
 			shExecStub.returns( '' );
 			getChangedFilesForCommit( 'a1b2c3d' );
 
 			expect( shExecStub.firstCall.args[ 0 ] ).to.not.match( /^git show/ );
+		} );
+
+		it( 'should not use "git log" command because it can show two parents commits', () => {
+			shExecStub.returns( '' );
+			getChangedFilesForCommit( 'a1b2c3d' );
+
+			expect( shExecStub.firstCall.args[ 0 ] ).to.not.match( /^git log/ );
 		} );
 	} );
 } );

--- a/packages/ckeditor5-dev-env/tests/release-tools/utils/transform-commit/getchangedfilesforcommit.js
+++ b/packages/ckeditor5-dev-env/tests/release-tools/utils/transform-commit/getchangedfilesforcommit.js
@@ -50,10 +50,19 @@ describe( 'dev-env/release-tools/utils/transform-commit', () => {
 			shExecStub.returns( `README.md
 packages/ckeditor5-dev-env/tests/index.js` );
 
-			expect( getChangedFilesForCommit( 'commit sha1' ) ).to.deep.equal( [
+			expect( getChangedFilesForCommit( 'a1b2c3d' ) ).to.deep.equal( [
 				'README.md',
 				'packages/ckeditor5-dev-env/tests/index.js'
 			] );
+
+			expect( shExecStub.firstCall.args[ 0 ] ).to.equal( 'git log -m -1 --name-only --pretty="format:" a1b2c3d' );
+		} );
+
+		it( 'should not use "git show" command for collecting changed files', () => {
+			shExecStub.returns( '' );
+			getChangedFilesForCommit( 'a1b2c3d' );
+
+			expect( shExecStub.firstCall.args[ 0 ] ).to.not.match( /^git show/ );
 		} );
 	} );
 } );

--- a/packages/ckeditor5-dev-env/tests/release-tools/utils/transform-commit/transformcommitforsubpackage.js
+++ b/packages/ckeditor5-dev-env/tests/release-tools/utils/transform-commit/transformcommitforsubpackage.js
@@ -70,7 +70,21 @@ describe( 'dev-env/release-tools/utils/transform-commit', () => {
 			expect( stubs.transformCommitForSubRepository.called ).to.equal( false );
 		} );
 
-		it( 'rejects the commit when it has changed files in other packages', () => {
+		it( 'rejects the commit when it changed files in other package', () => {
+			const commit = {
+				hash: 'abcd123'
+			};
+
+			stubs.getChangedFilesForCommit.returns( [
+				'packages/ckeditor5-dev-tests/CHANGELOG.md',
+				'packages/ckeditor5-dev-tests/README.md'
+			] );
+
+			expect( transformCommitForSubPackage( commit, context ) ).to.equal( undefined );
+			expect( stubs.transformCommitForSubRepository.called ).to.equal( false );
+		} );
+
+		it( 'accepts the commit when it has changed files in proper and other packages', () => {
 			const commit = {
 				hash: 'abcd123'
 			};
@@ -80,11 +94,13 @@ describe( 'dev-env/release-tools/utils/transform-commit', () => {
 				'packages/ckeditor5-dev-tests/README.md'
 			] );
 
-			expect( transformCommitForSubPackage( commit, context ) ).to.equal( undefined );
-			expect( stubs.transformCommitForSubRepository.called ).to.equal( false );
+			stubs.transformCommitForSubRepository.returnsArg( 0 );
+
+			expect( transformCommitForSubPackage( commit, context ) ).to.equal( commit );
+			expect( stubs.transformCommitForSubRepository.called ).to.equal( true );
 		} );
 
-		it( 'rejects the commit when it has changed files in root of the repository', () => {
+		it( 'accepts the commit when it has changed files in proper packages and root of the repository', () => {
 			const commit = {
 				hash: 'abcd123'
 			};
@@ -94,8 +110,10 @@ describe( 'dev-env/release-tools/utils/transform-commit', () => {
 				'README.md'
 			] );
 
-			expect( transformCommitForSubPackage( commit, context ) ).to.equal( undefined );
-			expect( stubs.transformCommitForSubRepository.called ).to.equal( false );
+			stubs.transformCommitForSubRepository.returnsArg( 0 );
+
+			expect( transformCommitForSubPackage( commit, context ) ).to.equal( commit );
+			expect( stubs.transformCommitForSubRepository.called ).to.equal( true );
 		} );
 
 		it( 'accepts the commit when it has changed files for proper package', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix:  Commits which changed files from a few packages will not be ignored now. `getChangedFilesForCommit()` returns a proper list of changed files for merge commits. Closes #172.