### PR TITLE
T/184: Add "internal" option to the version picker 

### DIFF
--- a/packages/ckeditor5-dev-env/lib/release-tools/tasks/generatechangelogforsinglepackage.js
+++ b/packages/ckeditor5-dev-env/lib/release-tools/tasks/generatechangelogforsinglepackage.js
@@ -6,6 +6,7 @@
 'use strict';
 
 const chalk = require( 'chalk' );
+const semver = require( 'semver' );
 const { tools, logger } = require( '@ckeditor/ckeditor5-dev-utils' );
 const cli = require( '../utils/cli' );
 const versionUtils = require( '../utils/versions' );
@@ -61,9 +62,17 @@ module.exports = function generateChangelogForSinglePackage( newVersion = null )
 				return Promise.resolve();
 			}
 
+			let isInternalRelease = false;
+
+			if ( version === 'internal' ) {
+				isInternalRelease = true;
+				version = semver.inc( packageJson.version, 'patch' );
+			}
+
 			const changelogOptions = {
 				version,
 				tagName,
+				isInternalRelease,
 				newTagName: 'v' + version,
 				transformCommit: transformCommitFunction
 			};

--- a/packages/ckeditor5-dev-env/lib/release-tools/tasks/generatechangelogforsubpackages.js
+++ b/packages/ckeditor5-dev-env/lib/release-tools/tasks/generatechangelogforsubpackages.js
@@ -6,6 +6,7 @@
 'use strict';
 
 const chalk = require( 'chalk' );
+const semver = require( 'semver' );
 const { tools, logger } = require( '@ckeditor/ckeditor5-dev-utils' );
 const getNewReleaseType = require( '../utils/getnewreleasetype' );
 const cli = require( '../utils/cli' );
@@ -92,9 +93,17 @@ module.exports = function generateChangelogForSubPackages( options ) {
 					return Promise.resolve();
 				}
 
+				let isInternalRelease = false;
+
+				if ( version === 'internal' ) {
+					isInternalRelease = true;
+					version = semver.inc( packageJson.version, 'patch' );
+				}
+
 				const changelogOptions = {
 					version,
 					tagName,
+					isInternalRelease,
 					newTagName: packageJson.name + '@' + version,
 					transformCommit: transformCommitFunction
 				};

--- a/packages/ckeditor5-dev-env/lib/release-tools/templates/template.hbs
+++ b/packages/ckeditor5-dev-env/lib/release-tools/templates/template.hbs
@@ -1,5 +1,9 @@
 {{> header}}
 
+{{#if isInternalRelease}}
+Internal changes only (updated dependencies, documentation, etc.).
+
+{{else}}
 {{#each commitGroups}}
 {{#if title}}
 ### {{title}}
@@ -13,4 +17,5 @@
 Internal changes only (updated dependencies, documentation, etc.).
 
 {{/each}}
+{{/if}}
 {{> footer}}

--- a/packages/ckeditor5-dev-env/lib/release-tools/templates/template.hbs
+++ b/packages/ckeditor5-dev-env/lib/release-tools/templates/template.hbs
@@ -17,5 +17,5 @@ Internal changes only (updated dependencies, documentation, etc.).
 Internal changes only (updated dependencies, documentation, etc.).
 
 {{/each}}
-{{/if}}
 {{> footer}}
+{{/if}}

--- a/packages/ckeditor5-dev-env/lib/release-tools/utils/cli.js
+++ b/packages/ckeditor5-dev-env/lib/release-tools/utils/cli.js
@@ -69,7 +69,7 @@ const cli = {
 			},
 
 			validate( input ) {
-				if ( input === 'skip' ) {
+				if ( input === 'skip' || input === 'internal' ) {
 					return true;
 				}
 

--- a/packages/ckeditor5-dev-env/lib/release-tools/utils/generatechangelogfromcommits.js
+++ b/packages/ckeditor5-dev-env/lib/release-tools/utils/generatechangelogfromcommits.js
@@ -21,6 +21,7 @@ const { stream, logger } = require( '@ckeditor/ckeditor5-dev-utils' );
  * @param {Function} options.transformCommit A function which transforms the commit.
  * @param {String|null} options.tagName Name of the last created tag for the repository.
  * @param {String} options.newTagName Name of the tag for current version.
+ * @param {Boolean} [options.isInternalRelease=false] Whether the changelog is generated for internal release.
  * @returns {Promise}
  */
 module.exports = function generateChangelogFromCommits( options ) {
@@ -37,7 +38,8 @@ module.exports = function generateChangelogFromCommits( options ) {
 			version: options.version,
 			currentTag: options.newTagName,
 			previousTag: options.tagName,
-			displayLogs: false
+			displayLogs: false,
+			isInternalRelease: options.isInternalRelease || false,
 		};
 
 		const gitRawCommitsOpts = {

--- a/packages/ckeditor5-dev-env/tests/release-tools/tasks/generatechangelogforsinglepackage.js
+++ b/packages/ckeditor5-dev-env/tests/release-tools/tasks/generatechangelogforsinglepackage.js
@@ -86,7 +86,8 @@ describe( 'dev-env/release-tools/tasks', () => {
 						version: '1.0.0',
 						tagName: 'v0.5.0',
 						newTagName: 'v1.0.0',
-						transformCommit: stubs.transformCommit
+						transformCommit: stubs.transformCommit,
+						isInternalRelease: false
 					} );
 
 					expect( stubs.logger.info.calledThrice ).to.equal( true );
@@ -115,7 +116,8 @@ describe( 'dev-env/release-tools/tasks', () => {
 						version: '0.1.0',
 						tagName: null,
 						newTagName: 'v0.1.0',
-						transformCommit: stubs.transformCommit
+						transformCommit: stubs.transformCommit,
+						isInternalRelease: false
 					} );
 
 					expect( stubs.getNewReleaseType.calledOnce ).to.equal( true );
@@ -162,6 +164,23 @@ describe( 'dev-env/release-tools/tasks', () => {
 					expect( stubs.tools.shExec.secondCall.args[ 0 ] ).to.equal(
 						'git commit -m "Docs: Changelog. [skip ci]"'
 					);
+				} );
+		} );
+
+		it( 'allows generating changelog as "internal"', () => {
+			stubs.versionUtils.getLastFromChangelog.returns( '0.0.1' );
+			stubs.generateChangelogFromCommits.returns( Promise.resolve() );
+
+			return generateChangelogForSinglePackage( 'internal' )
+				.then( () => {
+					expect( stubs.generateChangelogFromCommits.calledOnce ).to.equal( true );
+					expect( stubs.generateChangelogFromCommits.firstCall.args[ 0 ] ).to.deep.equal( {
+						version: '0.0.2',
+						tagName: 'v0.0.1',
+						newTagName: 'v0.0.2',
+						transformCommit: stubs.transformCommit,
+						isInternalRelease: true
+					} );
 				} );
 		} );
 	} );

--- a/packages/ckeditor5-dev-env/tests/release-tools/utils/generatechangelogfromcommits-integration.js
+++ b/packages/ckeditor5-dev-env/tests/release-tools/utils/generatechangelogfromcommits-integration.js
@@ -249,20 +249,43 @@ describe( 'dev-env/release-tools/utils', () => {
 					release( '0.4.1' );
 				} );
 		} );
+
+		// See: https://github.com/ckeditor/ckeditor5-dev/issues/184
+		it( 'generates changelog as "internal" even if commits were made', () => {
+			exec( 'git commit --allow-empty ' +
+				'--message "Feature: Issues will not be hoisted. Closes #8." ' +
+				'--message "All details have been described in #1." ' +
+				'--message "NOTE: Please read #1." ' +
+				'--message "BREAKING CHANGES: Some breaking change." ' );
+
+			exec( 'git commit --allow-empty ' +
+				'--message "Feature: Issues will not be hoisted. Closes #8." ' +
+				'--message "All details have been described in #1." ' +
+				'--message "NOTE: Please read #1." ' +
+				'--message "BREAKING CHANGES: Some breaking change." ' );
+
+			return generateChangelog( '0.4.1', '0.4.0', true )
+				.then( () => {
+					const latestChangelog = getChangesForVersion( '0.4.1' );
+
+					expect( latestChangelog ).to.equal( 'Internal changes only (updated dependencies, documentation, etc.).' );
+				} );
+		} );
 	} );
 
 	function exec( command ) {
 		return tools.shExec( command, { verbosity: 'error' } );
 	}
 
-	function generateChangelog( version, previousVersion = null ) {
+	function generateChangelog( version, previousVersion = null, isInternalRelease = false ) {
 		const transform = require( '../../../lib/release-tools/utils/transform-commit/transformcommitforsubrepository' );
 
 		return generateChangelogFromCommits( {
 			version,
+			isInternalRelease,
 			newTagName: 'v' + version,
 			tagName: previousVersion ? 'v' + previousVersion : null,
-			transformCommit: transform
+			transformCommit: transform,
 		} );
 	}
 

--- a/packages/ckeditor5-dev-env/tests/release-tools/utils/generatechangelogfromcommits-integration.js
+++ b/packages/ckeditor5-dev-env/tests/release-tools/utils/generatechangelogfromcommits-integration.js
@@ -264,11 +264,13 @@ describe( 'dev-env/release-tools/utils', () => {
 				'--message "NOTE: Please read #1." ' +
 				'--message "BREAKING CHANGES: Some breaking change." ' );
 
-			return generateChangelog( '0.4.1', '0.4.0', true )
+			return generateChangelog( '0.4.2', '0.4.1', true )
 				.then( () => {
-					const latestChangelog = getChangesForVersion( '0.4.1' );
+					const latestChangelog = getChangesForVersion( '0.4.2' );
 
 					expect( latestChangelog ).to.equal( 'Internal changes only (updated dependencies, documentation, etc.).' );
+
+					release( '0.4.2' );
 				} );
 		} );
 	} );

--- a/packages/ckeditor5-dev-env/tests/release-tools/utils/generatechangelogfromcommits.js
+++ b/packages/ckeditor5-dev-env/tests/release-tools/utils/generatechangelogfromcommits.js
@@ -140,7 +140,8 @@ describe( 'dev-env/release-tools/utils', () => {
 						displayLogs: false,
 						version: '1.0.0',
 						previousTag: 'v0.5.0',
-						currentTag: 'v1.0.0'
+						currentTag: 'v1.0.0',
+						isInternalRelease: false
 					} );
 					expect( conventionalChangelogArguments[ 2 ] ).to.have.property( 'from', 'v0.5.0' );
 					expect( conventionalChangelogArguments[ 4 ] ).to.deep.equal( { foo: 'bar' } );
@@ -149,6 +150,33 @@ describe( 'dev-env/release-tools/utils', () => {
 
 					expect( stubs.changelogUtils.saveChangelog.calledOnce ).to.equal( true );
 					expect( stubs.changelogUtils.saveChangelog.firstCall.args[ 0 ] ).to.equal( newChangelog );
+				} );
+		} );
+
+		it( 'allows generating "internal" release', () => {
+			changelogBuffer = Buffer.from( 'Internal changes only (updated dependencies, documentation, etc.).' );
+
+			stubs.fs.existsSync.returns( true );
+			stubs.changelogUtils.getChangelog.returns( changelogUtils.changelogHeader );
+
+			const options = {
+				version: '0.5.1',
+				transformCommit: stubs.transformCommit,
+				tagName: 'v0.5.0',
+				newTagName: 'v0.5.1',
+				isInternalRelease: true
+			};
+
+			return generateChangelogFromCommits( options )
+				.then( () => {
+					expect( conventionalChangelogArguments ).to.be.an( 'array' );
+					expect( conventionalChangelogArguments[ 1 ] ).to.deep.equal( {
+						displayLogs: false,
+						version: '0.5.1',
+						previousTag: 'v0.5.0',
+						currentTag: 'v0.5.1',
+						isInternalRelease: true
+					} );
 				} );
 		} );
 	} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Added `internal` option to the version picker. Closes #184.

If you type `internal` as a new version during generating the changelog, all commits were made will be ignored.

---

