### PR TITLE
T/343: PostCSS does not work on Windows

### DIFF
--- a/packages/ckeditor5-dev-utils/lib/styles/themeimporter.js
+++ b/packages/ckeditor5-dev-utils/lib/styles/themeimporter.js
@@ -188,7 +188,7 @@ function getThemeFilePath( themePath, inputFilePath ) {
 // @param {String} inputFilePath A path to the file.
 // @returns {String} The name of the package.
 function getPackageName( inputFilePath ) {
-	const match = inputFilePath.match( `ckeditor5-[^${ path.sep }]+` );
+	const match = inputFilePath.match( /ckeditor5-[^\\/]+/ );
 
 	if ( match ) {
 		return match.pop();


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Changed invalid regexp on Windows environments for importing themes (PostCSS). Closes #343.

---

Before merging this, check this out on Windows machine. It works for me but for unknown reasons may it does not work on your machine.