### PR TITLE
T/245: Removed invalid Promise rejection

### DIFF
--- a/packages/ckeditor5-dev-env/lib/release-tools/tasks/releasesubrepositories.js
+++ b/packages/ckeditor5-dev-env/lib/release-tools/tasks/releasesubrepositories.js
@@ -65,8 +65,10 @@ module.exports = function releaseSubRepositories( options ) {
 			}
 
 			return cli.confirmRelease( packagesToRelease )
-				.catch( () => {
-					throw new Error( BREAK_RELEASE_MESSAGE );
+				.then( isConfirmed => {
+					if ( !isConfirmed ) {
+						throw new Error( BREAK_RELEASE_MESSAGE );
+					}
 				} );
 		} )
 		.then( () => prepareDependenciesVersions() )

--- a/packages/ckeditor5-dev-env/lib/release-tools/utils/cli.js
+++ b/packages/ckeditor5-dev-env/lib/release-tools/utils/cli.js
@@ -34,7 +34,7 @@ const cli = {
 		};
 
 		return inquirer.prompt( [ confirmQuestion ] )
-			.then( answers => answers.confirm ? Promise.resolve() : Promise.reject() );
+			.then( answers => answers.confirm );
 	},
 
 	/**

--- a/packages/ckeditor5-dev-env/tests/release-tools/tasks/releasesubrepositories.js
+++ b/packages/ckeditor5-dev-env/tests/release-tools/tasks/releasesubrepositories.js
@@ -151,7 +151,7 @@ describe( 'dev-env/release-tools/tasks', function() {
 				packages: 'packages'
 			};
 
-			stubs.cli.confirmRelease.returns( Promise.reject() );
+			stubs.cli.confirmRelease.returns( Promise.resolve( false ) );
 
 			makeCommit( 'alpha', 'Feature: This is an initial commit.' );
 			makeChangelog( 'alpha', [
@@ -209,7 +209,7 @@ describe( 'dev-env/release-tools/tasks', function() {
 				]
 			};
 
-			stubs.cli.confirmRelease.returns( Promise.resolve() );
+			stubs.cli.confirmRelease.returns( Promise.resolve( true ) );
 
 			makeCommit( 'delta', 'Feature: Introduced another package. Yay!' );
 			makeChangelog( 'delta', [
@@ -249,7 +249,7 @@ describe( 'dev-env/release-tools/tasks', function() {
 				packages: 'packages'
 			};
 
-			stubs.cli.confirmRelease.returns( Promise.resolve() );
+			stubs.cli.confirmRelease.returns( Promise.resolve( true ) );
 
 			makeCommit( 'alpha', 'Feature: This is an initial commit.' );
 			makeChangelog( 'alpha', [
@@ -355,7 +355,7 @@ describe( 'dev-env/release-tools/tasks', function() {
 			].join( '\n' ) );
 			makeCommit( 'beta', 'Docs: Changelog. [skip ci]', [ 'CHANGELOG.md' ] );
 
-			stubs.cli.confirmRelease.returns( Promise.resolve() );
+			stubs.cli.confirmRelease.returns( Promise.resolve( true ) );
 
 			stubs.generateChangelogForSinglePackage.onFirstCall()
 				.returns( new Promise( resolve => {
@@ -489,7 +489,7 @@ describe( 'dev-env/release-tools/tasks', function() {
 			].join( '\n' ) );
 			makeCommit( 'beta', 'Docs: Changelog. [skip ci]', [ 'CHANGELOG.md' ] );
 
-			stubs.cli.confirmRelease.returns( Promise.resolve() );
+			stubs.cli.confirmRelease.returns( Promise.resolve( true ) );
 
 			stubs.generateChangelogForSinglePackage.onFirstCall()
 				.returns( new Promise( resolve => {

--- a/packages/ckeditor5-dev-env/tests/release-tools/utils/cli.js
+++ b/packages/ckeditor5-dev-env/tests/release-tools/utils/cli.js
@@ -10,11 +10,10 @@ const sinon = require( 'sinon' );
 const mockery = require( 'mockery' );
 
 describe( 'dev-env/release-tools/utils', () => {
-	let cli, sandbox, questionItems, hasConfirmedRelease;
+	let cli, sandbox, questionItems;
 
 	describe( 'cli', () => {
 		beforeEach( () => {
-			hasConfirmedRelease = undefined;
 			sandbox = sinon.sandbox.create();
 			questionItems = [];
 
@@ -29,14 +28,8 @@ describe( 'dev-env/release-tools/utils', () => {
 					questionItems.push( ...questions );
 					const questionItem = questions[ 0 ];
 
-					if ( typeof hasConfirmedRelease != 'undefined' ) {
-						return Promise.resolve( { confirm: hasConfirmedRelease } );
-					}
-
 					// Returns suggested value as a user input.
-					if ( questionItem.default ) {
-						return Promise.resolve( { version: questionItem.default } );
-					}
+					return Promise.resolve( { version: questionItem.default } );
 				}
 			} );
 
@@ -94,7 +87,6 @@ describe( 'dev-env/release-tools/utils', () => {
 
 		describe( 'confirmRelease()', () => {
 			it( 'displays packages and their versions (current and proposed) to release', () => {
-				hasConfirmedRelease = true;
 				const packagesMap = new Map();
 
 				packagesMap.set( '@ckeditor/ckeditor5-engine', {
@@ -118,7 +110,6 @@ describe( 'dev-env/release-tools/utils', () => {
 			} );
 
 			it( 'sorts the packages alphabetically', () => {
-				hasConfirmedRelease = true;
 				const packagesMap = new Map();
 
 				packagesMap.set( '@ckeditor/ckeditor5-list', {} );
@@ -145,21 +136,6 @@ describe( 'dev-env/release-tools/utils', () => {
 						expect( packagesAsArray[ 4 ] ).to.equal( '@ckeditor/ckeditor5-link' );
 						expect( packagesAsArray[ 5 ] ).to.equal( '@ckeditor/ckeditor5-list' );
 					} );
-			} );
-
-			it( 'rejects when user did not confirm the release', () => {
-				hasConfirmedRelease = false;
-				const packagesMap = new Map();
-
-				return cli.confirmRelease( packagesMap )
-					.then(
-						() => {
-							throw new Error( 'Supposed to be rejected.' );
-						},
-						() => {
-							expect( 'All is fine.' ).to.be.a( 'string' );
-						}
-					);
 			} );
 		} );
 	} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: `cli.confirmRelease()` shouldn't reject the promise if the user did not confirm the process. Closes #245.
