### PR TITLE
t/369: Implemented a responsive manual test layout with a 'back' button

### DIFF
--- a/packages/ckeditor5-dev-tests/lib/utils/manual-tests/compilehtmlfiles.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/manual-tests/compilehtmlfiles.js
@@ -73,7 +73,11 @@ function compileHtmlFile( buildDir, sourceFilePathBase, viewTemplate ) {
 
 	// Compile test instruction (Markdown file).
 	const parsedMarkdownTree = reader.parse( fs.readFileSync( sourceMDFilePath, 'utf-8' ) );
-	const manualTestInstruction = '<div class="manual-test-sidebar">' + writer.render( parsedMarkdownTree ) + '</div>';
+	const manualTestInstruction =
+		'<div class="manual-test-sidebar">' +
+			'<a href="/" class="manual-test-root-link">&larr; Back to the list</a>' +
+			writer.render( parsedMarkdownTree ) +
+		'</div>';
 
 	// Load test view (HTML file).
 	const htmlView = fs.readFileSync( sourceHtmlFilePath, 'utf-8' );

--- a/packages/ckeditor5-dev-tests/lib/utils/manual-tests/template.html
+++ b/packages/ckeditor5-dev-tests/lib/utils/manual-tests/template.html
@@ -5,20 +5,72 @@
 	<title>Manual Test</title>
 	<style>
 		.manual-test-container {
-			 padding-left: 425px;
+			padding: 30px;
+			padding-left: 420px;
 		}
 
 		.manual-test-sidebar {
+			font-family: sans-serif;
+			font-size: 14px;
+
+			box-sizing: border-box;
 			position: fixed;
-			left: 0;
 			top: 0;
+			left: 0;
 			bottom: 0;
-			width: 375px;
+			width: 390px;
 			background-color: #f7f7f7;
 			border-right: 1px solid #bfbfbf;
 			color: #333;
 			padding: 15px;
-			overflow: scroll;
+			overflow-x: hidden;
+			overflow-y: auto;
+			z-index: 9999;
+			box-shadow: 0 0 8px rgba(0,0,0,.15);
+		}
+
+		.manual-test-sidebar h1 {
+			font-size: 22px;
+		}
+
+		.manual-test-sidebar h2 {
+			font-size: 18px;
+		}
+
+		.manual-test-sidebar h3 {
+			font-size: 16px;
+		}
+
+		.manual-test-sidebar h4 {
+			font-size: 14px;
+		}
+
+		.manual-test-root-link {
+			display: inline-block;
+			padding: 8px 0;
+			text-align: center;
+			border-radius: 2px;
+			line-height: 15px;
+			text-decoration: none;
+		}
+
+		.manual-test-root-link:hover {
+			text-decoration: underline;
+		}
+
+		@media only screen and (max-width: 920px)  {
+			.manual-test-container {
+				padding-left: 45px;
+			}
+
+			.manual-test-sidebar {
+				left: -375px;
+				transition: .15s;
+			}
+
+			.manual-test-sidebar:hover {
+				left: 0;
+			}
 		}
 	</style>
 </head>

--- a/packages/ckeditor5-dev-tests/tests/utils/manual-tests/compilehtmlfiles.js
+++ b/packages/ckeditor5-dev-tests/tests/utils/manual-tests/compilehtmlfiles.js
@@ -132,7 +132,7 @@ describe( 'compileHtmlFiles', () => {
 			stubs.fs.outputFileSync,
 			path.join( 'buildDir', 'path', 'to', 'manual', 'file.html' ), [
 				'<div>template html content</div>',
-				'<div class="manual-test-sidebar"><h2>Markdown header</h2></div>',
+				'<div class="manual-test-sidebar"><a href="/" class="manual-test-root-link">&larr; Back to the list</a><h2>Markdown header</h2></div>',
 				'<div>html file content</div>',
 				`<body class="manual-test-container"><script src="${ path.sep + path.join( 'path', 'to', 'manual', 'file.js' ) }"></script></body>`
 			].join( '\n' )
@@ -165,7 +165,7 @@ describe( 'compileHtmlFiles', () => {
 			stubs.fs.outputFileSync,
 			path.join( 'buildDir', 'path', 'to', 'manual', 'file.abc.html' ), [
 				'<div>template html content</div>',
-				'<div class="manual-test-sidebar"><h2>Markdown header</h2></div>',
+				'<div class="manual-test-sidebar"><a href="/" class="manual-test-root-link">&larr; Back to the list</a><h2>Markdown header</h2></div>',
 				'<div>html file content</div>',
 				`<body class="manual-test-container"><script src="${ path.sep + path.join( 'path', 'to', 'manual', 'file.abc.js' ) }"></script></body>`
 			].join( '\n' )
@@ -253,7 +253,7 @@ describe( 'compileHtmlFiles', () => {
 			stubs.fs.outputFileSync,
 			path.join( 'buildDir', 'path', 'to', 'manual', 'file.html' ), [
 				'<div>template html content</div>',
-				'<div class="manual-test-sidebar"><h2>Markdown header</h2></div>',
+				'<div class="manual-test-sidebar"><a href="/" class="manual-test-root-link">&larr; Back to the list</a><h2>Markdown header</h2></div>',
 				'<div>html file content</div>',
 				`<body class="manual-test-container"><script src="${ path.sep +
 				path.join( 'path', 'to', 'manual', 'file.js' ) }"></script></body>`
@@ -293,7 +293,7 @@ describe( 'compileHtmlFiles', () => {
 			stubs.fs.outputFileSync,
 			path.join( 'buildDir', 'path', 'to', 'manual', 'file.html' ), [
 				'<div>template html content</div>',
-				'<div class="manual-test-sidebar"><h2>Markdown header</h2></div>',
+				'<div class="manual-test-sidebar"><a href="/" class="manual-test-root-link">&larr; Back to the list</a><h2>Markdown header</h2></div>',
 				'<div>html file content</div>',
 				`<body class="manual-test-container"><script src="/${ path.join( 'path', 'to', 'manual', 'file.js' ) }"></script></body>`
 			].join( '\n' )


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Implemented a responsive manual test layout with a 'back' button. Improved readability of the sidebar. Closes #369.
