### PR TITLE
Change default output directory name for translations

### DIFF
--- a/packages/ckeditor5-dev-webpack-plugin/lib/index.js
+++ b/packages/ckeditor5-dev-webpack-plugin/lib/index.js
@@ -34,7 +34,7 @@ module.exports = class CKEditorWebpackPlugin {
 	 * @param {Array.<String>|'all'} [options.additionalLanguages] Additional languages. Build is optimized when this option is not set.
 	 * When `additionalLanguages` is set to 'all' then script will be looking for all languages and according translations during
 	 * the compilation.
-	 * @param {String} [options.outputDirectory='lang'] Output directory for the emitted translation files,
+	 * @param {String} [options.outputDirectory='translations'] Output directory for the emitted translation files,
 	 * should be relative to the webpack context.
 	 * @param {Boolean} [options.strict] Option that make the plugin throw when the error is found during the compilation.
 	 * @param {Boolean} [options.verbose] Option that make this plugin log all warnings into the console.
@@ -43,7 +43,7 @@ module.exports = class CKEditorWebpackPlugin {
 		this.options = {
 			language: options.language,
 			additionalLanguages: options.additionalLanguages,
-			outputDirectory: options.outputDirectory || 'lang',
+			outputDirectory: options.outputDirectory || 'translations',
 			strict: !!options.strict,
 			verbose: !!options.verbose
 		};
@@ -73,7 +73,7 @@ module.exports = class CKEditorWebpackPlugin {
 		}
 
 		if ( !additionalLanguages ) {
-			if ( this.options.outputDirectory && this.options.verbose ) {
+			if ( this.options.outputDirectory !== 'translations' && this.options.verbose ) {
 				console.warn( chalk.yellow(
 					'Warning: `outputDirectory` option does not work for one language. It will be ignored.'
 				) );

--- a/packages/ckeditor5-dev-webpack-plugin/tests/index.js
+++ b/packages/ckeditor5-dev-webpack-plugin/tests/index.js
@@ -59,7 +59,7 @@ describe( 'webpack-plugin/CKEditorWebpackPlugin', () => {
 
 			const ckeditorWebpackPlugin = new CKEditorWebpackPlugin( options );
 
-			expect( ckeditorWebpackPlugin.options.outputDirectory ).to.equal( 'lang' );
+			expect( ckeditorWebpackPlugin.options.outputDirectory ).to.equal( 'translations' );
 		} );
 
 		it( 'should use `outputDirectory` if passed', () => {
@@ -145,6 +145,8 @@ describe( 'webpack-plugin/CKEditorWebpackPlugin', () => {
 				'en',
 				{ compileAllLanguages: true, additionalLanguages: [] }
 			);
+
+			sinon.assert.notCalled( console.warn );
 		} );
 
 		it( 'should log a warning if `additionalLanguages` is not specified while `outputDirectory` is set', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Changed default output directory name for translations. Closes #354.

---

### Additional information

PRs / branches in other repositories:

https://github.com/ckeditor/ckeditor5-build-balloon/tree/t/ckeditor5-dev/354
https://github.com/ckeditor/ckeditor5-build-classic/tree/t/ckeditor5-dev/354
https://github.com/ckeditor/ckeditor5-build-inline/tree/t/ckeditor5-dev/354
https://github.com/ckeditor/ckeditor5/tree/t/ckeditor5-dev/354
