### PR TITLE
T/276: Prevent from parsing invalid merge commit

### DIFF
--- a/packages/ckeditor5-dev-env/lib/release-tools/utils/transform-commit/transformcommitforsubpackage.js
+++ b/packages/ckeditor5-dev-env/lib/release-tools/utils/transform-commit/transformcommitforsubpackage.js
@@ -25,6 +25,18 @@ module.exports = function transformCommitForSubPackage( commit, context ) {
 		return;
 	}
 
+	// Our merge commit always contains two lines:
+	// Merge ...
+	// Prefix: Subject of the changes.
+	// Unfortunately, merge commit made by Git does not contain the second line.
+	// Because of that hash of the commit is parsed as a body and the changelog will crash.
+	// See: https://github.com/ckeditor/ckeditor5-dev/issues/276.
+	if ( commit.merge && !commit.hash ) {
+		commit.hash = commit.body;
+		commit.header = commit.merge;
+		commit.body = null;
+	}
+
 	const files = getChangedFilesForCommit( commit.hash );
 
 	if ( !files.length ) {

--- a/packages/ckeditor5-dev-env/tests/release-tools/utils/transform-commit/transformcommitforsubpackage.js
+++ b/packages/ckeditor5-dev-env/tests/release-tools/utils/transform-commit/transformcommitforsubpackage.js
@@ -151,5 +151,31 @@ describe( 'dev-env/release-tools/utils/transform-commit', () => {
 			expect( transformCommitForSubPackage( commit, context ) ).to.equal( commit );
 			expect( stubs.transformCommitForSubRepository.calledOnce ).to.equal( true );
 		} );
+
+		it( 'does not crash if the merge commit does not contain the second line', () => {
+			const commit = {
+				type: null,
+				subject: null,
+				merge: 'Merge branch \'master\' of github.com:ckeditor/ckeditor5-dev',
+				header: '-hash-',
+				body: '575e00bc8ece48826adefe226c4fb1fe071c73a7',
+				footer: null,
+				notes: [],
+				references: [],
+				mentions: [],
+				revert: null
+			};
+
+			stubs.getChangedFilesForCommit.returns( [] );
+
+			expect( () => {
+				transformCommitForSubPackage( commit, context );
+			} ).to.not.throw( Error );
+
+			expect( stubs.getChangedFilesForCommit.firstCall.args[ 0 ] ).to.equal( '575e00bc8ece48826adefe226c4fb1fe071c73a7' );
+			expect( commit.hash ).to.equal( '575e00bc8ece48826adefe226c4fb1fe071c73a7' );
+			expect( commit.header ).to.equal( 'Merge branch \'master\' of github.com:ckeditor/ckeditor5-dev' );
+			expect( commit.body ).to.equal( null );
+		} );
 	} );
 } );

--- a/packages/ckeditor5-dev-env/tests/release-tools/utils/transform-commit/transformcommitforsubrepository.js
+++ b/packages/ckeditor5-dev-env/tests/release-tools/utils/transform-commit/transformcommitforsubrepository.js
@@ -362,5 +362,49 @@ describe( 'dev-env/release-tools/utils/transform-commit', () => {
 			);
 			expect( commit.footer ).to.equal( null );
 		} );
+
+		it( 'fixes the commit which does not contain the second line', () => {
+			const commit = {
+				type: null,
+				subject: null,
+				merge: 'Merge branch \'master\' of github.com:ckeditor/ckeditor5-dev',
+				header: '-hash-',
+				body: '575e00bc8ece48826adefe226c4fb1fe071c73a7',
+				footer: null,
+				notes: [],
+				references: [],
+				mentions: [],
+				revert: null
+			};
+
+			transformCommitForSubRepository( commit, { displayLogs: true, packageData: packageJson } );
+
+			expect( commit.hash ).to.equal( '575e00b' );
+			expect( commit.header ).to.equal( 'Merge branch \'master\' of github.com:ckeditor/ckeditor5-dev' );
+			expect( commit.body ).to.equal( null );
+		} );
+
+		it( 'displays proper log if commit does not contain the second line', () => {
+			const commit = {
+				type: null,
+				subject: null,
+				merge: 'Merge branch \'master\' of github.com:ckeditor/ckeditor5-dev',
+				header: '-hash-',
+				body: '575e00bc8ece48826adefe226c4fb1fe071c73a7',
+				footer: null,
+				notes: [],
+				references: [],
+				mentions: [],
+				revert: null
+			};
+
+			transformCommitForSubRepository( commit, { displayLogs: true, packageData: packageJson } );
+
+			// The merge commit displays two lines:
+			// Prefix: Changes.
+			// Merge ...
+			// If the merge commit does not contain the second line, it should display only the one.
+			expect( stubs.logger.info.firstCall.args[ 0 ].split( '\n' ) ).length( 1 );
+		} );
 	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Merge commit which does not contain the second line will not crash the changelog tool. Closes #276.
