### PR TITLE
Add directory cleaning before pot files collecting

### DIFF
--- a/packages/ckeditor5-dev-env/lib/translations/collect-utils.js
+++ b/packages/ckeditor5-dev-env/lib/translations/collect-utils.js
@@ -5,6 +5,7 @@
 
 'use strict';
 
+const del = require( 'del' );
 const glob = require( 'glob' );
 const fs = require( 'fs-extra' );
 const path = require( 'path' );
@@ -117,6 +118,11 @@ const utils = {
 		}
 
 		return errors;
+	},
+
+	removeExistingPotFiles() {
+		const pathToTransifexDirectory = path.join( process.cwd(), 'build', '.transifex' );
+		del.sync( pathToTransifexDirectory );
 	},
 
 	/**

--- a/packages/ckeditor5-dev-env/lib/translations/collect.js
+++ b/packages/ckeditor5-dev-env/lib/translations/collect.js
@@ -33,6 +33,8 @@ module.exports = function collect() {
 		return;
 	}
 
+	utils.removeExistingPotFiles();
+
 	for ( const [ packageName, context ] of contexts ) {
 		const potFileHeader = utils.createPotFileHeader();
 		const potFileContent = utils.createPotFileContent( context );

--- a/packages/ckeditor5-dev-env/tests/translations/collect-utils.js
+++ b/packages/ckeditor5-dev-env/tests/translations/collect-utils.js
@@ -14,6 +14,7 @@ const mockery = require( 'mockery' );
 const glob = require( 'glob' );
 const fs = require( 'fs-extra' );
 const proxyquire = require( 'proxyquire' );
+const del = require( 'del' );
 
 describe( 'collect-utils', () => {
 	let sandbox, utils, stubs, originalStringMap;
@@ -34,10 +35,12 @@ describe( 'collect-utils', () => {
 			},
 			translations: {
 				findOriginalStrings: sandbox.spy( string => originalStringMap[ string ] )
-			}
+			},
+			delSync: sandbox.spy()
 		};
 
 		sandbox.stub( process, 'cwd', () => path.join( 'workspace', 'ckeditor5' ) );
+		sandbox.stub( del, 'sync', stubs.delSync );
 
 		utils = proxyquire( '../../lib/translations/collect-utils' , {
 			'@ckeditor/ckeditor5-dev-utils': {
@@ -237,6 +240,17 @@ describe( 'collect-utils', () => {
 			expect( errors ).to.deep.equal( [
 				'Context is duplicated for the key: util.'
 			] );
+		} );
+	} );
+
+	describe( 'removeExistingPotFiles', () => {
+		it( 'should remove existing po files from the transifex directory', () => {
+			utils.removeExistingPotFiles();
+
+			sinon.assert.calledWithExactly(
+				stubs.delSync,
+				path.join( 'workspace', 'ckeditor5', 'build', '.transifex' )
+			);
 		} );
 	} );
 

--- a/packages/ckeditor5-dev-env/tests/translations/collect-utils.js
+++ b/packages/ckeditor5-dev-env/tests/translations/collect-utils.js
@@ -243,7 +243,7 @@ describe( 'collect-utils', () => {
 		} );
 	} );
 
-	describe( 'removeExistingPotFiles', () => {
+	describe( 'removeExistingPotFiles()', () => {
 		it( 'should remove existing po files from the transifex directory', () => {
 			utils.removeExistingPotFiles();
 

--- a/packages/ckeditor5-dev-env/tests/translations/collect.js
+++ b/packages/ckeditor5-dev-env/tests/translations/collect.js
@@ -31,6 +31,7 @@ describe( 'collect', () => {
 				createPotFileHeader: sandbox.stub(),
 				createPotFileContent: sandbox.stub(),
 				savePotFile: sandbox.spy(),
+				removeExistingPotFiles: sandbox.spy(),
 			}
 		};
 
@@ -76,5 +77,13 @@ describe( 'collect', () => {
 
 		sinon.assert.notCalled( stubs.collectUtils.savePotFile );
 		sinon.assert.calledWithExactly( stubs.logger.error, 'ckeditor5-core/lang/context.json file is missing' );
+	} );
+
+	it( 'should remove existing po files', () => {
+		stubs.collectUtils.getContexts.returns( new Map() );
+
+		collect();
+
+		sinon.assert.calledOnce( stubs.collectUtils.removeExistingPotFiles );
 	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Added directory cleaning before pot files collecting. Closes #181.
