### PR TITLE
T/348: Removed CodeClimate, introduced Coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,10 @@ cache:
   - node_modules
 install:
   - npm install
-  - npm install codeclimate-test-reporter
+  - npm install coveralls
   - lerna bootstrap
 script:
   - npm run lint
   - npm run coverage
 after_success:
-  - node_modules/.bin/codeclimate-test-reporter < coverage/lcov.info
+  - cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ CKEditor 5 development tools packages
 
 [![Build Status](https://travis-ci.org/ckeditor/ckeditor5-dev.svg?branch=master)](https://travis-ci.org/ckeditor/ckeditor5-dev)
 [![Test Coverage](https://codeclimate.com/github/ckeditor/ckeditor5-dev/badges/coverage.svg)](https://codeclimate.com/github/ckeditor/ckeditor5-dev/coverage)
-[![Code Climate](https://codeclimate.com/github/ckeditor/ckeditor5-dev/badges/gpa.svg)](https://codeclimate.com/github/ckeditor/ckeditor5-dev)
+[![Coverage Status](https://coveralls.io/repos/github/ckeditor/ckeditor5-dev/badge.svg?branch=master)](https://coveralls.io/github/ckeditor/ckeditor5-dev?branch=master)
 
 ## Packages
 

--- a/packages/ckeditor5-dev-tests/bin/install-dependencies.sh
+++ b/packages/ckeditor5-dev-tests/bin/install-dependencies.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-npm install mgit2 lerna@^2.0.0-rc.1 codeclimate-test-reporter eslint-config-ckeditor5
+npm install mgit2 lerna@^2.0.0-rc.1 eslint-config-ckeditor5 karma-coveralls@^1.1.2
 
 node_modules/.bin/ckeditor5-dev-tests-create-mgit-json
 node_modules/.bin/ckeditor5-dev-tests-create-lerna-json

--- a/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getkarmaconfig.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getkarmaconfig.js
@@ -144,19 +144,24 @@ module.exports = function getKarmaConfig( options ) {
 	if ( options.coverage ) {
 		karmaConfig.reporters.push( 'coverage' );
 
+		if ( process.env.TRAVIS ) {
+			karmaConfig.reporters.push( 'coveralls' );
+		}
+
 		karmaConfig.coverageReporter = {
 			reporters: [
+				// Prints a table after tests result.
 				{
 					type: 'text-summary'
 				},
+				// Generates HTML tables with the results.
 				{
 					dir: coverageDir,
 					type: 'html'
 				},
-				// Generates "./coverage/lcov.info". Used by CodeClimate.
+				// Generates "lcov.info" file. It's used by external code coverage services.
 				{
 					type: 'lcovonly',
-					subdir: '.',
 					dir: coverageDir
 				}
 			]


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Introduced Coveralls instead of CodeClimate. Closes #348.