### PR TITLE
Remove babel loader rule from webpack's config when testing coverage

### DIFF
--- a/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getwebpackconfig.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getwebpackconfig.js
@@ -66,14 +66,6 @@ module.exports = function getWebpackConfigForAutomatedTests( options ) {
 		config.module.rules.push(
 			{
 				test: /\.js$/,
-				loader: 'babel-loader',
-				query: {
-					cacheDirectory: true,
-					plugins: [ require( 'babel-plugin-transform-es2015-modules-commonjs' ) ]
-				}
-			},
-			{
-				test: /\.js$/,
 				loader: 'istanbul-instrumenter-loader',
 				include: getPathsToIncludeForCoverage( options.files ),
 				exclude: [

--- a/packages/ckeditor5-dev-tests/tests/utils/automated-tests/getwebpackconfig.js
+++ b/packages/ckeditor5-dev-tests/tests/utils/automated-tests/getwebpackconfig.js
@@ -47,18 +47,11 @@ describe( 'getWebpackConfigForAutomatedTests()', () => {
 		expect( webpackConfig.devtool ).to.equal( undefined );
 	} );
 
-	it( 'should return webpack configutation with babel loader and istanbul loader', () => {
+	it( 'should return webpack configutation with istanbul loader', () => {
 		const webpackConfig = getWebpackConfigForAutomatedTests( {
 			coverage: true,
 			files: [ '**/*.js' ],
 		} );
-
-		const babelLoader = webpackConfig.module.rules
-			.find( rule => rule.loader === 'babel-loader' );
-
-		expect( babelLoader.query.plugins ).to.contain(
-			require( 'babel-plugin-transform-es2015-modules-commonjs' )
-		);
 
 		const istanbulLoader = webpackConfig.module.rules
 			.find( rule => rule.loader === 'istanbul-instrumenter-loader' );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Removed babel loader rule from webpack's config when testing coverage. Closes #66.
