### PR TITLE
T/207: getChangedFilesForCommit() sometimes does not work as it should

### DIFF
--- a/packages/ckeditor5-dev-env/lib/release-tools/utils/transform-commit/getchangedfilesforcommit.js
+++ b/packages/ckeditor5-dev-env/lib/release-tools/utils/transform-commit/getchangedfilesforcommit.js
@@ -14,12 +14,20 @@ const { tools } = require( '@ckeditor/ckeditor5-dev-utils' );
  * @returns {Array.<String>}
  */
 module.exports = function getChangedFilesForCommit( commitId ) {
-	const gitCommand = `git diff --name-only ${ commitId }~..${ commitId }`;
+	const gitCommand = `git log -m -1 --name-only --pretty="format:" ${ commitId }`;
 	const changedFiles = tools.shExec( gitCommand, { verbosity: 'error' } ).trim();
 
-	if ( !changedFiles ) {
-		return [];
+	// Merge commits can have two parents. Returned files for merge commits looks like:
+	// file1            <-- files from merged branch
+	// file2            <-- files from merged branch
+	// file             <-- files from merged branch
+	//
+	// other-file1      <-- files from last commit before merge
+	// other-file2      <-- files from last commit before merge
+	// We need to filter out files from commit before merge.
+	if ( changedFiles.indexOf( '\n\n' ) === -1 ) {
+		return changedFiles.split( '\n' );
 	}
 
-	return changedFiles.split( '\n' );
+	return changedFiles.split( '\n\n' )[ 0 ].split( '\n' );
 };

--- a/packages/ckeditor5-dev-env/lib/release-tools/utils/transform-commit/getchangedfilesforcommit.js
+++ b/packages/ckeditor5-dev-env/lib/release-tools/utils/transform-commit/getchangedfilesforcommit.js
@@ -25,9 +25,6 @@ module.exports = function getChangedFilesForCommit( commitId ) {
 	// other-file1      <-- files from last commit before merge
 	// other-file2      <-- files from last commit before merge
 	// We need to filter out files from commit before merge.
-	if ( changedFiles.indexOf( '\n\n' ) === -1 ) {
-		return changedFiles.split( '\n' );
-	}
 
 	return changedFiles.split( '\n\n' )[ 0 ].split( '\n' );
 };

--- a/packages/ckeditor5-dev-env/tests/release-tools/utils/transform-commit/getchangedfilesforcommit.js
+++ b/packages/ckeditor5-dev-env/tests/release-tools/utils/transform-commit/getchangedfilesforcommit.js
@@ -46,7 +46,11 @@ describe( 'dev-env/release-tools/utils/transform-commit', () => {
 		} );
 
 		it( 'returns files for initial commit', () => {
-			exec( 'touch {1..5}.txt' );
+			exec( 'touch 1.txt' );
+			exec( 'touch 2.txt' );
+			exec( 'touch 3.txt' );
+			exec( 'touch 4.txt' );
+			exec( 'touch 5.txt' );
 			exec( 'git add *.txt' );
 			exec( 'git commit -m "Initial commit."' );
 
@@ -62,11 +66,17 @@ describe( 'dev-env/release-tools/utils/transform-commit', () => {
 		} );
 
 		it( 'returns files for next commit after initial', () => {
-			exec( 'touch {1..5}.txt' );
+			exec( 'touch 1.txt' );
+			exec( 'touch 2.txt' );
+			exec( 'touch 3.txt' );
+			exec( 'touch 4.txt' );
+			exec( 'touch 5.txt' );
 			exec( 'git add *.txt' );
 			exec( 'git commit -m "Initial commit."' );
 
-			exec( 'touch {2..4}.js' );
+			exec( 'touch 2.js' );
+			exec( 'touch 3.js' );
+			exec( 'touch 4.js' );
 			exec( 'git add *.js' );
 			exec( 'git commit -m "Next commit after initial."' );
 
@@ -80,16 +90,23 @@ describe( 'dev-env/release-tools/utils/transform-commit', () => {
 		} );
 
 		it( 'returns files for commit on new branch', () => {
-			exec( 'touch {1..5}.txt' );
+			exec( 'touch 1.txt' );
+			exec( 'touch 2.txt' );
+			exec( 'touch 3.txt' );
+			exec( 'touch 4.txt' );
+			exec( 'touch 5.txt' );
 			exec( 'git add *.txt' );
 			exec( 'git commit -m "Initial commit."' );
 
-			exec( 'touch {2..4}.js' );
+			exec( 'touch 2.js' );
+			exec( 'touch 3.js' );
+			exec( 'touch 4.js' );
 			exec( 'git add *.js' );
 			exec( 'git commit -m "Next commit after initial."' );
 
 			exec( 'git checkout -b develop' );
-			exec( 'touch {5..6}.json' );
+			exec( 'touch 5.json' );
+			exec( 'touch 6.json' );
 			exec( 'git add *.json' );
 			exec( 'git commit -m "New commit on branch develop."' );
 
@@ -102,21 +119,30 @@ describe( 'dev-env/release-tools/utils/transform-commit', () => {
 		} );
 
 		it( 'returns files for merge commit', () => {
-			exec( 'touch {1..5}.txt' );
+			exec( 'touch 1.txt' );
+			exec( 'touch 2.txt' );
+			exec( 'touch 3.txt' );
+			exec( 'touch 4.txt' );
+			exec( 'touch 5.txt' );
 			exec( 'git add *.txt' );
 			exec( 'git commit -m "Initial commit."' );
 
-			exec( 'touch {2..4}.js' );
+			exec( 'touch 2.js' );
+			exec( 'touch 3.js' );
+			exec( 'touch 4.js' );
 			exec( 'git add *.js' );
 			exec( 'git commit -m "Next commit after initial."' );
 
 			exec( 'git checkout -b develop' );
-			exec( 'touch {5..6}.json' );
+			exec( 'touch 5.json' );
+			exec( 'touch 6.json' );
 			exec( 'git add *.json' );
 			exec( 'git commit -m "New commit on branch develop."' );
 
 			exec( 'git checkout master' );
-			exec( 'touch {10..12}.sh' );
+			exec( 'touch 10.sh' );
+			exec( 'touch 11.sh' );
+			exec( 'touch 12.sh' );
 			exec( 'git add *.sh' );
 			exec( 'git commit -m "New commit on branch master."' );
 

--- a/packages/ckeditor5-dev-env/tests/release-tools/utils/transform-commit/getchangedfilesforcommit.js
+++ b/packages/ckeditor5-dev-env/tests/release-tools/utils/transform-commit/getchangedfilesforcommit.js
@@ -5,69 +5,138 @@
 
 'use strict';
 
+const fs = require( 'fs' );
+const path = require( 'path' );
 const expect = require( 'chai' ).expect;
-const sinon = require( 'sinon' );
-const mockery = require( 'mockery' );
+const { tools } = require( '@ckeditor/ckeditor5-dev-utils' );
 
 describe( 'dev-env/release-tools/utils/transform-commit', () => {
-	let getChangedFilesForCommit, sandbox, shExecStub;
+	let tmpCwd, cwd, getChangedFilesForCommit;
 
-	describe( 'getChangedFilesForCommit()', () => {
+	describe( 'getChangedFilesForCommit()', function() {
+		this.timeout( 5000 );
+
+		before( () => {
+			cwd = process.cwd();
+			tmpCwd = fs.mkdtempSync( __dirname + path.sep );
+			process.chdir( tmpCwd );
+		} );
+
+		after( () => {
+			exec( `rm -rf ${ tmpCwd }` );
+			process.chdir( cwd );
+		} );
+
 		beforeEach( () => {
-			sandbox = sinon.sandbox.create();
+			exec( 'git init' );
 
-			mockery.enable( {
-				useCleanCache: true,
-				warnOnReplace: false,
-				warnOnUnregistered: false
-			} );
-
-			shExecStub = sandbox.stub();
-
-			mockery.registerMock( '@ckeditor/ckeditor5-dev-utils', {
-				tools: {
-					shExec: shExecStub
-				}
-			} );
-
-			getChangedFilesForCommit = require( '../../../../lib/release-tools/utils/transform-commit/getchangedfilesforcommit' );
+			if ( process.env.CI ) {
+				exec( 'git config user.email "ckeditor5@ckeditor.com"' );
+				exec( 'git config user.name "CKEditor5 CI"' );
+			}
 		} );
 
 		afterEach( () => {
-			sandbox.restore();
-			mockery.disable();
+			exec( `rm -rf ${ path.join( tmpCwd, '.git' ) }` );
+			exec( `rm -rf ${ path.join( tmpCwd, '*' ) }` );
 		} );
 
-		it( 'returns an empty array if commit was empty', () => {
-			shExecStub.returns( '' );
-
-			expect( getChangedFilesForCommit( 'commit sha1' ) ).to.deep.equal( [] );
+		beforeEach( () => {
+			getChangedFilesForCommit = require( '../../../../lib/release-tools/utils/transform-commit/getchangedfilesforcommit' );
 		} );
 
-		it( 'returns an array with changed files', () => {
-			shExecStub.returns( `README.md
-packages/ckeditor5-dev-env/tests/index.js` );
+		it( 'returns files for initial commit', () => {
+			exec( 'touch {1..5}.txt' );
+			exec( 'git add *.txt' );
+			exec( 'git commit -m "Initial commit."' );
 
-			expect( getChangedFilesForCommit( 'a1b2c3d' ) ).to.deep.equal( [
-				'README.md',
-				'packages/ckeditor5-dev-env/tests/index.js'
+			const files = getChangedFilesForCommit( getLastCommit() );
+
+			expect( files ).to.deep.equal( [
+				'1.txt',
+				'2.txt',
+				'3.txt',
+				'4.txt',
+				'5.txt',
 			] );
-
-			expect( shExecStub.firstCall.args[ 0 ] ).to.equal( 'git diff --name-only a1b2c3d~..a1b2c3d' );
 		} );
 
-		it( 'should not use "git show" command because it does not work for merge commits', () => {
-			shExecStub.returns( '' );
-			getChangedFilesForCommit( 'a1b2c3d' );
+		it( 'returns files for next commit after initial', () => {
+			exec( 'touch {1..5}.txt' );
+			exec( 'git add *.txt' );
+			exec( 'git commit -m "Initial commit."' );
 
-			expect( shExecStub.firstCall.args[ 0 ] ).to.not.match( /^git show/ );
+			exec( 'touch {2..4}.js' );
+			exec( 'git add *.js' );
+			exec( 'git commit -m "Next commit after initial."' );
+
+			const files = getChangedFilesForCommit( getLastCommit() );
+
+			expect( files ).to.deep.equal( [
+				'2.js',
+				'3.js',
+				'4.js',
+			] );
 		} );
 
-		it( 'should not use "git log" command because it can show two parents commits', () => {
-			shExecStub.returns( '' );
-			getChangedFilesForCommit( 'a1b2c3d' );
+		it( 'returns files for commit on new branch', () => {
+			exec( 'touch {1..5}.txt' );
+			exec( 'git add *.txt' );
+			exec( 'git commit -m "Initial commit."' );
 
-			expect( shExecStub.firstCall.args[ 0 ] ).to.not.match( /^git log/ );
+			exec( 'touch {2..4}.js' );
+			exec( 'git add *.js' );
+			exec( 'git commit -m "Next commit after initial."' );
+
+			exec( 'git checkout -b develop' );
+			exec( 'touch {5..6}.json' );
+			exec( 'git add *.json' );
+			exec( 'git commit -m "New commit on branch develop."' );
+
+			const files = getChangedFilesForCommit( getLastCommit() );
+
+			expect( files ).to.deep.equal( [
+				'5.json',
+				'6.json',
+			] );
+		} );
+
+		it( 'returns files for merge commit', () => {
+			exec( 'touch {1..5}.txt' );
+			exec( 'git add *.txt' );
+			exec( 'git commit -m "Initial commit."' );
+
+			exec( 'touch {2..4}.js' );
+			exec( 'git add *.js' );
+			exec( 'git commit -m "Next commit after initial."' );
+
+			exec( 'git checkout -b develop' );
+			exec( 'touch {5..6}.json' );
+			exec( 'git add *.json' );
+			exec( 'git commit -m "New commit on branch develop."' );
+
+			exec( 'git checkout master' );
+			exec( 'touch {10..12}.sh' );
+			exec( 'git add *.sh' );
+			exec( 'git commit -m "New commit on branch master."' );
+
+			exec( 'git merge develop' );
+			exec( 'git branch -d develop' );
+
+			const files = getChangedFilesForCommit( getLastCommit() );
+
+			expect( files ).to.deep.equal( [
+				'5.json',
+				'6.json',
+			] );
 		} );
 	} );
+
+	function exec( command ) {
+		return tools.shExec( command, { verbosity: 'error' } );
+	}
+
+	function getLastCommit() {
+		return exec( 'git log -n 1 --pretty=format:"%H"' ).trim();
+	}
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: A changed way for gathering changed files in a commit. Closes #207.
