### PR TITLE
Upgraded Lerna to 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ cache:
 install:
   - npm install
   - npm install coveralls
-  - lerna bootstrap
+  - lerna bootstrap --no-ci
 script:
   - npm run lint
   - npm run coverage

--- a/lerna.json
+++ b/lerna.json
@@ -1,13 +1,11 @@
 {
-  "lerna": "2.0.0-rc.1",
   "packages": [
-    "packages/*",
-    "."
+    "packages/*"
   ],
   "hoist": true,
   "nohoist": "guppy-pre-commit",
   "version": "independent",
-  "commands": {
+  "command": {
     "bootstrap": {
       "concurrency": 1
     }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "eslint-config-ckeditor5": "^1.0.8",
     "husky": "^0.14.3",
     "istanbul": "^0.4.4",
-    "lerna": "^2.2.0",
+    "lerna": "^3.4.0",
     "lint-staged": "^7.3.0",
     "mocha": "^5.0.5"
   },

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
     "minimatch": "^3.0.4"
   },
   "devDependencies": {
-    "@ckeditor/ckeditor5-dev-env": "^12.0.1",
     "chalk": "^2.4.1",
     "eslint": "^5.6.0",
     "eslint-config-ckeditor5": "^1.0.8",

--- a/packages/ckeditor5-dev-env/package.json
+++ b/packages/ckeditor5-dev-env/package.json
@@ -16,7 +16,7 @@
     "del": "^3.0.0",
     "fs-extra": "^7.0.0",
     "git-raw-commits": "^2.0.0",
-    "glob": "^7.1.2",
+    "glob": "^7.1.3",
     "inquirer": "^6.2.0",
     "minimatch": "^3.0.4",
     "moment": "^2.22.2",
@@ -28,7 +28,7 @@
     "chai": "^4.1.2",
     "handlebars": "^4.0.10",
     "mockery": "^2.1.0",
-    "proxyquire": "^2.0.1",
+    "proxyquire": "^2.1.0",
     "sinon": "^6.3.4"
   },
   "engines": {

--- a/packages/ckeditor5-dev-tests/package.json
+++ b/packages/ckeditor5-dev-tests/package.json
@@ -18,7 +18,7 @@
     "del": "^3.0.0",
     "dom-combiner": "^0.1.2",
     "fs-extra": "^7.0.0",
-    "glob": "^7.1.2",
+    "glob": "^7.1.3",
     "istanbul-instrumenter-loader": "^3.0.0",
     "karma": "^3.0.0",
     "karma-browserstack-launcher": "^1.3.0",

--- a/packages/jsdoc-plugins/package.json
+++ b/packages/jsdoc-plugins/package.json
@@ -5,7 +5,7 @@
   "keywords": [],
   "dependencies": {
     "fs-extra": "^7.0.0",
-    "lodash": "^4.17.10"
+    "lodash": "^4.17.11"
   },
   "devDependencies": {
     "chai": "^4.1.2"

--- a/scripts/changelog.js
+++ b/scripts/changelog.js
@@ -7,7 +7,7 @@
 
 'use strict';
 
-require( '@ckeditor/ckeditor5-dev-env' )
+require( '../packages/ckeditor5-dev-env' )
 	.generateChangelogForSubPackages( {
 		cwd: process.cwd(),
 		packages: 'packages'


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Upgraded Lerna to 3.x due to an error that blocks publishing a new version of packages. Closes #441.