### PR TITLE
Fix: compatiblity with extract-text-webpack-plugin. Closes #425

### DIFF
--- a/packages/ckeditor5-dev-utils/lib/translations/multiplelanguagetranslationservice.js
+++ b/packages/ckeditor5-dev-utils/lib/translations/multiplelanguagetranslationservice.js
@@ -166,6 +166,10 @@ module.exports = class MultipleLanguageTranslationService extends EventEmitter {
 		const compilationAssetNames = Object.keys( compilationAssets )
 			.filter( name => name.endsWith( '.js' ) );
 
+		if ( compilationAssetNames.length == 0 ) {
+			return [];
+		}
+
 		if ( compilationAssetNames.length > 1 ) {
 			this.emit( 'warning', [
 				'Because of the many found bundles, none of the bundles will contain the main language.',

--- a/packages/ckeditor5-dev-utils/tests/translations/multiplelanguagetranslationservice.js
+++ b/packages/ckeditor5-dev-utils/tests/translations/multiplelanguagetranslationservice.js
@@ -229,6 +229,19 @@ describe( 'translations', () => {
 				] );
 			} );
 
+			it( 'should return an array of empty assets when called for webpack plugins instead of ckeditor script', () => {
+				const translationService = new MultipleLanguageTranslationService( 'pl', { additionalLanguages: [ 'en' ] } );
+
+				const assets = translationService.getAssets( {
+					outputDirectory: 'lang',
+					compilationAssets: {
+						'SomeWebpackPlugin': { source: () => 'source' }
+					}
+				} );
+
+				expect( assets ).to.deep.equal( [] );
+			} );
+
 			it( 'should emit an error if the language is not present in language list', () => {
 				const translationService = new MultipleLanguageTranslationService( 'pl', { additionalLanguages: [ 'xxx' ] } );
 				const spy = sandbox.spy();


### PR DESCRIPTION
Fix: compatiblity with extract-text-webpack-plugin. Closes #425

---

### Additional information

When using extract-text-webpack-plugin the getAssets function is called multiple times and the compilationAssets contain extract-text-webpack-plugin-name instead of the ckeditor.js.
Only one call of getAssets contains the ckeditor.js.
So i changed getAssets to return translations only when a valid script file is in compilation assets.
