### PR TITLE
T/309:  [skip ci] will not occur in the generated changelog

### DIFF
--- a/packages/ckeditor5-dev-env/lib/release-tools/utils/transform-commit/transformcommitforsubrepository.js
+++ b/packages/ckeditor5-dev-env/lib/release-tools/utils/transform-commit/transformcommitforsubrepository.js
@@ -69,6 +69,9 @@ module.exports = function transformCommitForSubRepository( commit, context ) {
 		return context.returnInvalidCommit ? commit : undefined;
 	}
 
+	// Remove [skip ci] from the commit subject.
+	commit.subject = commit.subject.replace( /\[skip ci\]/, '' ).trim();
+
 	// If a dot is missing at the end of the subject...
 	if ( !commit.subject.endsWith( '.' ) ) {
 		// ...let's add it.

--- a/packages/ckeditor5-dev-env/tests/release-tools/utils/transform-commit/transformcommitforsubrepository.js
+++ b/packages/ckeditor5-dev-env/tests/release-tools/utils/transform-commit/transformcommitforsubrepository.js
@@ -407,5 +407,25 @@ describe( 'dev-env/release-tools/utils/transform-commit', () => {
 
 			expect( newCommit ).to.deep.equal( commit );
 		} );
+
+		it( 'removes [skip ci] from the commit message', () => {
+			const commit = {
+				hash: '684997d0eb2eca76b9e058fb1c3fa00b50059cdc',
+				header: 'Fix: README. [skip ci]',
+				type: 'Fix',
+				subject: 'README. [skip ci]',
+				body: null,
+				footer: null,
+				notes: []
+			};
+
+			transformCommitForSubRepository( commit, {
+				displayLogs: false,
+				packageData: packageJson,
+				returnInvalidCommit: true
+			} );
+
+			expect( commit.subject ).to.equal( 'README.' );
+		} );
 	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Additional tags for continuous integration services that occurred in commit message will be removed during generating the changelog. Closes #309.
