### PR TITLE
T/217: Utils - Bundler - "createEntryFile" should use "config" key from configuration build

### DIFF
--- a/packages/ckeditor5-dev-utils/lib/bundler/createentryfile.js
+++ b/packages/ckeditor5-dev-utils/lib/bundler/createentryfile.js
@@ -7,24 +7,25 @@
 
 const fs = require( 'fs' );
 const getPlugins = require( './getplugins' );
+const getEditorConfig = require( './geteditorconfig' );
 
 /**
  * Generates an entry file which can be compiled by bundler, e.g. Webpack or Rollup.
  *
  * @param {String} destinationPath A path where entry file will be saved.
  * @param {Object} options
- * @param {String} configPath A path to the configuration of the build. The file must expose a "config" key as a config for the editor.
  * @param {Array.<String>} options.plugins An array with paths to the plugins for the editor.
  * @param {String} options.moduleName Name of exported UMD module.
  * @param {String} options.editor A path to class which defined the editor.
+ * @param {Object} options.config Additional editor's configuration which will be built-in.
  */
-module.exports = function createEntryFile( destinationPath, configPath, options ) {
-	const entryFileContent = renderEntryFile( configPath, options );
+module.exports = function createEntryFile( destinationPath, options ) {
+	const entryFileContent = renderEntryFile( options );
 
 	fs.writeFileSync( destinationPath, entryFileContent );
 };
 
-function renderEntryFile( configPath, options ) {
+function renderEntryFile( options ) {
 	const plugins = getPlugins( options.plugins );
 	const date = new Date();
 
@@ -47,7 +48,7 @@ ${ options.moduleName }.build = {
 	plugins: [
 		${ Object.keys( plugins ).join( ',\n\t\t' ) }
 	],
-	config: require( '${ configPath }' ).config
+	config: ${ getEditorConfig( options.config ) }
 };
 `;
 

--- a/packages/ckeditor5-dev-utils/lib/bundler/createentryfile.js
+++ b/packages/ckeditor5-dev-utils/lib/bundler/createentryfile.js
@@ -13,8 +13,8 @@ const getPlugins = require( './getplugins' );
  *
  * @param {String} destinationPath A path where entry file will be saved.
  * @param {Object} options
+ * @param {String} configPath A path to the configuration of the build. The file must expose a "config" key as a config for the editor.
  * @param {Array.<String>} options.plugins An array with paths to the plugins for the editor.
- * @param {String} configPath A path to additional editor's configuration which will be built-in.
  * @param {String} options.moduleName Name of exported UMD module.
  * @param {String} options.editor A path to class which defined the editor.
  */
@@ -47,7 +47,7 @@ ${ options.moduleName }.build = {
 	plugins: [
 		${ Object.keys( plugins ).join( ',\n\t\t' ) }
 	],
-	config: require( '${ configPath }' )
+	config: require( '${ configPath }' ).config
 };
 `;
 

--- a/packages/ckeditor5-dev-utils/lib/bundler/geteditorconfig.js
+++ b/packages/ckeditor5-dev-utils/lib/bundler/geteditorconfig.js
@@ -19,13 +19,6 @@ module.exports = function getEditorConfig( config ) {
 	}
 
 	return javascriptStringify( config, null, '\t' )
-		.split( '\n' )
-		.map( ( line, index ) => {
-			if ( index === 0 ) {
-				return line;
-			}
-
-			return `\t${ line }`;
-		} )
-		.join( '\n' );
+		// Indent all but the first line (so it can be easily concatenated with `config = ${ editorConfig }`).
+		.replace( /\n/g, '\n\t' );
 };

--- a/packages/ckeditor5-dev-utils/lib/bundler/geteditorconfig.js
+++ b/packages/ckeditor5-dev-utils/lib/bundler/geteditorconfig.js
@@ -1,0 +1,39 @@
+/**
+ * @license Copyright (c) 2003-2017, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+'use strict';
+
+/**
+ * Transforms specified configuration to a string which can be inserted
+ * to generated an entry file.
+ *
+ * Keys and values will be wrapped in apostrophes instead of quotation marks.
+ *
+ * Keys which contains letters or/and numbers or/and underscore or/and a Dollar sign
+ * will not be wrapped in apostrophes.
+ *
+ * @param {Object} config
+ * @returns {String}
+ */
+module.exports = function getEditorConfig( config ) {
+	if ( !config ) {
+		return '{}';
+	}
+
+	return JSON.stringify( config, null, '\t' )
+		.split( '\n' )
+		.map( ( line, index ) => {
+			if ( index === 0 ) {
+				return line;
+			}
+
+			return `\t${ line }`;
+		} )
+		.join( '\n' )
+		// Replace quotation marks to apostrophes.
+		.replace( /"/g, '\'' )
+		// Removes apostrophes from single word keys.
+		.replace( /'([$A-Z0-9_]+)':/gi, '$1:' );
+};

--- a/packages/ckeditor5-dev-utils/lib/bundler/geteditorconfig.js
+++ b/packages/ckeditor5-dev-utils/lib/bundler/geteditorconfig.js
@@ -8,13 +8,7 @@
 const javascriptStringify = require( 'javascript-stringify' );
 
 /**
- * Transforms specified configuration to a string which can be inserted
- * to generated an entry file.
- *
- * Keys and values will be wrapped in apostrophes instead of quotation marks.
- *
- * Keys which contains letters or/and numbers or/and underscore or/and a Dollar sign
- * will not be wrapped in apostrophes.
+ * Transforms specified configuration to a string that match to our code style.
  *
  * @param {Object} config
  * @returns {String}

--- a/packages/ckeditor5-dev-utils/lib/bundler/geteditorconfig.js
+++ b/packages/ckeditor5-dev-utils/lib/bundler/geteditorconfig.js
@@ -5,6 +5,8 @@
 
 'use strict';
 
+const javascriptStringify = require( 'javascript-stringify' );
+
 /**
  * Transforms specified configuration to a string which can be inserted
  * to generated an entry file.
@@ -22,7 +24,7 @@ module.exports = function getEditorConfig( config ) {
 		return '{}';
 	}
 
-	return JSON.stringify( config, null, '\t' )
+	return javascriptStringify( config, null, '\t' )
 		.split( '\n' )
 		.map( ( line, index ) => {
 			if ( index === 0 ) {
@@ -31,9 +33,5 @@ module.exports = function getEditorConfig( config ) {
 
 			return `\t${ line }`;
 		} )
-		.join( '\n' )
-		// Replace quotation marks to apostrophes.
-		.replace( /"/g, '\'' )
-		// Removes apostrophes from single word keys.
-		.replace( /'([$A-Z0-9_]+)':/gi, '$1:' );
+		.join( '\n' );
 };

--- a/packages/ckeditor5-dev-utils/package.json
+++ b/packages/ckeditor5-dev-utils/package.json
@@ -10,6 +10,7 @@
     "escodegen": "git://github.com/ma2ciek/escodegen.git",
     "fs-extra": "^0.30.0",
     "gulp-util": "^3.0.7",
+    "javascript-stringify": "^1.6.0",
     "pofile": "^1.0.5",
     "shelljs": "^0.7.4",
     "through2": "^2.0.1"

--- a/packages/ckeditor5-dev-utils/tests/bundler/createentryfile.js
+++ b/packages/ckeditor5-dev-utils/tests/bundler/createentryfile.js
@@ -27,13 +27,21 @@ describe( 'bundler', () => {
 		it( 'should create an entry file', () => {
 			const writeFileSyncStub = sandbox.stub( fs, 'writeFileSync' );
 
-			createEntryFile( 'destination/path/file.js', './config-editor', {
+			createEntryFile( 'destination/path/file.js', {
 				plugins: [
 					'@ckeditor/ckeditor5-presets/src/article',
 					'@ckeditor/ckeditor5-clipboard/src/clipboard'
 				],
 				moduleName: 'ClassicEditor',
-				editor: '@ckeditor/ckeditor5-editor-classic/src/editor'
+				editor: '@ckeditor/ckeditor5-editor-classic/src/editor',
+				config: {
+					undo: {
+						step: 3,
+					},
+					toolbar: [
+						'image'
+					]
+				}
 			} );
 
 			const expectedEntryFile = `/**
@@ -52,7 +60,14 @@ ClassicEditor.build = {
 		ArticlePlugin,
 		ClipboardPlugin
 	],
-	config: require( './config-editor' ).config
+	config: {
+		undo: {
+			step: 3
+		},
+		toolbar: [
+			'image'
+		]
+	}
 };
 `;
 

--- a/packages/ckeditor5-dev-utils/tests/bundler/createentryfile.js
+++ b/packages/ckeditor5-dev-utils/tests/bundler/createentryfile.js
@@ -52,7 +52,7 @@ ClassicEditor.build = {
 		ArticlePlugin,
 		ClipboardPlugin
 	],
-	config: require( './config-editor' )
+	config: require( './config-editor' ).config
 };
 `;
 

--- a/packages/ckeditor5-dev-utils/tests/bundler/geteditorconfig.js
+++ b/packages/ckeditor5-dev-utils/tests/bundler/geteditorconfig.js
@@ -30,7 +30,8 @@ describe( 'bundler', () => {
 					enabled: true,
 					key: 'PRIVATE_KEY'
 				},
-				'key with spaces': null
+				'key with spaces': null,
+				anotherKey: 'Key with "quotation marks".'
 			};
 
 			const expectedConfig = `{
@@ -44,7 +45,8 @@ describe( 'bundler', () => {
 			enabled: true,
 			key: 'PRIVATE_KEY'
 		},
-		'key with spaces': null
+		'key with spaces': null,
+		anotherKey: 'Key with "quotation marks".'
 	}`;
 
 			expect( getEditorConfig( config ) ).to.equal( expectedConfig );

--- a/packages/ckeditor5-dev-utils/tests/bundler/geteditorconfig.js
+++ b/packages/ckeditor5-dev-utils/tests/bundler/geteditorconfig.js
@@ -1,0 +1,53 @@
+/**
+ * @license Copyright (c) 2003-2017, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/* jshint mocha:true */
+
+'use strict';
+
+const chai = require( 'chai' );
+const expect = chai.expect;
+
+describe( 'bundler', () => {
+	let getEditorConfig;
+
+	beforeEach( () => {
+		getEditorConfig = require( '../../lib/bundler/geteditorconfig' );
+	} );
+
+	describe( 'getEditorConfig()', () => {
+		it( 'returns empty object as string if config was not specified', () => {
+			expect( getEditorConfig() ).to.equal( '{}' );
+		} );
+
+		it( 'returns given object as string with proper indents', () => {
+			const config = {
+				firstKey: 1,
+				secondKey: [ 1, 2, 3 ],
+				plugin: {
+					enabled: true,
+					key: 'PRIVATE_KEY'
+				},
+				'key with spaces': null
+			};
+
+			const expectedConfig = `{
+		firstKey: 1,
+		secondKey: [
+			1,
+			2,
+			3
+		],
+		plugin: {
+			enabled: true,
+			key: 'PRIVATE_KEY'
+		},
+		'key with spaces': null
+	}`;
+
+			expect( getEditorConfig( config ) ).to.equal( expectedConfig );
+		} );
+	} );
+} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: `createEntryFile()` util will use the "config" key from configuration file. Closes #217.

[Read more why it is required and important.](https://github.com/ckeditor/ckeditor5-build-classic/issues/10#issuecomment-303398682)

BREAKING CHANGE: `createEntryFile()` function does not accept the `configPath` argument any more. You need to pass the configuration object as `options.config` instead of it.

---

### Additional information

Required for https://github.com/ckeditor/ckeditor5-build-classic/pull/13.
