### PR TITLE
T/187: The changelog generator crashes on non-existen CHANGELOG.md

### DIFF
--- a/packages/ckeditor5-dev-env/lib/release-tools/utils/changelog.js
+++ b/packages/ckeditor5-dev-env/lib/release-tools/utils/changelog.js
@@ -40,7 +40,7 @@ const utils = {
 	},
 
 	/**
-	 * @returns {String}
+	 * @returns {String|null}
 	 */
 	getChangelog() {
 		const changelogFile = path.resolve( utils.changelogFile );

--- a/packages/ckeditor5-dev-env/lib/release-tools/utils/versions.js
+++ b/packages/ckeditor5-dev-env/lib/release-tools/utils/versions.js
@@ -17,6 +17,11 @@ const versions = {
 	 */
 	getLastFromChangelog() {
 		const changelog = changelogUtils.getChangelog();
+
+		if ( !changelog ) {
+			return null;
+		}
+
 		const regexp = /\n## \[?([\da-z\.\-\+]+)/i;
 
 		const matches = changelog.match( regexp );

--- a/packages/ckeditor5-dev-env/tests/release-tools/utils/versions.js
+++ b/packages/ckeditor5-dev-env/tests/release-tools/utils/versions.js
@@ -97,6 +97,12 @@ describe( 'dev-env/release-tools/utils', () => {
 
 				expect( version.getLastFromChangelog() ).to.equal( null );
 			} );
+
+			it( 'returns null if changelog does not exist', () => {
+				changelogStub.returns( null );
+
+				expect( version.getLastFromChangelog() ).to.equal( null );
+			} );
 		} );
 
 		describe( 'getLastTagFromGit()', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Changelog's utils won't throw an error if the changelog file does not exist. Closes #187.
