### PR TITLE
Provide support for `@observable` tag

### DIFF
--- a/packages/ckeditor5-dev-docs/lib/index.js
+++ b/packages/ckeditor5-dev-docs/lib/index.js
@@ -46,6 +46,7 @@ function build( config ) {
 			require.resolve( '@ckeditor/jsdoc-plugins/lib/export-fixer/export-fixer' ),
 			require.resolve( '@ckeditor/jsdoc-plugins/lib/custom-tags/error' ),
 			require.resolve( '@ckeditor/jsdoc-plugins/lib/custom-tags/observable' ),
+			require.resolve( '@ckeditor/jsdoc-plugins/lib/observable-event-provider' ),
 			require.resolve( '@ckeditor/jsdoc-plugins/lib/relation-fixer' ),
 			require.resolve( '@ckeditor/jsdoc-plugins/lib/longname-fixer/longname-fixer' ),
 			require.resolve( '@ckeditor/jsdoc-plugins/lib/event-extender/event-extender' ),

--- a/packages/ckeditor5-dev-docs/lib/index.js
+++ b/packages/ckeditor5-dev-docs/lib/index.js
@@ -45,6 +45,7 @@ function build( config ) {
 			require.resolve( 'jsdoc/plugins/markdown' ),
 			require.resolve( '@ckeditor/jsdoc-plugins/lib/export-fixer/export-fixer' ),
 			require.resolve( '@ckeditor/jsdoc-plugins/lib/custom-tags/error' ),
+			require.resolve( '@ckeditor/jsdoc-plugins/lib/custom-tags/observable' ),
 			require.resolve( '@ckeditor/jsdoc-plugins/lib/relation-fixer' ),
 			require.resolve( '@ckeditor/jsdoc-plugins/lib/longname-fixer/longname-fixer' ),
 			require.resolve( '@ckeditor/jsdoc-plugins/lib/event-extender/event-extender' ),

--- a/packages/jsdoc-plugins/lib/custom-tags/observable.js
+++ b/packages/jsdoc-plugins/lib/custom-tags/observable.js
@@ -1,0 +1,28 @@
+/**
+ * @license Copyright (c) 2016-2017, CKSource - Frederico Knabben. All rights reserved.
+ * Licensed under the terms of the MIT License (see LICENSE.md).
+ */
+
+'use strict';
+
+const addMissingEventDoclets = require( '../observable-event-fixer/addmissingeventdoclets' );
+
+module.exports = {
+	// See http://usejsdoc.org/about-plugins.html#tag-definitions.
+	defineTags( dictionary ) {
+		dictionary.defineTag( 'observable', {
+			mustNotHaveDescription: false,
+			canHaveType: true,
+			canHaveName: true,
+			onTagged( doclet ) {
+				doclet.observable = true;
+			}
+		} );
+	},
+
+	handlers: {
+		processingComplete( e ) {
+			e.doclets = addMissingEventDoclets( e.doclets );
+		}
+	}
+};

--- a/packages/jsdoc-plugins/lib/custom-tags/observable.js
+++ b/packages/jsdoc-plugins/lib/custom-tags/observable.js
@@ -9,9 +9,6 @@ module.exports = {
 	// See http://usejsdoc.org/about-plugins.html#tag-definitions.
 	defineTags( dictionary ) {
 		dictionary.defineTag( 'observable', {
-			mustNotHaveDescription: false,
-			canHaveType: true,
-			canHaveName: true,
 			onTagged( doclet ) {
 				doclet.observable = true;
 			}

--- a/packages/jsdoc-plugins/lib/custom-tags/observable.js
+++ b/packages/jsdoc-plugins/lib/custom-tags/observable.js
@@ -5,8 +5,6 @@
 
 'use strict';
 
-const addMissingEventDoclets = require( '../observable-event-fixer/addmissingeventdoclets' );
-
 module.exports = {
 	// See http://usejsdoc.org/about-plugins.html#tag-definitions.
 	defineTags( dictionary ) {
@@ -18,11 +16,5 @@ module.exports = {
 				doclet.observable = true;
 			}
 		} );
-	},
-
-	handlers: {
-		processingComplete( e ) {
-			e.doclets = addMissingEventDoclets( e.doclets );
-		}
 	}
 };

--- a/packages/jsdoc-plugins/lib/observable-event-fixer/addmissingeventdoclets.js
+++ b/packages/jsdoc-plugins/lib/observable-event-fixer/addmissingeventdoclets.js
@@ -1,0 +1,109 @@
+/**
+ * @license Copyright (c) 2016-2017, CKSource - Frederico Knabben. All rights reserved.
+ * Licensed under the terms of the MIT License (see LICENSE.md).
+ */
+
+'use strict';
+
+const {	cloneDeep } = require( 'lodash' );
+
+module.exports = function addMissingEventDoclets( doclets ) {
+	doclets = fixFireTag( doclets );
+
+	const observableEvents = getObservableEvents( doclets );
+
+	const newDoclets = createMissingDoclets( doclets, observableEvents );
+
+	return doclets.concat( newDoclets );
+};
+
+function fixFireTag( doclets ) {
+	return doclets.map( doclet => {
+		if ( !doclet.observable ) {
+			return doclet;
+		}
+
+		const newDoclet = cloneDeep( doclet );
+		const eventName = newDoclet.memberof + '#event:change:' + newDoclet.name;
+
+		if ( !newDoclet.fires ) {
+			newDoclet.fires = [];
+		}
+
+		if ( !newDoclet.fires.includes( eventName ) ) {
+			newDoclet.fires.push( eventName );
+		}
+
+		return newDoclet;
+	} );
+}
+
+function getObservableEvents( doclets ) {
+	return doclets
+		.filter( doclet => doclet.observable )
+		.map( observableDoclet => {
+			const eventName = observableDoclet.memberof + '#event:change:' + observableDoclet.name;
+
+			return {
+				name: eventName,
+				method: observableDoclet
+			};
+		} );
+}
+
+function createMissingDoclets( doclets, observableEvents ) {
+	const eventLongNames = doclets.filter( d => d.kind === 'event' ).map( d => d.longname );
+
+	return observableEvents
+		// Skip for existing events.
+		.filter( observableEvent => !eventLongNames.includes( observableEvent.name ) )
+		.map( observableEvent => {
+			const originalMethod = observableEvent.method;
+
+			const typeNames = originalMethod.type ?
+				originalMethod.type.names :
+				[ '*' ];
+
+			return {
+				comment: '',
+				meta: cloneDeep( originalMethod.meta ),
+				description: '',
+				kind: 'event',
+				name: 'change:' + originalMethod.name,
+				params: [ {
+					type: {
+						names: [ 'module:utils/eventinfo~EventInfo' ]
+					},
+					description: '<p>An object containing information about the fired event.</p>',
+					name: 'eventInfo'
+				},
+				{
+					type: {
+						names: [ 'String' ]
+					},
+					description: '<p>Name of the fired method</p>',
+					name: 'eventName'
+				},
+				{
+					type: {
+						names: [ ...typeNames ]
+					},
+					description: [
+						'<p>New value of the attribute with given key or <code>null</code>, ',
+						'if operation should remove attribute.</p>'
+					].join( '' ),
+					name: 'value'
+				},
+				{
+					type: {
+						names: [ ...typeNames ]
+					},
+					description: '<p>Old value of the attribute with given key or <code>null</code>, if attribute was not set before.</p>',
+					name: 'oldValue'
+				} ],
+				memberof: originalMethod.memberof,
+				longname: observableEvent.name,
+				scope: 'instance'
+			};
+		} );
+}

--- a/packages/jsdoc-plugins/lib/observable-event-fixer/addmissingeventdoclets.js
+++ b/packages/jsdoc-plugins/lib/observable-event-fixer/addmissingeventdoclets.js
@@ -7,6 +7,13 @@
 
 const {	cloneDeep } = require( 'lodash' );
 
+/**
+ * Creates event doclets for observable properties if they're missing.
+ * See #285.
+ *
+ * @param {Array.<Doclet>} doclets
+ * @returns {Array.<Doclet>} An array of enhanced doclets.
+ */
 module.exports = function addMissingEventDoclets( doclets ) {
 	doclets = markFiredEvents( doclets );
 
@@ -15,6 +22,8 @@ module.exports = function addMissingEventDoclets( doclets ) {
 	return doclets.concat( newEventDoclets );
 };
 
+// @param {Array.<Doclet>} doclets
+// @returns {Array.<Doclet>} An array of doclets with fixed fires property.
 function markFiredEvents( doclets ) {
 	return doclets.map( doclet => {
 		if ( !doclet.observable ) {
@@ -36,6 +45,8 @@ function markFiredEvents( doclets ) {
 	} );
 }
 
+// @param {Array.<Doclet>} doclets
+// @returns {Array.<Doclet>} An array of new event doclets.
 function createMissingEventDoclets( doclets ) {
 	const eventLongNames = doclets.filter( d => d.kind === 'event' ).map( d => d.longname );
 	const observableEvents = getObservableEvents( doclets );

--- a/packages/jsdoc-plugins/lib/observable-event-provider/addmissingeventdocletsforobservables.js
+++ b/packages/jsdoc-plugins/lib/observable-event-provider/addmissingeventdocletsforobservables.js
@@ -64,7 +64,7 @@ function createMissingEventDoclets( doclets ) {
 			return {
 				comment: '',
 				meta: cloneDeep( originalProperty.meta ),
-				description: `<p>Fired when a(n) <code>${ originalProperty.name }</code> property changed value.<p>`,
+				description: `<p>Fired when the <code>${ originalProperty.name }</code> property changed value.<p>`,
 				kind: 'event',
 				name: 'change:' + originalProperty.name,
 				params: [ {
@@ -78,7 +78,7 @@ function createMissingEventDoclets( doclets ) {
 					type: {
 						names: [ 'String' ]
 					},
-					description: `<p>Name of the changed property name (<code>${ originalProperty.name }</code>)</p>`,
+					description: `<p>Name of the changed property (<code>${ originalProperty.name }</code>).</p>`,
 					name: 'name'
 				},
 				{

--- a/packages/jsdoc-plugins/lib/observable-event-provider/addmissingeventdocletsforobservables.js
+++ b/packages/jsdoc-plugins/lib/observable-event-provider/addmissingeventdocletsforobservables.js
@@ -14,7 +14,7 @@ const {	cloneDeep } = require( 'lodash' );
  * @param {Array.<Doclet>} doclets
  * @returns {Array.<Doclet>} An array of enhanced doclets.
  */
-module.exports = function addMissingEventDoclets( doclets ) {
+module.exports = function addMissingEventDocletsForObservables( doclets ) {
 	doclets = markFiredEvents( doclets );
 
 	const newEventDoclets = createMissingEventDoclets( doclets );

--- a/packages/jsdoc-plugins/lib/observable-event-provider/addmissingeventdocletsforobservables.js
+++ b/packages/jsdoc-plugins/lib/observable-event-provider/addmissingeventdocletsforobservables.js
@@ -5,7 +5,7 @@
 
 'use strict';
 
-const {	cloneDeep } = require( 'lodash' );
+const { cloneDeep } = require( 'lodash' );
 
 /**
  * Creates event doclets for observable properties if they're missing.

--- a/packages/jsdoc-plugins/lib/observable-event-provider/index.js
+++ b/packages/jsdoc-plugins/lib/observable-event-provider/index.js
@@ -1,0 +1,16 @@
+/**
+ * @license Copyright (c) 2016-2017, CKSource - Frederico Knabben. All rights reserved.
+ * Licensed under the terms of the MIT License (see LICENSE.md).
+ */
+
+'use strict';
+
+const addMissingEventDocletsForObservables = require( './addmissingeventdocletsforobservables' );
+
+module.exports = {
+	handlers: {
+		processingComplete( e ) {
+			e.doclets = addMissingEventDocletsForObservables( e.doclets );
+		}
+	}
+};

--- a/packages/jsdoc-plugins/tests/observable-event-provider/addmissingeventdocletsforobservables.js
+++ b/packages/jsdoc-plugins/tests/observable-event-provider/addmissingeventdocletsforobservables.js
@@ -1,0 +1,251 @@
+/**
+ * @license Copyright (c) 2016-2017, CKSource - Frederico Knabben. All rights reserved.
+ * Licensed under the terms of the MIT License (see LICENSE.md).
+ */
+
+'use strict';
+
+const { expect } = require( 'chai' );
+const addMissingEventDocletsForObservables = require( '../../lib/observable-event-provider/addmissingeventdocletsforobservables' );
+
+describe( 'jsdoc-plugins/observable-event-provider', () => {
+	describe( 'addMissingEventDocletsForObservables()', () => {
+		it( 'should provide new event doclet for the observable property', () => {
+			const inputDoclets = [ {
+				comment: '...',
+				meta: {
+					range: [
+						1861,
+						2061
+					],
+					filename: 'command.js',
+					lineno: 56,
+					path: '/Users/maciejbukowski/workspace/ckeditor5/packages/ckeditor5-core/src',
+					code: {}
+				},
+				description: '<p>Flag indicating whether a command is enabled or disabled.</p>',
+				observable: true,
+				readonly: true,
+				kind: 'member',
+				name: 'isEnabled',
+				type: {
+					names: [
+						'Boolean'
+					]
+				},
+				longname: 'module:core/command~Command#isEnabled',
+				scope: 'instance',
+				memberof: 'module:core/command~Command'
+			} ];
+
+			const outputDoclets = addMissingEventDocletsForObservables( inputDoclets );
+
+			expect( outputDoclets.length ).to.equal( 2 );
+			expect( outputDoclets[ 1 ] ).to.deep.equal( {
+				comment: '',
+				meta: {
+					range: [
+						1861,
+						2061
+					],
+					filename: 'command.js',
+					lineno: 56,
+					path: '/Users/maciejbukowski/workspace/ckeditor5/packages/ckeditor5-core/src',
+					code: {}
+				},
+				description: '<p>Fired when a(n) <code>isEnabled</code> property changed value.<p>',
+				kind: 'event',
+				name: 'change:isEnabled',
+				longname: 'module:core/command~Command#event:change:isEnabled',
+				params: [ {
+					type: {
+						names: [ 'module:utils/eventinfo~EventInfo' ]
+					},
+					description: '<p>An object containing information about the fired event.</p>',
+					name: 'eventInfo'
+				},
+				{
+					type: {
+						names: [ 'String' ]
+					},
+					description: '<p>Name of the changed property name (<code>isEnabled</code>)</p>',
+					name: 'name'
+				},
+				{
+					type: {
+						names: [ 'Boolean' ]
+					},
+					description: [
+						'<p>New value of the <code>isEnabled</code> property with given key or <code>null</code>, ',
+						'if operation should remove property.</p>'
+					].join( '' ),
+					name: 'value'
+				},
+				{
+					type: {
+						names: [ 'Boolean' ]
+					},
+					description: [
+						'<p>Old value of the <code>isEnabled</code> property with given key or <code>null</code>, ',
+						'if property was not set before.</p>'
+					].join( '' ),
+					name: 'oldValue'
+				} ],
+				scope: 'instance',
+				memberof: 'module:core/command~Command'
+			} );
+		} );
+
+		it( 'should not provide event doclet for an observable property if the doclet already exists', () => {
+			const inputDoclets = [ {
+				comment: '...',
+				meta: {
+					range: [
+						1861,
+						2061
+					],
+					filename: 'command.js',
+					lineno: 56,
+					path: '/Users/maciejbukowski/workspace/ckeditor5/packages/ckeditor5-core/src',
+					code: {}
+				},
+				description: '<p>Flag indicating whether a command is enabled or disabled.</p>',
+				observable: true,
+				readonly: true,
+				kind: 'member',
+				name: 'isEnabled',
+				type: {
+					names: [
+						'Boolean'
+					]
+				},
+				longname: 'module:core/command~Command#isEnabled',
+				scope: 'instance',
+				memberof: 'module:core/command~Command'
+			}, {
+				kind: 'event',
+				longname: 'module:core/command~Command#event:change:isEnabled'
+			} ];
+
+			const outputDoclets = addMissingEventDocletsForObservables( inputDoclets );
+
+			expect( outputDoclets.length ).to.equal( 2 );
+		} );
+
+		it( 'should add a proper event name to the fixes property', () => {
+			const inputDoclets = [ {
+				comment: '/**\n\t\t * Flag indicating whether a command is enabled or disabled.',
+				meta: {
+					range: [
+						1861,
+						2061
+					],
+					filename: 'command.js',
+					lineno: 56,
+					path: '/Users/maciejbukowski/workspace/ckeditor5/packages/ckeditor5-core/src',
+					code: {}
+				},
+				description: '<p>Flag indicating whether a command is enabled or disabled.</p>',
+				observable: true,
+				readonly: true,
+				kind: 'member',
+				name: 'isEnabled',
+				type: {
+					names: [
+						'Boolean'
+					]
+				},
+				longname: 'module:core/command~Command#isEnabled',
+				scope: 'instance',
+				memberof: 'module:core/command~Command'
+			} ];
+
+			const outputDoclets = addMissingEventDocletsForObservables( inputDoclets );
+
+			expect( outputDoclets[ 0 ].fires ).to.deep.equal( [
+				'module:core/command~Command#event:change:isEnabled'
+			] );
+		} );
+
+		it( 'should provide new event doclet with `*` type for the observable property that does not specify type', () => {
+			const inputDoclets = [ {
+				comment: '...',
+				meta: {
+					range: [
+						1861,
+						2061
+					],
+					filename: 'command.js',
+					lineno: 56,
+					path: '/Users/maciejbukowski/workspace/ckeditor5/packages/ckeditor5-core/src',
+					code: {}
+				},
+				description: '<p>Flag indicating whether a command is enabled or disabled.</p>',
+				observable: true,
+				readonly: true,
+				kind: 'member',
+				name: 'isEnabled',
+				longname: 'module:core/command~Command#isEnabled',
+				scope: 'instance',
+				memberof: 'module:core/command~Command'
+			} ];
+
+			const outputDoclets = addMissingEventDocletsForObservables( inputDoclets );
+
+			expect( outputDoclets.length ).to.equal( 2 );
+			expect( outputDoclets[ 1 ] ).to.deep.equal( {
+				comment: '',
+				meta: {
+					range: [
+						1861,
+						2061
+					],
+					filename: 'command.js',
+					lineno: 56,
+					path: '/Users/maciejbukowski/workspace/ckeditor5/packages/ckeditor5-core/src',
+					code: {}
+				},
+				description: '<p>Fired when a(n) <code>isEnabled</code> property changed value.<p>',
+				kind: 'event',
+				name: 'change:isEnabled',
+				longname: 'module:core/command~Command#event:change:isEnabled',
+				params: [ {
+					type: {
+						names: [ 'module:utils/eventinfo~EventInfo' ]
+					},
+					description: '<p>An object containing information about the fired event.</p>',
+					name: 'eventInfo'
+				},
+				{
+					type: {
+						names: [ 'String' ]
+					},
+					description: '<p>Name of the changed property name (<code>isEnabled</code>)</p>',
+					name: 'name'
+				},
+				{
+					type: {
+						names: [ '*' ]
+					},
+					description: [
+						'<p>New value of the <code>isEnabled</code> property with given key or <code>null</code>, ',
+						'if operation should remove property.</p>'
+					].join( '' ),
+					name: 'value'
+				},
+				{
+					type: {
+						names: [ '*' ]
+					},
+					description: [
+						'<p>Old value of the <code>isEnabled</code> property with given key or <code>null</code>, ',
+						'if property was not set before.</p>'
+					].join( '' ),
+					name: 'oldValue'
+				} ],
+				scope: 'instance',
+				memberof: 'module:core/command~Command'
+			} );
+		} );
+	} );
+} );

--- a/packages/jsdoc-plugins/tests/observable-event-provider/addmissingeventdocletsforobservables.js
+++ b/packages/jsdoc-plugins/tests/observable-event-provider/addmissingeventdocletsforobservables.js
@@ -20,7 +20,7 @@ describe( 'jsdoc-plugins/observable-event-provider', () => {
 					],
 					filename: 'command.js',
 					lineno: 56,
-					path: '/Users/maciejbukowski/workspace/ckeditor5/packages/ckeditor5-core/src',
+					path: '/workspace/ckeditor5/packages/ckeditor5-core/src',
 					code: {}
 				},
 				description: '<p>Flag indicating whether a command is enabled or disabled.</p>',
@@ -50,7 +50,7 @@ describe( 'jsdoc-plugins/observable-event-provider', () => {
 					],
 					filename: 'command.js',
 					lineno: 56,
-					path: '/Users/maciejbukowski/workspace/ckeditor5/packages/ckeditor5-core/src',
+					path: '/workspace/ckeditor5/packages/ckeditor5-core/src',
 					code: {}
 				},
 				description: '<p>Fired when a(n) <code>isEnabled</code> property changed value.<p>',
@@ -106,7 +106,7 @@ describe( 'jsdoc-plugins/observable-event-provider', () => {
 					],
 					filename: 'command.js',
 					lineno: 56,
-					path: '/Users/maciejbukowski/workspace/ckeditor5/packages/ckeditor5-core/src',
+					path: '/workspace/ckeditor5/packages/ckeditor5-core/src',
 					code: {}
 				},
 				description: '<p>Flag indicating whether a command is enabled or disabled.</p>',
@@ -132,7 +132,7 @@ describe( 'jsdoc-plugins/observable-event-provider', () => {
 			expect( outputDoclets.length ).to.equal( 2 );
 		} );
 
-		it( 'should add a proper event name to the fixes property', () => {
+		it( 'should add a proper event name to the fires property', () => {
 			const inputDoclets = [ {
 				comment: '/**\n\t\t * Flag indicating whether a command is enabled or disabled.',
 				meta: {
@@ -142,7 +142,7 @@ describe( 'jsdoc-plugins/observable-event-provider', () => {
 					],
 					filename: 'command.js',
 					lineno: 56,
-					path: '/Users/maciejbukowski/workspace/ckeditor5/packages/ckeditor5-core/src',
+					path: '/workspace/ckeditor5/packages/ckeditor5-core/src',
 					code: {}
 				},
 				description: '<p>Flag indicating whether a command is enabled or disabled.</p>',
@@ -177,7 +177,7 @@ describe( 'jsdoc-plugins/observable-event-provider', () => {
 					],
 					filename: 'command.js',
 					lineno: 56,
-					path: '/Users/maciejbukowski/workspace/ckeditor5/packages/ckeditor5-core/src',
+					path: '/workspace/ckeditor5/packages/ckeditor5-core/src',
 					code: {}
 				},
 				description: '<p>Flag indicating whether a command is enabled or disabled.</p>',
@@ -202,7 +202,7 @@ describe( 'jsdoc-plugins/observable-event-provider', () => {
 					],
 					filename: 'command.js',
 					lineno: 56,
-					path: '/Users/maciejbukowski/workspace/ckeditor5/packages/ckeditor5-core/src',
+					path: '/workspace/ckeditor5/packages/ckeditor5-core/src',
 					code: {}
 				},
 				description: '<p>Fired when a(n) <code>isEnabled</code> property changed value.<p>',


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Provided support for `@observable` tag. Closes #285.
