### PR TITLE
T/269: Autolinking GitHub repositories in the commit message

### DIFF
--- a/packages/ckeditor5-dev-env/lib/release-tools/utils/transform-commit/transform-commit-utils.js
+++ b/packages/ckeditor5-dev-env/lib/release-tools/utils/transform-commit/transform-commit-utils.js
@@ -39,25 +39,14 @@ const transformCommitUtils = {
 	},
 
 	/**
-	 * Replaces reference to user (@name) with a link to his profile.
+	 * Replaces reference to the user (`@name`) with a link to the user's profile.
 	 *
 	 * @param {String} comment
 	 * @returns {String}
 	 */
 	linkToGithubUser( comment ) {
-		return comment.replace( /(.?)@([0-9A-Z_-]+)(\/)?/ig, ( matchedText, charBeforeAt, nickName, charAfterUser ) => {
-			// Most probably the matched value is an email address.
-			if ( charBeforeAt && /[A-Z0-9_]/i.test( charBeforeAt ) ) {
-				return matchedText;
-			}
-
-			if ( charAfterUser === '/' ) {
-				return matchedText;
-			}
-
-			charAfterUser = charAfterUser || '';
-
-			return `${ charBeforeAt }[@${ nickName }](https://github.com/${ nickName })${ charAfterUser }`;
+		return comment.replace( /(^|[\s(])@([\w-]+)(?![/\w-])/ig, ( matchedText, charBefore, nickName ) => {
+			return `${ charBefore }[@${ nickName }](https://github.com/${ nickName })`;
 		} );
 	},
 
@@ -69,7 +58,7 @@ const transformCommitUtils = {
 	 * @returns {String}
 	 */
 	linkToGithubIssue( comment ) {
-		return comment.replace( /(\/?[A-Z0-9-_]+\/[A-Z0-9-_]+)?#([0-9]+)/ig, ( matchedText, maybeRepository, issueId ) => {
+		return comment.replace( /(\/?[\w-]+\/[\w-]+)?#([\d]+)/ig, ( matchedText, maybeRepository, issueId ) => {
 			if ( maybeRepository ) {
 				if ( maybeRepository.startsWith( '/' ) ) {
 					return matchedText;

--- a/packages/ckeditor5-dev-env/lib/release-tools/utils/transform-commit/transform-commit-utils.js
+++ b/packages/ckeditor5-dev-env/lib/release-tools/utils/transform-commit/transform-commit-utils.js
@@ -42,7 +42,7 @@ const transformCommitUtils = {
 	 * @param {String} comment
 	 * @returns {String}
 	 */
-	linkToGithubUsers( comment ) {
+	linkToGithubUser( comment ) {
 		return comment.replace( /@([0-9A-Z_-]+\/?)/ig, ( matchText, nickName ) => {
 			if ( nickName.endsWith( '/' ) ) {
 				return matchText;
@@ -58,7 +58,7 @@ const transformCommitUtils = {
 	 * @param {String} comment
 	 * @returns {String}
 	 */
-	linkToGithubIssues( comment ) {
+	linkToGithubIssue( comment ) {
 		const packageJson = getPackageJson();
 		const issuesUrl = ( typeof packageJson.bugs === 'object' ) ? packageJson.bugs.url : packageJson.bugs;
 
@@ -84,7 +84,7 @@ const transformCommitUtils = {
 	 * @param {String} comment
 	 * @returns {String}
 	 */
-	linkToGithubRepositories( comment ) {
+	linkToGithubRepository( comment ) {
 		return comment.replace( /(@|\.)?([A-Z0-9-_/]+)(#(\d+)?)?/gi, ( matchText, charBeforeRepo, repository, issueMark, issueId ) => {
 			if ( !isValidRepository() ) {
 				return matchText;

--- a/packages/ckeditor5-dev-env/lib/release-tools/utils/transform-commit/transformcommitforsubrepository.js
+++ b/packages/ckeditor5-dev-env/lib/release-tools/utils/transform-commit/transformcommitforsubrepository.js
@@ -96,10 +96,10 @@ module.exports = function transformCommitForSubRepository( commit, context ) {
 };
 
 function makeLinks( comment ) {
-	comment = utils.linkToGithubRepositories( comment );
+	comment = utils.linkToGithubRepository( comment );
 	comment = utils.linkToNpmScopedPackage( comment );
-	comment = utils.linkToGithubIssues( comment );
-	comment = utils.linkToGithubUsers( comment );
+	comment = utils.linkToGithubIssue( comment );
+	comment = utils.linkToGithubUser( comment );
 
 	return comment;
 }

--- a/packages/ckeditor5-dev-env/lib/release-tools/utils/transform-commit/transformcommitforsubrepository.js
+++ b/packages/ckeditor5-dev-env/lib/release-tools/utils/transform-commit/transformcommitforsubrepository.js
@@ -59,9 +59,7 @@ module.exports = function transformCommitForSubRepository( commit, context ) {
 	commit.type = utils.getCommitType( commit.type );
 
 	if ( typeof commit.subject === 'string' ) {
-		commit.subject = utils.linkGithubIssues(
-			utils.linkGithubUsers( commit.subject )
-		);
+		commit.subject = makeLinks( commit.subject );
 	}
 
 	if ( commit.footer && !commit.body && !commit.notes.length ) {
@@ -80,16 +78,15 @@ module.exports = function transformCommitForSubRepository( commit, context ) {
 			} )
 			.join( '\n' );
 
-		commit.body = utils.linkGithubIssues(
-			utils.linkGithubUsers( commit.body )
-		);
+		commit.body = makeLinks( commit.body );
 	}
 
 	for ( const note of commit.notes ) {
 		if ( note.title === 'BREAKING CHANGE' ) {
 			note.title = 'BREAKING CHANGES';
 		}
-		note.text = utils.linkGithubIssues( utils.linkGithubUsers( note.text ) );
+
+		note.text = makeLinks( note.text );
 	}
 
 	// Clear the references array - we don't want to hoist the issues.
@@ -97,6 +94,15 @@ module.exports = function transformCommitForSubRepository( commit, context ) {
 
 	return commit;
 };
+
+function makeLinks( comment ) {
+	comment = utils.linkToGithubRepositories( comment );
+	comment = utils.linkToNpmScopedPackage( comment );
+	comment = utils.linkToGithubIssues( comment );
+	comment = utils.linkToGithubUsers( comment );
+
+	return comment;
+}
 
 /**
  * @typedef {Object} Commit

--- a/packages/ckeditor5-dev-env/lib/release-tools/utils/transform-commit/transformcommitforsubrepository.js
+++ b/packages/ckeditor5-dev-env/lib/release-tools/utils/transform-commit/transformcommitforsubrepository.js
@@ -115,8 +115,6 @@ module.exports = function transformCommitForSubRepository( commit, context ) {
 };
 
 function makeLinks( comment ) {
-	comment = utils.linkToGithubRepository( comment );
-	comment = utils.linkToNpmScopedPackage( comment );
 	comment = utils.linkToGithubIssue( comment );
 	comment = utils.linkToGithubUser( comment );
 

--- a/packages/ckeditor5-dev-env/tests/release-tools/utils/transform-commit/transform-commit-utils.js
+++ b/packages/ckeditor5-dev-env/tests/release-tools/utils/transform-commit/transform-commit-utils.js
@@ -52,9 +52,19 @@ describe( 'dev-env/release-tools/utils/transform-commit', () => {
 					.to.equal( '[@CKSource](https://github.com/CKSource) Bar' );
 			} );
 
+			it( 'makes a link to GitHub profile if a user was mentioned at the beginning of a line', () => {
+				expect( transformCommit.linkToGithubUser( 'Foo\n@CKSource Bar' ) )
+					.to.equal( 'Foo\n[@CKSource](https://github.com/CKSource) Bar' );
+			} );
+
 			it( 'makes a link to GitHub profile if a user was mentioned in a comment at the ending', () => {
 				expect( transformCommit.linkToGithubUser( 'Bar @CKSource' ) )
 					.to.equal( 'Bar [@CKSource](https://github.com/CKSource)' );
+			} );
+
+			it( 'makes a link to GitHub profile if a user was mentioned in a bracket', () => {
+				expect( transformCommit.linkToGithubUser( 'Bar (@CKSource)' ) )
+					.to.equal( 'Bar ([@CKSource](https://github.com/CKSource))' );
 			} );
 
 			it( 'does nothing if a comment contains scoped package name', () => {
@@ -65,6 +75,11 @@ describe( 'dev-env/release-tools/utils/transform-commit', () => {
 			it( 'does nothing if an email is inside the comment', () => {
 				expect( transformCommit.linkToGithubUser( 'Foo foo@bar.com Bar' ) )
 					.to.equal( 'Foo foo@bar.com Bar' );
+			} );
+
+			it( 'does nothing if a user is already linked', () => {
+				expect( transformCommit.linkToGithubUser( 'Foo [@bar](https://github.com/bar) Bar' ) )
+					.to.equal( 'Foo [@bar](https://github.com/bar) Bar' );
 			} );
 		} );
 

--- a/packages/ckeditor5-dev-env/tests/release-tools/utils/transform-commit/transform-commit-utils.js
+++ b/packages/ckeditor5-dev-env/tests/release-tools/utils/transform-commit/transform-commit-utils.js
@@ -119,7 +119,7 @@ describe( 'dev-env/release-tools/utils/transform-commit', () => {
 					.to.equal( 'i/am/a/path' );
 			} );
 
-			it( 'does not make a link if a comment does not match to "@organization/repository"', () => {
+			it( 'does not make a link if a comment does not match to "organization/repository"', () => {
 				expect( transformCommit.linkToGithubRepository( 'ckeditor/ckeditor5-dev/' ) )
 					.to.equal( 'ckeditor/ckeditor5-dev/' );
 			} );

--- a/packages/ckeditor5-dev-env/tests/release-tools/utils/transform-commit/transform-commit-utils.js
+++ b/packages/ckeditor5-dev-env/tests/release-tools/utils/transform-commit/transform-commit-utils.js
@@ -41,25 +41,25 @@ describe( 'dev-env/release-tools/utils/transform-commit', () => {
 			} );
 		} );
 
-		describe( 'linkToGithubUsers()', () => {
+		describe( 'linkToGithubUser()', () => {
 			it( 'makes a link to GitHub profile if a user was mentioned in a comment', () => {
-				expect( transformCommit.linkToGithubUsers( '@CKSource' ) )
+				expect( transformCommit.linkToGithubUser( '@CKSource' ) )
 					.to.equal( '[@CKSource](https://github.com/CKSource)' );
 			} );
 
 			it( 'does nothing if a comment contains scoped package name', () => {
-				expect( transformCommit.linkToGithubUsers( '@ckeditor/ckeditor5-foo' ) )
+				expect( transformCommit.linkToGithubUser( '@ckeditor/ckeditor5-foo' ) )
 					.to.equal( '@ckeditor/ckeditor5-foo' );
 			} );
 		} );
 
-		describe( 'linkToGithubIssues()', () => {
+		describe( 'linkToGithubIssue()', () => {
 			it( 'throws an error if package.json does not contain the "bugs" property', () => {
 				stubs.getPackageJson.returns( {
 					name: 'test-package'
 				} );
 
-				expect( () => transformCommit.linkToGithubIssues( '' ) )
+				expect( () => transformCommit.linkToGithubIssue( '' ) )
 					.to.throw( Error, 'The package.json for "test-package" must contain the "bugs" property.' );
 			} );
 
@@ -69,7 +69,7 @@ describe( 'dev-env/release-tools/utils/transform-commit', () => {
 					bugs: '/issues'
 				} );
 
-				expect( transformCommit.linkToGithubIssues( 'Some issue #1.' ) )
+				expect( transformCommit.linkToGithubIssue( 'Some issue #1.' ) )
 					.to.equal( 'Some issue [#1](/issues/1).' );
 			} );
 
@@ -81,7 +81,7 @@ describe( 'dev-env/release-tools/utils/transform-commit', () => {
 					}
 				} );
 
-				expect( transformCommit.linkToGithubIssues( 'Some issue #1.' ) )
+				expect( transformCommit.linkToGithubIssue( 'Some issue #1.' ) )
 					.to.equal( 'Some issue [#1](https://github.com/ckeditor/ckeditor5-dev/issues/1).' );
 			} );
 
@@ -93,45 +93,45 @@ describe( 'dev-env/release-tools/utils/transform-commit', () => {
 					}
 				} );
 
-				expect( transformCommit.linkToGithubIssues( 'organization/repository#1' ) )
+				expect( transformCommit.linkToGithubIssue( 'organization/repository#1' ) )
 					.to.equal( 'organization/repository#1' );
 			} );
 		} );
 
-		describe( 'linkToGithubRepositories()', () => {
+		describe( 'linkToGithubRepository()', () => {
 			it( 'makes a link to GitHub if a comment matches to "organization/repository"', () => {
-				expect( transformCommit.linkToGithubRepositories( 'ckeditor/ckeditor5-dev' ) )
+				expect( transformCommit.linkToGithubRepository( 'ckeditor/ckeditor5-dev' ) )
 					.to.equal( '[ckeditor/ckeditor5-dev](https://github.com/ckeditor/ckeditor5-dev)' );
 			} );
 
 			it( 'makes a link to GitHub issue if a comment matches to "organization/repository#ID"', () => {
-				expect( transformCommit.linkToGithubRepositories( 'ckeditor/ckeditor5-dev#2' ) )
+				expect( transformCommit.linkToGithubRepository( 'ckeditor/ckeditor5-dev#2' ) )
 					.to.equal( '[ckeditor/ckeditor5-dev#2](https://github.com/ckeditor/ckeditor5-dev/issues/2)' );
 			} );
 
 			it( 'does not make a link from a comment which is a scoped package', () => {
-				expect( transformCommit.linkToGithubRepositories( '@ckeditor/ckeditor5-dev' ) )
+				expect( transformCommit.linkToGithubRepository( '@ckeditor/ckeditor5-dev' ) )
 					.to.equal( '@ckeditor/ckeditor5-dev' );
 			} );
 
 			it( 'does not make a link from a comment which is a path', () => {
-				expect( transformCommit.linkToGithubRepositories( 'i/am/a/path' ) )
+				expect( transformCommit.linkToGithubRepository( 'i/am/a/path' ) )
 					.to.equal( 'i/am/a/path' );
 			} );
 
 			it( 'does not make a link if a comment does not match to "@organization/repository"', () => {
-				expect( transformCommit.linkToGithubRepositories( 'ckeditor/ckeditor5-dev/' ) )
+				expect( transformCommit.linkToGithubRepository( 'ckeditor/ckeditor5-dev/' ) )
 					.to.equal( 'ckeditor/ckeditor5-dev/' );
 			} );
 
 			it( 'does not make a link from a comment which does not contain the issue id', () => {
-				expect( transformCommit.linkToGithubRepositories( 'ckeditor/ckeditor5-dev#' ) )
+				expect( transformCommit.linkToGithubRepository( 'ckeditor/ckeditor5-dev#' ) )
 					.to.equal( 'ckeditor/ckeditor5-dev#' );
 			} );
 
 			it( 'does not make a link from a comment which is a link to GitHub\'s profile', () => {
 				// "com/CKSource" matches to "organization/repository" pattern but it should not be changed.
-				expect( transformCommit.linkToGithubRepositories( '[@CKSource](https://github.com/CKSource)' ) )
+				expect( transformCommit.linkToGithubRepository( '[@CKSource](https://github.com/CKSource)' ) )
 					.to.equal( '[@CKSource](https://github.com/CKSource)' );
 			} );
 		} );
@@ -158,8 +158,8 @@ describe( 'dev-env/release-tools/utils/transform-commit', () => {
 			} );
 		} );
 
-		describe( 'linksTo* - integration', () => {
-			it( 'all linksTo* functions should work together with one another', () => {
+		describe( 'linkTo* - integration', () => {
+			it( 'all linkTo* functions should work together with one another', () => {
 				stubs.getPackageJson.returns( {
 					name: 'ckeditor5-dev',
 					bugs: 'https://github.com/ckeditor/ckeditor5-dev/issues'
@@ -196,10 +196,10 @@ describe( 'dev-env/release-tools/utils/transform-commit', () => {
 
 			function makeLinks( comment ) {
 				// Order of these functions doesn't matter.
-				comment = transformCommit.linkToGithubRepositories( comment );
+				comment = transformCommit.linkToGithubRepository( comment );
 				comment = transformCommit.linkToNpmScopedPackage( comment );
-				comment = transformCommit.linkToGithubIssues( comment );
-				comment = transformCommit.linkToGithubUsers( comment );
+				comment = transformCommit.linkToGithubIssue( comment );
+				comment = transformCommit.linkToGithubUser( comment );
 
 				return comment;
 			}

--- a/packages/ckeditor5-dev-env/tests/release-tools/utils/transform-commit/transformcommitforsubrepository.js
+++ b/packages/ckeditor5-dev-env/tests/release-tools/utils/transform-commit/transformcommitforsubrepository.js
@@ -151,7 +151,50 @@ describe( 'dev-env/release-tools/utils/transform-commit', () => {
 			expect( stubs.logger.info.firstCall.args[ 0 ].includes( 'INVALID' ) ).to.equal( true );
 		} );
 
-		it( 'makes URLs to issues on GitHub', () => {
+		it( 'makes proper links in the commit subject', () => {
+			const commit = {
+				hash: '76b9e058fb1c3fa00b50059cdc684997d0eb2eca',
+				header: 'Fix: Simple fix. See ckeditor/ckeditor5#1. Thanks to @CKEditor. Closes #2.',
+				type: 'Fix',
+				subject: 'Simple fix. See ckeditor/ckeditor5#1. Thanks to @CKEditor. Closes #2.',
+				body: null,
+				footer: null,
+				notes: []
+			};
+
+			transformCommitForSubRepository( commit, { displayLogs: true, packageData: packageJson } );
+
+			const expectedSubject = 'Simple fix. ' +
+				'See [ckeditor/ckeditor5#1](https://github.com/ckeditor/ckeditor5/issues/1). ' +
+				'Thanks to [@CKEditor](https://github.com/CKEditor). ' +
+				'Closes [#2](https://github.com/ckeditor/ckeditor5-dev/issues/2).';
+
+			expect( commit.subject ).to.equal( expectedSubject );
+		} );
+
+		it( 'makes proper links in the commit body', () => {
+			const commit = {
+				hash: '76b9e058fb1c3fa00b50059cdc684997d0eb2eca',
+				header: 'Fix: Simple fix. Closes #2.',
+				type: 'Fix',
+				subject: 'Simple fix. Closes #2',
+				body: 'See ckeditor/ckeditor5#1. Thanks to @CKEditor. Fix will be published under @ckeditor/ckeditor5-dev. Read more #2.',
+				footer: null,
+				notes: []
+			};
+
+			transformCommitForSubRepository( commit, { displayLogs: true, packageData: packageJson } );
+
+			// Remember about the indent in commit body.
+			const expectedBody = '  See [ckeditor/ckeditor5#1](https://github.com/ckeditor/ckeditor5/issues/1). ' +
+				'Thanks to [@CKEditor](https://github.com/CKEditor). ' +
+				'Fix will be published under [@ckeditor/ckeditor5-dev](https://npmjs.com/package/@ckeditor/ckeditor5-dev). ' +
+				'Read more [#2](https://github.com/ckeditor/ckeditor5-dev/issues/2).';
+
+			expect( commit.body ).to.equal( expectedBody );
+		} );
+
+		it( 'makes proper links in the commit notes', () => {
 			const commit = {
 				hash: '76b9e058fb1c3fa00b50059cdc684997d0eb2eca',
 				header: 'Fix: Simple fix. Closes #2.',
@@ -162,86 +205,26 @@ describe( 'dev-env/release-tools/utils/transform-commit', () => {
 				notes: [
 					{
 						title: 'BREAKING CHANGES',
-						text: 'Some issue #1.'
+						text: 'See ckeditor/ckeditor5#1. Thanks to @CKEditor.'
+					},
+					{
+						title: 'NOTE',
+						text: 'Fix will be published under @ckeditor/ckeditor5-dev. Read more #2.'
 					}
 				]
 			};
 
 			transformCommitForSubRepository( commit, { displayLogs: true, packageData: packageJson } );
 
-			const expectedSubject = 'Simple fix. Closes [#2](https://github.com/ckeditor/ckeditor5-dev/issues/2)';
-			expect( commit.subject ).to.equal( expectedSubject );
-			expect( commit.notes[ 0 ].text ).to.equal(
-				'Some issue [#1](https://github.com/ckeditor/ckeditor5-dev/issues/1).'
-			);
-		} );
+			const expectedFirstNoteText = 'See [ckeditor/ckeditor5#1](https://github.com/ckeditor/ckeditor5/issues/1). ' +
+				'Thanks to [@CKEditor](https://github.com/CKEditor).';
 
-		it( 'makes URLs to organization on GitHub', () => {
-			const commit = {
-				hash: '76b9e058fb1c3fa00b50059cdc684997d0eb2eca',
-				header: 'Internal: Thanks to @CKEditor',
-				type: 'Fix',
-				subject: 'Internal: Thanks to @CKEditor',
-				body: null,
-				footer: null,
-				notes: []
-			};
+			// eslint-disable-next-line max-len
+			const expectedSecondNodeText = 'Fix will be published under [@ckeditor/ckeditor5-dev](https://npmjs.com/package/@ckeditor/ckeditor5-dev). ' +
+				'Read more [#2](https://github.com/ckeditor/ckeditor5-dev/issues/2).';
 
-			transformCommitForSubRepository( commit, { displayLogs: true, packageData: packageJson } );
-
-			const expectedSubject = 'Internal: Thanks to [@CKEditor](https://github.com/CKEditor)';
-			expect( commit.subject ).to.equal( expectedSubject );
-		} );
-
-		it( 'makes URLs to issues in additional commit description', () => {
-			const commitDescription = [
-				'* See more in #1 and #2.'
-			];
-
-			const commitDescriptionWithIndents = [
-				'  * See more in [#1](https://github.com/ckeditor/ckeditor5-dev/issues/1) and ' +
-				'[#2](https://github.com/ckeditor/ckeditor5-dev/issues/2).'
-			].join( '\n' );
-
-			const commit = {
-				header: 'Other: Some improvements.',
-				hash: 'dea35014ab610be0c2150343c6a8a68620cfe5ad',
-				body: commitDescription.join( '\n' ),
-				footer: null,
-				mentions: [],
-				type: 'Other',
-				subject: 'Some improvements.',
-				notes: []
-			};
-
-			transformCommitForSubRepository( commit, { displayLogs: true, packageData: packageJson } );
-
-			expect( commit.body ).to.equal( commitDescriptionWithIndents );
-		} );
-
-		it( 'makes URLs to organization in additional commit description', () => {
-			const commitDescription = [
-				'* Thanks to @CKSource and @CKEditor.'
-			];
-
-			const commitDescriptionWithIndents = [
-				'  * Thanks to [@CKSource](https://github.com/CKSource) and [@CKEditor](https://github.com/CKEditor).'
-			].join( '\n' );
-
-			const commit = {
-				header: 'Other: Some improvements.',
-				hash: 'dea35014ab610be0c2150343c6a8a68620cfe5ad',
-				body: commitDescription.join( '\n' ),
-				footer: null,
-				mentions: [],
-				type: 'Other',
-				subject: 'Some improvements.',
-				notes: []
-			};
-
-			transformCommitForSubRepository( commit, { displayLogs: true, packageData: packageJson } );
-
-			expect( commit.body ).to.equal( commitDescriptionWithIndents );
+			expect( commit.notes[ 0 ].text ).to.equal( expectedFirstNoteText );
+			expect( commit.notes[ 1 ].text ).to.equal( expectedSecondNodeText );
 		} );
 
 		it( 'attaches additional commit description with correct indent', () => {

--- a/packages/ckeditor5-dev-env/tests/release-tools/utils/transform-commit/transformcommitforsubrepository.js
+++ b/packages/ckeditor5-dev-env/tests/release-tools/utils/transform-commit/transformcommitforsubrepository.js
@@ -178,7 +178,7 @@ describe( 'dev-env/release-tools/utils/transform-commit', () => {
 				header: 'Fix: Simple fix. Closes #2.',
 				type: 'Fix',
 				subject: 'Simple fix. Closes #2',
-				body: 'See ckeditor/ckeditor5#1. Thanks to @CKEditor. Fix will be published under @ckeditor/ckeditor5-dev. Read more #2.',
+				body: 'See ckeditor/ckeditor5#1. Thanks to @CKEditor. Read more #2.',
 				footer: null,
 				notes: []
 			};
@@ -188,7 +188,6 @@ describe( 'dev-env/release-tools/utils/transform-commit', () => {
 			// Remember about the indent in commit body.
 			const expectedBody = '  See [ckeditor/ckeditor5#1](https://github.com/ckeditor/ckeditor5/issues/1). ' +
 				'Thanks to [@CKEditor](https://github.com/CKEditor). ' +
-				'Fix will be published under [@ckeditor/ckeditor5-dev](https://npmjs.com/package/@ckeditor/ckeditor5-dev). ' +
 				'Read more [#2](https://github.com/ckeditor/ckeditor5-dev/issues/2).';
 
 			expect( commit.body ).to.equal( expectedBody );
@@ -209,7 +208,7 @@ describe( 'dev-env/release-tools/utils/transform-commit', () => {
 					},
 					{
 						title: 'NOTE',
-						text: 'Fix will be published under @ckeditor/ckeditor5-dev. Read more #2.'
+						text: 'Read more #2.'
 					}
 				]
 			};
@@ -220,8 +219,7 @@ describe( 'dev-env/release-tools/utils/transform-commit', () => {
 				'Thanks to [@CKEditor](https://github.com/CKEditor).';
 
 			// eslint-disable-next-line max-len
-			const expectedSecondNodeText = 'Fix will be published under [@ckeditor/ckeditor5-dev](https://npmjs.com/package/@ckeditor/ckeditor5-dev). ' +
-				'Read more [#2](https://github.com/ckeditor/ckeditor5-dev/issues/2).';
+			const expectedSecondNodeText = 'Read more [#2](https://github.com/ckeditor/ckeditor5-dev/issues/2).';
 
 			expect( commit.notes[ 0 ].text ).to.equal( expectedFirstNoteText );
 			expect( commit.notes[ 1 ].text ).to.equal( expectedSecondNodeText );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: If a part of the comment matches to "organization/repository#id", this part will be replaced with a link which leads to the issue in the specified repository. Closes #269.

