### PR TITLE
Publishing package on GH will not break the process

### DIFF
--- a/packages/ckeditor5-dev-env/lib/release-tools/tasks/releasesubrepositories.js
+++ b/packages/ckeditor5-dev-env/lib/release-tools/tasks/releasesubrepositories.js
@@ -275,13 +275,21 @@ module.exports = function releaseSubRepositories( options ) {
 			};
 
 			return createGithubRelease( releaseOptions.token, githubReleaseOptions )
-				.then( () => {
-					// eslint-disable-next-line max-len
-					const url = `https://github.com/${ repositoryInfo.owner }/${ repositoryInfo.name }/releases/tag/v${ releaseDetails.version }`;
-					log.info( `Created the release: ${ url }` );
+				.then(
+					() => {
+						// eslint-disable-next-line max-len
+						const url = `https://github.com/${ repositoryInfo.owner }/${ repositoryInfo.name }/releases/tag/v${ releaseDetails.version }`;
+						log.info( `Created the release: ${ url }` );
 
-					return Promise.resolve();
-				} );
+						return Promise.resolve();
+					},
+					err => {
+						log.info( 'Cannot create a release on GitHub. Skipping that package.' );
+						log.error( err );
+
+						return Promise.resolve();
+					}
+				);
 		} );
 	}
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: An error that occurs during publishing a package on GitHub will not break the whole process and the rest packages would be published. Closes #397.
