### PR TITLE
Add access property to events generated from observables

### DIFF
--- a/packages/jsdoc-plugins/lib/observable-event-provider/addmissingeventdocletsforobservables.js
+++ b/packages/jsdoc-plugins/lib/observable-event-provider/addmissingeventdocletsforobservables.js
@@ -103,7 +103,8 @@ function createMissingEventDoclets( doclets ) {
 				} ],
 				memberof: originalProperty.memberof,
 				longname: observableEvent.name,
-				scope: 'instance'
+				scope: 'instance',
+				access: originalProperty.access ? originalProperty.access : 'public'
 			};
 		} );
 }

--- a/packages/jsdoc-plugins/tests/observable-event-provider/addmissingeventdocletsforobservables.js
+++ b/packages/jsdoc-plugins/tests/observable-event-provider/addmissingeventdocletsforobservables.js
@@ -35,7 +35,8 @@ describe( 'jsdoc-plugins/observable-event-provider', () => {
 				},
 				longname: 'module:core/command~Command#isEnabled',
 				scope: 'instance',
-				memberof: 'module:core/command~Command'
+				memberof: 'module:core/command~Command',
+				access: 'protected'
 			} ];
 
 			const outputDoclets = addMissingEventDocletsForObservables( inputDoclets );
@@ -92,7 +93,8 @@ describe( 'jsdoc-plugins/observable-event-provider', () => {
 					name: 'oldValue'
 				} ],
 				scope: 'instance',
-				memberof: 'module:core/command~Command'
+				memberof: 'module:core/command~Command',
+				access: 'protected'
 			} );
 		} );
 
@@ -157,7 +159,8 @@ describe( 'jsdoc-plugins/observable-event-provider', () => {
 				},
 				longname: 'module:core/command~Command#isEnabled',
 				scope: 'instance',
-				memberof: 'module:core/command~Command'
+				memberof: 'module:core/command~Command',
+				access: 'public'
 			} ];
 
 			const outputDoclets = addMissingEventDocletsForObservables( inputDoclets );
@@ -244,7 +247,8 @@ describe( 'jsdoc-plugins/observable-event-provider', () => {
 					name: 'oldValue'
 				} ],
 				scope: 'instance',
-				memberof: 'module:core/command~Command'
+				memberof: 'module:core/command~Command',
+				access: 'public'
 			} );
 		} );
 	} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Add access property to events generated from observables. Closes #300.
