### PR TITLE
Upgrade webpack plugin and testing environment for webpack v4 

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "devDependencies": {
     "@ckeditor/ckeditor5-dev-env": "^10.0.0",
-    "chalk": "^2.1.0",
+    "chalk": "^2.4.1",
     "eslint": "^4.15.0",
     "eslint-config-ckeditor5": "^1.0.8",
     "husky": "^0.14.3",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     ]
   },
   "eslintIgnore": [
-    "coverage/**"
+	"coverage/**",
+	"packages/*/node_modules/**"
   ],
   "version": "0.0.67"
 }

--- a/packages/ckeditor5-dev-env/package.json
+++ b/packages/ckeditor5-dev-env/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "@ckeditor/ckeditor5-dev-utils": "^9.0.1",
     "@octokit/rest": "^14.0.0",
-    "chalk": "^2.1.0",
+    "chalk": "^2.4.1",
     "compare-func": "^1.3.2",
     "concat-stream": "^1.6.0",
     "conventional-changelog": "^1.1.3",

--- a/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getwebpackconfig.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getwebpackconfig.js
@@ -15,6 +15,8 @@ const { getPostCssConfig } = require( '@ckeditor/ckeditor5-dev-utils' ).styles;
  */
 module.exports = function getWebpackConfigForAutomatedTests( options ) {
 	const config = {
+		mode: 'development',
+
 		module: {
 			rules: [
 				{

--- a/packages/ckeditor5-dev-tests/lib/utils/manual-tests/getwebpackconfig.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/manual-tests/getwebpackconfig.js
@@ -16,6 +16,8 @@ const { getPostCssConfig } = require( '@ckeditor/ckeditor5-dev-utils' ).styles;
  */
 module.exports = function getWebpackConfigForManualTests( entryObject, buildDir, themePath ) {
 	return {
+		mode: 'development',
+
 		// Use cheap source maps because Safari had problem with ES6 + inline source maps.
 		// We could use cheap source maps every where but karma-webpack doesn't support it:
 		// https://github.com/webpack/karma-webpack/pull/76

--- a/packages/ckeditor5-dev-tests/package.json
+++ b/packages/ckeditor5-dev-tests/package.json
@@ -36,11 +36,11 @@
     "mkdirp": "^0.5.1",
     "mocha": "^5.0.5",
     "mockery": "^2.1.0",
-    "postcss-loader": "^2.0.10",
+    "postcss-loader": "^2.1.1",
     "raw-loader": "^0.5.1",
     "sinon": "^4.0.0",
     "style-loader": "^0.20.3",
-    "webpack": "^3.11.0"
+    "webpack": "^4.1.0"
   },
   "devDependencies": {
     "mockery": "^2.1.0"

--- a/packages/ckeditor5-dev-tests/package.json
+++ b/packages/ckeditor5-dev-tests/package.json
@@ -40,7 +40,7 @@
     "raw-loader": "^0.5.1",
     "sinon": "^4.0.0",
     "style-loader": "^0.20.3",
-    "webpack": "^4.1.0"
+    "webpack": "^4.2.0"
   },
   "devDependencies": {
     "mockery": "^2.1.0"

--- a/packages/ckeditor5-dev-tests/package.json
+++ b/packages/ckeditor5-dev-tests/package.json
@@ -29,7 +29,7 @@
     "karma-mocha-reporter": "^2.2.4",
     "karma-sinon": "^1.0.5",
     "karma-sourcemap-loader": "^0.3.7",
-    "karma-webpack": "^2.0.13",
+    "karma-webpack": "^3.0.0",
     "lodash": "^4.17.4",
     "mgit2": "^0.8.0",
     "minimist": "^1.2.0",
@@ -39,7 +39,7 @@
     "postcss-loader": "^2.1.1",
     "raw-loader": "^0.5.1",
     "sinon": "^4.0.0",
-    "style-loader": "^0.20.3",
+    "style-loader": "^0.21.0",
     "webpack": "^4.2.0"
   },
   "devDependencies": {

--- a/packages/ckeditor5-dev-tests/tests/utils/automated-tests/getwebpackconfig.js
+++ b/packages/ckeditor5-dev-tests/tests/utils/automated-tests/getwebpackconfig.js
@@ -26,10 +26,6 @@ describe( 'getWebpackConfigForAutomatedTests()', () => {
 			}
 		} );
 
-		mockery.registerMock( 'CKEditorWebpackPlugin', function CKEditorWebpackPlugin( options ) {
-			this.options = options;
-		} );
-
 		getWebpackConfigForAutomatedTests = require( '../../../lib/utils/automated-tests/getwebpackconfig' );
 	} );
 

--- a/packages/ckeditor5-dev-utils/lib/bundler/getlicensebanner.js
+++ b/packages/ckeditor5-dev-utils/lib/bundler/getlicensebanner.js
@@ -10,10 +10,10 @@ module.exports = function getLicenseBanner() {
 
 	/* eslint-disable indent */
 	return (
-`/*--------------------------------------------------------------------------------------*
- * @license Copyright (c) 2003-${ date.getFullYear() }, CKSource - Frederico Knabben. All rights reserved. *
- * For licensing, see LICENSE.md.                                                       *
- *--------------------------------------------------------------------------------------*/`
+`/*!
+ * @license Copyright (c) 2003-${ date.getFullYear() }, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */`
 	);
 	/* eslint-enable indent */
 };

--- a/packages/ckeditor5-dev-utils/lib/bundler/getlicensebanner.js
+++ b/packages/ckeditor5-dev-utils/lib/bundler/getlicensebanner.js
@@ -10,10 +10,10 @@ module.exports = function getLicenseBanner() {
 
 	/* eslint-disable indent */
 	return (
-`/*!
- * @license Copyright (c) 2003-${ date.getFullYear() }, CKSource - Frederico Knabben. All rights reserved.
- * For licensing, see LICENSE.md.
- */`
+`/*--------------------------------------------------------------------------------------*
+ * @license Copyright (c) 2003-${ date.getFullYear() }, CKSource - Frederico Knabben. All rights reserved. *
+ * For licensing, see LICENSE.md.                                                       *
+ *--------------------------------------------------------------------------------------*/`
 	);
 	/* eslint-enable indent */
 };

--- a/packages/ckeditor5-dev-utils/lib/bundler/getlicensebanner.js
+++ b/packages/ckeditor5-dev-utils/lib/bundler/getlicensebanner.js
@@ -10,7 +10,7 @@ module.exports = function getLicenseBanner() {
 
 	/* eslint-disable indent */
 	return (
-`/**
+`/*!
  * @license Copyright (c) 2003-${ date.getFullYear() }, CKSource - Frederico Knabben. All rights reserved.
  * For licensing, see LICENSE.md.
  */`

--- a/packages/ckeditor5-dev-utils/lib/bundler/getlicensebanner.js
+++ b/packages/ckeditor5-dev-utils/lib/bundler/getlicensebanner.js
@@ -8,6 +8,10 @@
 module.exports = function getLicenseBanner() {
 	const date = new Date();
 
+	// License banner starts with `!`. That combines with uglifyjs' `comments` /^!/ option
+	// make webpack preserve that banner while cleaning code from others comments during the build task.
+	// It's because UglifyJsWebpackPlugin minification takes place after adding a banner.
+
 	/* eslint-disable indent */
 	return (
 `/*!

--- a/packages/ckeditor5-dev-utils/tests/bundler/getlicensebanner.js
+++ b/packages/ckeditor5-dev-utils/tests/bundler/getlicensebanner.js
@@ -10,6 +10,6 @@ const getLicenseBanner = require( '../../lib/bundler/getlicensebanner' );
 
 describe( 'bundler', () => {
 	describe( 'getLicenseBanner()', () => {
-		expect( getLicenseBanner() ).to.match( /\/\*[\S\s]+\*\//g );
+		expect( getLicenseBanner() ).to.match( /\/\*![\S\s]+\*\//g );
 	} );
 } );

--- a/packages/ckeditor5-dev-utils/tests/bundler/getlicensebanner.js
+++ b/packages/ckeditor5-dev-utils/tests/bundler/getlicensebanner.js
@@ -10,6 +10,6 @@ const getLicenseBanner = require( '../../lib/bundler/getlicensebanner' );
 
 describe( 'bundler', () => {
 	describe( 'getLicenseBanner()', () => {
-		expect( getLicenseBanner() ).to.match( /\/\*\*[\S\s]+\*\//g );
+		expect( getLicenseBanner() ).to.match( /\/\*[\S\s]+\*\//g );
 	} );
 } );

--- a/packages/ckeditor5-dev-webpack-plugin/lib/ckeditor5-env-utils.js
+++ b/packages/ckeditor5-dev-webpack-plugin/lib/ckeditor5-env-utils.js
@@ -15,7 +15,8 @@ const CKEditor5PackageSrcFileRegExp = /[/\\]ckeditor5-[^/\\]+[/\\]src[/\\].+\.js
  * Easily replaceable and testable set of CKEditor5 - related methods used by CKEditorWebpackPlugin internally.
  */
 module.exports = {
-	getCorePackage,
+	getCorePackageSampleResource,
+	getCorePackagePath,
 	getPathToPackage,
 	getLoaders
 };
@@ -27,14 +28,24 @@ module.exports = {
  * @param {Object} resolver Webpack resolver that can resolve the resource's request.
  * @returns {Promise<String>}
  */
-function getCorePackage( cwd, resolver ) {
-	return new Promise( res => {
-		resolver.resolve( cwd, cwd, '@ckeditor/ckeditor5-core/src/editor/editor.js', ( err, result ) => {
-			const pathToCoreTranslationPackage = result.match( CKEditor5CoreRegExp )[ 0 ];
 
-			res( pathToCoreTranslationPackage );
-		} );
-	} );
+/**
+ * Returns sample resource in CKEditor5-core.
+ *
+ * @returns {String}
+ */
+function getCorePackageSampleResource() {
+	return '@ckeditor/ckeditor5-core/src/editor/editor.js';
+}
+
+/**
+ * Returns path to the core package.
+ *
+ * @param {String} resource Sample resource.
+ * @returns {String}
+ */
+function getCorePackagePath( resource ) {
+	return resource.match( CKEditor5CoreRegExp )[ 0 ];
 }
 
 /**

--- a/packages/ckeditor5-dev-webpack-plugin/lib/ckeditor5-env-utils.js
+++ b/packages/ckeditor5-dev-webpack-plugin/lib/ckeditor5-env-utils.js
@@ -64,14 +64,18 @@ function getPathToPackage( cwd, resource ) {
  * @param {String} cwd Current working directory.
  * @param {String} resource Absolute path to the resource.
  * @param {Array.<String|Object>} loaders Array of Webpack loaders.
+ * @param {Object} options Options for the new loader.
  * @returns {Array.<String|Object>}
  */
-function getLoaders( cwd, resource, loaders ) {
+function getLoaders( cwd, resource, loaders, options ) {
 	const relativePathToResource = path.relative( cwd, resource );
 
 	if ( relativePathToResource.match( CKEditor5PackageSrcFileRegExp ) ) {
 		return [
-			path.join( __dirname, 'translatesourceloader.js' ),
+			{
+				loader: path.join( __dirname, 'translatesourceloader.js' ),
+				options
+			},
 			...loaders
 		];
 	}

--- a/packages/ckeditor5-dev-webpack-plugin/lib/servetranslations.js
+++ b/packages/ckeditor5-dev-webpack-plugin/lib/servetranslations.js
@@ -82,39 +82,38 @@ module.exports = function serveTranslations( compiler, options, translationServi
 				translationService.loadPackage( pathToPackage );
 			}
 		} );
-	} );
 
-	// At the end of the compilation add assets generated from the PO files.
-	// Use `optimize-chunk-assets` instead of `emit` to emit assets before the `webpack.BannerPlugin`.
-	compiler.hooks.emit.tap( 'CKEditor5Plugin', compilation => {
-		compilation.plugin( 'optimize-chunk-assets', ( chunks, done ) => {
-			const generatedAssets = translationService.getAssets( {
-				outputDirectory: options.outputDirectory,
-				compilationAssets: compilation.assets
-			} );
+		// At the end of the compilation add assets generated from the PO files.
+		// Use `optimize-chunk-assets` instead of `emit` to emit assets before the `webpack.BannerPlugin`.
+		compilation.hooks.optimizeChunks.tap( 'CKEditor5Plugin', chunks => {
+			compiler.hooks.emit.tap( 'CKEditor5Plugin', () => {
+				const generatedAssets = translationService.getAssets( {
+					outputDirectory: options.outputDirectory,
+					compilationAssets: compilation.assets
+				} );
 
-			const allFiles = chunks.reduce( ( acc, chunk ) => [ ...acc, ...chunk.files ], [] );
+				const allFiles = chunks.reduce( ( acc, chunk ) => [ ...acc, ...chunk.files ], [] );
 
-			for ( const asset of generatedAssets ) {
-				if ( asset.shouldConcat ) {
-					// We need to concat sources here to support source maps for CKE5 code.
-					const originalAsset = compilation.assets[ asset.outputPath ];
-					compilation.assets[ asset.outputPath ] = new ConcatSource( asset.outputBody, '\n', originalAsset );
-				} else {
-					const chunkExists = allFiles.includes( asset.outputPath );
+				for ( const asset of generatedAssets ) {
+					if ( asset.shouldConcat ) {
+						// We need to concat sources here to support source maps for CKE5 code.
+						const originalAsset = compilation.assets[ asset.outputPath ];
 
-					if ( !chunkExists ) {
-						// RawSource is used when corresponding chunk does not exist.
-						compilation.assets[ asset.outputPath ] = new RawSource( asset.outputBody );
+						compilation.assets[ asset.outputPath ] = new ConcatSource( asset.outputBody, '\n', originalAsset );
 					} else {
-						// String is used when corresponding chunk exists and maintain proper sourcemaps.
-						// Changing to RawSource would drop source maps.
-						compilation.assets[ asset.outputPath ] = asset.outputBody;
+						const chunkExists = allFiles.includes( asset.outputPath );
+
+						if ( !chunkExists ) {
+							// RawSource is used when corresponding chunk does not exist.
+							compilation.assets[ asset.outputPath ] = new RawSource( asset.outputBody );
+						} else {
+							// String is used when corresponding chunk exists and maintain proper sourcemaps.
+							// Changing to RawSource would drop source maps.
+							compilation.assets[ asset.outputPath ] = asset.outputBody;
+						}
 					}
 				}
-			}
-
-			done();
+			} );
 		} );
 	} );
 

--- a/packages/ckeditor5-dev-webpack-plugin/lib/servetranslations.js
+++ b/packages/ckeditor5-dev-webpack-plugin/lib/servetranslations.js
@@ -29,8 +29,8 @@ const { RawSource, ConcatSource } = require( 'webpack-sources' );
 module.exports = function serveTranslations( compiler, options, translationService, envUtils ) {
 	const cwd = process.cwd();
 
-	// Provides translateSource method for the `translatesourceloader` loader.
-	compiler.options.translateSource = ( source, sourceFile ) => translationService.translateSource( source, sourceFile );
+	// Provides translateSource function for the `translatesourceloader` loader.
+	const translateSource = ( source, sourceFile ) => translationService.translateSource( source, sourceFile );
 
 	// Watch for warnings and errors during translation process.
 	translationService.on( 'error', emitError );
@@ -67,7 +67,7 @@ module.exports = function serveTranslations( compiler, options, translationServi
 	compiler.plugin( 'normal-module-factory', nmf => {
 		nmf.plugin( 'after-resolve', ( resolveOptions, done ) => {
 			const pathToPackage = envUtils.getPathToPackage( cwd, resolveOptions.resource );
-			resolveOptions.loaders = envUtils.getLoaders( cwd, resolveOptions.resource, resolveOptions.loaders );
+			resolveOptions.loaders = envUtils.getLoaders( cwd, resolveOptions.resource, resolveOptions.loaders, { translateSource } );
 
 			if ( pathToPackage ) {
 				translationService.loadPackage( pathToPackage );

--- a/packages/ckeditor5-dev-webpack-plugin/lib/translatesourceloader.js
+++ b/packages/ckeditor5-dev-webpack-plugin/lib/translatesourceloader.js
@@ -13,5 +13,5 @@
  * @returns {String}
  */
 module.exports = function translateSourceLoader( source ) {
-	return this.options.translateSource( source, this.resourcePath );
+	return this.query.translateSource( source, this.resourcePath );
 };

--- a/packages/ckeditor5-dev-webpack-plugin/package.json
+++ b/packages/ckeditor5-dev-webpack-plugin/package.json
@@ -8,6 +8,9 @@
     "@ckeditor/ckeditor5-dev-utils": "^9.0.1",
     "rimraf": "^2.6.2"
   },
+  "peerDependencies": {
+	  "webpack": "^4.0.0"
+  },
   "engines": {
     "node": ">=6.0.0",
     "npm": ">=3.0.0"

--- a/packages/ckeditor5-dev-webpack-plugin/package.json
+++ b/packages/ckeditor5-dev-webpack-plugin/package.json
@@ -8,7 +8,7 @@
     "@ckeditor/ckeditor5-dev-utils": "^9.0.1",
     "chalk": "^2.4.1",
     "rimraf": "^2.6.2",
-    "webpack-sources": "^1.0.0"
+    "webpack-sources": "^1.1.0"
   },
   "peerDependencies": {
 	"webpack": "^4.0.0"

--- a/packages/ckeditor5-dev-webpack-plugin/package.json
+++ b/packages/ckeditor5-dev-webpack-plugin/package.json
@@ -6,10 +6,12 @@
   "main": "lib/index.js",
   "dependencies": {
     "@ckeditor/ckeditor5-dev-utils": "^9.0.1",
-    "rimraf": "^2.6.2"
+    "chalk": "^2.4.1",
+    "rimraf": "^2.6.2",
+    "webpack-sources": "^1.0.0"
   },
   "peerDependencies": {
-	  "webpack": "^4.0.0"
+	"webpack": "^4.0.0"
   },
   "engines": {
     "node": ">=6.0.0",

--- a/packages/ckeditor5-dev-webpack-plugin/tests/translatesourceloader.js
+++ b/packages/ckeditor5-dev-webpack-plugin/tests/translatesourceloader.js
@@ -18,7 +18,7 @@ describe( 'webpack-plugin/translateSourceLoader()', () => {
 
 	it( 'should return translated code', () => {
 		const ctx = {
-			options: {
+			query: {
 				translateSource: sandbox.spy( () => 'output' )
 			},
 			resourcePath: 'file.js'
@@ -26,8 +26,8 @@ describe( 'webpack-plugin/translateSourceLoader()', () => {
 
 		const result = translateSourceLoader.call( ctx, 'Source' );
 
-		sinon.assert.calledOnce( ctx.options.translateSource );
-		sinon.assert.calledWithExactly( ctx.options.translateSource, 'Source', 'file.js' );
+		sinon.assert.calledOnce( ctx.query.translateSource );
+		sinon.assert.calledWithExactly( ctx.query.translateSource, 'Source', 'file.js' );
 
 		expect( result ).to.equal( 'output' );
 	} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Updated `CKEditorWebpackPlugin` to support webpack@4. Updated webpack in testing tools. Closes #371.

---

### Additional information

Changes in other repos:
* https://github.com/ckeditor/ckeditor5/tree/t/ckeditor5-dev/371 (https://github.com/ckeditor/ckeditor5/pull/1118)
* https://github.com/ckeditor/ckeditor5-build-classic/tree/t/ckeditor5-dev/371
* https://github.com/ckeditor/ckeditor5-build-inline/tree/t/ckeditor5-dev/371
* https://github.com/ckeditor/ckeditor5-build-balloon/tree/t/ckeditor5-dev/371
* https://github.com/ckeditor/ckeditor5-build-decoupled-document/tree/t/ckeditor5-dev/371

BREAKING CHANGE: Breaks compatibility with webpack v3.
