### PR TITLE
Fix paths in webpack-plugin for Windows environment

### DIFF
--- a/packages/ckeditor5-dev-webpack-plugin/lib/replacetcalls.js
+++ b/packages/ckeditor5-dev-webpack-plugin/lib/replacetcalls.js
@@ -7,6 +7,7 @@
 
 const path = require( 'path' );
 const {	TranslationService } = require( '@ckeditor/ckeditor5-dev-utils' ).translations;
+const utils = require( './utils' );
 
 /**
  * Replaces all function call parameters with translated strings for the t function.
@@ -26,7 +27,7 @@ module.exports = function replaceTCalls( compiler, language ) {
 			process.cwd(),
 			'@ckeditor/ckeditor5-core/src/editor/editor.js',
 			( err, result ) => {
-				const pathToCoreTranslationPackage = result.match( /.+[/\\]ckeditor5-core/ )[ 0 ];
+				const pathToCoreTranslationPackage = result.match( utils.CKEditor5CoreRegExp )[ 0 ];
 
 				translationService.loadPackage( pathToCoreTranslationPackage );
 			}
@@ -44,7 +45,7 @@ module.exports = function replaceTCalls( compiler, language ) {
 
 	// Adds package to the translations if the resource comes from ckeditor5-* package.
 	function maybeLoadPackage( resolveOptions ) {
-		const packageNameRegExp = /[/\\]ckeditor5-[^/\\]+[/\\]/;
+		const packageNameRegExp = utils.CKEditor5PackageNameRegExp;
 		const match = resolveOptions.resource.match( packageNameRegExp );
 
 		if ( match ) {
@@ -57,7 +58,7 @@ module.exports = function replaceTCalls( compiler, language ) {
 
 	// Injects loader when the file comes from ckeditor5-* packages.
 	function maybeAddLoader( resolveOptions ) {
-		if ( resolveOptions.resource.match( /[/\\]ckeditor5-[^/\\]+[/\\]src[/\\].+\.js$/ ) ) {
+		if ( resolveOptions.resource.match( utils.CKEditor5PackageSrcFileRegExp ) ) {
 			resolveOptions.loaders.unshift( path.join( __dirname, 'translatesourceloader.js' ) );
 		}
 	}

--- a/packages/ckeditor5-dev-webpack-plugin/lib/replacetcalls.js
+++ b/packages/ckeditor5-dev-webpack-plugin/lib/replacetcalls.js
@@ -26,9 +26,9 @@ module.exports = function replaceTCalls( compiler, language ) {
 			process.cwd(),
 			'@ckeditor/ckeditor5-core/src/editor/editor.js',
 			( err, result ) => {
-				const pathToCoreTranslationPackage = result.match( /.+\/ckeditor5-core/ )[ 0 ];
+				const pathToCoreTranslationPackage = result.match( /.+[/\\]ckeditor5-core/ )[ 0 ];
 
-				translationService.loadPackage( pathToCoreTranslationPackage.replace( '/', path.sep ) );
+				translationService.loadPackage( pathToCoreTranslationPackage );
 			}
 		);
 	} );
@@ -44,20 +44,20 @@ module.exports = function replaceTCalls( compiler, language ) {
 
 	// Adds package to the translations if the resource comes from ckeditor5-* package.
 	function maybeLoadPackage( resolveOptions ) {
-		const packageNameRegExp = /\/ckeditor5-[^/]+\//;
+		const packageNameRegExp = /[/\\]ckeditor5-[^/\\]+[/\\]/;
 		const match = resolveOptions.resource.match( packageNameRegExp );
 
 		if ( match ) {
 			const index = resolveOptions.resource.search( packageNameRegExp ) + match[ 0 ].length;
 			const pathToPackage = resolveOptions.resource.slice( 0, index );
 
-			translationService.loadPackage( pathToPackage.replace( '/', path.sep ) );
+			translationService.loadPackage( pathToPackage );
 		}
 	}
 
 	// Injects loader when the file comes from ckeditor5-* packages.
 	function maybeAddLoader( resolveOptions ) {
-		if ( resolveOptions.resource.match( /\/ckeditor5-[^/]+\/src\/.+\.js$/ ) ) {
+		if ( resolveOptions.resource.match( /[/\\]ckeditor5-[^/\\]+[/\\]src[/\\].+\.js$/ ) ) {
 			resolveOptions.loaders.unshift( path.join( __dirname, 'translatesourceloader.js' ) );
 		}
 	}

--- a/packages/ckeditor5-dev-webpack-plugin/lib/utils.js
+++ b/packages/ckeditor5-dev-webpack-plugin/lib/utils.js
@@ -1,0 +1,12 @@
+/**
+ * @license Copyright (c) 2003-2017, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+'use strict';
+
+module.exports = {
+	CKEditor5CoreRegExp: /.+[/\\]ckeditor5-core/,
+	CKEditor5PackageNameRegExp: /[/\\]ckeditor5-[^/\\]+[/\\]/,
+	CKEditor5PackageSrcFileRegExp: /[/\\]ckeditor5-[^/\\]+[/\\]src[/\\].+\.js$/
+};

--- a/packages/ckeditor5-dev-webpack-plugin/tests/utils.js
+++ b/packages/ckeditor5-dev-webpack-plugin/tests/utils.js
@@ -1,0 +1,78 @@
+/**
+ * @license Copyright (c) 2003-2017, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+'use strict';
+
+const { expect } = require( 'chai' );
+const utils = require( '../lib/utils.js' );
+
+describe( 'webpack-plugin/utils', () => {
+	describe( 'CKEditor5CoreRegExp', () => {
+		it( 'should match CKEditor5 core package on Unix systems', () => {
+			const path = 'path/to/the/ckeditor5-core/src/file.js';
+
+			const match = path.match( utils.CKEditor5CoreRegExp );
+
+			expect( match ).to.not.be.null;
+			expect( match.length ).to.equal( 1 );
+			expect( match[ 0 ] ).to.equal( 'path/to/the/ckeditor5-core' );
+		} );
+
+		it( 'should match CKEditor5 core package on Windows systems', () => {
+			const path = 'C:\\some path\\to\\the\\ckeditor5-core\\src\\file.js';
+
+			const match = path.match( utils.CKEditor5CoreRegExp );
+
+			expect( match ).to.not.be.null;
+			expect( match.length ).to.equal( 1 );
+			expect( match[ 0 ] ).to.equal( 'C:\\some path\\to\\the\\ckeditor5-core' );
+		} );
+	} );
+
+	describe( 'CKEditor5PackageNameRegExp', () => {
+		it( 'should match CKEditor5 package name on Unix systems', () => {
+			const path = 'path/to/the/ckeditor5-enter/src/file.js';
+
+			const match = path.match( utils.CKEditor5PackageNameRegExp );
+
+			expect( match ).to.not.be.null;
+			expect( match.length ).to.equal( 1 );
+			expect( match[ 0 ] ).to.equal( '/ckeditor5-enter/' );
+		} );
+
+		it( 'should match CKEditor5 package name on Windows systems', () => {
+			const path = 'C:\\some path\\to\\the\\ckeditor5-enter\\src\\file.js';
+
+			const match = path.match( utils.CKEditor5PackageNameRegExp );
+
+			expect( match ).to.not.be.null;
+			expect( match.length ).to.equal( 1 );
+			expect( match[ 0 ] ).to.equal( '\\ckeditor5-enter\\' );
+		} );
+	} );
+
+	describe( 'CKEditor5PackageSrcFileRegExp', () => {
+		it( 'should match CKEditor5 package src file on Unix systems', () => {
+			const path = 'path/to/the/ckeditor5-enter/src/file.js';
+
+			const match = path.match( utils.CKEditor5PackageSrcFileRegExp );
+
+			expect( match ).to.not.be.null;
+			expect( match.length ).to.equal( 1 );
+			expect( match[ 0 ] ).to.equal( '/ckeditor5-enter/src/file.js' );
+		} );
+
+		it( 'should match CKEditor5 package src file on Windows systems', () => {
+			const path = 'C:\\some path\\to\\the\\ckeditor5-enter\\src\\file.js';
+
+			const match = path.match( utils.CKEditor5PackageSrcFileRegExp );
+
+			expect( match ).to.not.be.null;
+			expect( match.length ).to.equal( 1 );
+			expect( match[ 0 ] ).to.equal( '\\ckeditor5-enter\\src\\file.js' );
+		} );
+	} );
+} );
+


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Fixed paths in webpack-plugin for Windows environment. Closes #297.
