### PR TITLE
T/183: Add "Changelog" section to each readme

### DIFF
--- a/packages/ckeditor5-dev-bundler-rollup/README.md
+++ b/packages/ckeditor5-dev-bundler-rollup/README.md
@@ -83,6 +83,10 @@ module.exports = {
 };
 ```
 
+## Changelog
+
+The changes are described in the [`CHANGELOG.md`](https://github.com/ckeditor/ckeditor5-dev/blob/master/packages/ckeditor5-dev-bundler-rollup/CHANGELOG.md) file.
+
 ## License
 
 Licensed under the GPL, LGPL and MPL licenses, at your choice. For full details about the license, please check the `LICENSE.md` file.

--- a/packages/ckeditor5-dev-bundler-rollup/README.md
+++ b/packages/ckeditor5-dev-bundler-rollup/README.md
@@ -85,7 +85,7 @@ module.exports = {
 
 ## Changelog
 
-The changes are described in the [`CHANGELOG.md`](https://github.com/ckeditor/ckeditor5-dev/blob/master/packages/ckeditor5-dev-bundler-rollup/CHANGELOG.md) file.
+See the [`CHANGELOG.md`](https://github.com/ckeditor/ckeditor5-dev/blob/master/packages/ckeditor5-dev-bundler-rollup/CHANGELOG.md) file.
 
 ## License
 

--- a/packages/ckeditor5-dev-docs/README.md
+++ b/packages/ckeditor5-dev-docs/README.md
@@ -5,6 +5,10 @@ Tasks used to build documentation for [CKEditor 5](https://ckeditor5.github.io).
 
 More information about development tools packages can be found at the following URL: <https://github.com/ckeditor/ckeditor5-dev>.
 
+## Changelog
+
+The changes are described in the [`CHANGELOG.md`](https://github.com/ckeditor/ckeditor5-dev/blob/master/packages/ckeditor5-dev-docs/CHANGELOG.md) file.
+
 ## License
 
 Licensed under the GPL, LGPL and MPL licenses, at your choice. For full details about the license, please check the `LICENSE.md` file.

--- a/packages/ckeditor5-dev-docs/README.md
+++ b/packages/ckeditor5-dev-docs/README.md
@@ -7,7 +7,7 @@ More information about development tools packages can be found at the following 
 
 ## Changelog
 
-The changes are described in the [`CHANGELOG.md`](https://github.com/ckeditor/ckeditor5-dev/blob/master/packages/ckeditor5-dev-docs/CHANGELOG.md) file.
+See the [`CHANGELOG.md`](https://github.com/ckeditor/ckeditor5-dev/blob/master/packages/ckeditor5-dev-docs/CHANGELOG.md) file.
 
 ## License
 

--- a/packages/ckeditor5-dev-env/README.md
+++ b/packages/ckeditor5-dev-env/README.md
@@ -66,7 +66,7 @@ The process implemented by the tool:
 
 ## Changelog
 
-The changes are described in the [`CHANGELOG.md`](https://github.com/ckeditor/ckeditor5-dev/blob/master/packages/ckeditor5-dev-env/CHANGELOG.md) file.
+See the [`CHANGELOG.md`](https://github.com/ckeditor/ckeditor5-dev/blob/master/packages/ckeditor5-dev-env/CHANGELOG.md) file.
 
 ## License
 

--- a/packages/ckeditor5-dev-env/README.md
+++ b/packages/ckeditor5-dev-env/README.md
@@ -63,6 +63,10 @@ Process:
 
 Notes for the release are taken from the changelog.
 
+## Changelog
+
+The changes are described in the [`CHANGELOG.md`](https://github.com/ckeditor/ckeditor5-dev/blob/master/packages/ckeditor5-dev-env/CHANGELOG.md) file.
+
 ## License
 
 Licensed under the GPL, LGPL and MPL licenses, at your choice. For full details about the license, please check the `LICENSE.md` file.

--- a/packages/ckeditor5-dev-lint/README.md
+++ b/packages/ckeditor5-dev-lint/README.md
@@ -39,7 +39,7 @@ const ckeditor5Lint = require( '@ckeditor/ckeditor5-dev-lint' )( {
 
 ## Changelog
 
-The changes are described in the [`CHANGELOG.md`](https://github.com/ckeditor/ckeditor5-dev/blob/master/packages/ckeditor5-dev-lint/CHANGELOG.md) file.
+See the [`CHANGELOG.md`](https://github.com/ckeditor/ckeditor5-dev/blob/master/packages/ckeditor5-dev-lint/CHANGELOG.md) file.
 
 ## License
 

--- a/packages/ckeditor5-dev-lint/README.md
+++ b/packages/ckeditor5-dev-lint/README.md
@@ -37,6 +37,10 @@ const ckeditor5Lint = require( '@ckeditor/ckeditor5-dev-lint' )( {
 } );
 ```
 
+## Changelog
+
+The changes are described in the [`CHANGELOG.md`](https://github.com/ckeditor/ckeditor5-dev/blob/master/packages/ckeditor5-dev-lint/CHANGELOG.md) file.
+
 ## License
 
 Licensed under the GPL, LGPL and MPL licenses, at your choice. For full details about the license, please check the `LICENSE.md` file.

--- a/packages/ckeditor5-dev-tests/README.md
+++ b/packages/ckeditor5-dev-tests/README.md
@@ -96,6 +96,10 @@ $ gulp test --files='!(engine|ui)'
 | `*` | `node_modules/ckeditor5-*/tests/**/*.js` | all installed package's tests |
 | `/` | `tests/**/*.js` | current package's tests only |
 
+## Changelog
+
+The changes are described in the [`CHANGELOG.md`](https://github.com/ckeditor/ckeditor5-dev/blob/master/packages/ckeditor5-dev-tests/CHANGELOG.md) file.
+
 ## License
 
 Licensed under the GPL, LGPL and MPL licenses, at your choice. For full details about the license, please check the `LICENSE.md` file.

--- a/packages/ckeditor5-dev-tests/README.md
+++ b/packages/ckeditor5-dev-tests/README.md
@@ -98,7 +98,7 @@ $ gulp test --files='!(engine|ui)'
 
 ## Changelog
 
-The changes are described in the [`CHANGELOG.md`](https://github.com/ckeditor/ckeditor5-dev/blob/master/packages/ckeditor5-dev-tests/CHANGELOG.md) file.
+See the [`CHANGELOG.md`](https://github.com/ckeditor/ckeditor5-dev/blob/master/packages/ckeditor5-dev-tests/CHANGELOG.md) file.
 
 ## License
 

--- a/packages/ckeditor5-dev-utils/README.md
+++ b/packages/ckeditor5-dev-utils/README.md
@@ -45,7 +45,7 @@ errorLog.error( 'Message.' );
 
 ## Changelog
 
-The changes are described in the [`CHANGELOG.md`](https://github.com/ckeditor/ckeditor5-dev/blob/master/packages/ckeditor5-dev-utils/CHANGELOG.md) file.
+See the [`CHANGELOG.md`](https://github.com/ckeditor/ckeditor5-dev/blob/master/packages/ckeditor5-dev-utils/CHANGELOG.md) file.
 
 ## License
 

--- a/packages/ckeditor5-dev-utils/README.md
+++ b/packages/ckeditor5-dev-utils/README.md
@@ -43,6 +43,10 @@ errorLog.warning( 'Message.' );
 errorLog.error( 'Message.' );
 ```
 
+## Changelog
+
+The changes are described in the [`CHANGELOG.md`](https://github.com/ckeditor/ckeditor5-dev/blob/master/packages/ckeditor5-dev-utils/CHANGELOG.md) file.
+
 ## License
 
 Licensed under the GPL, LGPL and MPL licenses, at your choice. For full details about the license, please check the `LICENSE.md` file.

--- a/packages/ckeditor5-dev-webpack-plugin/README.md
+++ b/packages/ckeditor5-dev-webpack-plugin/README.md
@@ -13,7 +13,7 @@ TODO
 
 ## Changelog
 
-The changes are described in the [`CHANGELOG.md`](https://github.com/ckeditor/ckeditor5-dev/blob/master/packages/ckeditor5-dev-webpack-plugin/CHANGELOG.md) file.
+See the [`CHANGELOG.md`](https://github.com/ckeditor/ckeditor5-dev/blob/master/packages/ckeditor5-dev-webpack-plugin/CHANGELOG.md) file.
 
 ## License
 

--- a/packages/ckeditor5-dev-webpack-plugin/README.md
+++ b/packages/ckeditor5-dev-webpack-plugin/README.md
@@ -11,6 +11,10 @@ More information about development tools packages can be found at the following 
 
 TODO
 
+## Changelog
+
+The changes are described in the [`CHANGELOG.md`](https://github.com/ckeditor/ckeditor5-dev/blob/master/packages/ckeditor5-dev-webpack-plugin/CHANGELOG.md) file.
+
 ## License
 
 Licensed under the GPL, LGPL and MPL licenses, at your choice. For full details about the license, please check the `LICENSE.md` file.

--- a/packages/eslint-config-ckeditor5/README.md
+++ b/packages/eslint-config-ckeditor5/README.md
@@ -17,4 +17,4 @@ Configure ESLint with a `.eslintrc` file using the following contents:
 
 ## Changelog
 
-The changes are described in the [`CHANGELOG.md`](https://github.com/ckeditor/ckeditor5-dev/blob/master/packages/eslint-config-ckeditor5/CHANGELOG.md) file.
+See the [`CHANGELOG.md`](https://github.com/ckeditor/ckeditor5-dev/blob/master/packages/eslint-config-ckeditor5/CHANGELOG.md) file.

--- a/packages/eslint-config-ckeditor5/README.md
+++ b/packages/eslint-config-ckeditor5/README.md
@@ -14,3 +14,7 @@ Configure ESLint with a `.eslintrc` file using the following contents:
 	"extends": "ckeditor5"
 }
 ```
+
+## Changelog
+
+The changes are described in the [`CHANGELOG.md`](https://github.com/ckeditor/ckeditor5-dev/blob/master/packages/eslint-config-ckeditor5/CHANGELOG.md) file.

--- a/packages/jsdoc-plugins/README.md
+++ b/packages/jsdoc-plugins/README.md
@@ -173,4 +173,4 @@ It also adds additional properties to doclets of classes, interfaces and mixins 
 
 ## Changelog
 
-The changes are described in the [`CHANGELOG.md`](https://github.com/ckeditor/ckeditor5-dev/blob/master/packages/jsdoc-plugins/CHANGELOG.md) file.
+See the [`CHANGELOG.md`](https://github.com/ckeditor/ckeditor5-dev/blob/master/packages/jsdoc-plugins/CHANGELOG.md) file.

--- a/packages/jsdoc-plugins/README.md
+++ b/packages/jsdoc-plugins/README.md
@@ -170,3 +170,7 @@ It also adds additional properties to doclets of classes, interfaces and mixins 
 * `implementsNested` - array of longnames of implemented interfaces,
 * `mixesNested` - array of longnames of mixed mixins,
 * `descendants` - array of longnames of entities which implement, mix or extend the doclet.
+
+## Changelog
+
+The changes are described in the [`CHANGELOG.md`](https://github.com/ckeditor/ckeditor5-dev/blob/master/packages/jsdoc-plugins/CHANGELOG.md) file.


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Added Changelog section to README. Closes #183.
