### PR TITLE
Disabled "save-revision" script for pull requests builds

### DIFF
--- a/packages/ckeditor5-dev-tests/bin/save-revision.js
+++ b/packages/ckeditor5-dev-tests/bin/save-revision.js
@@ -8,9 +8,10 @@
 'use strict';
 
 const branch = process.env.TRAVIS_BRANCH;
+const buildType = process.env.TRAVIS_EVENT_TYPE;
 
-// Save revision only when master branches are updated.
-if ( branch !== 'master' ) {
+// Save revision only when commit has made directly on the "master" branch.
+if ( branch !== 'master' || buildType !== 'push' ) {
 	process.exit();
 }
 
@@ -63,6 +64,8 @@ if ( exec( 'git status -s' ).trim().length ) {
 
 	const lastCommit = exec( 'git log -1 --format="%h"' );
 	console.log( `Successfully saved the revision under ${ mainRepoUrl }/commit/${ lastCommit }` );
+} else {
+	console.log( 'Nothing to commit.' );
 }
 
 function exec( command ) {

--- a/packages/ckeditor5-dev-tests/bin/save-revision.js
+++ b/packages/ckeditor5-dev-tests/bin/save-revision.js
@@ -65,7 +65,7 @@ if ( exec( 'git status -s' ).trim().length ) {
 	const lastCommit = exec( 'git log -1 --format="%h"' );
 	console.log( `Successfully saved the revision under ${ mainRepoUrl }/commit/${ lastCommit }` );
 } else {
-	console.log( 'Nothing to commit.' );
+	console.log( 'Nothing to commit. The revision log is up to date.' );
 }
 
 function exec( command ) {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Disabled "save-revision" script for pull requests builds. Closes #434.
