### PR TITLE
Improvements for a changelog generator

### DIFF
--- a/packages/ckeditor5-dev-env/lib/release-tools/utils/transform-commit/parser-options.js
+++ b/packages/ckeditor5-dev-env/lib/release-tools/utils/transform-commit/parser-options.js
@@ -6,9 +6,8 @@
 'use strict';
 
 module.exports = {
-	mergePattern: /^Merge pull request #(\d+) from .*$/,
-	mergeCorrespondence: [ 'pullRequestId' ],
-	headerPattern: /^([^:]+): (.*\.)/,
+	mergePattern: /^Merge .*$/,
+	headerPattern: /^([^:]+): (.*)$/,
 	headerCorrespondence: [
 		'type',
 		'subject'

--- a/packages/ckeditor5-dev-env/lib/release-tools/utils/transform-commit/transform-commit-utils.js
+++ b/packages/ckeditor5-dev-env/lib/release-tools/utils/transform-commit/transform-commit-utils.js
@@ -13,8 +13,10 @@ const transformCommitUtils = {
 	 * Types marked as `false` will be ignored during generating the changelog.
 	 */
 	availableCommitTypes: new Map( [
-		[ 'Feature', true ],
 		[ 'Fix', true ],
+		[ 'Fixes', true ],
+		[ 'Fixed', true ],
+		[ 'Feature', true ],
 		[ 'Other', true ],
 		[ 'Code style', false ],
 		[ 'Docs', false ],
@@ -77,6 +79,8 @@ const transformCommitUtils = {
 				return 'Features';
 
 			case 'Fix':
+			case 'Fixes':
+			case 'Fixed':
 				return 'Bug fixes';
 
 			case 'Other':

--- a/packages/ckeditor5-dev-env/lib/release-tools/utils/transform-commit/transformcommitforsubrepository.js
+++ b/packages/ckeditor5-dev-env/lib/release-tools/utils/transform-commit/transformcommitforsubrepository.js
@@ -55,6 +55,12 @@ module.exports = function transformCommitForSubRepository( commit, context ) {
 		return;
 	}
 
+	// If a dot is missing at the end of the subject...
+	if ( !commit.subject.endsWith( '.' ) ) {
+		// ...let's add it.
+		commit.subject += '.';
+	}
+
 	commit.rawType = commit.type;
 	commit.type = utils.getCommitType( commit.type );
 

--- a/packages/ckeditor5-dev-env/tests/release-tools/utils/generatechangelogfromcommits-integration.js
+++ b/packages/ckeditor5-dev-env/tests/release-tools/utils/generatechangelogfromcommits-integration.js
@@ -349,6 +349,54 @@ describe( 'dev-env/release-tools/utils', () => {
 					release();
 				} );
 		} );
+
+		// See: https://github.com/ckeditor/ckeditor5-dev/issues/271
+		it( 'works with prefix "Fixes"', () => {
+			exec( 'git commit --allow-empty ' +
+				'--message "Fixes: Foo Bar."'
+			);
+
+			return generateChangelog( '0.5.3' )
+				.then( () => {
+					const latestChangelog = replaceCommitIds( getChangesForVersion( lastChangelogVersion ) );
+
+					/* eslint-disable max-len */
+					const expectedChangelog = `
+### Bug fixes
+
+* Foo Bar. ([XXXXXXX](https://github.com/ckeditor/ckeditor5-test-package/commit/XXXXXXX))
+`;
+					/* eslint-enable max-len */
+
+					expect( latestChangelog ).to.equal( expectedChangelog.trim() );
+
+					release();
+				} );
+		} );
+
+		// See: https://github.com/ckeditor/ckeditor5-dev/issues/271
+		it( 'works with prefix "Fixed"', () => {
+			exec( 'git commit --allow-empty ' +
+				'--message "Fixed: Bar Foo."'
+			);
+
+			return generateChangelog( '0.5.4' )
+				.then( () => {
+					const latestChangelog = replaceCommitIds( getChangesForVersion( lastChangelogVersion ) );
+
+					/* eslint-disable max-len */
+					const expectedChangelog = `
+### Bug fixes
+
+* Bar Foo. ([XXXXXXX](https://github.com/ckeditor/ckeditor5-test-package/commit/XXXXXXX))
+`;
+					/* eslint-enable max-len */
+
+					expect( latestChangelog ).to.equal( expectedChangelog.trim() );
+
+					release();
+				} );
+		} );
 	} );
 
 	function exec( command ) {

--- a/packages/ckeditor5-dev-env/tests/release-tools/utils/transform-commit/transform-commit-utils.js
+++ b/packages/ckeditor5-dev-env/tests/release-tools/utils/transform-commit/transform-commit-utils.js
@@ -92,6 +92,11 @@ describe( 'dev-env/release-tools/utils/transform-commit', () => {
 				expect( transformCommit.getCommitType( 'Fix' ) ).to.equal( 'Bug fixes' );
 				expect( transformCommit.getCommitType( 'Other' ) ).to.equal( 'Other changes' );
 			} );
+
+			it( 'should support aliases for the "Fix" type', () => {
+				expect( transformCommit.getCommitType( 'Fixes' ), 'Fixes' ).to.equal( 'Bug fixes' );
+				expect( transformCommit.getCommitType( 'Fixed' ), 'Fixed' ).to.equal( 'Bug fixes' );
+			} );
 		} );
 
 		describe( 'truncate()', () => {

--- a/packages/ckeditor5-dev-env/tests/release-tools/utils/transform-commit/transformcommitforsubrepository.js
+++ b/packages/ckeditor5-dev-env/tests/release-tools/utils/transform-commit/transformcommitforsubrepository.js
@@ -156,7 +156,7 @@ describe( 'dev-env/release-tools/utils/transform-commit', () => {
 				hash: '76b9e058fb1c3fa00b50059cdc684997d0eb2eca',
 				header: 'Fix: Simple fix. Closes #2.',
 				type: 'Fix',
-				subject: 'Simple fix. Closes #2',
+				subject: 'Simple fix. Closes #2.',
 				body: null,
 				footer: null,
 				notes: [
@@ -169,7 +169,7 @@ describe( 'dev-env/release-tools/utils/transform-commit', () => {
 
 			transformCommitForSubRepository( commit, { displayLogs: true, packageData: packageJson } );
 
-			const expectedSubject = 'Simple fix. Closes [#2](https://github.com/ckeditor/ckeditor5-dev/issues/2)';
+			const expectedSubject = 'Simple fix. Closes [#2](https://github.com/ckeditor/ckeditor5-dev/issues/2).';
 			expect( commit.subject ).to.equal( expectedSubject );
 			expect( commit.notes[ 0 ].text ).to.equal(
 				'Some issue [#1](https://github.com/ckeditor/ckeditor5-dev/issues/1).'
@@ -179,9 +179,9 @@ describe( 'dev-env/release-tools/utils/transform-commit', () => {
 		it( 'makes URLs to organization on GitHub', () => {
 			const commit = {
 				hash: '76b9e058fb1c3fa00b50059cdc684997d0eb2eca',
-				header: 'Internal: Thanks to @CKEditor',
+				header: 'Internal: Thanks to @CKEditor.',
 				type: 'Fix',
-				subject: 'Internal: Thanks to @CKEditor',
+				subject: 'Internal: Thanks to @CKEditor.',
 				body: null,
 				footer: null,
 				notes: []
@@ -189,7 +189,7 @@ describe( 'dev-env/release-tools/utils/transform-commit', () => {
 
 			transformCommitForSubRepository( commit, { displayLogs: true, packageData: packageJson } );
 
-			const expectedSubject = 'Internal: Thanks to [@CKEditor](https://github.com/CKEditor)';
+			const expectedSubject = 'Internal: Thanks to [@CKEditor](https://github.com/CKEditor).';
 			expect( commit.subject ).to.equal( expectedSubject );
 		} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Several issues related to proper typing the commit subject. Closes #270. Closes #271.

* If a commit didn't end with a dot, it was ignored. Now it will be handled.
* Added aliases for `Fix` type of the commit. Now `Fixes` and `Fixed` will be handled as `Fix`.
* Merge commit which wasn't a pull request was ignored. Now it will be handled.