### PR TITLE
Allows hiding links in generated changelog

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,25 @@ CKEditor 5 development tools packages
 
 Tests:
 
-```
+```bash
 npm test
+```
+
+Tests with Debug mode:
+
+```bash
+DEBUG=true npm test 
+```
+
+Test a single package:
+
+```bash
+./node_modules/.bin/mocha packages/ckeditor5-dev-env/tests/* --recursive
 ```
 
 Code coverage:
 
-```
+```bash
 npm run coverage
 ```
 

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
   "bugs": "https://github.com/ckeditor/ckeditor5-dev/issues",
   "homepage": "https://github.com/ckeditor/ckeditor5-dev#readme",
   "scripts": {
-    "test": "mocha packages/*/tests --recursive --timeout 5000",
-    "coverage": "istanbul cover _mocha packages/*/tests -- --recursive --timeout 5000",
+    "test": "mocha packages/*/tests/**/*.js --recursive --timeout 5000",
+    "coverage": "istanbul cover _mocha packages/*/tests/**/*.js -- --recursive --timeout 5000",
     "changelog": "node ./scripts/changelog.js",
     "lint": "eslint --quiet '**/*.js'",
     "precommit": "lint-staged"

--- a/packages/ckeditor5-dev-env/lib/release-tools/tasks/generatechangelogforsinglepackage.js
+++ b/packages/ckeditor5-dev-env/lib/release-tools/tasks/generatechangelogforsinglepackage.js
@@ -25,9 +25,11 @@ const transformCommitFunction = require( '../utils/transform-commit/transformcom
  * should be generated.
  *
  * @param {String|null} [newVersion=null] A version for which changelog will be generated.
+ * @param {Object} [options={}] Additional options.
+ * @param {Boolean} [options.skipLinks=false] If set on true, links to release or commits will be omitted.
  * @returns {Promise}
  */
-module.exports = function generateChangelogForSinglePackage( newVersion = null ) {
+module.exports = function generateChangelogForSinglePackage( newVersion = null, options = {} ) {
 	const log = logger();
 	const packageJson = getPackageJson();
 
@@ -74,7 +76,8 @@ module.exports = function generateChangelogForSinglePackage( newVersion = null )
 				tagName,
 				isInternalRelease,
 				newTagName: 'v' + version,
-				transformCommit: transformCommitFunction
+				transformCommit: transformCommitFunction,
+				skipLinks: !!options.skipLinks
 			};
 
 			return generateChangelogFromCommits( changelogOptions )

--- a/packages/ckeditor5-dev-env/lib/release-tools/templates/commit.hbs
+++ b/packages/ckeditor5-dev-env/lib/release-tools/templates/commit.hbs
@@ -4,23 +4,25 @@
   {{~title}}
 {{~/if}}
 
-{{~!-- commit link --}} {{#if @root.linkReferences~}}
-  ([{{hash}}](
-  {{~#if @root.repository}}
-    {{~#if @root.host}}
-      {{~@root.host}}/
-    {{~/if}}
-    {{~#if @root.owner}}
-      {{~@root.owner}}/
-    {{~/if}}
-    {{~@root.repository}}
-  {{~else}}
-    {{~@root.repoUrl}}
-  {{~/if}}/
-  {{~@root.commit}}/{{hash}}))
-{{~else}}
-  {{~hash}}
-{{~/if}}
+{{~#if showLinks}}
+	{{~!-- commit link --}} {{#if @root.linkReferences~}}
+	  ([{{hash}}](
+	  {{~#if @root.repository}}
+		{{~#if @root.host}}
+		  {{~@root.host}}/
+		{{~/if}}
+		{{~#if @root.owner}}
+		  {{~@root.owner}}/
+		{{~/if}}
+		{{~@root.repository}}
+	  {{~else}}
+		{{~@root.repoUrl}}
+	  {{~/if}}/
+	  {{~@root.commit}}/{{hash}}))
+	{{~else}}
+	  {{~hash}}
+	{{~/if}}
+{{/if}}
 {{#if body}}
 
 

--- a/packages/ckeditor5-dev-env/lib/release-tools/templates/commit.hbs
+++ b/packages/ckeditor5-dev-env/lib/release-tools/templates/commit.hbs
@@ -4,7 +4,7 @@
   {{~title}}
 {{~/if}}
 
-{{~#if showLinks}}
+{{~#if @root.linkCommit}}
 	{{~!-- commit link --}} {{#if @root.linkReferences~}}
 	  ([{{hash}}](
 	  {{~#if @root.repository}}

--- a/packages/ckeditor5-dev-env/lib/release-tools/templates/template.hbs
+++ b/packages/ckeditor5-dev-env/lib/release-tools/templates/template.hbs
@@ -8,8 +8,8 @@ Internal changes only (updated dependencies, documentation, etc.).
 {{#each commitGroups}}
 ### {{title}}
 
-{{#if (lookup ../additionalNotes title)}}
-{{ lookup ../additionalNotes title }}
+{{#if (lookup @root.additionalNotes title)}}
+{{ lookup @root.additionalNotes title }}
 
 {{/if}}
 {{#each commits}}

--- a/packages/ckeditor5-dev-env/lib/release-tools/utils/generatechangelogfromcommits.js
+++ b/packages/ckeditor5-dev-env/lib/release-tools/utils/generatechangelogfromcommits.js
@@ -62,13 +62,15 @@ module.exports = function generateChangelogFromCommits( options ) {
 		const writerOptions = getWriterOptions( options.transformCommit );
 
 		conventionalChangelog( {}, context, gitRawCommitsOpts, parserOptions, writerOptions )
-			.pipe( saveChangelogPipe( options.version, resolve, options.doNotSave ) );
+			.pipe( changelogPipe( options.version, resolve, {
+				doNotSave: options.doNotSave
+			} ) );
 	} );
 };
 
-function saveChangelogPipe( version, done, doNotSave = false ) {
+function changelogPipe( version, done, options ) {
 	return stream.noop( changes => {
-		if ( doNotSave ) {
+		if ( options.doNotSave ) {
 			return done( changes.toString() );
 		}
 

--- a/packages/ckeditor5-dev-env/lib/release-tools/utils/generatechangelogfromcommits.js
+++ b/packages/ckeditor5-dev-env/lib/release-tools/utils/generatechangelogfromcommits.js
@@ -46,7 +46,8 @@ module.exports = function generateChangelogFromCommits( options ) {
 			displayLogs: false,
 			isInternalRelease: options.isInternalRelease || false,
 			additionalNotes: {},
-			showLinks: typeof options.skipLinks == 'undefined' ? true : !options.skipLinks
+			linkCommit: typeof options.skipLinks == 'undefined' ? true : !options.skipLinks,
+			linkCompare: typeof options.skipLinks == 'undefined' ? true : !options.skipLinks
 		};
 
 		if ( options.additionalNotes ) {

--- a/packages/ckeditor5-dev-env/lib/release-tools/utils/generatechangelogfromcommits.js
+++ b/packages/ckeditor5-dev-env/lib/release-tools/utils/generatechangelogfromcommits.js
@@ -62,6 +62,10 @@ module.exports = function generateChangelogFromCommits( options ) {
 
 		const writerOptions = getWriterOptions( options.transformCommit );
 
+		if ( process.env.DEBUG ) {
+			writerOptions.debug = getDebugFuntion();
+		}
+
 		conventionalChangelog( {}, context, gitRawCommitsOpts, parserOptions, writerOptions )
 			.pipe( changelogPipe( options.version, resolve, {
 				doNotSave: options.doNotSave
@@ -89,4 +93,10 @@ function changelogPipe( version, done, options ) {
 
 		done( version );
 	} );
+}
+
+function getDebugFuntion() {
+	return ( ...params ) => {
+		console.log( ...params );
+	};
 }

--- a/packages/ckeditor5-dev-env/lib/release-tools/utils/generatechangelogfromcommits.js
+++ b/packages/ckeditor5-dev-env/lib/release-tools/utils/generatechangelogfromcommits.js
@@ -26,6 +26,7 @@ const { additionalCommitNotes } = require( './transform-commit/transform-commit-
  * @param {Boolean} [options.doNotSave=false] If set on `true`, changes will be resolved in returned promise
  * instead of saving in CHANGELOG file.
  * @param {Boolean} [options.additionalNotes=false] If set on `true, each category will contain additional description.
+ * @param {Boolean} [options.skipLinks=false] If set on true, links to release or commits will be omitted.
  * @returns {Promise}
  */
 module.exports = function generateChangelogFromCommits( options ) {
@@ -45,6 +46,7 @@ module.exports = function generateChangelogFromCommits( options ) {
 			displayLogs: false,
 			isInternalRelease: options.isInternalRelease || false,
 			additionalNotes: {},
+			showLinks: typeof options.skipLinks == 'undefined' ? true : !options.skipLinks
 		};
 
 		if ( options.additionalNotes ) {

--- a/packages/ckeditor5-dev-env/tests/release-tools/tasks/generatechangelogforsinglepackage.js
+++ b/packages/ckeditor5-dev-env/tests/release-tools/tasks/generatechangelogforsinglepackage.js
@@ -85,7 +85,8 @@ describe( 'dev-env/release-tools/tasks', () => {
 						tagName: 'v0.5.0',
 						newTagName: 'v1.0.0',
 						transformCommit: stubs.transformCommit,
-						isInternalRelease: false
+						isInternalRelease: false,
+						skipLinks: false
 					} );
 
 					expect( stubs.logger.info.calledThrice ).to.equal( true );
@@ -115,7 +116,8 @@ describe( 'dev-env/release-tools/tasks', () => {
 						tagName: null,
 						newTagName: 'v0.1.0',
 						transformCommit: stubs.transformCommit,
-						isInternalRelease: false
+						isInternalRelease: false,
+						skipLinks: false
 					} );
 
 					expect( stubs.getNewReleaseType.calledOnce ).to.equal( true );
@@ -177,7 +179,30 @@ describe( 'dev-env/release-tools/tasks', () => {
 						tagName: 'v0.0.1',
 						newTagName: 'v0.0.2',
 						transformCommit: stubs.transformCommit,
-						isInternalRelease: true
+						isInternalRelease: true,
+						skipLinks: false
+					} );
+				} );
+		} );
+
+		it( 'passes the "skipLinks" option to the changelog generator', () => {
+			stubs.getNewReleaseType.returns( Promise.resolve( {
+				releaseType: 'minor'
+			} ) );
+			stubs.cli.provideVersion.returns( Promise.resolve( '0.1.0' ) );
+			stubs.versionUtils.getLastFromChangelog.returns( null );
+			stubs.generateChangelogFromCommits.returns( Promise.resolve() );
+
+			return generateChangelogForSinglePackage( null, { skipLinks: true } )
+				.then( () => {
+					expect( stubs.generateChangelogFromCommits.calledOnce ).to.equal( true );
+					expect( stubs.generateChangelogFromCommits.firstCall.args[ 0 ] ).to.deep.equal( {
+						version: '0.1.0',
+						tagName: null,
+						newTagName: 'v0.1.0',
+						transformCommit: stubs.transformCommit,
+						isInternalRelease: false,
+						skipLinks: true
 					} );
 				} );
 		} );

--- a/packages/ckeditor5-dev-env/tests/release-tools/templates/commit.js
+++ b/packages/ckeditor5-dev-env/tests/release-tools/templates/commit.js
@@ -26,11 +26,12 @@ describe( 'dev-env/release-tools/changelog/templates', () => {
 			repository: 'repository',
 			commit: 'commit',
 			issue: 'issues',
-			linkReferences: true
+			linkReferences: true,
+			linkCommit: true
 		};
 		templateOptions = {
 			data: {
-				root: rootOptions
+				root: rootOptions,
 			}
 		};
 	} );
@@ -84,6 +85,15 @@ describe( 'dev-env/release-tools/changelog/templates', () => {
 
 			const expectedEntry = '* Test ([1234qwe](https://github.com/organization/repository/commit/1234qwe))' +
 				'\n\n  Some paragraph.\n\n  * List Item 1.\n  * List Item 2.';
+			expect( template( data, templateOptions ) ).to.equal( expectedEntry + '\n' );
+		} );
+
+		it( 'hide the commit hash', () => {
+			rootOptions.linkCommit = false;
+
+			const data = { subject: 'Test', hash: '1234qwe' };
+
+			const expectedEntry = '* Test';
 			expect( template( data, templateOptions ) ).to.equal( expectedEntry + '\n' );
 		} );
 	} );

--- a/packages/ckeditor5-dev-env/tests/release-tools/utils/generatechangelogfromcommits-integration.js
+++ b/packages/ckeditor5-dev-env/tests/release-tools/utils/generatechangelogfromcommits-integration.js
@@ -11,7 +11,25 @@ const expect = require( 'chai' ).expect;
 const sinon = require( 'sinon' );
 const proxyquire = require( 'proxyquire' );
 const { tools, stream } = require( '@ckeditor/ckeditor5-dev-utils' );
-const { changelogHeader, getChangelog, getChangesForVersion } = require( '../../../lib/release-tools/utils/changelog' );
+const {
+	changelogHeader,
+	getChangelog: _getChangelog,
+	getChangesForVersion: _getChangesForVersion
+} = require( '../../../lib/release-tools/utils/changelog' );
+
+// Because of the Windows end of the line, we need to normalize them.
+// If we won't do it, some of the assertions will fail because strings will be ending with "\r" that wasn't expected.
+function normalizeStrings( content ) {
+	return content.replace( /\r\n/g, '\n' );
+}
+
+function getChangelog() {
+	return normalizeStrings( _getChangelog() );
+}
+
+function getChangesForVersion( ...params ) {
+	return normalizeStrings( _getChangesForVersion( ...params ) );
+}
 
 describe( 'dev-env/release-tools/utils', () => {
 	const url = 'https://github.com/ckeditor/ckeditor5-test-package';
@@ -118,13 +136,13 @@ describe( 'dev-env/release-tools/utils', () => {
 					const latestChangelog = replaceCommitIds( getChangesForVersion( lastChangelogVersion ) );
 
 					/* eslint-disable max-len */
-					const expectedChangelog = `
+					const expectedChangelog = normalizeStrings( `
 ### Features
 
 * Another feature. Closes [#2](https://github.com/ckeditor/ckeditor5-test-package/issues/2). ([XXXXXXX](https://github.com/ckeditor/ckeditor5-test-package/commit/XXXXXXX))
 
   This PR also closes [#3](https://github.com/ckeditor/ckeditor5-test-package/issues/3) and [#4](https://github.com/ckeditor/ckeditor5-test-package/issues/4).
-`;
+` );
 					/* eslint-enable max-len */
 
 					expect( latestChangelog ).to.equal( expectedChangelog.trim() );
@@ -144,13 +162,13 @@ describe( 'dev-env/release-tools/utils', () => {
 					const latestChangelog = replaceCommitIds( getChangesForVersion( lastChangelogVersion ) );
 
 					/* eslint-disable max-len */
-					const expectedChangelog = `
+					const expectedChangelog = normalizeStrings( `
 ### Bug fixes
 
 * Amazing fix. Closes [#5](https://github.com/ckeditor/ckeditor5-test-package/issues/5). ([XXXXXXX](https://github.com/ckeditor/ckeditor5-test-package/commit/XXXXXXX))
 
   The PR also finally closes [#3](https://github.com/ckeditor/ckeditor5-test-package/issues/3) and [#4](https://github.com/ckeditor/ckeditor5-test-package/issues/4). So good!
-`;
+` );
 					/* eslint-enable max-len */
 
 					expect( latestChangelog ).to.equal( expectedChangelog.trim() );
@@ -172,7 +190,7 @@ describe( 'dev-env/release-tools/utils', () => {
 					const latestChangelog = replaceCommitIds( getChangesForVersion( lastChangelogVersion ) );
 
 					/* eslint-disable max-len */
-					const expectedChangelog = `
+					const expectedChangelog = normalizeStrings( `
 ### Other changes
 
 * Some docs improvements. Closes [#6](https://github.com/ckeditor/ckeditor5-test-package/issues/6). ([XXXXXXX](https://github.com/ckeditor/ckeditor5-test-package/commit/XXXXXXX))
@@ -186,7 +204,7 @@ describe( 'dev-env/release-tools/utils', () => {
 ### NOTE
 
 * Please read [#1](https://github.com/ckeditor/ckeditor5-test-package/issues/1).
-`;
+` );
 					/* eslint-enable max-len */
 
 					expect( latestChangelog ).to.equal( expectedChangelog.trim() );
@@ -207,7 +225,7 @@ describe( 'dev-env/release-tools/utils', () => {
 					const latestChangelog = replaceCommitIds( getChangesForVersion( lastChangelogVersion ) );
 
 					/* eslint-disable max-len */
-					const expectedChangelog = `
+					const expectedChangelog = normalizeStrings( `
 ### Features
 
 * Issues will not be hoisted. Closes [#8](https://github.com/ckeditor/ckeditor5-test-package/issues/8). ([XXXXXXX](https://github.com/ckeditor/ckeditor5-test-package/commit/XXXXXXX))
@@ -221,7 +239,7 @@ describe( 'dev-env/release-tools/utils', () => {
 ### NOTE
 
 * Please read [#1](https://github.com/ckeditor/ckeditor5-test-package/issues/1).
-`;
+` );
 					/* eslint-enable max-len */
 
 					expect( latestChangelog ).to.equal( expectedChangelog.trim() );
@@ -246,7 +264,7 @@ describe( 'dev-env/release-tools/utils', () => {
 					const changelogAsArray = replaceDates( getChangelog() ).replace( changelogHeader, '' ).split( '\n' );
 
 					expectedChangelogeEntries.forEach( ( row, index ) => {
-						expect( row ).to.equal( changelogAsArray[ index ], `Index: ${ index }` );
+						expect( row.trim() ).to.equal( changelogAsArray[ index ].trim(), `Index: ${ index }` );
 					} );
 
 					release();
@@ -287,11 +305,11 @@ describe( 'dev-env/release-tools/utils', () => {
 					const latestChangelog = replaceCommitIds( getChangesForVersion( lastChangelogVersion ) );
 
 					/* eslint-disable max-len */
-					const expectedChangelog = `
+					const expectedChangelog = normalizeStrings( `
 ### Features
 
 * Another feature. Closes [#2](https://github.com/ckeditor/ckeditor5-test-package/issues/2). ([XXXXXXX](https://github.com/ckeditor/ckeditor5-test-package/commit/XXXXXXX))
-`;
+` );
 					/* eslint-enable max-len */
 
 					expect( latestChangelog ).to.equal( expectedChangelog.trim() );
@@ -312,11 +330,11 @@ describe( 'dev-env/release-tools/utils', () => {
 					const latestChangelog = replaceCommitIds( getChangesForVersion( lastChangelogVersion ) );
 
 					/* eslint-disable max-len */
-					const expectedChangelog = `
+					const expectedChangelog = normalizeStrings( `
 ### Bug fixes
 
 * Foo. ([XXXXXXX](https://github.com/ckeditor/ckeditor5-test-package/commit/XXXXXXX))
-`;
+` );
 					/* eslint-enable max-len */
 
 					expect( latestChangelog ).to.equal( expectedChangelog.trim() );
@@ -337,11 +355,11 @@ describe( 'dev-env/release-tools/utils', () => {
 					const latestChangelog = replaceCommitIds( getChangesForVersion( lastChangelogVersion ) );
 
 					/* eslint-disable max-len */
-					const expectedChangelog = `
+					const expectedChangelog = normalizeStrings( `
 ### Bug fixes
 
 * Foo. ([XXXXXXX](https://github.com/ckeditor/ckeditor5-test-package/commit/XXXXXXX))
-`;
+` );
 					/* eslint-enable max-len */
 
 					expect( latestChangelog ).to.equal( expectedChangelog.trim() );
@@ -361,11 +379,11 @@ describe( 'dev-env/release-tools/utils', () => {
 					const latestChangelog = replaceCommitIds( getChangesForVersion( lastChangelogVersion ) );
 
 					/* eslint-disable max-len */
-					const expectedChangelog = `
+					const expectedChangelog = normalizeStrings( `
 ### Bug fixes
 
 * Foo Bar. ([XXXXXXX](https://github.com/ckeditor/ckeditor5-test-package/commit/XXXXXXX))
-`;
+` );
 					/* eslint-enable max-len */
 
 					expect( latestChangelog ).to.equal( expectedChangelog.trim() );
@@ -385,11 +403,11 @@ describe( 'dev-env/release-tools/utils', () => {
 					const latestChangelog = replaceCommitIds( getChangesForVersion( lastChangelogVersion ) );
 
 					/* eslint-disable max-len */
-					const expectedChangelog = `
+					const expectedChangelog = normalizeStrings( `
 ### Bug fixes
 
 * Bar Foo. ([XXXXXXX](https://github.com/ckeditor/ckeditor5-test-package/commit/XXXXXXX))
-`;
+` );
 					/* eslint-enable max-len */
 
 					expect( latestChangelog ).to.equal( expectedChangelog.trim() );
@@ -408,13 +426,13 @@ describe( 'dev-env/release-tools/utils', () => {
 					const latestChangelog = replaceCommitIds( getChangesForVersion( lastChangelogVersion ) );
 
 					/* eslint-disable max-len */
-					const expectedChangelog = `
+					const expectedChangelog = normalizeStrings( `
 ### Bug fixes
 
 Besides changes in the dependencies, this version also contains the following bug fixes:
 
 * Foo Bar. ([XXXXXXX](https://github.com/ckeditor/ckeditor5-test-package/commit/XXXXXXX))
-`;
+` );
 					/* eslint-enable max-len */
 
 					expect( latestChangelog ).to.equal( expectedChangelog.trim() );
@@ -492,17 +510,13 @@ Besides changes in the dependencies, this version also contains the following bu
 	function generateChangelog( version, options = {} ) {
 		lastChangelogVersion = version;
 
-		const isInternalRelease = !!options.isInternalRelease;
-		const additionalNotes = !!options.additionalNotes;
-		const skipLinks = !!options.skipLinks;
-
 		const transform = require( '../../../lib/release-tools/utils/transform-commit/transformcommitforsubrepository' );
 
 		return generateChangelogFromCommits( {
 			version,
-			isInternalRelease,
-			additionalNotes,
-			skipLinks,
+			isInternalRelease: options.isInternalRelease,
+			additionalNotes: options.additionalNotes,
+			skipLinks: options.skipLinks,
 			newTagName: 'v' + version,
 			tagName: lastReleasedVersion ? 'v' + lastReleasedVersion : null,
 			transformCommit: transform
@@ -526,6 +540,6 @@ Besides changes in the dependencies, this version also contains the following bu
 	}
 
 	function replaceDates( changelog ) {
-		return changelog.replace( /\) \(\d{4}-\d{2}-\d{2}\)/g, ') (0000-00-00)' );
+		return changelog.replace( /\d{4}-\d{2}-\d{2}/g, '0000-00-00' );
 	}
 } );

--- a/packages/ckeditor5-dev-env/tests/release-tools/utils/generatechangelogfromcommits-integration.js
+++ b/packages/ckeditor5-dev-env/tests/release-tools/utils/generatechangelogfromcommits-integration.js
@@ -51,8 +51,8 @@ describe( 'dev-env/release-tools/utils', () => {
 		} );
 
 		after( () => {
-			exec( `rm -rf ${ tmpCwd }` );
 			process.chdir( cwd );
+			exec( `rm -rf ${ tmpCwd }` );
 		} );
 
 		beforeEach( () => {

--- a/packages/ckeditor5-dev-env/tests/release-tools/utils/generatechangelogfromcommits-integration.js
+++ b/packages/ckeditor5-dev-env/tests/release-tools/utils/generatechangelogfromcommits-integration.js
@@ -491,12 +491,27 @@ Besides changes in the dependencies, this version also contains the following bu
 				} );
 		} );
 
-		it.only( 'does not generate links to commits and release', () => {
-			exec( 'git commit --allow-empty --message "Feature: Some amazing feature. Closes #1."' );
+		it( 'does not generate links to commits and release', () => {
+			exec( 'git commit --allow-empty --message "Feature: Some amazing feature."' );
 
-			return generateChangelog( '0.6.0' )
+			return generateChangelog( '0.6.0', { skipLinks: true } )
 				.then( () => {
-					console.log( getChangesForVersion( '0.6.0' ) );
+					const changelogAsArray = getChangelog().split( '\n' ).slice( 0, 10 );
+
+					expect( changelogAsArray[ 0 ], 'Index: 0' ).to.equal( 'Changelog' );
+					expect( changelogAsArray[ 1 ], 'Index: 1' ).to.equal( '=========' );
+					expect( changelogAsArray[ 2 ], 'Index: 2' ).to.equal( '' );
+					expect( replaceDates( changelogAsArray[ 3 ] ), 'Index: 3' ).to.equal(
+						'## 0.6.0 (0000-00-00)'
+					);
+					expect( changelogAsArray[ 4 ], 'Index: 4' ).to.equal( '' );
+					expect( changelogAsArray[ 5 ], 'Index: 5' ).to.equal( '### Features' );
+					expect( changelogAsArray[ 6 ], 'Index: 6' ).to.equal( '' );
+					expect( changelogAsArray[ 7 ], 'Index: 7' ).to.equal(
+						'* Some amazing feature.'
+					);
+					expect( changelogAsArray[ 8 ], 'Index: 8' ).to.equal( '' );
+					expect( changelogAsArray[ 9 ], 'Index: 9' ).to.equal( '' );
 
 					release();
 				} );

--- a/packages/ckeditor5-dev-env/tests/release-tools/utils/generatechangelogfromcommits.js
+++ b/packages/ckeditor5-dev-env/tests/release-tools/utils/generatechangelogfromcommits.js
@@ -160,7 +160,8 @@ describe( 'dev-env/release-tools/utils', () => {
 						currentTag: 'v1.0.0',
 						isInternalRelease: false,
 						additionalNotes: {},
-						showLinks: true
+						linkCommit: true,
+						linkCompare: true
 					} );
 					expect( conventionalChangelogArguments[ 2 ] ).to.have.property( 'from', 'v0.5.0' );
 					expect( conventionalChangelogArguments[ 4 ] ).to.deep.equal( { foo: 'bar' } );
@@ -196,7 +197,8 @@ describe( 'dev-env/release-tools/utils', () => {
 						currentTag: 'v0.5.1',
 						isInternalRelease: true,
 						additionalNotes: {},
-						showLinks: true
+						linkCommit: true,
+						linkCompare: true
 					} );
 				} );
 		} );
@@ -267,7 +269,8 @@ describe( 'dev-env/release-tools/utils', () => {
 						currentTag: 'v0.5.1',
 						isInternalRelease: false,
 						additionalNotes: additionalCommitNotes,
-						showLinks: true
+						linkCommit: true,
+						linkCompare: true
 					} );
 				} );
 		} );
@@ -306,7 +309,8 @@ describe( 'dev-env/release-tools/utils', () => {
 						currentTag: 'v0.5.1',
 						isInternalRelease: false,
 						additionalNotes: {},
-						showLinks: false
+						linkCommit: false,
+						linkCompare: false
 					} );
 				} );
 		} );

--- a/packages/ckeditor5-dev-env/tests/release-tools/utils/generatechangelogfromcommits.js
+++ b/packages/ckeditor5-dev-env/tests/release-tools/utils/generatechangelogfromcommits.js
@@ -104,7 +104,7 @@ describe( 'dev-env/release-tools/utils', () => {
 				} );
 		} );
 
-		it( 'does not crate a changelog file if is not present but the "doNotSave" option is set on `true`', () => {
+		it( 'does not create a changelog file if is not present but the "doNotSave" option is set on `true`', () => {
 			changelogBuffer = Buffer.from( 'Changelog.' );
 
 			stubs.fs.existsSync.returns( false );
@@ -230,7 +230,7 @@ describe( 'dev-env/release-tools/utils', () => {
 				} );
 		} );
 
-		it( 'allows appending additional notes for groups of commits ', () => {
+		it( 'allows appending additional notes for groups of commits', () => {
 			const newChangelogChunk = [
 				'## 1.0.0',
 				'',

--- a/packages/ckeditor5-dev-env/tests/release-tools/utils/generatechangelogfromcommits.js
+++ b/packages/ckeditor5-dev-env/tests/release-tools/utils/generatechangelogfromcommits.js
@@ -159,7 +159,8 @@ describe( 'dev-env/release-tools/utils', () => {
 						previousTag: 'v0.5.0',
 						currentTag: 'v1.0.0',
 						isInternalRelease: false,
-						additionalNotes: {}
+						additionalNotes: {},
+						showLinks: true
 					} );
 					expect( conventionalChangelogArguments[ 2 ] ).to.have.property( 'from', 'v0.5.0' );
 					expect( conventionalChangelogArguments[ 4 ] ).to.deep.equal( { foo: 'bar' } );
@@ -194,7 +195,8 @@ describe( 'dev-env/release-tools/utils', () => {
 						previousTag: 'v0.5.0',
 						currentTag: 'v0.5.1',
 						isInternalRelease: true,
-						additionalNotes: {}
+						additionalNotes: {},
+						showLinks: true
 					} );
 				} );
 		} );
@@ -264,7 +266,47 @@ describe( 'dev-env/release-tools/utils', () => {
 						previousTag: 'v0.5.0',
 						currentTag: 'v0.5.1',
 						isInternalRelease: false,
-						additionalNotes: additionalCommitNotes
+						additionalNotes: additionalCommitNotes,
+						showLinks: true
+					} );
+				} );
+		} );
+
+		it( 'allows generating changelog without links to commits ("skipLinks" option)', () => {
+			const newChangelogChunk = [
+				'## 1.0.0',
+				'',
+				'### Features',
+				'',
+				'Besides new features introduced in the dependencies, this build also introduces these features:',
+				'',
+				'* This test should pass!'
+			].join( '\n' );
+
+			changelogBuffer = Buffer.from( newChangelogChunk );
+
+			stubs.fs.existsSync.returns( true );
+			stubs.changelogUtils.getChangelog.returns( changelogUtils.changelogHeader );
+
+			const options = {
+				version: '0.5.1',
+				transformCommit: stubs.transformCommit,
+				tagName: 'v0.5.0',
+				newTagName: 'v0.5.1',
+				skipLinks: true
+			};
+
+			return generateChangelogFromCommits( options )
+				.then( () => {
+					expect( conventionalChangelogArguments ).to.be.an( 'array' );
+					expect( conventionalChangelogArguments[ 1 ] ).to.deep.equal( {
+						displayLogs: false,
+						version: '0.5.1',
+						previousTag: 'v0.5.0',
+						currentTag: 'v0.5.1',
+						isInternalRelease: false,
+						additionalNotes: {},
+						showLinks: false
 					} );
 				} );
 		} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: The changelog generator for a single package (`generateChangelogForSinglePackage()`) allows hiding a link to compare releases on GitHub and links to particular commits. Closes #415.

---

### Additional information

Because I'm on Windows, I had to fix a few things in the tests and `package.json`.
