### PR TITLE
Revert "T/290: Tests are executed as a single entry point"

### DIFF
--- a/packages/ckeditor5-dev-tests/lib/tasks/runautomatedtests.js
+++ b/packages/ckeditor5-dev-tests/lib/tasks/runautomatedtests.js
@@ -16,13 +16,7 @@ module.exports = function runAutomatedTests( options ) {
 	return new Promise( ( resolve, reject ) => {
 		const config = getKarmaConfig( options );
 
-		if ( !config ) {
-			return reject( 'Cannot load the configuration file because specified options are invalid.' );
-		}
-
 		const server = new KarmaServer( config, exitCode => {
-			config.removeEntryFile();
-
 			if ( exitCode === 0 ) {
 				resolve();
 			} else {

--- a/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getkarmaconfig.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getkarmaconfig.js
@@ -6,101 +6,67 @@
 /* jshint browser: false, node: true, strict: true */
 'use strict';
 
-const fs = require( 'fs' );
 const path = require( 'path' );
-const glob = require( 'glob' );
-const minimatch = require( 'minimatch' );
-const tmp = require( 'tmp' );
-const karmaLogger = require( 'karma/lib/logger.js' );
 const getWebpackConfigForAutomatedTests = require( './getwebpackconfig' );
 const transformFileOptionToTestGlob = require( '../transformfileoptiontotestglob' );
 
-const AVAILABLE_REPORTERS = [
+const reporters = [
 	'mocha',
 	'dots'
 ];
 
-// Glob patterns that should be ignored. It means if specified test file
-// match to these patterns, this file will be skipped.
-const IGNORE_GLOBS = [
-	// Ignore files which are saved in `manual/` directory. There are manual tests.
-	path.join( '**', 'tests', '**', 'manual', '**', '*.js' ),
-	// Ignore `_utils` directory as well because there are saved utils for tests.
-	path.join( '**', 'tests', '**', '_utils', '**', '*.js' )
-];
+const coverageDir = path.join( process.cwd(), 'coverage' );
 
 /**
  * @param {Object} options
- * @returns {Object|undefined}
+ * @returns {Object}
  */
 module.exports = function getKarmaConfig( options ) {
-	const basePath = process.cwd();
-	const coverageDir = path.join( basePath, 'coverage' );
-	const log = karmaLogger.create( 'config' );
-
 	if ( !Array.isArray( options.files ) || options.files.length === 0 ) {
-		return log.error( 'Karma requires files to tests. `options.files` has to be non-empty array.' );
+		throw new Error( 'Karma requires files to tests. `options.files` has to be non-empty array.' );
 	}
 
-	if ( !AVAILABLE_REPORTERS.includes( options.reporter ) ) {
-		return log.error( 'Specified reporter is not supported. Available reporters: %s.', AVAILABLE_REPORTERS.join( ', ' ) );
+	if ( !reporters.includes( options.reporter ) ) {
+		throw new Error( `Given Mocha reporter is not supported. Available reporters: ${ reporters.join( ', ' ) }.` );
 	}
 
-	const globPatterns = options.files.map( file => transformFileOptionToTestGlob( file ) );
-	const allFiles = [];
+	const files = options.files.map( file => transformFileOptionToTestGlob( file ) );
 
-	// We want to create a single entry point for Karma.
-	// Every pattern must be resolved before Karma starts work.
-	for ( const singlePattern of globPatterns ) {
-		const files = glob.sync( singlePattern );
+	const preprocessorMap = {};
 
-		if ( !files.length ) {
-			log.warn( 'Pattern "%s" does not match any file.', singlePattern );
+	for ( const file of files ) {
+		preprocessorMap[ file ] = [ 'webpack' ];
+
+		if ( options.sourceMap ) {
+			preprocessorMap[ file ].push( 'sourcemap' );
 		}
-
-		allFiles.push(
-			...files.filter( file => !IGNORE_GLOBS.some( globPattern => minimatch( file, globPattern ) ) )
-		);
-	}
-
-	if ( !allFiles.length ) {
-		return log.error( 'Not found files to tests. Specified patterns are invalid.' );
-	}
-
-	const tempFile = tmp.fileSync();
-
-	const filesImports = allFiles
-		.map( file => 'import "' + file + '";' )
-		.join( '\n' );
-
-	fs.writeFileSync( tempFile.name, filesImports );
-
-	log.info( 'Entry file saved in "%s".', tempFile.name );
-
-	const preprocessorMap = {
-		[ tempFile.name ]: [ 'webpack' ]
-	};
-
-	if ( options.sourceMap ) {
-		preprocessorMap[ tempFile.name ].push( 'sourcemap' );
 	}
 
 	const karmaConfig = {
 		// Base path that will be used to resolve all patterns (eg. files, exclude).
-		basePath,
+		basePath: process.cwd(),
 
 		// Frameworks to use. Available frameworks: https://npmjs.org/browse/keyword/karma-adapter
 		frameworks: [ 'mocha', 'chai', 'sinon' ],
 
 		// List of files/patterns to load in the browser.
-		files: [ tempFile.name ],
+		files,
+
+		// List of files to exclude.
+		exclude: [
+			// Ignore all utils which aren't tests.
+			path.join( '**', 'tests', '**', '_utils', '**', '*.js' ),
+
+			// And all manual tests.
+			path.join( '**', 'tests', '**', 'manual', '**', '*.js' )
+		],
 
 		// Preprocess matching files before serving them to the browser.
 		// Available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
 		preprocessors: preprocessorMap,
 
 		webpack: getWebpackConfigForAutomatedTests( {
-			files: allFiles,
+			files,
 			sourceMap: options.sourceMap,
 			coverage: options.coverage
 		} ),
@@ -153,10 +119,6 @@ module.exports = function getKarmaConfig( options ) {
 		// Shows differences in object comparison.
 		mochaReporter: {
 			showDiff: true
-		},
-
-		removeEntryFile() {
-			return tempFile.removeCallback();
 		}
 	};
 

--- a/packages/ckeditor5-dev-tests/package.json
+++ b/packages/ckeditor5-dev-tests/package.json
@@ -31,7 +31,6 @@
     "karma-webpack": "^2.0.4",
     "lodash": "^4.17.4",
     "mgit2": "^0.7.2",
-    "minimatch": "^3.0.4",
     "minimist": "^1.2.0",
     "mocha": "^3.5.3",
     "mockery": "^2.1.0",
@@ -40,7 +39,6 @@
     "sass-loader": "^6.0.6",
     "sinon": "^4.0.0",
     "style-loader": "^0.18.2",
-    "tmp": "0.0.33",
     "webpack": "^3.6.0"
   },
   "devDependencies": {

--- a/packages/ckeditor5-dev-tests/tests/utils/automated-tests/getkarmaconfig.js
+++ b/packages/ckeditor5-dev-tests/tests/utils/automated-tests/getkarmaconfig.js
@@ -9,60 +9,27 @@ const mockery = require( 'mockery' );
 const { expect } = require( 'chai' );
 const sinon = require( 'sinon' );
 const path = require( 'path' );
-const proxyquire = require( 'proxyquire' );
 
 describe( 'getKarmaConfig', () => {
-	let getKarmaConfig, sandbox, stubs;
+	let getKarmaConfig, sandbox;
 	const originalEnv = process.env;
 
 	beforeEach( () => {
 		sandbox = sinon.sandbox.create();
 		sandbox.stub( process, 'cwd' ).returns( 'workspace' );
+
+		// sinon cannot stub non-existing props.
+		process.env = Object.assign( {}, originalEnv, { TRAVIS: false } );
 		sandbox.stub( path, 'join' ).callsFake( ( ...chunks ) => chunks.join( '/' ) );
 		sandbox.stub( path, 'sep' ).value( '/' );
-		// Sinon cannot stub non-existing props.
-		process.env = Object.assign( {}, originalEnv, { TRAVIS: false } );
-
-		stubs = {
-			fs: {
-				writeFileSync: sandbox.stub()
-			},
-			log: {
-				info: sandbox.stub(),
-				warn: sandbox.stub(),
-				error: sandbox.stub(),
-			},
-			glob: {
-				sync: sandbox.stub()
-			},
-			tmp: {
-				fileSync: sandbox.stub().callsFake( () => stubs.tmp._fileSync ),
-				_fileSync: {
-					name: '',
-					removeCallback: sandbox.stub()
-				}
-			}
-		};
 
 		mockery.enable( {
 			warnOnReplace: false,
 			warnOnUnregistered: false
 		} );
-
-		mockery.registerMock( 'karma/lib/logger.js', {
-			create( name ) {
-				expect( name ).to.equal( 'config' );
-
-				return stubs.log;
-			}
-		} );
 		mockery.registerMock( './getwebpackconfig', options => options );
 
-		getKarmaConfig = proxyquire( '../../../lib/utils/automated-tests/getkarmaconfig', {
-			tmp: stubs.tmp,
-			fs: stubs.fs,
-			glob: stubs.glob
-		} );
+		getKarmaConfig = require( '../../../lib/utils/automated-tests/getkarmaconfig' );
 	} );
 
 	afterEach( () => {
@@ -72,57 +39,7 @@ describe( 'getKarmaConfig', () => {
 		process.env = originalEnv;
 	} );
 
-	it( 'should warn if specified pattern is invalid', () => {
-		stubs.glob.sync.returns( [] );
-
-		getKarmaConfig( {
-			files: [ 'invalid-package' ],
-			reporter: 'mocha',
-			sourceMap: false,
-			coverage: false,
-			browsers: [ 'Chrome' ],
-			watch: false,
-			verbose: false
-		} );
-
-		expect( stubs.log.warn.calledOnce ).to.equal( true );
-		expect( stubs.log.warn.firstCall.args[ 0 ] ).to.equal( 'Pattern "%s" does not match any file.' );
-		expect( stubs.log.warn.firstCall.args[ 1 ] ).to.equal( 'workspace/packages/ckeditor5-invalid-package/tests/**/*.js' );
-	} );
-
-	it( 'should log error if not found files to tests', () => {
-		stubs.glob.sync.returns( [] );
-
-		getKarmaConfig( {
-			files: [ 'invalid-package', 'invalid/foo.js' ],
-			reporter: 'mocha',
-			sourceMap: false,
-			coverage: false,
-			browsers: [ 'Chrome' ],
-			watch: false,
-			verbose: false
-		} );
-
-		expect( stubs.log.warn.calledTwice ).to.equal( true );
-		expect( stubs.log.warn.firstCall.args[ 0 ] ).to.equal( 'Pattern "%s" does not match any file.' );
-		expect( stubs.log.warn.firstCall.args[ 1 ] ).to.equal( 'workspace/packages/ckeditor5-invalid-package/tests/**/*.js' );
-		expect( stubs.log.warn.secondCall.args[ 0 ] ).to.equal( 'Pattern "%s" does not match any file.' );
-		expect( stubs.log.warn.secondCall.args[ 1 ] ).to.equal( 'workspace/packages/ckeditor5-invalid/tests/foo.js' );
-		expect( stubs.log.error.calledOnce ).to.equal( true );
-		expect( stubs.log.error.firstCall.args[ 0 ] ).to.equal( 'Not found files to tests. Specified patterns are invalid.' );
-	} );
-
 	it( 'should return basic karma config for all tested files', () => {
-		const allFiles = [
-			'workspace/packages/ckeditor5-autoformat/tests/foo.js',
-			'workspace/packages/ckeditor5-basic-styles/tests/bar.js',
-			'workspace/packages/ckeditor5-engine/tests/foo/bar.js'
-		];
-
-		stubs.glob.sync.returns( allFiles );
-
-		sandbox.stub( stubs.tmp._fileSync, 'name' ).value( '/tmp/file' );
-
 		const karmaConfig = getKarmaConfig( {
 			files: [ '*' ],
 			reporter: 'mocha',
@@ -133,65 +50,172 @@ describe( 'getKarmaConfig', () => {
 			verbose: false
 		} );
 
-		expect( stubs.fs.writeFileSync.calledOnce ).to.equal( true );
-		expect( stubs.fs.writeFileSync.firstCall.args[ 0 ] ).to.equal( '/tmp/file' );
-		expect( stubs.fs.writeFileSync.firstCall.args[ 1 ] ).to.equal( [
-			'import "workspace/packages/ckeditor5-autoformat/tests/foo.js";',
-			'import "workspace/packages/ckeditor5-basic-styles/tests/bar.js";',
-			'import "workspace/packages/ckeditor5-engine/tests/foo/bar.js";'
-		].join( '\n' ) );
+		const expectedFile = 'workspace/packages/ckeditor5-*/tests/**/*.js';
 
-		expect( stubs.log.info.calledOnce ).to.equal( true );
-		expect( stubs.log.info.firstCall.args[ 0 ] ).to.equal( 'Entry file saved in "%s".' );
-		expect( stubs.log.info.firstCall.args[ 1 ] ).to.equal( '/tmp/file' );
-
-		expect( karmaConfig ).to.have.own.property( 'basePath', 'workspace' );
-		expect( karmaConfig ).to.have.own.property( 'frameworks' );
-		expect( karmaConfig ).to.have.own.property( 'files' );
-		expect( karmaConfig ).to.have.own.property( 'preprocessors' );
-		expect( karmaConfig ).to.have.own.property( 'webpack' );
-		expect( karmaConfig.webpack.files ).to.deep.equal( allFiles );
-		expect( karmaConfig.webpack.sourceMap ).to.equal( false );
-		expect( karmaConfig.webpack.coverage ).to.equal( false );
-		expect( karmaConfig ).to.have.own.property( 'webpackMiddleware' );
-		expect( karmaConfig ).to.have.own.property( 'reporters' );
-		expect( karmaConfig ).to.have.own.property( 'browsers' );
-		expect( karmaConfig ).to.have.own.property( 'singleRun', true );
+		expect( karmaConfig ).to.deep.equal( {
+			basePath: 'workspace',
+			frameworks: [ 'mocha', 'chai', 'sinon' ],
+			files: [ expectedFile ],
+			exclude: [
+				path.join( '**', 'tests', '**', '_utils', '**', '*.js' ),
+				path.join( '**', 'tests', '**', 'manual', '**', '*.js' )
+			],
+			preprocessors: {
+				[ expectedFile ]: [ 'webpack' ]
+			},
+			webpack: {
+				files: [ expectedFile ],
+				sourceMap: false,
+				coverage: false,
+			},
+			webpackMiddleware: {
+				noInfo: true,
+				stats: {
+					chunks: false
+				}
+			},
+			reporters: [ 'mocha' ],
+			port: 9876,
+			colors: true,
+			logLevel: 'INFO',
+			browsers: [ 'CHROME_LOCAL' ],
+			customLaunchers: {
+				CHROME_TRAVIS_CI: {
+					base: 'Chrome',
+					flags: [ '--no-sandbox', '--disable-background-timer-throttling' ]
+				},
+				CHROME_LOCAL: {
+					base: 'Chrome',
+					flags: [ '--disable-background-timer-throttling' ]
+				},
+			},
+			singleRun: true,
+			concurrency: Infinity,
+			browserNoActivityTimeout: 0,
+			mochaReporter: {
+				showDiff: true
+			}
+		} );
 	} );
 
-	it( 'allows removing temporary entry point', () => {
-		const allFiles = [
-			'workspace/packages/ckeditor5-autoformat/tests/foo.js',
-			'workspace/packages/ckeditor5-basic-styles/tests/bar.js',
-			'workspace/packages/ckeditor5-engine/tests/foo/bar.js'
-		];
-
-		stubs.glob.sync.returns( allFiles );
-
-		sandbox.stub( stubs.tmp._fileSync, 'name' ).value( '/tmp/file' );
-
+	it( 'should return karma config with current package\'s tests', () => {
 		const karmaConfig = getKarmaConfig( {
-			files: [ '*' ],
-			reporter: 'mocha',
-			sourceMap: false,
-			coverage: false,
-			browsers: [ 'Chrome' ],
-			watch: false,
-			verbose: false
+			files: [ '/' ],
+			reporter: 'mocha'
 		} );
 
-		expect( karmaConfig.removeEntryFile ).to.be.a( 'function' );
-		expect( stubs.tmp._fileSync.removeCallback.called ).to.equal( false );
-		karmaConfig.removeEntryFile();
-		expect( stubs.tmp._fileSync.removeCallback.called ).to.equal( true );
+		expect( karmaConfig.files ).to.deep.eq( [
+			'workspace/tests/**/*.js',
+		] );
 	} );
 
-	it( 'should log error if no files are provided', () => {
-		getKarmaConfig( { reporter: 'mocha' } );
+	it( 'should return karma config with transformed given package files', () => {
+		const karmaConfig = getKarmaConfig( {
+			files: [ 'engine', 'utils' ],
+			reporter: 'mocha'
+		} );
 
-		expect( stubs.log.error.calledOnce ).to.equal( true );
-		expect( stubs.log.error.firstCall.args[ 0 ] ).to.equal(
-			'Karma requires files to tests. `options.files` has to be non-empty array.'
-		);
+		expect( karmaConfig.files ).to.deep.eq( [
+			'workspace/packages/ckeditor5-engine/tests/**/*.js',
+			'workspace/packages/ckeditor5-utils/tests/**/*.js',
+		] );
+	} );
+
+	it( 'should return karma config with transformed excluded packages as files', () => {
+		const karmaConfig = getKarmaConfig( {
+			files: [ '!engine' ],
+			reporter: 'mocha'
+		} );
+
+		expect( karmaConfig.files ).to.deep.eq( [
+			'workspace/packages/ckeditor5-!(engine)*/tests/**/*.js',
+		] );
+	} );
+
+	it( 'should return karma config with transformed package directories as files', () => {
+		const karmaConfig = getKarmaConfig( {
+			files: [ 'engine/view' ],
+			reporter: 'mocha'
+		} );
+
+		expect( karmaConfig.files ).to.deep.eq( [
+			'workspace/packages/ckeditor5-engine/tests/view/**/*.js',
+		] );
+	} );
+
+	it( 'should return karma config with transformed glob as files', () => {
+		const karmaConfig = getKarmaConfig( {
+			files: [ 'engine/model/**/*.js' ],
+			reporter: 'mocha'
+		} );
+
+		expect( karmaConfig.files ).to.deep.eq( [
+			'workspace/packages/ckeditor5-engine/tests/model/**/*.js',
+		] );
+	} );
+
+	it( 'should return karma config with coverage reporter', () => {
+		const karmaConfig = getKarmaConfig( {
+			files: [ 'engine/model/**/*.js' ],
+			reporter: 'mocha',
+			coverage: true,
+		} );
+
+		expect( karmaConfig.reporters ).to.deep.eq( [ 'mocha', 'coverage' ] );
+		expect( karmaConfig.coverageReporter ).to.deep.eq( {
+			reporters: [
+				{
+					type: 'text-summary'
+				},
+				{
+					dir: 'workspace/coverage',
+					type: 'html'
+				},
+				{
+					type: 'lcovonly',
+					subdir: '.',
+					dir: 'workspace/coverage'
+				}
+			]
+		} );
+	} );
+
+	it( 'should return karma config for options.server=true', () => {
+		const karmaConfig = getKarmaConfig( {
+			files: [ '/' ],
+			reporter: 'mocha',
+			server: true
+		} );
+
+		expect( karmaConfig.browsers ).to.equal( null );
+		expect( karmaConfig.autoWatch ).to.equal( true );
+		expect( karmaConfig.singleRun ).to.equal( false );
+	} );
+
+	it( 'should return karma config for options.watch=true', () => {
+		const karmaConfig = getKarmaConfig( {
+			files: [ '/' ],
+			reporter: 'mocha',
+			watch: true,
+			browsers: [ 'Chrome' ]
+		} );
+
+		expect( karmaConfig.browsers ).to.deep.equal( [ 'CHROME_LOCAL' ] );
+		expect( karmaConfig.autoWatch ).to.equal( true );
+		expect( karmaConfig.singleRun ).to.equal( false );
+	} );
+
+	it( 'should throw an error if no files are provided', () => {
+		const spy = sandbox.spy( getKarmaConfig );
+
+		try {
+			spy( {
+				reporter: 'mocha'
+			} );
+		} catch ( err ) {
+			expect( err ).to.be.an.instanceof( Error );
+		}
+
+		expect( spy.threw() ).to.equal( true );
 	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Revert: "T/290: Tests are executed as a single entry point" (https://github.com/ckeditor/ckeditor5-dev/commit/5fc685f).