### PR TITLE
T/323: AT - Windows - SVG Loader

### DIFF
--- a/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getwebpackconfig.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getwebpackconfig.js
@@ -18,7 +18,7 @@ module.exports = function getWebpackConfigForAutomatedTests( options ) {
 			rules: [
 				{
 					// test: **/ckeditor5-*/theme/icons/*.svg
-					test: /ckeditor5-[^/]+\/theme\/icons\/[^/]+\.svg$/,
+					test: /ckeditor5-[^/\\]+[/\\]theme[/\\]icons[/\\][^/\\]+\.svg$/,
 					use: [ 'raw-loader' ]
 				},
 				{

--- a/packages/ckeditor5-dev-tests/tests/utils/automated-tests/getwebpackconfig.js
+++ b/packages/ckeditor5-dev-tests/tests/utils/automated-tests/getwebpackconfig.js
@@ -9,7 +9,7 @@ const getWebpackConfigForAutomatedTests = require( '../../../lib/utils/automated
 const mockery = require( 'mockery' );
 const { expect } = require( 'chai' );
 
-describe( 'getWebpackConfigForAutomatedTests', () => {
+describe( 'getWebpackConfigForAutomatedTests()', () => {
 	const escapedPathSep = require( 'path' ).sep == '/' ? '/' : '\\\\';
 
 	beforeEach( () => {
@@ -111,5 +111,21 @@ describe( 'getWebpackConfigForAutomatedTests', () => {
 
 		expect( secondPath ).to.match( /node_modules$/ );
 		expect( require( 'fs' ).existsSync( secondPath ) ).to.equal( true );
+	} );
+
+	it( 'should load svg files properly', () => {
+		const webpackConfig = getWebpackConfigForAutomatedTests( {} );
+		const svgRule = webpackConfig.module.rules.find( rule => {
+			return rule.test.toString().endsWith( '.svg$/' );
+		} );
+
+		if ( !svgRule ) {
+			throw new Error( 'Not found loader for "svg".' );
+		}
+
+		const svgRegExp = svgRule.test;
+
+		expect( 'C:\\Program Files\\ckeditor\\ckeditor5-basic-styles\\theme\\icons\\italic.svg' ).to.match( svgRegExp, 'Windows' );
+		expect( '/home/ckeditor/ckeditor5-basic-styles/theme/icons/italic.svg' ).to.match( svgRegExp, 'Linux' );
 	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Svg loader used in Webpack configuration for automated tests will work on Windows properly. Closes #323.
