### PR TITLE
T/233: The publish-nightly script fails ugly when there's nothing to commit

### DIFF
--- a/packages/ckeditor5-dev-docs/bin/publish-nightly.js
+++ b/packages/ckeditor5-dev-docs/bin/publish-nightly.js
@@ -25,7 +25,7 @@ const mainRepoUrl = 'https://github.com/CKEditor5/ckeditor5.github.io';
 // Install required dependencies for building the documentation.
 exec( 'npm run install-optional-dependencies' );
 
-// Clone te CKEditor 5 page.
+// Clone the CKEditor 5 page.
 exec( `git clone ${ mainRepoUrl }.git` );
 
 // Build the documentation.
@@ -47,12 +47,16 @@ exec( `echo "https://${ process.env.GITHUB_TOKEN }:@github.com" > .git/credentia
 exec( 'git config credential.helper "store --file=.git/credentials"' );
 
 // Commit the documentation.
-exec( 'git add docs/' );
-exec( 'git commit -m "Documentation build."' );
-exec( 'git push origin master --quiet' );
+if ( exec( 'git diff --name-only docs/' ).trim().length ) {
+	exec( 'git add docs/' );
+	exec( 'git commit -m "Documentation build."' );
+	exec( 'git push origin master --quiet' );
 
-const lastCommit = exec( 'git log -1 --format="%h"' );
-console.log( `Successfully published the documentation under ${ mainRepoUrl }/commit/${ lastCommit }` );
+	const lastCommit = exec( 'git log -1 --format="%h"' );
+	console.log( `Successfully published the documentation under ${ mainRepoUrl }/commit/${ lastCommit }` );
+} else {
+	console.log( 'Documentation is up to date.' );
+}
 
 function exec( command ) {
 	return tools.shExec( command, { verbosity: 'error' } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Script for nightly build the documentation will not crash if there's nothing to commit. Closes #233.