### PR TITLE
Fixed invalid logs in the release tool

### DIFF
--- a/packages/ckeditor5-dev-env/lib/release-tools/tasks/releasesubrepositories.js
+++ b/packages/ckeditor5-dev-env/lib/release-tools/tasks/releasesubrepositories.js
@@ -276,7 +276,8 @@ module.exports = function releaseSubRepositories( options ) {
 
 			return createGithubRelease( releaseOptions.token, githubReleaseOptions )
 				.then( () => {
-					const url = `https://github.com/${ repositoryInfo.owner }/${ repositoryInfo.name }/releases/tag/v${ options.version }`;
+					// eslint-disable-next-line max-len
+					const url = `https://github.com/${ repositoryInfo.owner }/${ repositoryInfo.name }/releases/tag/v${ releaseDetails.version }`;
 					log.info( `Created the release: ${ url }` );
 
 					return Promise.resolve();

--- a/packages/ckeditor5-dev-env/tests/release-tools/tasks/releasesubrepositories.js
+++ b/packages/ckeditor5-dev-env/tests/release-tools/tasks/releasesubrepositories.js
@@ -297,6 +297,14 @@ describe( 'dev-env/release-tools/tasks', function() {
 				.then( () => {
 					expect( executedCommand.length ).to.equal( 14 );
 					expect( stubs.createGithubRelease.callCount ).to.equal( 2 );
+					expect( stubs.logger.info.callCount ).to.equal( 12 );
+
+					expect( stubs.logger.info.getCall( 9 ).args[ 0 ] ).to.equal(
+						'Created the release: https://github.com/ckeditor/ckeditor5-test-alpha/releases/tag/v0.1.0'
+					);
+					expect( stubs.logger.info.getCall( 11 ).args[ 0 ] ).to.equal(
+						'Created the release: https://github.com/ckeditor/ckeditor5-test-beta/releases/tag/v0.2.1'
+					);
 
 					// Alpha
 					expect( executedCommand[ 0 ], 'Alpha diff' ).to.equal( 'git diff --name-only package.json' );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: An invalid parameter was passed to the logger and it caused that logs were displayed incorrectly. Closes #380.
