### PR TITLE
Fix inheritance in event doclets for observables

### DIFF
--- a/packages/jsdoc-plugins/lib/observable-event-provider/addmissingeventdocletsforobservables.js
+++ b/packages/jsdoc-plugins/lib/observable-event-provider/addmissingeventdocletsforobservables.js
@@ -61,7 +61,7 @@ function createMissingEventDoclets( doclets ) {
 				originalProperty.type.names :
 				[ '*' ];
 
-			return {
+			const eventDoclet = {
 				comment: '',
 				meta: cloneDeep( originalProperty.meta ),
 				description: `<p>Fired when the <code>${ originalProperty.name }</code> property changed value.<p>`,
@@ -104,8 +104,20 @@ function createMissingEventDoclets( doclets ) {
 				memberof: originalProperty.memberof,
 				longname: observableEvent.name,
 				scope: 'instance',
-				access: originalProperty.access ? originalProperty.access : 'public'
+				access: originalProperty.access ? originalProperty.access : 'public',
+				inherited: originalProperty.inherited,
+				mixed: originalProperty.mixed
 			};
+
+			if ( originalProperty.inherited ) {
+				eventDoclet.inherited = true;
+			}
+
+			if ( originalProperty.mixed ) {
+				eventDoclet.mixed = true;
+			}
+
+			return eventDoclet;
 		} );
 }
 

--- a/packages/jsdoc-plugins/lib/observable-event-provider/addmissingeventdocletsforobservables.js
+++ b/packages/jsdoc-plugins/lib/observable-event-provider/addmissingeventdocletsforobservables.js
@@ -104,9 +104,7 @@ function createMissingEventDoclets( doclets ) {
 				memberof: originalProperty.memberof,
 				longname: observableEvent.name,
 				scope: 'instance',
-				access: originalProperty.access ? originalProperty.access : 'public',
-				inherited: originalProperty.inherited,
-				mixed: originalProperty.mixed
+				access: originalProperty.access ? originalProperty.access : 'public'
 			};
 
 			if ( originalProperty.inherited ) {

--- a/packages/jsdoc-plugins/tests/observable-event-provider/addmissingeventdocletsforobservables.js
+++ b/packages/jsdoc-plugins/tests/observable-event-provider/addmissingeventdocletsforobservables.js
@@ -251,5 +251,37 @@ describe( 'jsdoc-plugins/observable-event-provider', () => {
 				access: 'public'
 			} );
 		} );
+
+		it( 'should mark new event doclet as inherited if the observable property inherited from other class', () => {
+			const inputDoclets = [ {
+				comment: '...',
+				meta: {
+					range: [
+						1861,
+						2061
+					],
+					filename: 'command.js',
+					lineno: 56,
+					path: '/workspace/ckeditor5/packages/ckeditor5-core/src',
+					code: {}
+				},
+				description: '<p>Flag indicating whether a command is enabled or disabled.</p>',
+				observable: true,
+				readonly: true,
+				kind: 'member',
+				name: 'isEnabled',
+				longname: 'module:core/command~Command#isEnabled',
+				scope: 'instance',
+				memberof: 'module:core/command~Command',
+				inherited: true,
+				mixed: true
+			} ];
+
+			const outputDoclets = addMissingEventDocletsForObservables( inputDoclets );
+
+			expect( outputDoclets.length ).to.equal( 2 );
+			expect( outputDoclets[ 1 ].inherited ).to.be.true;
+			expect( outputDoclets[ 1 ].mixed ).to.be.true;
+		} );
 	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Fixed inheritance in event doclets for observables. Closes #368.