### PR TITLE
Issue #381 resolution (ckeditor5-build-classic issue #41)

### DIFF
--- a/packages/ckeditor5-dev-utils/lib/styles/themeimporter.js
+++ b/packages/ckeditor5-dev-utils/lib/styles/themeimporter.js
@@ -188,7 +188,7 @@ function getThemeFilePath( themePath, inputFilePath ) {
 // @param {String} inputFilePath A path to the file.
 // @returns {String} The name of the package.
 function getPackageName( inputFilePath ) {
-	const match = inputFilePath.match( /ckeditor5-[^\\/]+/ );
+	const match = inputFilePath.match( /ckeditor5-[^\\/]+/ig );
 
 	if ( match ) {
 		return match.pop();


### PR DESCRIPTION
Added ig to get the last match instead of the first match.  This will allow the project to start with ckeditor5- and still work properly.

### Suggested merge commit message (patch)

Type: Message. Closes #381.

---

### Additional information

Encountered the problem originally while trying to build the ckeditor5-build-classic.  I traced it down to not importing the themes.  This was due to the repository folder on my computer matching the search params for the theme.

After tracing the issue, I was able to determine it was a bug in the themeimporter.js.  It was doing a name match on "ckeditor5-" in the getPackageName method.

The match line was:
`const match = inputFilePath.match( /ckeditor5-[^\\/]+/ );`

I changed it to:
`const match = inputFilePath.match( /ckeditor5-[^\\/]+/ig );`

This ensures I'm getting the last ckeditor5- match, which is the package name.  The way the method was written (returning `match.pop()`) makes me believe the intended result was to return the last match.  Adding ig ensures the search returns all matches and makes `match.pop()` return the last match, which is the package name.
