### PR TITLE
T/278: Dependency Checker

### DIFF
--- a/packages/ckeditor5-dev-tests/bin/check-dependencies.js
+++ b/packages/ckeditor5-dev-tests/bin/check-dependencies.js
@@ -29,11 +29,16 @@ for ( const filePath of glob.sync( globPattern ) ) {
 		continue;
 	}
 
-	fs.readFileSync( filePath, 'utf-8' )
-		.split( '\n' )
-		.forEach( line => {
-			// Find required package name.
-			const matchedImport = /^import[^;]+from '(@ckeditor\/[^/]+)[^']+';/mg.exec( line );
+	const fileContent = fs.readFileSync( filePath, 'utf-8' );
+	const matchedImports = fileContent.match( /^import[^;]+from '(@ckeditor\/[^/]+)[^']+';/mg );
+
+	if ( !matchedImports ) {
+		continue;
+	}
+
+	matchedImports
+		.forEach( importLine => {
+			const matchedImport = importLine.match( /(@ckeditor\/[^/]+)/ );
 
 			if ( !matchedImport ) {
 				return;

--- a/packages/ckeditor5-dev-tests/bin/check-dependencies.js
+++ b/packages/ckeditor5-dev-tests/bin/check-dependencies.js
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+
+/**
+ * @license Copyright (c) 2003-2017, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+'use strict';
+
+const fs = require( 'fs' );
+const path = require( 'path' );
+const glob = require( 'glob' );
+
+const cwd = process.cwd();
+const packageJson = require( path.join( cwd, 'package.json' ) );
+
+const currentPackageName = packageJson.name;
+const dependencies = Object.keys( packageJson.dependencies || {} );
+const devDependencies = Object.keys( packageJson.devDependencies || {} );
+
+const missingDependencies = new Set();
+const missingDevDependencies = new Set();
+const invalidFiles = new Set();
+
+const globPattern = path.join( cwd, '@(src|tests)/**/*.js' );
+
+for ( const filePath of glob.sync( globPattern ) ) {
+	fs.readFileSync( filePath, 'utf-8' )
+		.split( '\n' )
+		.forEach( line => {
+			// Find required package name.
+			let packageName = /^import .* from '(@ckeditor\/[^/]+)\/.*/.exec( line );
+
+			if ( !packageName ) {
+				return;
+			}
+
+			packageName = packageName[ 1 ];
+
+			// Current package cannot be added as dependency.
+			if ( currentPackageName === packageName ) {
+				return;
+			}
+
+			// Check whether the package is defined as dependency and dev-dependency.
+			const containPackageAsDependency = dependencies.includes( packageName );
+			const containPackageAsDevDependency = devDependencies.includes( packageName );
+
+			// If so, current checking line is fine.
+			if ( containPackageAsDependency || containPackageAsDevDependency ) {
+				return;
+			}
+
+			// If found package is missing and current file is "source" file, add the package as a missing dependency.
+			if ( !containPackageAsDependency && filePath.match( /\/src\// ) ) {
+				missingDependencies.add( packageName );
+			}
+
+			// If found package is missing and current file is "test" file, add the package as a missing dev-dependency.
+			if ( !containPackageAsDevDependency && filePath.match( /\/tests\// ) ) {
+				missingDevDependencies.add( packageName );
+			}
+
+			// Mark current file as invalid (it can help for manual debugging).
+			invalidFiles.add( filePath.replace( cwd + '/', './' ) );
+		} );
+}
+
+if ( invalidFiles.size ) {
+	let errorMessage = 'The files listed below contain dependencies which are not defined in "package.json":\n\n';
+	errorMessage += [ ...invalidFiles ].map( formatLine ).join( '\n' );
+
+	if ( missingDependencies.size ) {
+		errorMessage += '\n\nMissing dependencies:\n\n';
+		errorMessage += [ ...missingDependencies ].map( formatLine ).join( '\n' );
+	}
+
+	if ( missingDevDependencies.size ) {
+		errorMessage += '\n\nMissing dev-dependencies:\n\n';
+		errorMessage += [ ...missingDevDependencies ].map( formatLine ).join( '\n' );
+	}
+
+	throw new Error( errorMessage + '\n' );
+}
+
+function formatLine( line ) {
+	return '  - ' + line;
+}

--- a/packages/ckeditor5-dev-tests/bin/check-dependencies.js
+++ b/packages/ckeditor5-dev-tests/bin/check-dependencies.js
@@ -25,6 +25,11 @@ const invalidFiles = new Set();
 const globPattern = path.join( cwd, '@(src|tests)/**/*.js' );
 
 for ( const filePath of glob.sync( globPattern ) ) {
+	// Skip "src/lib" directory.
+	if ( filePath.match( /\/src\/lib\// ) ) {
+		continue;
+	}
+
 	fs.readFileSync( filePath, 'utf-8' )
 		.split( '\n' )
 		.forEach( line => {

--- a/packages/ckeditor5-dev-tests/bin/check-dependencies.js
+++ b/packages/ckeditor5-dev-tests/bin/check-dependencies.js
@@ -14,7 +14,6 @@ const glob = require( 'glob' );
 const cwd = process.cwd();
 const packageJson = require( path.join( cwd, 'package.json' ) );
 
-const currentPackageName = packageJson.name;
 const dependencies = Object.keys( packageJson.dependencies || {} );
 const devDependencies = Object.keys( packageJson.devDependencies || {} );
 
@@ -41,11 +40,6 @@ for ( const filePath of glob.sync( globPattern ) ) {
 			}
 
 			const packageName = matchedImport[ 1 ];
-
-			// Current package cannot be added as dependency.
-			if ( currentPackageName === packageName ) {
-				return;
-			}
 
 			// Check whether the package is defined as dependency and dev-dependency.
 			const containPackageAsDependency = dependencies.includes( packageName );

--- a/packages/ckeditor5-dev-tests/bin/check-dependencies.js
+++ b/packages/ckeditor5-dev-tests/bin/check-dependencies.js
@@ -81,7 +81,7 @@ if ( invalidFiles.size ) {
 	}
 
 	if ( missingDevDependencies.size ) {
-		console.error( 'Missing dev-dependencies:\n' );
+		console.error( 'Missing devDependencies:\n' );
 		console.error( [ ...missingDevDependencies ].map( formatLine ).join( '\n' ) + '\n' );
 	}
 	console.error( '='.repeat( 120 ) + '\n' );

--- a/packages/ckeditor5-dev-tests/bin/check-dependencies.js
+++ b/packages/ckeditor5-dev-tests/bin/check-dependencies.js
@@ -67,20 +67,22 @@ for ( const filePath of glob.sync( globPattern ) ) {
 }
 
 if ( invalidFiles.size ) {
-	let errorMessage = 'The files listed below contain dependencies which are not defined in "package.json":\n\n';
-	errorMessage += [ ...invalidFiles ].map( formatLine ).join( '\n' );
+	console.error( '\n' + '='.repeat( 120 ) );
+	console.error( '\nThe files listed below require dependencies which are not defined in "package.json":\n' );
+	console.error( [ ...invalidFiles ].map( formatLine ).join( '\n' ) + '\n' );
 
 	if ( missingDependencies.size ) {
-		errorMessage += '\n\nMissing dependencies:\n\n';
-		errorMessage += [ ...missingDependencies ].map( formatLine ).join( '\n' );
+		console.error( 'Missing dependencies:\n' );
+		console.error( [ ...missingDependencies ].map( formatLine ).join( '\n' ) + '\n' );
 	}
 
 	if ( missingDevDependencies.size ) {
-		errorMessage += '\n\nMissing dev-dependencies:\n\n';
-		errorMessage += [ ...missingDevDependencies ].map( formatLine ).join( '\n' );
+		console.error( 'Missing dev-dependencies:\n' );
+		console.error( [ ...missingDevDependencies ].map( formatLine ).join( '\n' ) + '\n' );
 	}
+	console.error( '='.repeat( 120 ) + '\n' );
 
-	throw new Error( errorMessage + '\n' );
+	throw new Error( 'Some of the files require dependencies which are not defined in "package.json".' );
 }
 
 function formatLine( line ) {

--- a/packages/ckeditor5-dev-tests/bin/check-dependencies.js
+++ b/packages/ckeditor5-dev-tests/bin/check-dependencies.js
@@ -34,13 +34,13 @@ for ( const filePath of glob.sync( globPattern ) ) {
 		.split( '\n' )
 		.forEach( line => {
 			// Find required package name.
-			let packageName = /^import .* from '(@ckeditor\/[^/]+)\/.*/.exec( line );
+			const matchedImport = /^import[^;]+from '(@ckeditor\/[^/]+)[^']+';/mg.exec( line );
 
-			if ( !packageName ) {
+			if ( !matchedImport ) {
 				return;
 			}
 
-			packageName = packageName[ 1 ];
+			const packageName = matchedImport[ 1 ];
 
 			// Current package cannot be added as dependency.
 			if ( currentPackageName === packageName ) {

--- a/packages/ckeditor5-dev-tests/bin/test-travis.sh
+++ b/packages/ckeditor5-dev-tests/bin/test-travis.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
 
 node_modules/.bin/gulp lint && \
+node_modules/.bin/ckeditor5-dev-tests-check-dependencies && \
 node_modules/.bin/ckeditor5-dev-tests --coverage --reporter=dots

--- a/packages/ckeditor5-dev-tests/package.json
+++ b/packages/ckeditor5-dev-tests/package.json
@@ -55,7 +55,8 @@
     "ckeditor5-dev-tests-create-mgit-json": "./bin/create-mgit-json.js",
     "ckeditor5-dev-tests-create-lerna-json": "./bin/create-lerna-json.js",
     "ckeditor5-dev-tests-install-dependencies": "./bin/install-dependencies.sh",
-    "ckeditor5-dev-tests-save-revision": "./bin/save-revision.js"
+    "ckeditor5-dev-tests-save-revision": "./bin/save-revision.js",
+    "ckeditor5-dev-tests-check-dependencies": "./bin/check-dependencies.js"
   },
   "author": "CKSource (http://cksource.com/)",
   "license": "(GPL-2.0 OR LGPL-2.1 OR MPL-1.1)",


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Adds "dependency-checker" which allows validating whether required dependencies are specified in package.json. Closes #278.

---

<details>
    <summary>I run this tool for our packages. The result is below:</summary>

`editor-inline`

Error: The files listed below contain dependencies which are not defined in "package.json":

  - ./tests/manual/tickets/23/1.js

Missing dev-dependencies:

  - @ckeditor/ckeditor5-enter
  - @ckeditor/ckeditor5-typing
  - @ckeditor/ckeditor5-heading
  - @ckeditor/ckeditor5-undo

---

`engine`

Error: The files listed below contain dependencies which are not defined in "package.json":

  - ./tests/manual/tickets/880/1.js
  - ./tests/manual/tickets/887/1.js

Missing dev-dependencies:

  - @ckeditor/ckeditor5-essentials

---

`image`

Error: The files listed below contain dependencies which are not defined in "package.json":

  - ./tests/manual/autohoist.js
  - ./tests/manual/caption.js
  - ./tests/manual/tickets/127/1.js

Missing dev-dependencies:

  - @ckeditor/ckeditor5-essentials
  - @ckeditor/ckeditor5-list
  - @ckeditor/ckeditor5-link

---

`list`

Error: The files listed below contain dependencies which are not defined in "package.json":

  - ./tests/manual/nestedlists.js

Missing dev-dependencies:

  - @ckeditor/ckeditor5-link
</details>