### PR TITLE
JSDoc: Support extending typedefs

### DIFF
--- a/packages/jsdoc-plugins/lib/relation-fixer/buildrelations.js
+++ b/packages/jsdoc-plugins/lib/relation-fixer/buildrelations.js
@@ -38,7 +38,7 @@ function addRelationArrays( originalDoclets ) {
 	// Doclets for which we want to create relation arrays.
 	// We want classes, interfaces and mixins.
 	const subjectDoclets = docletCollection.getAll().filter( item => {
-		return item.kind === 'class' || item.kind === 'interface' || item.kind === 'mixin';
+		return item.kind === 'class' || item.kind === 'interface' || item.kind === 'mixin' || item.kind === 'typedef';
 	} );
 
 	subjectDoclets.forEach( d => {

--- a/packages/jsdoc-plugins/lib/relation-fixer/getmissingdocletsdata.js
+++ b/packages/jsdoc-plugins/lib/relation-fixer/getmissingdocletsdata.js
@@ -118,20 +118,35 @@ function getRelationProperty( allDoclets, childDoclet, memberDoclet, relation ) 
 
 	const memberDocletParent = allDoclets.find( d => d.longname === memberDoclet.memberof );
 
+	let isInherited = false;
+	let isMixed = false;
+
+	// If doclet is a child of a mixin, it's 'mixed'. Else if it's a child of another class, it's 'inhertied'.
 	if ( isNonEmptyArray( memberDocletParent.descendants ) ) {
 		for ( const longname of memberDocletParent.descendants ) {
 			const doclet = allDoclets.find( d => d.longname === longname );
 
-			if ( doclet && doclet.kind === 'class' ) {
+			if ( doclet && doclet.kind === 'mixin' ) {
 				if ( isNonEmptyArray( doclet.descendants ) &&
 					doclet.descendants.indexOf( childDoclet.longname ) !== -1 ) {
-					return 'inherited';
+					isMixed = true;
+				}
+			} else if ( doclet && doclet.kind === 'class' ) {
+				if ( isNonEmptyArray( doclet.descendants ) &&
+					doclet.descendants.indexOf( childDoclet.longname ) !== -1 ) {
+					isInherited = true;
 				}
 			}
 		}
 	}
 
-	return null;
+	if ( isMixed ) {
+		return 'mixed';
+	} else if ( isInherited ) {
+		return 'inherited';
+	} else {
+		return null;
+	}
 }
 
 function checkIfExplicitlyInherits( doclets ) {

--- a/packages/jsdoc-plugins/tests/relation-fixer/relationfixerintegration.js
+++ b/packages/jsdoc-plugins/tests/relation-fixer/relationfixerintegration.js
@@ -74,6 +74,50 @@ describe( 'JSDoc relation-fixer plugin', () => {
 				scope: 'static',
 				memberof: 'classB',
 				inheritdoc: ''
+			},
+			{
+				name: 'typedefA',
+				longname: 'typedefA',
+				kind: 'typedef',
+				properties: [
+					{
+						type: {
+							names: [
+								'String'
+							]
+						},
+						description: 'Some description',
+						name: 'modelElement'
+					},
+					{
+						type: {
+							names: [
+								'String'
+							]
+						},
+						description: 'Another description',
+						name: 'viewElement'
+					}
+				]
+			},
+			{
+				name: 'typedefB',
+				longname: 'typedefB',
+				kind: 'typedef',
+				augments: [
+					'typedefA'
+				],
+				properties: [
+					{
+						type: {
+							names: [
+								'String'
+							]
+						},
+						description: 'Some other description',
+						name: 'modelElement'
+					}
+				]
 			}
 		];
 	} );
@@ -87,7 +131,7 @@ describe( 'JSDoc relation-fixer plugin', () => {
 			scope: 'static',
 			memberof: 'classB',
 			description: 'Interface B prop description',
-			inherited: true
+			mixed: true
 		};
 
 		expect( newDoclets ).to.deep.include( expectedDoclet );
@@ -101,7 +145,8 @@ describe( 'JSDoc relation-fixer plugin', () => {
 			kind: 'member',
 			scope: 'static',
 			memberof: 'classA',
-			description: 'Interface B prop description'
+			description: 'Interface B prop description',
+			mixed: true
 		};
 
 		expect( newDoclets ).to.deep.include( expectedDoclet );
@@ -115,6 +160,47 @@ describe( 'JSDoc relation-fixer plugin', () => {
 			kind: 'event',
 			memberof: 'classB',
 			inherited: true
+		};
+
+		expect( newDoclets ).to.deep.include( expectedDoclet );
+	} );
+
+	it( 'should extend typedefs', () => {
+		const newDoclets = addMissingDoclets( buildRelations( testDoclets ) );
+		const expectedDoclet = {
+			name: 'typedefB',
+			longname: 'typedefB',
+			kind: 'typedef',
+			augments: [
+				'typedefA'
+			],
+			augmentsNested: [
+				'typedefA'
+			],
+			implementsNested: [],
+			mixesNested: [],
+			descendants: [],
+			properties: [
+				{
+					type: {
+						names: [
+							'String'
+						]
+					},
+					description: 'Some other description',
+					name: 'modelElement'
+				},
+				{
+					type: {
+						names: [
+							'String'
+						]
+					},
+					description: 'Another description',
+					name: 'viewElement',
+					inherited: true
+				}
+			]
 		};
 
 		expect( newDoclets ).to.deep.include( expectedDoclet );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: JSDoc: Support extending typedefs. Closes #355.