### PR TITLE
Add current timestamp to project name for builds on BrowserStack

### DIFF
--- a/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getkarmaconfig.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getkarmaconfig.js
@@ -131,7 +131,7 @@ module.exports = function getKarmaConfig( options ) {
 		karmaConfig.browserStack = {
 			username: process.env.BROWSER_STACK_USERNAME,
 			accessKey: process.env.BROWSER_STACK_ACCESS_KEY,
-			build: process.env.TRAVIS_REPO_SLUG,
+			build: getBuildName(),
 			project: 'ckeditor5'
 		};
 
@@ -191,6 +191,23 @@ function getBrowsers( options ) {
 	// If the BrowserStack is disabled, all browsers that start with a prefix "BrowserStack" should be filtered out.
 	// See: https://github.com/ckeditor/ckeditor5-dev/issues/358 and https://github.com/ckeditor/ckeditor5-dev/issues/402.
 	return browsers.filter( browser => !browser.startsWith( 'BrowserStack' ) );
+}
+
+// Formats name of the build for BrowserStack. It merges repository name and current timestamp.
+// If env variable `TRAVIS_REPO_SLUG` is not available, the function returns `undefined`.
+//
+// @returns {String|undefined}
+function getBuildName() {
+	const repoSlug = process.env.TRAVIS_REPO_SLUG;
+
+	if ( !repoSlug ) {
+		return;
+	}
+
+	const repositoryName = repoSlug.split( '/' )[ 1 ];
+	const date = new Date().getTime();
+
+	return `${ repositoryName }_${ date }`;
 }
 
 function shouldEnableBrowserStack() {

--- a/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getkarmaconfig.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getkarmaconfig.js
@@ -207,7 +207,7 @@ function getBuildName() {
 	const repositoryName = repoSlug.split( '/' )[ 1 ];
 	const date = new Date().getTime();
 
-	return `${ repositoryName }_${ date }`;
+	return `${ repositoryName } ${ date }`;
 }
 
 function shouldEnableBrowserStack() {

--- a/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getkarmaconfig.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getkarmaconfig.js
@@ -204,7 +204,7 @@ function getBuildName() {
 		return;
 	}
 
-	const repositoryName = repoSlug.split( '/' )[ 1 ];
+	const repositoryName = repoSlug.split( '/' )[ 1 ].replace( /-/g, '_' );
 	const date = new Date().getTime();
 
 	return `${ repositoryName } ${ date }`;


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Add current timestamp to project name for builds on BrowserStack. Thanks to that, badges will always show a status of the latest build and its link open the build instead of the first created build.
