### PR TITLE
T/146: Issues with generating changelog entries for more complex commits

### DIFF
--- a/packages/ckeditor5-dev-env/lib/release-tools/templates/footer.hbs
+++ b/packages/ckeditor5-dev-env/lib/release-tools/templates/footer.hbs
@@ -5,7 +5,7 @@
 {{#each notes}}
 * {{text}}
 {{/each}}
-{{/each}}
 
+{{/each}}
 {{/if}}
 

--- a/packages/ckeditor5-dev-env/lib/release-tools/utils/transform-commit/parser-options.js
+++ b/packages/ckeditor5-dev-env/lib/release-tools/utils/transform-commit/parser-options.js
@@ -6,6 +6,8 @@
 'use strict';
 
 module.exports = {
+	mergePattern: /^Merge pull request #(\d+) from .*$/,
+	mergeCorrespondence: [ 'pullRequestId' ],
 	headerPattern: /^([^\:]+): (.*\.)/,
 	headerCorrespondence: [
 		'type',

--- a/packages/ckeditor5-dev-env/lib/release-tools/utils/transform-commit/transform-commit-utils.js
+++ b/packages/ckeditor5-dev-env/lib/release-tools/utils/transform-commit/transform-commit-utils.js
@@ -85,6 +85,19 @@ const transformCommitUtils = {
 			default:
 				throw new Error( `Given invalid type of commit ("${ commitType }").` );
 		}
+	},
+
+	/**
+	 * @param {String} sentence
+	 * @param {Number} length
+	 * @returns {String}
+	 */
+	truncate( sentence, length ) {
+		if ( sentence.length <= length ) {
+			return sentence;
+		}
+
+		return sentence.slice( 0, length - 3 ).trim() + '...';
 	}
 };
 

--- a/packages/ckeditor5-dev-env/lib/release-tools/utils/transform-commit/transformcommitforsubrepository.js
+++ b/packages/ckeditor5-dev-env/lib/release-tools/utils/transform-commit/transformcommitforsubrepository.js
@@ -35,7 +35,7 @@ module.exports = function transformCommitForSubRepository( commit, context ) {
 	const hasCorrectType = utils.availableCommitTypes.has( commit.type );
 	const isCommitIncluded = utils.availableCommitTypes.get( commit.type );
 
-	let logMessage = `* ${ chalk.yellow( commit.hash ) } "${ commit.header }" `;
+	let logMessage = `* ${ chalk.yellow( commit.hash ) } "${ utils.truncate( commit.header, 100 ) }" `;
 
 	if ( hasCorrectType && isCommitIncluded ) {
 		logMessage += chalk.green( 'INCLUDED' );

--- a/packages/ckeditor5-dev-env/tests/release-tools/utils/generatechangelogfromcommits-integration.js
+++ b/packages/ckeditor5-dev-env/tests/release-tools/utils/generatechangelogfromcommits-integration.js
@@ -82,7 +82,6 @@ describe( 'dev-env/release-tools/utils', () => {
 
 			return generateChangelog( '0.2.0', '0.1.0' )
 				.then( () => {
-					const url = 'https://github.com/ckeditor/ckeditor5-test-package';
 					const latestChangelog = replaceCommitIds( getChangesForVersion( '0.2.0' ) );
 
 					expect( latestChangelog.split( '\n' ).length ).to.equal( 5 );
@@ -107,7 +106,6 @@ describe( 'dev-env/release-tools/utils', () => {
 
 			return generateChangelog( '0.2.1', '0.2.0' )
 				.then( () => {
-					const url = 'https://github.com/ckeditor/ckeditor5-test-package';
 					const latestChangelog = replaceCommitIds( getChangesForVersion( '0.2.1' ) );
 
 					expect( latestChangelog.split( '\n' ).length ).to.equal( 5 );

--- a/packages/ckeditor5-dev-env/tests/release-tools/utils/generatechangelogfromcommits-integration.js
+++ b/packages/ckeditor5-dev-env/tests/release-tools/utils/generatechangelogfromcommits-integration.js
@@ -67,9 +67,7 @@ describe( 'dev-env/release-tools/utils', () => {
 
 			return generateChangelog( '0.1.0', '0.0.1' )
 				.then( () => {
-					const expectedTitle = '## [0.1.0](https://github.com/ckeditor/ckeditor5-test-package/compare/v0.0.1...v0.1.0)';
-
-					expect( getChangelog() ).to.contain( expectedTitle );
+					expect( getChangelog() ).to.contain( '## [0.1.0](https://github.com/ckeditor/ckeditor5-test-package/compare/v0.0.1...v0.1.0)' );
 
 					release( '0.1.0' );
 				} );
@@ -84,15 +82,15 @@ describe( 'dev-env/release-tools/utils', () => {
 				.then( () => {
 					const latestChangelog = replaceCommitIds( getChangesForVersion( '0.2.0' ) );
 
-					expect( latestChangelog.split( '\n' ).length ).to.equal( 5 );
+					const expectedChangelog = `
+### Features
 
-					const changesAsArray = latestChangelog.split( '\n' ).filter( ( line ) => line.trim().length );
+* Another feature. Closes [#2](https://github.com/ckeditor/ckeditor5-test-package/issues/2). ([XXXXXXX](https://github.com/ckeditor/ckeditor5-test-package/commit/XXXXXXX))
 
-					//jscs:disable maximumLineLength
-					expect( changesAsArray[ 0 ] ).to.equal( '### Features' );
-					expect( changesAsArray[ 1 ] ).to.equal( `* Another feature. Closes [#2](${ url }/issues/2). ([XXXXXXX](${ url }/commit/XXXXXXX))` );
-					expect( changesAsArray[ 2 ] ).to.equal( `  This PR also closes [#3](${ url }/issues/3) and [#4](${ url }/issues/4).` );
-					//jscs:enable maximumLineLength
+  This PR also closes [#3](https://github.com/ckeditor/ckeditor5-test-package/issues/3) and [#4](https://github.com/ckeditor/ckeditor5-test-package/issues/4).
+`;
+
+					expect( latestChangelog ).to.equal( expectedChangelog.trim() );
 
 					release( '0.2.0' );
 				} );
@@ -108,15 +106,15 @@ describe( 'dev-env/release-tools/utils', () => {
 				.then( () => {
 					const latestChangelog = replaceCommitIds( getChangesForVersion( '0.2.1' ) );
 
-					expect( latestChangelog.split( '\n' ).length ).to.equal( 5 );
+					const expectedChangelog = `
+### Bug fixes
 
-					const changesAsArray = latestChangelog.split( '\n' ).filter( ( line ) => line.trim().length );
+* Amazing fix. Closes [#5](https://github.com/ckeditor/ckeditor5-test-package/issues/5). ([XXXXXXX](https://github.com/ckeditor/ckeditor5-test-package/commit/XXXXXXX))
 
-					//jscs:disable maximumLineLength
-					expect( changesAsArray[ 0 ] ).to.equal( '### Bug fixes' );
-					expect( changesAsArray[ 1 ] ).to.equal( `* Amazing fix. Closes [#5](${ url }/issues/5). ([XXXXXXX](${ url }/commit/XXXXXXX))` );
-					expect( changesAsArray[ 2 ] ).to.equal( `  The PR also finally closes [#3](${ url }/issues/3) and [#4](${ url }/issues/4). So good!` );
-					//jscs:enable maximumLineLength
+  The PR also finally closes [#3](https://github.com/ckeditor/ckeditor5-test-package/issues/3) and [#4](https://github.com/ckeditor/ckeditor5-test-package/issues/4). So good!
+`;
+
+					expect( latestChangelog ).to.equal( expectedChangelog.trim() );
 
 					release( '0.2.1' );
 				} );
@@ -134,19 +132,23 @@ describe( 'dev-env/release-tools/utils', () => {
 				.then( () => {
 					const latestChangelog = replaceCommitIds( getChangesForVersion( '0.3.0' ) );
 
-					expect( latestChangelog.split( '\n' ).length ).to.equal( 13 );
+					const expectedChangelog = `
+### Other changes
 
-					const changesAsArray = latestChangelog.split( '\n' ).filter( ( line ) => line.trim().length );
+* Some docs improvements. Closes [#6](https://github.com/ckeditor/ckeditor5-test-package/issues/6). ([XXXXXXX](https://github.com/ckeditor/ckeditor5-test-package/commit/XXXXXXX))
 
-					//jscs:disable maximumLineLength
-					expect( changesAsArray[ 0 ] ).to.equal( '### Other changes' );
-					expect( changesAsArray[ 1 ] ).to.equal( `* Some docs improvements. Closes [#6](${ url }/issues/6). ([XXXXXXX](${ url }/commit/XXXXXXX))` );
-					expect( changesAsArray[ 2 ] ).to.equal( `  Did you see the [#3](${ url }/issues/3) and [#4](${ url }/issues/4)?` );
-					expect( changesAsArray[ 3 ] ).to.equal( '### BREAKING CHANGES' );
-					expect( changesAsArray[ 4 ] ).to.equal( '* Some breaking change.' );
-					expect( changesAsArray[ 5 ] ).to.equal( '### NOTE' );
-					expect( changesAsArray[ 6 ] ).to.equal( `* Please read [#1](${ url }/issues/1).` );
-					//jscs:enable maximumLineLength
+  Did you see the [#3](https://github.com/ckeditor/ckeditor5-test-package/issues/3) and [#4](https://github.com/ckeditor/ckeditor5-test-package/issues/4)?
+
+### BREAKING CHANGES
+
+* Some breaking change.
+
+### NOTE
+
+* Please read [#1](https://github.com/ckeditor/ckeditor5-test-package/issues/1).
+`;
+
+					expect( latestChangelog ).to.equal( expectedChangelog.trim() );
 
 					release( '0.3.0' );
 				} );
@@ -163,19 +165,23 @@ describe( 'dev-env/release-tools/utils', () => {
 				.then( () => {
 					const latestChangelog = replaceCommitIds( getChangesForVersion( '0.4.0' ) );
 
-					expect( latestChangelog.split( '\n' ).length ).to.equal( 13 );
+					const expectedChangelog = `
+### Features
 
-					const changesAsArray = latestChangelog.split( '\n' ).filter( ( line ) => line.trim().length );
+* Issues will not be hoisted. Closes [#8](https://github.com/ckeditor/ckeditor5-test-package/issues/8). ([XXXXXXX](https://github.com/ckeditor/ckeditor5-test-package/commit/XXXXXXX))
 
-					//jscs:disable maximumLineLength
-					expect( changesAsArray[ 0 ] ).to.equal( '### Features' );
-					expect( changesAsArray[ 1 ] ).to.equal( `* Issues will not be hoisted. Closes [#8](${ url }/issues/8). ([XXXXXXX](${ url }/commit/XXXXXXX))` );
-					expect( changesAsArray[ 2 ] ).to.equal( `  All details have been described in [#1](${ url }/issues/1).` );
-					expect( changesAsArray[ 3 ] ).to.equal( '### BREAKING CHANGES' );
-					expect( changesAsArray[ 4 ] ).to.equal( '* Some breaking change.' );
-					expect( changesAsArray[ 5 ] ).to.equal( '### NOTE' );
-					expect( changesAsArray[ 6 ] ).to.equal( `* Please read [#1](${ url }/issues/1).` );
-					//jscs:enable maximumLineLength
+  All details have been described in [#1](https://github.com/ckeditor/ckeditor5-test-package/issues/1).
+
+### BREAKING CHANGES
+
+* Some breaking change.
+
+### NOTE
+
+* Please read [#1](https://github.com/ckeditor/ckeditor5-test-package/issues/1).
+`;
+
+					expect( latestChangelog ).to.equal( expectedChangelog.trim() );
 
 					release( '0.4.0' );
 				} );
@@ -187,11 +193,13 @@ describe( 'dev-env/release-tools/utils', () => {
 	}
 
 	function generateChangelog( version, previousVersion = null ) {
+		const transform = require( '../../../lib/release-tools/utils/transform-commit/transformcommitforsubrepository' );
+
 		return generateChangelogFromCommits( {
 			version,
 			newTagName: 'v' + version,
 			tagName: previousVersion ? 'v' + previousVersion : null,
-			transformCommit: require( '../../../lib/release-tools/utils/transform-commit/transformcommitforsubrepository' )
+			transformCommit: transform
 		} );
 	}
 

--- a/packages/ckeditor5-dev-env/tests/release-tools/utils/transform-commit/transform-commit-utils.js
+++ b/packages/ckeditor5-dev-env/tests/release-tools/utils/transform-commit/transform-commit-utils.js
@@ -95,5 +95,19 @@ describe( 'dev-env/release-tools/utils/transform-commit', () => {
 				expect( transformCommit.getCommitType( 'Other' ) ).to.equal( 'Other changes' );
 			} );
 		} );
+
+		describe( 'truncate()', () => {
+			it( 'does not modify too short sentence', () => {
+				const sentence = 'This is a short sentence.';
+
+				expect( transformCommit.truncate( sentence, 25 ) ).to.equal( sentence );
+			} );
+
+			it( 'truncates too long sentence', () => {
+				const sentence = 'This is a short sentence.';
+
+				expect( transformCommit.truncate( sentence, 13 ) ).to.equal( 'This is a...' );
+			} );
+		} );
 	} );
 } );

--- a/packages/ckeditor5-dev-env/tests/release-tools/utils/transform-commit/transformcommitforsubrepository.js
+++ b/packages/ckeditor5-dev-env/tests/release-tools/utils/transform-commit/transformcommitforsubrepository.js
@@ -88,7 +88,7 @@ describe( 'dev-env/release-tools/utils/transform-commit', () => {
 			transformCommitForSubRepository( commit, { displayLogs: true, packageData: packageJson } );
 
 			expect( stubs.logger.info.calledOnce ).to.equal( true );
-			expect( stubs.logger.info.firstCall.args[ 0 ] ).to.match( /\* 684997d "Fix: Simple fix\." \u001b\[32mINCLUDED/ );
+			expect( stubs.logger.info.firstCall.args[ 0 ] ).to.match( /\* \u001b\[33m684997d\u001b\[39m "Fix: Simple fix\." \u001b\[32mINCLUDED/ );
 		} );
 
 		it( 'does not attach valid "internal" commit to the changelog', () => {
@@ -105,7 +105,7 @@ describe( 'dev-env/release-tools/utils/transform-commit', () => {
 			transformCommitForSubRepository( commit, { displayLogs: true, packageData: packageJson } );
 
 			expect( stubs.logger.info.calledOnce ).to.equal( true );
-			expect( stubs.logger.info.firstCall.args[ 0 ] ).to.match( /\* 684997d "Docs: README\." \u001b\[90mSKIPPED/ );
+			expect( stubs.logger.info.firstCall.args[ 0 ] ).to.match( /\* \u001b\[33m684997d\u001b\[39m "Docs: README\." \u001b\[90mSKIPPED/ );
 		} );
 
 		it( 'does not attach invalid commit to the changelog', () => {
@@ -122,7 +122,7 @@ describe( 'dev-env/release-tools/utils/transform-commit', () => {
 			transformCommitForSubRepository( commit, { displayLogs: true, packageData: packageJson } );
 
 			expect( stubs.logger.info.calledOnce ).to.equal( true );
-			expect( stubs.logger.info.firstCall.args[ 0 ] ).to.match( /\* 684997d "Invalid commit\." \u001b\[31mINVALID/ );
+			expect( stubs.logger.info.firstCall.args[ 0 ] ).to.match( /\* \u001b\[33m684997d\u001b\[39m "Invalid commit\." \u001b\[31mINVALID/ );
 		} );
 
 		it( 'makes URLs to issues on GitHub', () => {
@@ -252,99 +252,16 @@ describe( 'dev-env/release-tools/utils/transform-commit', () => {
 			expect( stubs.logger.info.firstCall.args[ 0 ] ).to.match( /\u001b\[32mINCLUDED/ );
 		} );
 
-		it( 'does not duplicate the commit header in additional description for merge commits', () => {
-			const commitDescription = [
-				'* Release task - rebuilt module for collecting dependencies to release.',
-				'* Release task - a new version to release will be read from CHANGELOG file.',
-				'* Changelog task - will not break if changelog does not exist.',
-				'* Used `semver` package for bumping the version (instead of a custom module).',
-			];
-
-			const commitDescriptionWithIndents = [
-				'  * Release task - rebuilt module for collecting dependencies to release.',
-				'  * Release task - a new version to release will be read from CHANGELOG file.',
-				'  * Changelog task - will not break if changelog does not exist.',
-				'  * Used `semver` package for bumping the version (instead of a custom module).',
-			].join( '\n' );
-
-			const commit = {
-				header: 'Merge pull request #75 from ckeditor/t/64',
-				hash: 'dea35014ab610be0c2150343c6a8a68620cfe5ad',
-				body: null,
-				footer: [
-					'Feature: Introduced a brand new release tools with a new set of requirements. See #64.',
-					'',
-					...commitDescription,
-					''
-				].join( '\n' ),
-				mentions: [],
-				type: null,
-				subject: null,
-				notes: []
-			};
-
-			transformCommitForSubRepository( commit, { displayLogs: true, packageData: packageJson } );
-
-			expect( commit.type ).to.equal( 'Features' );
-			expect( commit.subject ).to.equal( 'Introduced a brand new release tools with a new set of requirements. ' +
-				'See [#64](https://github.com/ckeditor/ckeditor5-dev/issues/64).' );
-			expect( commit.body ).to.equal( commitDescriptionWithIndents );
-
-			expect( stubs.logger.info.calledOnce ).to.equal( true );
-
-			const commitRegexp = /\* dea3501 "Merge pull request #75 from ckeditor\/t\/64" \u001b\[32mINCLUDED/;
-			expect( stubs.logger.info.firstCall.args[ 0 ] ).to.match( commitRegexp );
-		} );
-
-		it( 'reads commit details from "footer" for merge commit from Github', () => {
-			const commit = {
-				header: 'Merge pull request #75 from ckeditor/t/64',
-				hash: 'dea35014ab610be0c2150343c6a8a68620cfe5ad',
-				body: null,
-				footer: 'Feature: Introduced a brand new release tools with a new set of requirements. See #64.',
-				mentions: [],
-				type: null,
-				subject: null,
-				notes: []
-			};
-
-			transformCommitForSubRepository( commit, { displayLogs: true, packageData: packageJson } );
-
-			expect( commit.header ).to.equal( 'Merge pull request #75 from ckeditor/t/64' );
-			expect( commit.type ).to.equal( 'Features' );
-			expect( commit.subject ).to.equal( 'Introduced a brand new release tools with a new set of requirements. ' +
-				'See [#64](https://github.com/ckeditor/ckeditor5-dev/issues/64).' );
-		} );
-
-		it( 'reads commit details from "body" for manually merge commit', () => {
-			const commit = {
-				header: 'Merge pull request #75 from ckeditor/t/64',
-				hash: 'dea35014ab610be0c2150343c6a8a68620cfe5ad',
-				body: 'Feature: Introduced a brand new release tools with a new set of requirements. See #64.',
-				footer: null,
-				mentions: [],
-				type: null,
-				subject: null,
-				notes: []
-			};
-
-			transformCommitForSubRepository( commit, { displayLogs: true, packageData: packageJson } );
-
-			expect( commit.header ).to.equal( 'Merge pull request #75 from ckeditor/t/64' );
-			expect( commit.type ).to.equal( 'Features' );
-			expect( commit.subject ).to.equal( 'Introduced a brand new release tools with a new set of requirements. ' +
-				'See [#64](https://github.com/ckeditor/ckeditor5-dev/issues/64).' );
-		} );
-
 		it( 'attaches additional subject for merge commits to the commit list', () => {
 			const commit = {
-				header: 'Merge pull request #75 from ckeditor/t/64',
+				merge: 'Merge pull request #75 from ckeditor/t/64',
 				hash: 'dea35014ab610be0c2150343c6a8a68620cfe5ad',
-				body: 'Feature: Introduced a brand new release tools with a new set of requirements.',
+				header: 'Feature: Introduced a brand new release tools with a new set of requirements.',
+				type: 'Feature',
+				subject: 'Introduced a brand new release tools with a new set of requirements.',
+				body: null,
 				footer: null,
 				mentions: [],
-				type: null,
-				subject: null,
 				notes: []
 			};
 
@@ -354,12 +271,14 @@ describe( 'dev-env/release-tools/utils/transform-commit', () => {
 			expect( stubs.logger.info.firstCall.args[ 0 ] ).to.be.a( 'string' );
 
 			const logMessageAsArray = stubs.logger.info.firstCall.args[ 0 ].split( '\n' );
-			const mergeCommitPattern = /\* dea3501 "Merge pull request #75 from ckeditor\/t\/64" \u001b\[32mINCLUDED/;
-			const detailsPattern = /Feature: Introduced a brand new release tools with a new set of requirements\./;
+			//jscs:disable maximumLineLength
+			const commitDetailsPattern = /\* \u001b\[33mdea3501\u001b\[39m "Feature: Introduced a brand new release tools with a new set of requirements\." \u001b\[32mINCLUDED/;
+			//jscs:enable maximumLineLength
+			const mergeCommitPattern = /Merge pull request #75 from ckeditor\/t\/64/;
 
 			expect( logMessageAsArray.length ).to.equal( 2 );
-			expect( logMessageAsArray[ 0 ] ).to.match( mergeCommitPattern );
-			expect( logMessageAsArray[ 1 ] ).to.match( detailsPattern );
+			expect( logMessageAsArray[ 0 ] ).to.match( commitDetailsPattern );
+			expect( logMessageAsArray[ 1 ] ).to.match( mergeCommitPattern );
 		} );
 
 		it( 'allows hiding the logs', () => {
@@ -396,6 +315,23 @@ describe( 'dev-env/release-tools/utils/transform-commit', () => {
 			transformCommitForSubRepository( commit, { displayLogs: false } );
 
 			expect( commit.references ).to.equal( undefined );
+		} );
+
+		it( 'uses commit\'s footer as a commit\'s body when commit does not have additional notes', () => {
+			const commit = {
+				hash: 'dea35014ab610be0c2150343c6a8a68620cfe5ad',
+				header: 'Feature: Introduced a brand new release tools with a new set of requirements.',
+				type: 'Feature',
+				subject: 'Introduced a brand new release tools with a new set of requirements.',
+				body: null,
+				footer: 'Additional description has been parsed as a footer but it should be a body.',
+				notes: []
+			};
+
+			transformCommitForSubRepository( commit, { displayLogs: false, packageData: packageJson } );
+
+			expect( commit.body ).to.equal( '  Additional description has been parsed as a footer but it should be a body.' );
+			expect( commit.footer ).to.equal( null );
 		} );
 	} );
 } );

--- a/packages/ckeditor5-dev-env/tests/release-tools/utils/transform-commit/transformcommitforsubrepository.js
+++ b/packages/ckeditor5-dev-env/tests/release-tools/utils/transform-commit/transformcommitforsubrepository.js
@@ -91,6 +91,25 @@ describe( 'dev-env/release-tools/utils/transform-commit', () => {
 			expect( stubs.logger.info.firstCall.args[ 0 ] ).to.match( /\* \u001b\[33m684997d\u001b\[39m "Fix: Simple fix\." \u001b\[32mINCLUDED/ );
 		} );
 
+		it( 'truncates too long commit\'s subject', () => {
+			const commit = {
+				hash: '684997d0eb2eca76b9e058fb1c3fa00b50059cdc',
+				header: 'Fix: Reference site about Lorem Ipsum, giving information on its origins, as well as a random Lipsum generator.',
+				type: 'Fix',
+				subject: 'Reference site about Lorem Ipsum, giving information on its origins, as well as a random Lipsum generator.',
+				body: null,
+				footer: null,
+				notes: []
+			};
+
+			transformCommitForSubRepository( commit, { displayLogs: true, packageData: packageJson } );
+
+			expect( stubs.logger.info.calledOnce ).to.equal( true );
+			//jscs:disable maximumLineLength
+			expect( stubs.logger.info.firstCall.args[ 0 ] ).to.match( /\* \u001b\[33m684997d\u001b\[39m "Fix: Reference site about Lorem Ipsum, giving information on its origins, as well as a random Lip\.\.\." \u001b\[32mINCLUDED/ );
+			//jscs:enable maximumLineLength
+		} );
+
 		it( 'does not attach valid "internal" commit to the changelog', () => {
 			const commit = {
 				hash: '684997d0eb2eca76b9e058fb1c3fa00b50059cdc',


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Complex commits will be parsed correctly. Closes #146.

---

### Additional information

This PR requires an integration test which was introduced in #180 so before reviewing this PR, **please merge the #180**.

A lot of our workaround for merge commits could be done using [`merge` option](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-commits-parser#merge) for conventional-changelog (which parses the commits).

On the occasion, I changed:
- a color of commit ids displayed on the list during generating the changelog,
- swap an order of commit header and merge note for merge commits. Now the header of the commit will be displayed first. If the commit is a merge commit, below the line will be displayed a note about the merge.

![image](https://cloud.githubusercontent.com/assets/2270764/25845111/0068e5f0-34ad-11e7-8ab2-2ca73dfc3257.png)

