### PR TITLE
T171: Links to commits are incorrect in subpackages case

### DIFF
--- a/packages/ckeditor5-dev-bundler-rollup/package.json
+++ b/packages/ckeditor5-dev-bundler-rollup/package.json
@@ -42,5 +42,5 @@
   "license": "(GPL-2.0 OR LGPL-2.1 OR MPL-1.1)",
   "homepage": "https://github.com/ckeditor/ckeditor5-dev/tree/master/packages/ckeditor5-dev-bundler-rollup",
   "bugs": "https://github.com/ckeditor/ckeditor5-dev/issues",
-  "repository": "https://github.com/ckeditor/ckeditor5-dev/tree/master/packages/ckeditor5-dev-bundler-rollup"
+  "repository": "https://github.com/ckeditor/ckeditor5-dev"
 }

--- a/packages/ckeditor5-dev-docs/package.json
+++ b/packages/ckeditor5-dev-docs/package.json
@@ -18,5 +18,5 @@
   "license": "(GPL-2.0 OR LGPL-2.1 OR MPL-1.1)",
   "homepage": "https://github.com/ckeditor/ckeditor5-dev/tree/master/packages/ckeditor5-dev-docs",
   "bugs": "https://github.com/ckeditor/ckeditor5-dev/issues",
-  "repository": "https://github.com/ckeditor/ckeditor5-dev/tree/master/packages/ckeditor5-dev-docs"
+  "repository": "https://github.com/ckeditor/ckeditor5-dev"
 }

--- a/packages/ckeditor5-dev-env/package.json
+++ b/packages/ckeditor5-dev-env/package.json
@@ -38,5 +38,5 @@
   "license": "(GPL-2.0 OR LGPL-2.1 OR MPL-1.1)",
   "homepage": "https://github.com/ckeditor/ckeditor5-dev/tree/master/packages/ckeditor5-dev-env",
   "bugs": "https://github.com/ckeditor/ckeditor5-dev/issues",
-  "repository": "https://github.com/ckeditor/ckeditor5-dev/tree/master/packages/ckeditor5-dev-env"
+  "repository": "https://github.com/ckeditor/ckeditor5-dev"
 }

--- a/packages/ckeditor5-dev-lint/package.json
+++ b/packages/ckeditor5-dev-lint/package.json
@@ -31,5 +31,5 @@
   "license": "(GPL-2.0 OR LGPL-2.1 OR MPL-1.1)",
   "homepage": "https://github.com/ckeditor/ckeditor5-dev/tree/master/packages/ckeditor5-dev-lint",
   "bugs": "https://github.com/ckeditor/ckeditor5-dev/issues",
-  "repository": "https://github.com/ckeditor/ckeditor5-dev/tree/master/packages/ckeditor5-dev-lint"
+  "repository": "https://github.com/ckeditor/ckeditor5-dev"
 }

--- a/packages/ckeditor5-dev-tests/package.json
+++ b/packages/ckeditor5-dev-tests/package.json
@@ -63,5 +63,5 @@
   "license": "(GPL-2.0 OR LGPL-2.1 OR MPL-1.1)",
   "homepage": "https://github.com/ckeditor/ckeditor5-dev/tree/master/packages/ckeditor5-dev-tests",
   "bugs": "https://github.com/ckeditor/ckeditor5-dev/issues",
-  "repository": "https://github.com/ckeditor/ckeditor5-dev/tree/master/packages/ckeditor5-dev-tests"
+  "repository": "https://github.com/ckeditor/ckeditor5-dev"
 }

--- a/packages/ckeditor5-dev-utils/package.json
+++ b/packages/ckeditor5-dev-utils/package.json
@@ -28,5 +28,5 @@
   "license": "(GPL-2.0 OR LGPL-2.1 OR MPL-1.1)",
   "homepage": "https://github.com/ckeditor/ckeditor5-dev/tree/master/packages/ckeditor5-dev-utils",
   "bugs": "https://github.com/ckeditor/ckeditor5-dev/issues",
-  "repository": "https://github.com/ckeditor/ckeditor5-dev/tree/master/packages/ckeditor5-dev-utils"
+  "repository": "https://github.com/ckeditor/ckeditor5-dev"
 }

--- a/packages/ckeditor5-dev-webpack-plugin/package.json
+++ b/packages/ckeditor5-dev-webpack-plugin/package.json
@@ -16,5 +16,5 @@
   "license": "(GPL-2.0 OR LGPL-2.1 OR MPL-1.1)",
   "homepage": "https://github.com/ckeditor/ckeditor5-dev/tree/master/packages/ckeditor5-dev-webpack-plugin",
   "bugs": "https://github.com/ckeditor/ckeditor5-dev/issues",
-  "repository": "https://github.com/ckeditor/ckeditor5-dev/tree/master/packages/ckeditor5-dev-webpack-plugin"
+  "repository": "https://github.com/ckeditor/ckeditor5-dev"
 }

--- a/packages/jsdoc-plugins/package.json
+++ b/packages/jsdoc-plugins/package.json
@@ -17,5 +17,5 @@
   "license": "MIT",
   "homepage": "https://github.com/ckeditor/ckeditor5-dev/tree/master/packages/jsdoc-plugins",
   "bugs": "https://github.com/ckeditor/ckeditor5-dev/issues",
-  "repository": "https://github.com/ckeditor/ckeditor5-dev/tree/master/packages/jsdoc-plugins"
+  "repository": "https://github.com/ckeditor/ckeditor5-dev"
 }


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Fixed invalid repository URL in package.json for all packages. Closes #171.