### PR TITLE
"master-revisions" will be synced with "master" correctly

### DIFF
--- a/packages/ckeditor5-dev-tests/bin/save-revision.js
+++ b/packages/ckeditor5-dev-tests/bin/save-revision.js
@@ -21,7 +21,10 @@ const mainRepoUrl = 'https://github.com/ckeditor/ckeditor5';
 const revisionBranch = `${ branch }-revisions`;
 
 // Clone the repository.
-exec( `git clone -b ${ revisionBranch } ${ mainRepoUrl }.git` );
+exec( `git clone ${ mainRepoUrl }.git` );
+
+// And check out to the revision branch.
+exec( `git checkout ${ revisionBranch } ` );
 
 // Change current dir to cloned repository.
 process.chdir( path.join( process.cwd(), 'ckeditor5' ) );
@@ -29,8 +32,11 @@ process.chdir( path.join( process.cwd(), 'ckeditor5' ) );
 // Install Mgit.
 exec( 'npm install -g mgit2' );
 
-// Get the latest `mgit.json`.
-exec( `git checkout origin/${ branch } .` );
+// Sync the revision branch with the master.
+exec( `git checkout ${ branch } -- .` );
+
+// Remove all files from "staged".
+exec( 'git reset -q .' );
 
 // Install dependencies.
 exec( 'mgit bootstrap --recursive --resolver-url-template="https://github.com/\\${ path }.git"' );
@@ -38,7 +44,8 @@ exec( 'mgit bootstrap --recursive --resolver-url-template="https://github.com/\\
 // Save hashes from all dependencies.
 exec( 'mgit save-hashes' );
 
-exec( 'git add mgit.json' );
+// Add all files (perhaps the changes from master will be committed).
+exec( 'git add .' );
 
 const repository = process.env.TRAVIS_REPO_SLUG;
 const commit = process.env.TRAVIS_COMMIT;


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: During saving revisions, the branches `master-revisions` and `master` weren't synced correctly. Closes #375.
