### PR TITLE
Upgraded Github package (@octokit/rest")

### DIFF
--- a/packages/ckeditor5-dev-env/lib/release-tools/utils/creategithubrelease.js
+++ b/packages/ckeditor5-dev-env/lib/release-tools/utils/creategithubrelease.js
@@ -5,7 +5,7 @@
 
 'use strict';
 
-const GitHubApi = require( 'github' );
+const GitHubApi = require( '@octokit/rest' );
 
 /**
  * Create a Github release.

--- a/packages/ckeditor5-dev-env/package.json
+++ b/packages/ckeditor5-dev-env/package.json
@@ -6,6 +6,7 @@
   "main": "lib/index.js",
   "dependencies": {
     "@ckeditor/ckeditor5-dev-utils": "^8.0.0",
+    "@octokit/rest": "^14.0.0",
     "chalk": "^2.1.0",
     "compare-func": "^1.3.2",
     "concat-stream": "^1.6.0",
@@ -15,7 +16,6 @@
     "del": "^3.0.0",
     "fs-extra": "^5.0.0",
     "git-raw-commits": "^1.2.0",
-    "github": "^9.2.0",
     "glob": "^7.1.2",
     "inquirer": "^5.2.0",
     "minimatch": "^3.0.4",

--- a/packages/ckeditor5-dev-env/tests/release-tools/utils/creategithubrelease.js
+++ b/packages/ckeditor5-dev-env/tests/release-tools/utils/creategithubrelease.js
@@ -33,7 +33,7 @@ describe( 'dev-env/release-tools/tasks', () => {
 				warnOnUnregistered: false
 			} );
 
-			mockery.registerMock( 'github', function GitHubApi() {
+			mockery.registerMock( '@octokit/rest', function GitHubApi() {
 				return {
 					authenticate: stubs.authenticate,
 					repos: {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Upgraded the `github` package that has been renamed to `@octokit/rest`. Closes #396.

---

I reviewed the release notes and there are no breaking changes for us.
