### PR TITLE
Fixed JSDoc relation-fixer plugin to not include interfaces in inheri…

### DIFF
--- a/packages/jsdoc-plugins/lib/relation-fixer/buildrelations.js
+++ b/packages/jsdoc-plugins/lib/relation-fixer/buildrelations.js
@@ -93,6 +93,11 @@ function getAncestors( docletCollection, currentDoclet, options ) {
 
 					// Push relation arrays of doclet's ancestors to current doclet resultRelations.
 					for ( const key of Object.keys( resultRelations ) ) {
+						// Only classes can be put in inheritance tree. See #361.
+						if ( key === 'augmentsNested' && ancestor.kind !== 'class' ) {
+							continue;
+						}
+
 						resultRelations[ key ].push( ...ancestorsResultRelations[ key ] );
 					}
 				} );

--- a/packages/jsdoc-plugins/tests/relation-fixer/buildrelations.js
+++ b/packages/jsdoc-plugins/tests/relation-fixer/buildrelations.js
@@ -13,6 +13,7 @@ const buildRelations = require( '../../lib/relation-fixer/buildrelations' );
 
 describe( 'JSDoc relation-fixer buildrelations module', () => {
 	let testDoclets;
+	let testDoclets2;
 
 	beforeEach( () => {
 		testDoclets = [
@@ -64,6 +65,34 @@ describe( 'JSDoc relation-fixer buildrelations module', () => {
 					'classA',
 					'classA'
 				]
+			}
+		];
+
+		testDoclets2 = [
+			{
+				name: 'interfaceA',
+				longname: 'interfaceA',
+				kind: 'interface'
+			},
+			{
+				name: 'interfaceB',
+				longname: 'interfaceB',
+				kind: 'interface',
+				augments: [ 'interfaceA' ]
+			},
+			{
+				name: 'classA',
+				longname: 'classA',
+				kind: 'class',
+				implements: [
+					'interfaceB'
+				]
+			},
+			{
+				name: 'classB',
+				longname: 'classB',
+				kind: 'class',
+				augments: [ 'classA' ]
 			}
 		];
 	} );
@@ -134,5 +163,12 @@ describe( 'JSDoc relation-fixer buildrelations module', () => {
 		expect( testedClass ).to.have.property( 'mixesNested' ).and.to.deep.equal( expectedMixesNested );
 		expect( testedClass ).to.have.property( 'augmentsNested' ).and.to.deep.equal( expectedAugmentsNested );
 		expect( testedInterface ).to.have.property( 'descendants' ).and.to.deep.equal( expectedDescendants );
+	} );
+
+	it( 'should not put non-classes to inheritance hierarchy', () => {
+		const newDoclets = buildRelations( testDoclets2 );
+		const testedDoclet = newDoclets.find( d => d.longname === 'classB' );
+
+		expect( testedDoclet ).to.have.property( 'augmentsNested' ).and.to.deep.equal( [ 'classA' ] );
 	} );
 } );


### PR DESCRIPTION
…tance hierarchy

### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Fixed JSDoc relation-fixer plugin to not include interfaces in inheritance hierarchy. Closes #361.