### PR TITLE
Disabled minify of CSS animations in the postCSS config.

### DIFF
--- a/packages/ckeditor5-dev-utils/lib/styles/getpostcssconfig.js
+++ b/packages/ckeditor5-dev-utils/lib/styles/getpostcssconfig.js
@@ -35,7 +35,8 @@ module.exports = function getPostCssConfig( options = {} ) {
 	if ( options.minify ) {
 		config.plugins.push( require( 'cssnano' )( {
 			preset: 'default',
-			autoprefixer: false
+			autoprefixer: false,
+			reduceIdents: true
 		} ) );
 	}
 

--- a/packages/ckeditor5-dev-utils/lib/styles/getpostcssconfig.js
+++ b/packages/ckeditor5-dev-utils/lib/styles/getpostcssconfig.js
@@ -36,7 +36,7 @@ module.exports = function getPostCssConfig( options = {} ) {
 		config.plugins.push( require( 'cssnano' )( {
 			preset: 'default',
 			autoprefixer: false,
-			reduceIdents: true
+			reduceIdents: false
 		} ) );
 	}
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Disabled minify of CSS Animations (`@keyframes`). Closes #350.
