### PR TITLE
T/224: [Lint] `getGitIgnore()` should transform directories as the glob patterns for Gulp

### DIFF
--- a/packages/ckeditor5-dev-lint/lib/utils/getgitignore.js
+++ b/packages/ckeditor5-dev-lint/lib/utils/getgitignore.js
@@ -26,10 +26,10 @@ module.exports = function getGitIgnore() {
 		.map( i => '!' + i )
 		// Add "**" to folders to have everything inside them ignored.
 		.map( path => {
-			if ( !path.endsWith( '/' ) ) {
-				return path;
+			if ( path.endsWith( '/' ) ) {
+				return path + '**';
 			}
 
-			return path + '**';
+			return path;
 		} );
 };

--- a/packages/ckeditor5-dev-lint/lib/utils/getgitignore.js
+++ b/packages/ckeditor5-dev-lint/lib/utils/getgitignore.js
@@ -23,5 +23,13 @@ module.exports = function getGitIgnore() {
 		// Remove empty entries.
 		.filter( path => !!path )
 		// Add `!` for ignore glob.
-		.map( i => '!' + i );
+		.map( i => '!' + i )
+		// Add "**" to folders to have everything inside them ignored.
+		.map( path => {
+			if ( !path.endsWith( '/' ) ) {
+				return path;
+			}
+
+			return path + '**';
+		} );
 };

--- a/packages/ckeditor5-dev-lint/tests/utils/getgitignore.js
+++ b/packages/ckeditor5-dev-lint/tests/utils/getgitignore.js
@@ -41,15 +41,15 @@ describe( 'dev-lint/utils', () => {
 		it( 'returns a list of ignored files as glob patterns', () => {
 			stubs.fs.readFileSync.returns( `
 # These files will be ignored.
-**/node_modules/**
-coverage/**
+node_modules/
+coverage/
 
 lerna-debug.log
 npm-debug.log
 ` );
 
 			expect( getGitIgnore() ).to.deep.equal( [
-				'!**/node_modules/**',
+				'!node_modules/**',
 				'!coverage/**',
 				'!lerna-debug.log',
 				'!npm-debug.log'


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: `getGitIgnore()` will transform directories to glob patterns. Closes #224.

Required in order to [use a more standard `"directory/"` notation in `.gitignore`](https://github.com/ckeditor/ckeditor5/issues/456).