### PR TITLE
T/296: Remove gulp dependency.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ npm run coverage
 ## Releasing
 
 1. Fetch all changes and switch to `master`!
-1. Execute `gulp changelog`.
+1. Execute `npm run changelog`.
    * At the current stage, a single change will be added to all packages which it touched. Sometimes, this means that in one of these packages the entry will not have much sense. Browse the changes, check if they are relevant.
       * If not and the package should not be released, just type "skip". However, this is not the best option because Lerna will also recognised this package as changed and will try to release it.
       * If the changes are a bit irrelevant, but the package still should be released, pick the "patch" bump, remove all the irrelevant entries from the changelog and if it became empty after that, add the "Internal changes only (updated dependencies, documentation, etc.)" text.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
     "chalk": "^2.1.0",
     "eslint": "^4.8.0",
     "eslint-config-ckeditor5": "^1.0.6",
-    "gulp": "^3.9.1",
     "husky": "^0.14.3",
     "istanbul": "^0.4.4",
     "lerna": "^2.2.0",
@@ -24,6 +23,7 @@
   "scripts": {
     "test": "mocha `./scripts/get-test-directories.sh` --recursive",
     "coverage": "istanbul cover _mocha `./scripts/get-test-directories.sh` -- --recursive",
+    "changelog": "node ./scripts/changelog.js",
     "lint": "eslint --quiet '**/*.js'",
     "precommit": "lint-staged"
   },

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "devDependencies": {
     "@ckeditor/ckeditor5-dev-env": "^5.1.12",
+    "chalk": "^2.1.0",
     "eslint": "^4.8.0",
     "eslint-config-ckeditor5": "^1.0.6",
     "gulp": "^3.9.1",

--- a/package.json
+++ b/package.json
@@ -32,5 +32,8 @@
       "eslint --quiet"
     ]
   },
+  "eslintIgnore": [
+    "coverage/**"
+  ],
   "version": "0.0.34"
 }

--- a/package.json
+++ b/package.json
@@ -35,5 +35,5 @@
   "eslintIgnore": [
     "coverage/**"
   ],
-  "version": "0.0.346
+  "version": "0.0.36"
 }

--- a/packages/ckeditor5-dev-docs/bin/publish-nightly.js
+++ b/packages/ckeditor5-dev-docs/bin/publish-nightly.js
@@ -34,7 +34,7 @@ exec( `git clone ${ mainRepoUrl }.git` );
 
 // Build the documentation.
 console.log( 'Building documentation...' );
-exec( 'gulp docs --production' );
+exec( 'npm run docs -- --production' );
 
 console.log( 'Copying files...' );
 

--- a/packages/ckeditor5-dev-docs/lib/index.js
+++ b/packages/ckeditor5-dev-docs/lib/index.js
@@ -84,7 +84,7 @@ function build( config ) {
 					try {
 						tools.shExec( `${ cmd } -c ${ tmpConfig.name }`, { verbosity: 'info' } );
 					} catch ( error ) {
-						return reject( 'Error during JSDoc generation.' );
+						return reject( `Error during JSDoc generation: ${ error.message }` );
 					}
 
 					console.log( `Documented ${ files.length } files!` );

--- a/packages/ckeditor5-dev-docs/lib/index.js
+++ b/packages/ckeditor5-dev-docs/lib/index.js
@@ -5,8 +5,12 @@
 
 'use strict';
 
-const gulp = require( 'gulp' );
-const jsdoc = require( 'gulp-jsdoc3' );
+const fs = require( 'fs' );
+const tmp = require( 'tmp' );
+const map = require( 'map-stream' );
+const vfs = require( 'vinyl-fs' );
+
+const { tools } = require( '@ckeditor/ckeditor5-dev-utils' );
 
 module.exports = {
 	build
@@ -34,35 +38,59 @@ function build( config ) {
 		process.env.JSDOC_VALIDATE_ONLY = true;
 	}
 
-	const jsDocConfig = {
-		opts: {
-			encoding: 'utf8',
-			recurse: true,
-			access: 'all',
-			template: 'templates/silent'
-		},
-		plugins: [
-			require.resolve( 'jsdoc/plugins/markdown' ),
-			require.resolve( '@ckeditor/jsdoc-plugins/lib/export-fixer/export-fixer' ),
-			require.resolve( '@ckeditor/jsdoc-plugins/lib/custom-tags/error' ),
-			require.resolve( '@ckeditor/jsdoc-plugins/lib/custom-tags/observable' ),
-			require.resolve( '@ckeditor/jsdoc-plugins/lib/observable-event-provider' ),
-			require.resolve( '@ckeditor/jsdoc-plugins/lib/relation-fixer' ),
-			require.resolve( '@ckeditor/jsdoc-plugins/lib/longname-fixer/longname-fixer' ),
-			require.resolve( '@ckeditor/jsdoc-plugins/lib/event-extender/event-extender' ),
-			require.resolve( '@ckeditor/jsdoc-plugins/lib/validator/validator' ),
-			require.resolve( '@ckeditor/jsdoc-plugins/lib/utils/doclet-logger' )
-		]
-	};
+	const files = [];
 
 	return new Promise( ( resolve, reject ) => {
-		gulp.src( sourceFiles, { read: false } )
-			.pipe( jsdoc( jsDocConfig, result => {
-				if ( result instanceof Error ) {
-					return reject( result.message );
-				}
+		vfs.src( sourceFiles )
+			.pipe( map( ( file, callback ) => {
+				files.push( file.path );
+				callback( null, file );
+			} ).on( 'end', () => {
+				const jsDocConfig = {
+					plugins: [
+						require.resolve( 'jsdoc/plugins/markdown' ),
+						require.resolve( '@ckeditor/jsdoc-plugins/lib/export-fixer/export-fixer' ),
+						require.resolve( '@ckeditor/jsdoc-plugins/lib/custom-tags/error' ),
+						require.resolve( '@ckeditor/jsdoc-plugins/lib/custom-tags/observable' ),
+						require.resolve( '@ckeditor/jsdoc-plugins/lib/observable-event-provider' ),
+						require.resolve( '@ckeditor/jsdoc-plugins/lib/relation-fixer' ),
+						require.resolve( '@ckeditor/jsdoc-plugins/lib/longname-fixer/longname-fixer' ),
+						require.resolve( '@ckeditor/jsdoc-plugins/lib/event-extender/event-extender' ),
+						require.resolve( '@ckeditor/jsdoc-plugins/lib/validator/validator' ),
+						require.resolve( '@ckeditor/jsdoc-plugins/lib/utils/doclet-logger' )
+					],
+					source: {
+						include: files
+					},
+					opts: {
+						encoding: 'utf8',
+						recurse: true,
+						access: 'all',
+						template: 'templates/silent'
+					}
+				};
 
-				return resolve( result );
+				const tmpConfig = tmp.fileSync();
+
+				fs.writeFile( tmpConfig.name, JSON.stringify( jsDocConfig ), 'utf8', error => {
+					if ( error ) {
+						return reject( error );
+					}
+
+					const cmd = require.resolve( 'jsdoc/jsdoc.js' );
+
+					console.log( 'JSDoc started...' );
+
+					try {
+						tools.shExec( `${ cmd } -c ${ tmpConfig.name }`, { verbosity: 'info' } );
+					} catch ( error ) {
+						return reject( 'Error during JSDoc generation.' );
+					}
+
+					console.log( `Documented ${ files.length } files!` );
+
+					resolve();
+				} );
 			} ) );
 	} );
 }

--- a/packages/ckeditor5-dev-docs/package.json
+++ b/packages/ckeditor5-dev-docs/package.json
@@ -7,8 +7,9 @@
   "dependencies": {
     "@ckeditor/ckeditor5-dev-utils": "^4.0.2",
     "@ckeditor/jsdoc-plugins": "^1.8.0",
-    "gulp": "^3.9.1",
-    "gulp-jsdoc3": "ckeditor/gulp-jsdoc3"
+    "jsdoc": "3.4.3",
+    "map-stream": "0.0.7",
+    "vinyl-fs": "^2.4.4"
   },
   "engines": {
     "node": ">=6.0.0",

--- a/packages/ckeditor5-dev-env/README.md
+++ b/packages/ckeditor5-dev-env/README.md
@@ -64,6 +64,41 @@ The process implemented by the tool:
 
 	Notes for the release are taken from the changelog.
 
+## Translation tools
+
+Available tasks:
+- `collect` - Collects translation strings ( from `t()` calls ) and stores them in ckeditor5/build/.transifex directory.
+- `upload` - Uploads translations to the Transifex from collected files.
+- `download` - Downloads translations from the Transifex for each package and language.
+
+### Usage
+
+```
+npm i --save-dev @ckeditor/ckeditor5-dev-env
+```
+
+Then use `ckeditor5-dev-env-translations` command:
+
+```
+# directly from command line:
+node ./node_modules/bin/ckeditor5-dev-env-translations collect
+
+# using npx:
+npx ckeditor5-dev-env-translations collect
+```
+
+Or add to `package.json` scripts:
+
+```
+{
+  "scripts": {
+    "translations:collect": "ckeditor5-dev-env-translations collect",
+    "translations:download": "ckeditor5-dev-env-translations download",
+    "translations:upload": "ckeditor5-dev-env-translations upload"
+  }
+}
+```
+
 ## Changelog
 
 See the [`CHANGELOG.md`](https://github.com/ckeditor/ckeditor5-dev/blob/master/packages/ckeditor5-dev-env/CHANGELOG.md) file.

--- a/packages/ckeditor5-dev-env/README.md
+++ b/packages/ckeditor5-dev-env/README.md
@@ -13,33 +13,31 @@ More information about development tools packages can be found at the following 
 npm i --save-dev @ckeditor/ckeditor5-dev-env
 ```
 
-Then add tasks to your `gulpfile.js`:
+Then create a script that run tasks:
 
 ```js
-// Generate changelog for the current package.
-gulp.task( 'changelog:self', () => {
-	return require( '@ckeditor/ckeditor5-dev-env' ).generateChangelogForSinglePackage();
-} );
+// scripts/changelog-self.js: Generate changelog for the current package. 
+require( '@ckeditor/ckeditor5-dev-env' ).generateChangelogForSinglePackage();
+```
 
-// Generate changelog for all dependencies (repository using multiple repositories).
-gulp.task( 'changelog:packages', () => {
-	return require( '@ckeditor/ckeditor5-dev-env' ).generateChangelogForSubRepositories( /* options */ );
-} );
+```js
+// scripts/changelog-repos.js: Generate changelog for all dependencies (repository using multiple repositories).
+require( '@ckeditor/ckeditor5-dev-env' ).generateChangelogForSubRepositories( /* options */ );
+```
 
-// Generate changelog for all packages (repository contains multiple packages).
-gulp.task( 'changelog:packages', () => {
-	return require( '@ckeditor/ckeditor5-dev-env' ).generateChangelogForSubPackages( /* options */ );
-} );
+```js
+// scripts/changelog-packages.js: Generate changelog for all packages (repository contains multiple packages).
+require( '@ckeditor/ckeditor5-dev-env' ).generateChangelogForSubPackages( /* options */ );
+```
 
-// Create release for the current package.
-gulp.task( 'release:self', () => {
-	return require( '@ckeditor/ckeditor5-dev-env' ).releaseRepository();
-} );
+```js
+// scripts/release-self.js: Create release for the current package.
+require( '@ckeditor/ckeditor5-dev-env' ).releaseRepository();
+```
 
-// Create release for all dependencies.
-gulp.task( 'release:packages', () => {
-	return require( '@ckeditor/ckeditor5-dev-env' ).releaseSubRepositories( /* options */ );
-} );
+```js
+// scripts/release-packages.js: Create release for all dependencies.
+require( '@ckeditor/ckeditor5-dev-env' ).releaseSubRepositories( /* options */ );
 ```
 
 ### Generating changelog

--- a/packages/ckeditor5-dev-env/bin/translations.js
+++ b/packages/ckeditor5-dev-env/bin/translations.js
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+
+/**
+ * @license Copyright (c) 2003-2017, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+'use strict';
+
+const chalk = require( 'chalk' );
+
+const task = process.argv[ 2 ];
+
+const tasks = {
+	/**
+	 * Collects translation strings ( from `t()` calls ) and stores them in ckeditor5/build/.transifex directory.
+	 */
+	collect() {
+		const collectTranslations = require( './../lib/translations/collect' );
+
+		collectTranslations();
+	},
+
+	/**
+	 * Uploads translation strings on the Transifex server.
+	 *
+	 * @returns {Promise}
+	 */
+	upload() {
+		const uploadTranslations = require( './../lib/translations/upload' );
+		const getToken = require( './../lib/translations/gettoken' );
+
+		return getToken()
+			.then( credentials => uploadTranslations( credentials ) );
+	},
+
+	/**
+	 * Download translations from the Transifex server.
+	 *
+	 * @returns {Promise}
+	 */
+	download() {
+		const downloadTranslations = require( './../lib/translations/download' );
+		const getToken = require( './../lib/translations/gettoken' );
+
+		return getToken()
+			.then( credentials => downloadTranslations( credentials ) );
+	}
+};
+
+const taskNames = Object.keys( tasks );
+
+if ( !task || !tasks[ task ] ) {
+	console.log( `Please provide valid task name. Available tasks: ${ taskNames.map( task => chalk.bold( task ) ).join( ', ' ) }.` );
+
+	process.exit( 1 );
+}
+
+tasks[ task ]();

--- a/packages/ckeditor5-dev-env/lib/index.js
+++ b/packages/ckeditor5-dev-env/lib/index.js
@@ -25,41 +25,6 @@ const tasks = {
 	generateChangelogForSubRepositories( ...args ) {
 		return require( './release-tools/tasks/generatechangelogforsubrepositories' )( ...args );
 	},
-
-	/**
-	 * Collects translation strings ( from `t()` calls ) and stores them in ckeditor5/build/.transifex directory.
-	 */
-	collectTranslations() {
-		const collectTranslations = require( './translations/collect' );
-
-		collectTranslations();
-	},
-
-	/**
-	 * Uploads translation strings on the Transifex server.
-	 *
-	 * @returns {Promise}
-	 */
-	uploadTranslations() {
-		const uploadTranslations = require( './translations/upload' );
-		const getToken = require( './translations/gettoken' );
-
-		return getToken()
-			.then( credentials => uploadTranslations( credentials ) );
-	},
-
-	/**
-	 * Download translations from the Transifex server.
-	 *
-	 * @returns {Promise}
-	 */
-	downloadTranslations() {
-		const downloadTranslations = require( './translations/download' );
-		const getToken = require( './translations/gettoken' );
-
-		return getToken()
-			.then( credentials => downloadTranslations( credentials ) );
-	}
 };
 
 module.exports = tasks;

--- a/packages/ckeditor5-dev-env/lib/release-tools/utils/transform-commit/transformcommitforsubrepository.js
+++ b/packages/ckeditor5-dev-env/lib/release-tools/utils/transform-commit/transformcommitforsubrepository.js
@@ -9,9 +9,9 @@ const chalk = require( 'chalk' );
 const { logger } = require( '@ckeditor/ckeditor5-dev-utils' );
 const utils = require( './transform-commit-utils' );
 
-// A size of indent for a log. The number is equal to length of the Gulp log string:
-// '[XX:YY:ZZ] * 1234567 ', where '1234567' is a short commit id.
-const INDENT_SIZE = 21;
+// A size of indent for a log. The number is equal to length of the log string:
+// '* 1234567 ', where '1234567' is a short commit id.
+const INDENT_SIZE = 10;
 
 /**
  * Parses a single commit:

--- a/packages/ckeditor5-dev-env/package.json
+++ b/packages/ckeditor5-dev-env/package.json
@@ -34,6 +34,9 @@
     "node": ">=6.0.0",
     "npm": ">=3.0.0"
   },
+  "bin": {
+    "ckeditor5-dev-env-translations": "./bin/translations.js"
+  },
   "author": "CKSource (http://cksource.com/)",
   "license": "(GPL-2.0 OR LGPL-2.1 OR MPL-1.1)",
   "homepage": "https://github.com/ckeditor/ckeditor5-dev/tree/master/packages/ckeditor5-dev-env",

--- a/packages/ckeditor5-dev-env/tests/index.js
+++ b/packages/ckeditor5-dev-env/tests/index.js
@@ -147,38 +147,4 @@ describe( 'dev-env/index', () => {
 				} );
 		} );
 	} );
-
-	describe( 'collectTranslations()', () => {
-		it( 'should collect translations', () => {
-			tasks.collectTranslations();
-
-			sinon.assert.calledOnce( stubs.translations.collect );
-		} );
-	} );
-
-	describe( 'uploadTranslations()', () => {
-		it( 'should upload translations', () => {
-			stubs.translations.getToken.returns( Promise.resolve( { token: 'token' } ) );
-
-			return tasks.uploadTranslations().then( () => {
-				sinon.assert.calledOnce( stubs.translations.upload );
-				sinon.assert.alwaysCalledWithExactly( stubs.translations.upload, {
-					token: 'token',
-				} );
-			} );
-		} );
-	} );
-
-	describe( 'downloadTranslations()', () => {
-		it( 'should download translations', () => {
-			stubs.translations.getToken.returns( Promise.resolve( { token: 'token' } ) );
-
-			return tasks.downloadTranslations().then( () => {
-				sinon.assert.calledOnce( stubs.translations.download );
-				sinon.assert.alwaysCalledWithExactly( stubs.translations.download, {
-					token: 'token',
-				} );
-			} );
-		} );
-	} );
 } );

--- a/packages/ckeditor5-dev-tests/README.md
+++ b/packages/ckeditor5-dev-tests/README.md
@@ -13,22 +13,24 @@ First, you need to install the package:
 npm i --save-dev @ckeditor/ckeditor5-dev-tests
 ```
 
-An example [gulp.js](http://gulpjs.com/) task to test CKEditor 5 packages (used e.g. in https://github.com/ckeditor/ckeditor5) can look like this:
+An example npm task to test CKEditor 5 packages (used e.g. in https://github.com/ckeditor/ckeditor5) can look like this:
 
-```js
-gulp.task( 'test', () => {
-	return require( '@ckeditor/ckeditor5-dev-tests' )
-		.runAutomatedTests( getTestOptions() );
-} );
+```json
+{
+  "scripts": {
+      "test": "node ./node_modules/.bin/ckeditor5-dev-tests",
+      "test:manual": "node ./node_modules/.bin/ckeditor5-dev-tests-manual"
+  }
+}
+```
 
-gulp.task( 'test:manual', () => {
-	return require( '@ckeditor/ckeditor5-dev-tests' )
-		.runManualTests( getTestOptions() );
-} );
+If you encounter problems with big test folders pass `--max_old_space_size=4096` option to node runner: 
 
-function getTestOptions() {
-	return require( '@ckeditor/ckeditor5-dev-tests' )
-		.parseArguments( process.argv.slice( 2 ) );
+```json
+{
+  "scripts": {
+      "test": "node --max_old_space_size=4096 ./node_modules/.bin/ckeditor5-dev-tests"
+  }
 }
 ```
 
@@ -57,32 +59,32 @@ You can also use the bin script for testing a package:
 Test the `ckeditor5-enter` and `ckeditor5-paragraph` packages and generate code coverage report:
 
 ```bash
-$ gulp test -c --files=enter,paragraph
+$ npm t -- -c --files=enter,paragraph
 ```
 
 Run `tests/view/**/*.js` tests from `ckeditor5-engine` and rerun them once any file change (the watch mode):
 
 ```bash
-$ gulp test -w --files=engine/view
+$ npm t -- -w --files=engine/view
 ```
 
 Test specified files in `ckeditor5-basic-styles` on two browsers (Chrome and Firefox) you can use:
 
 ```bash
-$ gulp test --browsers=Chrome,Firefox --files=basic-styles/boldengine.js,basic-styles/italicengine.js
+$ npm t -- --browsers=Chrome,Firefox --files=basic-styles/boldengine.js,basic-styles/italicengine.js
 ```
 
 Test all installed packages:
 
 ```bash
-$ gulp test --files=*
+$ npm t -- --files=*
 ```
 
 Test all installed packages except one (or more):
 
 ```bash
-$ gulp test --files='!(engine)'
-$ gulp test --files='!(engine|ui)'
+$ npm t -- --files='!(engine)'
+$ npm t -- --files='!(engine|ui)'
 ```
 
 ### Rules for converting `--files` option to glob pattern:

--- a/packages/ckeditor5-dev-tests/bin/install-dependencies.sh
+++ b/packages/ckeditor5-dev-tests/bin/install-dependencies.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-npm install gulp mgit2 lerna@^2.0.0-rc.1 codeclimate-test-reporter eslint-config-ckeditor5
+npm install mgit2 lerna@^2.0.0-rc.1 codeclimate-test-reporter eslint-config-ckeditor5
 
 node_modules/.bin/ckeditor5-dev-tests-create-mgit-json
 node_modules/.bin/ckeditor5-dev-tests-create-lerna-json

--- a/packages/ckeditor5-dev-tests/bin/test-manual.js
+++ b/packages/ckeditor5-dev-tests/bin/test-manual.js
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+
+/**
+ * @license Copyright (c) 2003-2017, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+'use strict';
+
+const chalk = require( 'chalk' );
+const tests = require( '../lib/index' );
+
+const cwd = process.cwd();
+const options = tests.parseArguments( process.argv.slice( 2 ) );
+
+if ( options.files.length === 0 ) {
+	if ( cwd.endsWith( 'ckeditor5' ) ) {
+		options.files = [ '*' ];
+	} else {
+		options.files = [ '/' ];
+	}
+}
+
+tests.runManualTests( options )
+	.catch( error => {
+		// Mark result of this task as invalid.
+		process.exitCode = 1;
+
+		console.log( chalk.red( error ) );
+	} );

--- a/packages/ckeditor5-dev-tests/bin/test.js
+++ b/packages/ckeditor5-dev-tests/bin/test.js
@@ -7,7 +7,7 @@
 
 'use strict';
 
-const gutil = require( 'gulp-util' );
+const chalk = require( 'chalk' );
 const tests = require( '../lib/index' );
 
 const cwd = process.cwd();
@@ -26,5 +26,5 @@ tests.runAutomatedTests( options )
 		// Mark result of this task as invalid.
 		process.exitCode = 1;
 
-		gutil.log( gutil.colors.red( error ) );
+		console.log( chalk.red( error ) );
 	} );

--- a/packages/ckeditor5-dev-tests/lib/tasks/runautomatedtests.js
+++ b/packages/ckeditor5-dev-tests/lib/tasks/runautomatedtests.js
@@ -10,7 +10,7 @@
 const getKarmaConfig = require( '../utils/automated-tests/getkarmaconfig' );
 const KarmaServer = require( 'karma' ).Server;
 const path = require( 'path' );
-const gutil = require( 'gulp-util' );
+const chalk = require( 'chalk' );
 
 module.exports = function runAutomatedTests( options ) {
 	return new Promise( ( resolve, reject ) => {
@@ -35,7 +35,7 @@ module.exports = function runAutomatedTests( options ) {
 					const { logger } = require( '@ckeditor/ckeditor5-dev-utils' );
 					const log = logger();
 
-					log.info( `Coverage report saved in '${ gutil.colors.cyan( coveragePath ) }'.` );
+					log.info( `Coverage report saved in '${ chalk.cyan( coveragePath ) }'.` );
 				} );
 			} );
 		}

--- a/packages/ckeditor5-dev-tests/lib/utils/manual-tests/compilehtmlfiles.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/manual-tests/compilehtmlfiles.js
@@ -10,7 +10,7 @@
 const path = require( 'path' );
 const fs = require( 'fs-extra' );
 const _ = require( 'lodash' );
-const gutil = require( 'gulp-util' );
+const chalk = require( 'chalk' );
 const commonmark = require( 'commonmark' );
 const combine = require( 'dom-combiner' );
 const chokidar = require( 'chokidar' );
@@ -69,7 +69,7 @@ function compileHtmlFile( buildDir, sourceFilePathBase, viewTemplate ) {
 	const absoluteHtmlFilePath = getRelativeFilePath( sourceHtmlFilePath );
 	const absoluteJSFilePath = getRelativeFilePath( sourceJSFilePath );
 
-	log.info( `Processing '${ gutil.colors.cyan( sourceFilePathBase ) }'...` );
+	log.info( `Processing '${ chalk.cyan( sourceFilePathBase ) }'...` );
 
 	// Compile test instruction (Markdown file).
 	const parsedMarkdownTree = reader.parse( fs.readFileSync( sourceMDFilePath, 'utf-8' ) );
@@ -92,7 +92,7 @@ function compileHtmlFile( buildDir, sourceFilePathBase, viewTemplate ) {
 
 	fs.outputFileSync( outputFilePath, preparedHtml );
 
-	log.info( `Finished writing '${ gutil.colors.cyan( outputFilePath ) }'` );
+	log.info( `Finished writing '${ chalk.cyan( outputFilePath ) }'` );
 }
 
 // Copies all non JS/HTML/MD files to build dir. Their relative paths to JS/HTML files are maintained.

--- a/packages/ckeditor5-dev-tests/lib/utils/manual-tests/removedir.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/manual-tests/removedir.js
@@ -7,7 +7,7 @@
 
 const del = require( 'del' );
 const { logger } = require( '@ckeditor/ckeditor5-dev-utils' );
-const gutil = require( 'gulp-util' );
+const chalk = require( 'chalk' );
 
 /**
  * Removes directory
@@ -18,6 +18,6 @@ const gutil = require( 'gulp-util' );
  */
 module.exports = function removeDir( dir ) {
 	return del( dir ).then( () => {
-		logger().info( `Removed directory '${ gutil.colors.cyan( dir ) }'` );
+		logger().info( `Removed directory '${ chalk.cyan( dir ) }'` );
 	} );
 };

--- a/packages/ckeditor5-dev-tests/lib/utils/manual-tests/webpacknotifierplugin.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/manual-tests/webpacknotifierplugin.js
@@ -29,13 +29,13 @@ module.exports = class WebpackNotifierPlugin {
 		compiler.plugin( 'done', stats => {
 			if ( stats.compilation.errors.length ) {
 				for ( const item of stats.compilation.errors ) {
-					this.log.error( item.message, { raw: true } );
+					this.log.error( item.message );
 				}
 			}
 
 			if ( stats.compilation.warnings.length ) {
 				for ( const item of stats.compilation.warnings ) {
-					this.log.warning( item.message, { raw: true } );
+					this.log.warning( item.message );
 				}
 			}
 

--- a/packages/ckeditor5-dev-tests/package.json
+++ b/packages/ckeditor5-dev-tests/package.json
@@ -50,6 +50,7 @@
   },
   "bin": {
     "ckeditor5-dev-tests": "./bin/test.js",
+    "ckeditor5-dev-tests-manual": "./bin/test-manual.js",
     "ckeditor5-dev-tests-travis": "./bin/test-travis.sh",
     "ckeditor5-dev-tests-create-mgit-json": "./bin/create-mgit-json.js",
     "ckeditor5-dev-tests-create-lerna-json": "./bin/create-lerna-json.js",

--- a/packages/ckeditor5-dev-tests/package.json
+++ b/packages/ckeditor5-dev-tests/package.json
@@ -18,7 +18,6 @@
     "dom-combiner": "^0.1.2",
     "fs-extra": "^4.0.2",
     "glob": "^7.1.2",
-    "gulp-util": "^3.0.8",
     "istanbul-instrumenter-loader": "^3.0.0",
     "karma": "^1.7.1",
     "karma-chai": "^0.1.0",

--- a/packages/ckeditor5-dev-tests/tests/utils/manual-tests/compilehtmlfiles.js
+++ b/packages/ckeditor5-dev-tests/tests/utils/manual-tests/compilehtmlfiles.js
@@ -9,7 +9,6 @@ const mockery = require( 'mockery' );
 const sinon = require( 'sinon' );
 const path = require( 'path' );
 const chokidar = require( 'chokidar' );
-const gutil = require( 'gulp-util' );
 
 const fakeDirname = path.dirname( require.resolve( '../../../lib/utils/manual-tests/compilehtmlfiles' ) );
 
@@ -46,13 +45,11 @@ describe( 'compileHtmlFiles', () => {
 
 			commonmark: {
 				parse: sandbox.spy(),
-				render: sandbox.spy( () => '<h2>Markdown header</h2>' ),
+				render: sandbox.spy( () => '<h2>Markdown header</h2>' )
 			},
 
-			gutil: {
-				colors: sandbox.stub( gutil, 'colors' ).value( {
-					cyan: text => text
-				} )
+			chalk: {
+				cyan: sandbox.spy( text => text )
 			},
 
 			chokidar: {
@@ -108,7 +105,7 @@ describe( 'compileHtmlFiles', () => {
 
 		patternFiles = {
 			[ path.join( 'manualTestPattern', '*.js' ) ]: [ path.join( 'path', 'to', 'manual', 'file.js' ) ],
-			[ path.join( 'path', 'to', 'manual', '**', '*.!(js|html|md)' ) ]: [ 'static-file.png' ],
+			[ path.join( 'path', 'to', 'manual', '**', '*.!(js|html|md)' ) ]: [ 'static-file.png' ]
 		};
 
 		compileHtmlFiles( 'buildDir', [ path.join( 'manualTestPattern', '*.js' ) ] );
@@ -144,7 +141,7 @@ describe( 'compileHtmlFiles', () => {
 
 		patternFiles = {
 			[ path.join( 'manualTestPattern', '*.js' ) ]: [ path.join( 'path', 'to', 'manual', 'file.abc.js' ) ],
-			[ path.join( 'path', 'to', 'manual', '**', '*.!(js|html|md)' ) ]: [],
+			[ path.join( 'path', 'to', 'manual', '**', '*.!(js|html|md)' ) ]: []
 		};
 
 		compileHtmlFiles( 'buildDir', [ path.join( 'manualTestPattern', '*.js' ) ] );
@@ -175,7 +172,7 @@ describe( 'compileHtmlFiles', () => {
 			[ path.join( 'manualTestPattern', '*.js' ) ]: [ path.join( 'path', 'to', 'manual', 'file.js' ) ],
 			[ path.join( 'anotherPattern', '*.js' ) ]: [ path.join( 'path', 'to', 'another', 'manual', 'file.js' ) ],
 			[ path.join( 'path', 'to', 'manual', '**', '*.!(js|html|md)' ) ]: [ 'static-file.png' ],
-			[ path.join( 'path', 'to', 'another', 'manual', '**', '*.!(js|html|md)' ) ]: [],
+			[ path.join( 'path', 'to', 'another', 'manual', '**', '*.!(js|html|md)' ) ]: []
 		};
 
 		compileHtmlFiles( 'buildDir', [
@@ -205,7 +202,7 @@ describe( 'compileHtmlFiles', () => {
 		patternFiles = {
 			[ path.join( 'manualTestPattern', '*.js' ) ]: [ path.join( 'path', 'to', 'manual', 'file.js' ) ],
 			[ path.join( 'anotherPattern', '*.js' ) ]: [ path.join( 'path', 'to', 'another', 'file.js' ) ],
-			[ path.join( 'path', 'to', 'manual', '**', '*.!(js|html|md)' ) ]: [ 'static-file.png' ],
+			[ path.join( 'path', 'to', 'manual', '**', '*.!(js|html|md)' ) ]: [ 'static-file.png' ]
 		};
 
 		compileHtmlFiles( 'buildDir', [
@@ -229,7 +226,7 @@ describe( 'compileHtmlFiles', () => {
 		patternFiles = {
 			[ path.join( 'manualTestPattern', '*.js' ) ]: [ path.join( 'path', 'to', 'manual', 'file.js' ) ],
 			// Glob pattern has problem with file names containing dots.
-			[ path.join( 'path', 'to', 'manual', '**', '*.!(js|html|md)' ) ]: [ 'some.file.md' ],
+			[ path.join( 'path', 'to', 'manual', '**', '*.!(js|html|md)' ) ]: [ 'some.file.md' ]
 		};
 
 		compileHtmlFiles( 'buildDir', [ path.join( 'manualTestPattern', '*.js' ) ] );
@@ -244,7 +241,8 @@ describe( 'compileHtmlFiles', () => {
 				'<div>template html content</div>',
 				'<div class="manual-test-sidebar"><h2>Markdown header</h2></div>',
 				'<div>html file content</div>',
-				`<body class="manual-test-container"><script src="${ path.sep + path.join( 'path', 'to', 'manual', 'file.js' ) }"></script></body>`
+				`<body class="manual-test-container"><script src="${ path.sep +
+				path.join( 'path', 'to', 'manual', 'file.js' ) }"></script></body>`
 			].join( '\n' )
 		);
 		/* eslint-enable max-len */

--- a/packages/ckeditor5-dev-tests/tests/utils/manual-tests/removedir.js
+++ b/packages/ckeditor5-dev-tests/tests/utils/manual-tests/removedir.js
@@ -34,10 +34,8 @@ describe( 'removeDir', () => {
 			} );
 		} );
 
-		mockery.registerMock( 'gulp-util', {
-			colors: {
-				cyan: message => `\u001b[36m${ message }\u001b[39m`
-			}
+		mockery.registerMock( 'chalk', {
+			cyan: message => `\u001b[36m${ message }\u001b[39m`
 		} );
 
 		removeDir = require( '../../../lib/utils/manual-tests/removedir' );

--- a/packages/ckeditor5-dev-utils/lib/logger.js
+++ b/packages/ckeditor5-dev-utils/lib/logger.js
@@ -6,6 +6,7 @@
 'use strict';
 
 const gutil = require( 'gulp-util' );
+const chalk = require( 'chalk' );
 const levels = new Map();
 
 // Displays everything.
@@ -71,7 +72,7 @@ module.exports = ( moduleVerbosity = 'info' ) => {
 		 * @param {Boolean} [options.raw=false] Whether to display non-modified message.
 		 */
 		warning( message, options = { raw: false } ) {
-			this._log( 'warning', gutil.colors.yellow( message ), options );
+			this._log( 'warning', chalk.yellow( message ), options );
 		},
 
 		/**
@@ -82,7 +83,7 @@ module.exports = ( moduleVerbosity = 'info' ) => {
 		 * @param {Boolean} [options.raw=false] Whether to display non-modified message.
 		 */
 		error( message, options = { raw: false } ) {
-			this._log( 'error', gutil.colors.red( message ), options );
+			this._log( 'error', chalk.red( message ), options );
 		},
 
 		/**

--- a/packages/ckeditor5-dev-utils/lib/logger.js
+++ b/packages/ckeditor5-dev-utils/lib/logger.js
@@ -5,7 +5,6 @@
 
 'use strict';
 
-const gutil = require( 'gulp-util' );
 const chalk = require( 'chalk' );
 const levels = new Map();
 
@@ -57,52 +56,40 @@ module.exports = ( moduleVerbosity = 'info' ) => {
 		 * Displays a message when verbosity level is equal to 'info'.
 		 *
 		 * @param {String} message Message to log.
-		 * @param {Object} options
-		 * @param {Boolean} options.raw Whether to display non-modified message.
 		 */
-		info( message, options = { raw: false } ) {
-			this._log( 'info', message, options );
+		info( message ) {
+			this._log( 'info', message );
 		},
 
 		/**
 		 * Displays a warning message when verbosity level is equal to 'info' or 'warning'.
 		 *
 		 * @param {String} message Message to log.
-		 * @param {Object} options
-		 * @param {Boolean} [options.raw=false] Whether to display non-modified message.
 		 */
-		warning( message, options = { raw: false } ) {
-			this._log( 'warning', chalk.yellow( message ), options );
+		warning( message ) {
+			this._log( 'warning', chalk.yellow( message ) );
 		},
 
 		/**
 		 * Displays an error message.
 		 *
 		 * @param {String} message Message to log.
-		 * @param {Object} options
-		 * @param {Boolean} [options.raw=false] Whether to display non-modified message.
 		 */
-		error( message, options = { raw: false } ) {
-			this._log( 'error', chalk.red( message ), options );
+		error( message ) {
+			this._log( 'error', chalk.red( message ) );
 		},
 
 		/**
 		 * @private
 		 * @param {String} messageVerbosity Verbosity of particular message.
 		 * @param {String} message Message to log.
-		 * @param {Object} options
-		 * @param {Boolean} [options.raw=false] Whether to display non-modified message.
 		 */
-		_log( messageVerbosity, message, options ) {
+		_log( messageVerbosity, message ) {
 			if ( !levels.get( messageVerbosity ).has( moduleVerbosity ) ) {
 				return;
 			}
 
-			if ( options.raw ) {
-				console.log( message );
-			} else {
-				gutil.log( message );
-			}
+			console.log( message );
 		}
 	};
 };

--- a/packages/ckeditor5-dev-utils/lib/tools.js
+++ b/packages/ckeditor5-dev-utils/lib/tools.js
@@ -27,27 +27,27 @@ module.exports = {
 		sh.config.silent = true;
 
 		const ret = sh.exec( command );
-		const logOptions = { raw: true };
+
 		const grey = chalk.grey;
 
 		if ( ret.code ) {
 			if ( ret.stdout ) {
-				log.error( grey( ret.stdout ), logOptions );
+				log.error( grey( ret.stdout ) );
 			}
 
 			if ( ret.stderr ) {
-				log.error( grey( ret.stderr ), logOptions );
+				log.error( grey( ret.stderr ) );
 			}
 
 			throw new Error( `Error while executing ${ command }: ${ ret.stderr }` );
 		}
 
 		if ( ret.stdout ) {
-			log.info( grey( ret.stdout ), logOptions );
+			log.info( grey( ret.stdout ) );
 		}
 
 		if ( ret.stderr ) {
-			log.info( grey( ret.stderr ), logOptions );
+			log.info( grey( ret.stderr ) );
 		}
 
 		return ret.stdout;

--- a/packages/ckeditor5-dev-utils/lib/tools.js
+++ b/packages/ckeditor5-dev-utils/lib/tools.js
@@ -5,7 +5,7 @@
 
 'use strict';
 
-const gutil = require( 'gulp-util' );
+const chalk = require( 'chalk' );
 const path = require( 'path' );
 const fs = require( 'fs-extra' );
 
@@ -28,7 +28,7 @@ module.exports = {
 
 		const ret = sh.exec( command );
 		const logOptions = { raw: true };
-		const grey = gutil.colors.grey;
+		const grey = chalk.grey;
 
 		if ( ret.code ) {
 			if ( ret.stdout ) {
@@ -335,7 +335,7 @@ module.exports = {
 				const log = require( './logger' )( options.verbosity );
 
 				paths.forEach( p => {
-					log.info( `Deleted file '${ gutil.colors.cyan( p ) }'.` );
+					log.info( `Deleted file '${ chalk.cyan( p ) }'.` );
 				} );
 			} );
 	}

--- a/packages/ckeditor5-dev-utils/package.json
+++ b/packages/ckeditor5-dev-utils/package.json
@@ -9,7 +9,6 @@
     "del": "^3.0.0",
     "escodegen": "git://github.com/ma2ciek/escodegen.git",
     "fs-extra": "^4.0.2",
-    "gulp-util": "^3.0.8",
     "javascript-stringify": "^1.6.0",
     "pofile": "^1.0.9",
     "shelljs": "^0.7.8",

--- a/packages/ckeditor5-dev-utils/tests/logger.js
+++ b/packages/ckeditor5-dev-utils/tests/logger.js
@@ -8,7 +8,6 @@
 const sinon = require( 'sinon' );
 const chai = require( 'chai' );
 const expect = chai.expect;
-const gutil = require( 'gulp-util' );
 const logger = require( '../lib/logger' );
 
 describe( 'logger', () => {
@@ -32,65 +31,41 @@ describe( 'logger', () => {
 			log = logger( 'info' );
 		} );
 
-		describe( 'loggger.info()', () => {
+		describe( 'logger.info()', () => {
 			it( 'should log a message', () => {
-				const gutilLog = sandbox.stub( gutil, 'log' );
+				const consoleLog = sandbox.stub( console, 'log' );
 
 				log.info( logMessage );
 
-				expect( gutilLog.calledOnce ).to.equal( true );
-				expect( gutilLog.firstCall.args[ 0 ] ).to.equal( logMessage );
-			} );
-
-			it( 'should log a non-modified message', () => {
-				const consoleLog = sandbox.stub( console, 'log' );
-
-				log.info( logMessage, { raw: true } );
-
 				expect( consoleLog.calledOnce ).to.equal( true );
 				expect( consoleLog.firstCall.args[ 0 ] ).to.equal( logMessage );
+
 				consoleLog.restore();
 			} );
 		} );
 
-		describe( 'loggger.warning()', () => {
+		describe( 'logger.warning()', () => {
 			it( 'should log a message', () => {
-				const gutilLog = sandbox.stub( gutil, 'log' );
+				const consoleLog = sandbox.stub( console, 'log' );
 
 				log.warning( logMessage );
 
-				expect( gutilLog.calledOnce ).to.equal( true );
-				expect( gutilLog.firstCall.args[ 0 ] ).to.match( new RegExp( logMessage ) );
-			} );
-
-			it( 'should log a non-modified message', () => {
-				const consoleLog = sandbox.stub( console, 'log' );
-
-				log.warning( logMessage, { raw: true } );
-
 				expect( consoleLog.calledOnce ).to.equal( true );
 				expect( consoleLog.firstCall.args[ 0 ] ).to.match( new RegExp( logMessage ) );
+
 				consoleLog.restore();
 			} );
 		} );
 
-		describe( 'loggger.error()', () => {
+		describe( 'logger.error()', () => {
 			it( 'should log a message', () => {
-				const gutilLog = sandbox.stub( gutil, 'log' );
+				const consoleLog = sandbox.stub( console, 'log' );
 
 				log.error( logMessage );
 
-				expect( gutilLog.calledOnce ).to.equal( true );
-				expect( gutilLog.firstCall.args[ 0 ] ).to.match( new RegExp( logMessage ) );
-			} );
-
-			it( 'should log a non-modified message', () => {
-				const consoleLog = sandbox.stub( console, 'log' );
-
-				log.error( logMessage, { raw: true } );
-
 				expect( consoleLog.calledOnce ).to.equal( true );
 				expect( consoleLog.firstCall.args[ 0 ] ).to.match( new RegExp( logMessage ) );
+
 				consoleLog.restore();
 			} );
 		} );
@@ -101,59 +76,40 @@ describe( 'logger', () => {
 			log = logger( 'warning' );
 		} );
 
-		describe( 'loggger.info()', () => {
+		describe( 'logger.info()', () => {
 			it( 'should not log any message', () => {
-				const gutilLog = sandbox.stub( gutil, 'log' );
 				const consoleLog = sandbox.stub( console, 'log' );
 
 				log.info( logMessage );
-				log.info( logMessage, { raw: true } );
 
-				expect( gutilLog.called ).to.equal( false );
 				expect( consoleLog.called ).to.equal( false );
 
 				consoleLog.restore();
 			} );
 		} );
 
-		describe( 'loggger.warning()', () => {
+		describe( 'logger.warning()', () => {
 			it( 'should log a message', () => {
-				const gutilLog = sandbox.stub( gutil, 'log' );
+				const consoleLog = sandbox.stub( console, 'log' );
 
 				log.warning( logMessage );
 
-				expect( gutilLog.calledOnce ).to.equal( true );
-				expect( gutilLog.firstCall.args[ 0 ] ).to.match( new RegExp( logMessage ) );
-			} );
-
-			it( 'should log a non-modified message', () => {
-				const consoleLog = sandbox.stub( console, 'log' );
-
-				log.warning( logMessage, { raw: true } );
-
 				expect( consoleLog.calledOnce ).to.equal( true );
 				expect( consoleLog.firstCall.args[ 0 ] ).to.match( new RegExp( logMessage ) );
+
 				consoleLog.restore();
 			} );
 		} );
 
-		describe( 'loggger.error()', () => {
+		describe( 'logger.error()', () => {
 			it( 'should log a message', () => {
-				const gutilLog = sandbox.stub( gutil, 'log' );
+				const consoleLog = sandbox.stub( console, 'log' );
 
 				log.error( logMessage );
 
-				expect( gutilLog.calledOnce ).to.equal( true );
-				expect( gutilLog.firstCall.args[ 0 ] ).to.match( new RegExp( logMessage ) );
-			} );
-
-			it( 'should log a non-modified message', () => {
-				const consoleLog = sandbox.stub( console, 'log' );
-
-				log.error( logMessage, { raw: true } );
-
 				expect( consoleLog.calledOnce ).to.equal( true );
 				expect( consoleLog.firstCall.args[ 0 ] ).to.match( new RegExp( logMessage ) );
+
 				consoleLog.restore();
 			} );
 		} );
@@ -164,53 +120,39 @@ describe( 'logger', () => {
 			log = logger( 'error' );
 		} );
 
-		describe( 'loggger.info()', () => {
+		describe( 'logger.info()', () => {
 			it( 'should not log any message', () => {
-				const gutilLog = sandbox.stub( gutil, 'log' );
 				const consoleLog = sandbox.stub( console, 'log' );
 
 				log.info( logMessage );
-				log.info( logMessage, { raw: true } );
 
-				expect( gutilLog.called ).to.equal( false );
 				expect( consoleLog.called ).to.equal( false );
 
 				consoleLog.restore();
 			} );
 		} );
 
-		describe( 'loggger.warning()', () => {
+		describe( 'logger.warning()', () => {
 			it( 'should not log any message', () => {
-				const gutilLog = sandbox.stub( gutil, 'log' );
 				const consoleLog = sandbox.stub( console, 'log' );
 
 				log.warning( logMessage );
-				log.warning( logMessage, { raw: true } );
 
-				expect( gutilLog.called ).to.equal( false );
 				expect( consoleLog.called ).to.equal( false );
 
 				consoleLog.restore();
 			} );
 		} );
 
-		describe( 'loggger.error()', () => {
+		describe( 'logger.error()', () => {
 			it( 'should log a message', () => {
-				const gutilLog = sandbox.stub( gutil, 'log' );
+				const consoleLog = sandbox.stub( console, 'log' );
 
 				log.error( logMessage );
 
-				expect( gutilLog.calledOnce ).to.equal( true );
-				expect( gutilLog.firstCall.args[ 0 ] ).to.match( new RegExp( logMessage ) );
-			} );
-
-			it( 'should log a non-modified message', () => {
-				const consoleLog = sandbox.stub( console, 'log' );
-
-				log.error( logMessage, { raw: true } );
-
 				expect( consoleLog.calledOnce ).to.equal( true );
 				expect( consoleLog.firstCall.args[ 0 ] ).to.match( new RegExp( logMessage ) );
+
 				consoleLog.restore();
 			} );
 		} );
@@ -221,14 +163,16 @@ describe( 'logger', () => {
 			log = logger();
 		} );
 
-		describe( 'loggger.info()', () => {
+		describe( 'logger.info()', () => {
 			it( 'should log a message', () => {
-				const gutilLog = sandbox.stub( gutil, 'log' );
+				const consoleLog = sandbox.stub( console, 'log' );
 
 				log.info( logMessage );
 
-				expect( gutilLog.calledOnce ).to.equal( true );
-				expect( gutilLog.firstCall.args[ 0 ] ).to.equal( logMessage );
+				expect( consoleLog.calledOnce ).to.equal( true );
+				expect( consoleLog.firstCall.args[ 0 ] ).to.equal( logMessage );
+
+				consoleLog.restore();
 			} );
 		} );
 	} );

--- a/packages/ckeditor5-dev-utils/tests/tools.js
+++ b/packages/ckeditor5-dev-utils/tests/tools.js
@@ -75,9 +75,7 @@ describe( 'utils', () => {
 				expect( errorSpy.called ).to.equal( false );
 				expect( infoSpy.calledTwice ).to.equal( true );
 				expect( infoSpy.firstCall.args[ 0 ] ).to.match( /out/ );
-				expect( infoSpy.firstCall.args[ 1 ] ).to.deep.equal( { raw: true } );
 				expect( infoSpy.secondCall.args[ 0 ] ).to.match( /err/ );
-				expect( infoSpy.secondCall.args[ 1 ] ).to.deep.equal( { raw: true } );
 			} );
 
 			it( 'should output using log functions when exit code is not equal to 0', () => {
@@ -93,9 +91,7 @@ describe( 'utils', () => {
 				expect( execStub.calledOnce ).to.equal( true );
 				expect( errorSpy.calledTwice ).to.equal( true );
 				expect( errorSpy.firstCall.args[ 0 ] ).to.match( /out/ );
-				expect( errorSpy.firstCall.args[ 1 ] ).to.deep.equal( { raw: true } );
 				expect( errorSpy.secondCall.args[ 0 ] ).to.match( /err/ );
-				expect( errorSpy.secondCall.args[ 1 ] ).to.deep.equal( { raw: true } );
 			} );
 
 			it( 'should not log if no output from executed command', () => {

--- a/scripts/changelog.js
+++ b/scripts/changelog.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 /**
  * @license Copyright (c) 2003-2017, CKSource - Frederico Knabben. All rights reserved.
  * For licensing, see LICENSE.md.
@@ -5,11 +7,8 @@
 
 'use strict';
 
-const gulp = require( 'gulp' );
-
-gulp.task( 'changelog', () => {
-	return require( '@ckeditor/ckeditor5-dev-env' ).generateChangelogForSubPackages( {
+require( '@ckeditor/ckeditor5-dev-env' )
+	.generateChangelogForSubPackages( {
 		cwd: process.cwd(),
 		packages: 'packages'
 	} );
-} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Remove gulp dependency. Closes #296.

Now all packages are independent of gulp. Depending on usage you might either create "script " entry in pacakge.json to invoke bin executables or require library into script.

* Package `ckeditor5-dev-env` exposes new `translations` binary.
* Removed `gulp-jsdoc3` from building API documentation. Now `jsdoc` is invoked directly.
* Removed `options` param from logger methods. Logger no longer uses `gutil.log` method.

BREAKING CHANGE: Gulp is no longer required to run tasks from ckeditor5-dev-* packages use npm scripts instead.
BREAKING CHANGE: Gulp task are removed. New npm scripts were introduced.

---

Required for https://github.com/ckeditor/ckeditor5/pull/602.