### PR TITLE
Manual test server will work properly if cwd does not ends with "ckeditor5"

### DIFF
--- a/packages/ckeditor5-dev-tests/bin/test-manual.js
+++ b/packages/ckeditor5-dev-tests/bin/test-manual.js
@@ -15,9 +15,12 @@ const cwd = process.cwd();
 const options = tests.parseArguments( process.argv.slice( 2 ) );
 
 if ( options.files.length === 0 ) {
-	if ( cwd.endsWith( 'ckeditor5' ) ) {
+	// Checks whether the test command was called from the main repository.
+	// If so then take all packages files to tests.
+	if ( require( path.join( cwd, 'package.json' ) ).name === 'ckeditor5' ) {
 		options.files = [ '*' ];
 	} else {
+	// In other case take files from the current package.
 		options.files = [ '/' ];
 	}
 }

--- a/packages/ckeditor5-dev-tests/lib/tasks/runmanualtests.js
+++ b/packages/ckeditor5-dev-tests/lib/tasks/runmanualtests.js
@@ -23,7 +23,7 @@ const transformFileOptionToTestGlob = require( '../utils/transformfileoptiontote
  */
 module.exports = function runManualTests( options ) {
 	const buildDir = path.join( process.cwd(), 'build', '.manual-tests' );
-	const files = ( options.files && options.files.length ) ? options.files : [ '*' ];
+	const files = normalizeFiles( options.files );
 	const manualTestFilesPattern = files.map( file => transformFileOptionToTestGlob( file, true ) );
 
 	return Promise.resolve()
@@ -34,3 +34,18 @@ module.exports = function runManualTests( options ) {
 		] ) )
 		.then( () => createManualTestServer( buildDir ) );
 };
+
+function normalizeFiles( files ) {
+	if ( !files || !files.length ) {
+		return [ '*' ];
+	}
+
+	// '/' means tests from current package will be compiled. The main repository
+	// does not contain any test so it doesn't make sense to have '/' here.
+	// Using '*' allows compiling all packages tests'.
+	if ( files.length === 1 && files[ 0 ] === '/' ) {
+		return [ '*' ];
+	}
+
+	return files;
+}

--- a/packages/ckeditor5-dev-tests/lib/tasks/runmanualtests.js
+++ b/packages/ckeditor5-dev-tests/lib/tasks/runmanualtests.js
@@ -23,7 +23,7 @@ const transformFileOptionToTestGlob = require( '../utils/transformfileoptiontote
  */
 module.exports = function runManualTests( options ) {
 	const buildDir = path.join( process.cwd(), 'build', '.manual-tests' );
-	const files = normalizeFiles( options.files );
+	const files = ( options.files && options.files.length ) ? options.files : [ '*' ];
 	const manualTestFilesPattern = files.map( file => transformFileOptionToTestGlob( file, true ) );
 
 	return Promise.resolve()
@@ -34,18 +34,3 @@ module.exports = function runManualTests( options ) {
 		] ) )
 		.then( () => createManualTestServer( buildDir ) );
 };
-
-function normalizeFiles( files ) {
-	if ( !files || !files.length ) {
-		return [ '*' ];
-	}
-
-	// '/' means tests from current package will be compiled. The main repository
-	// does not contain any test so it doesn't make sense to have '/' here.
-	// Using '*' allows compiling all packages tests'.
-	if ( files.length === 1 && files[ 0 ] === '/' ) {
-		return [ '*' ];
-	}
-
-	return files;
-}

--- a/packages/ckeditor5-dev-tests/lib/utils/getrelativefilepath.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/getrelativefilepath.js
@@ -3,15 +3,18 @@
  * For licensing, see LICENSE.md.
  */
 
-/* jshint node: true, strict: true */
-
 'use strict';
 
-// Get a path to a source file which will uniquely identify this file in
-// a build directory, once all package are gathered together.
-//
-// In order to do that, everything up to `ckeditor-*/` is removed:
-// /work/space/ckeditor5-foo/tests/manual/foo.js -> ckeditor5-foo/tests/manual/foo.js
+/**
+ * Get a path to a source file which will uniquely identify this file in
+ * a build directory, once all packages are gathered together.
+ *
+ * In order to do that, everything up to `ckeditor5-packageName` is removed:
+ * /work/space/ckeditor5-foo/tests/manual/foo.js -> ckeditor5-foo/tests/manual/foo.js
+ *
+ * @param {String} filePath
+ * @returns {String}
+ */
 module.exports = function getRelativeFilePath( filePath ) {
 	return filePath.replace( /^.+[/\\]ckeditor5-/, 'ckeditor5-' );
 };

--- a/packages/ckeditor5-dev-tests/lib/utils/getrelativefilepath.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/getrelativefilepath.js
@@ -7,14 +7,11 @@
 
 'use strict';
 
-const path = require( 'path' );
-const escapedPathSep = path.sep == '/' ? '/' : '\\\\';
-
 // Get a path to a source file which will uniquely identify this file in
 // a build directory, once all package are gathered together.
 //
 // In order to do that, everything up to `ckeditor-*/` is removed:
 // /work/space/ckeditor5-foo/tests/manual/foo.js -> ckeditor5-foo/tests/manual/foo.js
 module.exports = function getRelativeFilePath( filePath ) {
-	return filePath.replace( new RegExp( '^.+?' + escapedPathSep + 'ckeditor5-' ), 'ckeditor5-' );
+	return filePath.replace( /^.+[/\\]ckeditor5-/, 'ckeditor5-' );
 };

--- a/packages/ckeditor5-dev-tests/lib/utils/manual-tests/createserver.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/manual-tests/createserver.js
@@ -12,9 +12,6 @@ const combine = require( 'dom-combiner' );
 const { logger } = require( '@ckeditor/ckeditor5-dev-utils' );
 const globSync = require( '../glob' );
 
-// TODO this bit repeats in 3 files.
-const escapedPathSep = path.sep == '/' ? '/' : '\\\\';
-
 /**
  * Basic HTTP server.
  *
@@ -117,8 +114,7 @@ function generateIndex( sourcePath ) {
 	const viewTemplate = fs.readFileSync( path.join( __dirname, 'template.html' ), 'utf-8' );
 	const listElements = globSync( path.join( sourcePath, '**', '*.html' ) )
 		.map( file => {
-			// TODO this bit repeates in runmanualtests.js
-			const relativeFilePath = file.replace( new RegExp( '^.+?' + escapedPathSep + 'ckeditor5-' ), 'ckeditor5-' );
+			const relativeFilePath = file.replace( sourcePath + path.sep, '' );
 
 			return `<li><a href="${ relativeFilePath }">${ relativeFilePath }</a></li>`;
 		} );

--- a/packages/ckeditor5-dev-tests/tests/utils/getrelativefilepath.js
+++ b/packages/ckeditor5-dev-tests/tests/utils/getrelativefilepath.js
@@ -1,0 +1,82 @@
+/**
+ * @license Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+'use strict';
+
+const { expect } = require( 'chai' );
+
+describe( 'dev-tests/utils', () => {
+	let getRelativeFilePath;
+
+	beforeEach( () => {
+		getRelativeFilePath = require( '../../lib/utils/getrelativefilepath' );
+	} );
+
+	describe( 'getRelativeFilePath()', () => {
+		describe( 'Unix paths', () => {
+			it( 'returns path which starts with package name (simple check)', () => {
+				checkPath( '/work/space/ckeditor5-foo/tests/manual/foo.js', 'ckeditor5-foo/tests/manual/foo.js' );
+			} );
+
+			it( 'returns path which starts with package name (workspace directory looks like package name)', () => {
+				checkPath(
+					'/Users/foo/ckeditor5-workspace/ckeditor5/packages/ckeditor5-foo/tests/manual/foo.js',
+					'ckeditor5-foo/tests/manual/foo.js'
+				);
+			} );
+
+			it( 'returns path which starts with package name (nested dependencies)', () => {
+				checkPath(
+					'/home/foo/ckeditor5/packages/ckeditor5-build-classic/node_modules/@ckeditor/ckeditor5-foo/tests/manual/foo.js',
+					'ckeditor5-foo/tests/manual/foo.js'
+				);
+			} );
+
+			it( 'returns path which starts with package name (combined workspace looks like package and nested dependencies)', () => {
+				/* eslint-disable max-len */
+				checkPath(
+					'/Users/foo/ckeditor5-workspace/ckeditor5/ckeditor5-build-classic/node_modules/@ckeditor/ckeditor5-foo/tests/manual/foo.js',
+					'ckeditor5-foo/tests/manual/foo.js'
+				);
+				/* eslint-enable max-len */
+			} );
+		} );
+
+		describe( 'Windows paths', () => {
+			it( 'returns path which starts with package name (simple check)', () => {
+				checkPath( 'C:\\work\\space\\ckeditor5-foo\\tests\\manual\\foo.js', 'ckeditor5-foo\\tests\\manual\\foo.js' );
+			} );
+
+			it( 'returns path which starts with package name (workspace directory looks like package name)', () => {
+				checkPath(
+					'C:\\Document and settings\\foo\\ckeditor5-workspace\\ckeditor5\\packages\\ckeditor5-foo\\tests\\manual\\foo.js',
+					'ckeditor5-foo\\tests\\manual\\foo.js'
+				);
+			} );
+
+			it( 'returns path which starts with package name (nested dependencies)', () => {
+				/* eslint-disable max-len */
+				checkPath(
+					'C:\\Document and settings\\ckeditor5\\packages\\ckeditor5-build-classic\\node_modules\\@ckeditor\\ckeditor5-foo\\tests\\manual\\foo.js',
+					'ckeditor5-foo\\tests\\manual\\foo.js'
+				);
+				/* eslint-enable max-len */
+			} );
+
+			it( 'returns path which starts with package name (combined workspace looks like package and nested dependencies)', () => {
+				/* eslint-disable max-len */
+				checkPath(
+					'C:\\Users\\foo\\ckeditor5-workspace\\ckeditor5\\ckeditor5-build-classic\\node_modules\\@ckeditor\\ckeditor5-foo\\tests\\manual\\foo.js',
+					'ckeditor5-foo\\tests\\manual\\foo.js'
+				);
+				/* eslint-enable max-len */
+			} );
+		} );
+	} );
+
+	function checkPath( filePath, expectedPath ) {
+		expect( getRelativeFilePath( filePath ) ).to.equal( expectedPath );
+	}
+} );

--- a/packages/ckeditor5-dev-utils/lib/styles/themeimporter.js
+++ b/packages/ckeditor5-dev-utils/lib/styles/themeimporter.js
@@ -12,6 +12,7 @@ const path = require( 'path' );
 const postcss = require( 'postcss' );
 const chalk = require( 'chalk' );
 const log = require( '../logger' )();
+const getPackageName = require( './utils/getpackagename' );
 
 /**
  * A PostCSS plugin that loads a theme files from specified path.
@@ -172,29 +173,6 @@ function getThemeFilePath( themePath, inputFilePath ) {
 
 	// A corresponding theme file e.g. "/foo/bar/ckeditor5-theme-baz/theme/ckeditor5-qux/components/button.css".
 	return path.resolve( themePath, packageName, inputFileName );
-}
-
-// Returns a (CKEditor 5) package name the file belongs to.
-//
-// E.g., for the path to the file:
-//
-//		"/foo/ckeditor5/packages/ckeditor5-bar/baz.css"
-//
-// it outputs
-//
-//		"ckeditor5-bar"
-//
-// @private
-// @param {String} inputFilePath A path to the file.
-// @returns {String} The name of the package.
-function getPackageName( inputFilePath ) {
-	const match = inputFilePath.match( /ckeditor5-[^\\/]+/g );
-
-	if ( match ) {
-		return match.pop();
-	} else {
-		return null;
-	}
 }
 
 /**

--- a/packages/ckeditor5-dev-utils/lib/styles/themeimporter.js
+++ b/packages/ckeditor5-dev-utils/lib/styles/themeimporter.js
@@ -188,7 +188,7 @@ function getThemeFilePath( themePath, inputFilePath ) {
 // @param {String} inputFilePath A path to the file.
 // @returns {String} The name of the package.
 function getPackageName( inputFilePath ) {
-	const match = inputFilePath.match( /ckeditor5-[^\\/]+/ );
+	const match = inputFilePath.match( /ckeditor5-[^\\/]+/g );
 
 	if ( match ) {
 		return match.pop();

--- a/packages/ckeditor5-dev-utils/lib/styles/utils/getpackagename.js
+++ b/packages/ckeditor5-dev-utils/lib/styles/utils/getpackagename.js
@@ -1,0 +1,44 @@
+/**
+ * @license Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+'use strict';
+
+/* eslint-env node */
+
+/**
+ * Returns a (CKEditor 5) package name the file belongs to.
+ *
+ * E.g., for the path to the file:
+ *
+ *        "/foo/ckeditor5/packages/ckeditor5-bar/baz.css"
+ *
+ * it outputs
+ *
+ *        "ckeditor5-bar"
+ *
+ * It always returns the last found package. Sometimes the whole project can be located
+ * under path which starts with `ckeditor5-`. In this case it isn't a package and it doesn't make
+ * sense to return the directory name. See #381.
+ *
+ * E.g., for the path from the build directory to the file:
+ *
+ *        "/foo/ckeditor5/packages/ckeditor5-build-classic/node_modules/@ckeditor/ckeditor5-bar/baz.css"
+ *
+ * it outputs
+ *
+ *        "ckeditor5-bar"
+ *
+ * @param {String} inputFilePath A path to the file.
+ * @returns {String} The name of the package.
+ */
+module.exports = function getPackageName( inputFilePath ) {
+	const match = inputFilePath.match( /^.+[/\\](ckeditor5-[^/\\]+)/ );
+
+	if ( match ) {
+		return match.pop();
+	} else {
+		return null;
+	}
+};

--- a/packages/ckeditor5-dev-utils/tests/styles/utils/getpackagename.js
+++ b/packages/ckeditor5-dev-utils/tests/styles/utils/getpackagename.js
@@ -1,0 +1,82 @@
+/**
+ * @license Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+'use strict';
+
+const { expect } = require( 'chai' );
+
+describe( 'dev-tests/utils', () => {
+	let getPackageName;
+
+	beforeEach( () => {
+		getPackageName = require( '../../../lib/styles/utils/getpackagename' );
+	} );
+
+	describe( 'getPackageName()', () => {
+		describe( 'Unix paths', () => {
+			it( 'returns package name for path which starts with package name (simple check)', () => {
+				checkPackage( '/work/space/ckeditor5-foo/tests/manual/foo.js', 'ckeditor5-foo' );
+			} );
+
+			it( 'returns package name for path which starts with package name (workspace directory looks like package name)', () => {
+				checkPackage(
+					'/Users/foo/ckeditor5-workspace/ckeditor5/packages/ckeditor5-foo/tests/manual/foo.js',
+					'ckeditor5-foo'
+				);
+			} );
+
+			it( 'returns package name for path which starts with package name (nested dependencies)', () => {
+				checkPackage(
+					'/home/foo/ckeditor5/packages/ckeditor5-build-classic/node_modules/@ckeditor/ckeditor5-foo/tests/manual/foo.js',
+					'ckeditor5-foo'
+				);
+			} );
+
+			/* eslint-disable max-len */
+			it( 'returns package name for path which starts with package name (combined workspace looks like package and nested dependencies)', () => {
+				checkPackage(
+					'/Users/foo/ckeditor5-workspace/ckeditor5/ckeditor5-build-classic/node_modules/@ckeditor/ckeditor5-foo/tests/manual/foo.js',
+					'ckeditor5-foo'
+				);
+			} );
+			/* eslint-enable max-len */
+		} );
+
+		describe( 'Windows paths', () => {
+			it( 'returns package name for path which starts with package name (simple check)', () => {
+				checkPackage( 'C:\\work\\space\\ckeditor5-foo\\tests\\manual\\foo.js', 'ckeditor5-foo' );
+			} );
+
+			it( 'returns package name for path which starts with package name (workspace directory looks like package name)', () => {
+				checkPackage(
+					'C:\\Document and settings\\foo\\ckeditor5-workspace\\ckeditor5\\packages\\ckeditor5-foo\\tests\\manual\\foo.js',
+					'ckeditor5-foo'
+				);
+			} );
+
+			it( 'returns package name for path which starts with package name (nested dependencies)', () => {
+				/* eslint-disable max-len */
+				checkPackage(
+					'C:\\Document and settings\\ckeditor5\\packages\\ckeditor5-build-classic\\node_modules\\@ckeditor\\ckeditor5-foo\\tests\\manual\\foo.js',
+					'ckeditor5-foo'
+				);
+				/* eslint-enable max-len */
+			} );
+
+			/* eslint-disable max-len */
+			it( 'returns package name for path which starts with package name (combined workspace looks like package and nested dependencies)', () => {
+				checkPackage(
+					'C:\\Users\\foo\\ckeditor5-workspace\\ckeditor5\\ckeditor5-build-classic\\node_modules\\@ckeditor\\ckeditor5-foo\\tests\\manual\\foo.js',
+					'ckeditor5-foo'
+				);
+			} );
+			/* eslint-enable max-len */
+		} );
+	} );
+
+	function checkPackage( filePath, expectedPath ) {
+		expect( getPackageName( filePath ) ).to.equal( expectedPath );
+	}
+} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Manual tests server no longer depends on the directory name. It means that the whole project can be located under a path that doesn't have to ends with `ckeditor5`. Closes #351. Closes #381.