### PR TITLE
T/175: Links to compare the versions for sub packages are invalid

### DIFF
--- a/packages/ckeditor5-dev-env/lib/release-tools/tasks/generatechangelogforsinglepackage.js
+++ b/packages/ckeditor5-dev-env/lib/release-tools/tasks/generatechangelogforsinglepackage.js
@@ -64,6 +64,7 @@ module.exports = function generateChangelogForSinglePackage( newVersion = null )
 			const changelogOptions = {
 				version,
 				tagName,
+				newTagName: 'v' + version,
 				transformCommit: transformCommitFunction
 			};
 

--- a/packages/ckeditor5-dev-env/lib/release-tools/tasks/generatechangelogforsubpackages.js
+++ b/packages/ckeditor5-dev-env/lib/release-tools/tasks/generatechangelogforsubpackages.js
@@ -95,6 +95,7 @@ module.exports = function generateChangelogForSubPackages( options ) {
 				const changelogOptions = {
 					version,
 					tagName,
+					newTagName: packageJson.name + '@' + version,
 					transformCommit: transformCommitFunction
 				};
 

--- a/packages/ckeditor5-dev-env/lib/release-tools/utils/generatechangelogfromcommits.js
+++ b/packages/ckeditor5-dev-env/lib/release-tools/utils/generatechangelogfromcommits.js
@@ -20,7 +20,7 @@ const { stream, logger } = require( '@ckeditor/ckeditor5-dev-utils' );
  * @param {String} options.version A version for generated changelog.
  * @param {Function} options.transformCommit A function which transforms the commit.
  * @param {String|null} options.tagName Name of the last created tag for the repository.
- * @param {String} options.newTagName Name of tag for current version.
+ * @param {String} options.newTagName Name of the tag for current version.
  * @returns {Promise}
  */
 module.exports = function generateChangelogFromCommits( options ) {

--- a/packages/ckeditor5-dev-env/lib/release-tools/utils/generatechangelogfromcommits.js
+++ b/packages/ckeditor5-dev-env/lib/release-tools/utils/generatechangelogfromcommits.js
@@ -20,6 +20,7 @@ const { stream, logger } = require( '@ckeditor/ckeditor5-dev-utils' );
  * @param {String} options.version A version for generated changelog.
  * @param {Function} options.transformCommit A function which transforms the commit.
  * @param {String|null} options.tagName Name of the last created tag for the repository.
+ * @param {String} options.newTagName Name of tag for current version.
  * @returns {Promise}
  */
 module.exports = function generateChangelogFromCommits( options ) {
@@ -34,6 +35,8 @@ module.exports = function generateChangelogFromCommits( options ) {
 
 		const context = {
 			version: options.version,
+			currentTag: options.newTagName,
+			previousTag: options.tagName,
 			displayLogs: false
 		};
 

--- a/packages/ckeditor5-dev-env/tests/release-tools/tasks/generatechangelogforsinglepackage.js
+++ b/packages/ckeditor5-dev-env/tests/release-tools/tasks/generatechangelogforsinglepackage.js
@@ -87,6 +87,7 @@ describe( 'dev-env/release-tools/tasks', () => {
 					expect( stubs.generateChangelogFromCommits.firstCall.args[ 0 ] ).to.deep.equal( {
 						version: '1.0.0',
 						tagName: 'v0.5.0',
+						newTagName: 'v1.0.0',
 						transformCommit: stubs.transformCommit
 					} );
 
@@ -111,6 +112,7 @@ describe( 'dev-env/release-tools/tasks', () => {
 					expect( stubs.generateChangelogFromCommits.firstCall.args[ 0 ] ).to.deep.equal( {
 						version: '0.1.0',
 						tagName: null,
+						newTagName: 'v0.1.0',
 						transformCommit: stubs.transformCommit
 					} );
 

--- a/packages/ckeditor5-dev-env/tests/release-tools/tasks/generatechangelogforsubpackages.js
+++ b/packages/ckeditor5-dev-env/tests/release-tools/tasks/generatechangelogforsubpackages.js
@@ -164,6 +164,20 @@ describe( 'dev-env/release-tools/tasks', () => {
 					expect( stubs.tools.shExec.calledTwice ).to.equal( true );
 					expect( stubs.tools.shExec.firstCall.args[ 0 ] ).to.equal( 'git add packages/**/CHANGELOG.md' );
 					expect( stubs.tools.shExec.secondCall.args[ 0 ] ).to.equal( 'git commit -m "Docs: Updated changelog for packages. [skip ci]"' );
+
+					expect( stubs.generateChangelogFromCommits.calledTwice ).to.equal( true );
+					expect( stubs.generateChangelogFromCommits.firstCall.args[ 0 ] ).to.deep.equal( {
+						version: '1.0.1',
+						transformCommit: stubs.transformCommit,
+						tagName: '@ckeditor/ckeditor5-dev-foo@1.0.0',
+						newTagName: '@ckeditor/ckeditor5-dev-foo@1.0.1'
+					} );
+					expect( stubs.generateChangelogFromCommits.secondCall.args[ 0 ] ).to.deep.equal( {
+						version: '2.1.0',
+						transformCommit: stubs.transformCommit,
+						tagName: '@ckeditor/ckeditor5-dev-bar@2.0.0',
+						newTagName: '@ckeditor/ckeditor5-dev-bar@2.1.0'
+					} );
 				} );
 		} );
 
@@ -207,6 +221,13 @@ describe( 'dev-env/release-tools/tasks', () => {
 					expect( stubs.displaySkippedPackages.firstCall.args[ 0 ] ).to.deep.equal( new Set( [
 						'/ckeditor5-dev/packages/ckeditor5-dev-bar'
 					] ) );
+
+					expect( stubs.generateChangelogFromCommits.firstCall.args[ 0 ] ).to.deep.equal( {
+						version: '1.0.1',
+						transformCommit: stubs.transformCommit,
+						tagName: '@ckeditor/ckeditor5-dev-foo@1.0.0',
+						newTagName: '@ckeditor/ckeditor5-dev-foo@1.0.1'
+					} );
 				} );
 		} );
 
@@ -251,6 +272,7 @@ describe( 'dev-env/release-tools/tasks', () => {
 					] ) );
 
 					expect( stubs.tools.shExec.called ).to.equal( false );
+					expect( stubs.generateChangelogFromCommits.called ).to.equal( false );
 				} );
 		} );
 	} );

--- a/packages/ckeditor5-dev-env/tests/release-tools/utils/generatechangelogfromcommits.js
+++ b/packages/ckeditor5-dev-env/tests/release-tools/utils/generatechangelogfromcommits.js
@@ -126,7 +126,8 @@ describe( 'dev-env/release-tools/utils', () => {
 			const options = {
 				version: '1.0.0',
 				transformCommit: stubs.transformCommit,
-				tagName: 'v0.5.0'
+				tagName: 'v0.5.0',
+				newTagName: 'v1.0.0'
 			};
 
 			return generateChangelogFromCommits( options )
@@ -137,7 +138,9 @@ describe( 'dev-env/release-tools/utils', () => {
 					expect( conventionalChangelogArguments ).to.be.an( 'array' );
 					expect( conventionalChangelogArguments[ 1 ] ).to.deep.equal( {
 						displayLogs: false,
-						version: '1.0.0'
+						version: '1.0.0',
+						previousTag: 'v0.5.0',
+						currentTag: 'v1.0.0'
 					} );
 					expect( conventionalChangelogArguments[ 2 ] ).to.have.property( 'from', 'v0.5.0' );
 					expect( conventionalChangelogArguments[ 4 ] ).to.deep.equal( { foo: 'bar' } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Fixed invalid comparison version links in the changelog. Closes #175.