### PR TITLE
Added missing @link part validation.

### DIFF
--- a/packages/jsdoc-plugins/lib/validator/doclet-validator.js
+++ b/packages/jsdoc-plugins/lib/validator/doclet-validator.js
@@ -158,9 +158,21 @@ class DocletValidator {
 		const allLinkRegExp = /\{@link\s+[^}]+\}/g;
 		const pathRegExp = /^\{@link\s+([^}\s]+)[^}]*\}$/;
 
+		const optionalTagWithBracedContentRegExp = /(@[a-z]+ )?\{[^}]+\}/g;
+
 		for ( const element of this._collection.getAll() ) {
 			if ( !element.comment ) {
 				continue;
+			}
+
+			// Find all missing `@link` parts inside comments.
+			for ( const commentPart of element.comment.match( optionalTagWithBracedContentRegExp ) || [] ) {
+				if ( commentPart.startsWith( '{module:' ) ) {
+					// If the comment part starts with the '{module:' it means that:
+					// * it's not a normal tag (tags starts with `@` and the tagName).
+					// * it's not a link (the part misses the `@link` part), but it supposed to be (it contains the `module:` part).
+					this._addError( element, `Link misses the '@link' part: ${ commentPart }` );
+				}
 			}
 
 			const refs = ( element.comment.match( allLinkRegExp ) || [] )

--- a/packages/jsdoc-plugins/tests/doclet-validator.js
+++ b/packages/jsdoc-plugins/tests/doclet-validator.js
@@ -249,6 +249,28 @@ describe( 'Linter plugin', () => {
 			expect( linter._errors.length ).to.be.equal( 1 );
 			expect( linter._errors[ 0 ].message ).to.match( /Incorrect link:/ );
 		} );
+
+		it( 'should validate links that does not contain the @link part', () => {
+			const linter = new DocletValidator( [ {
+				comment: `
+				@param {module:ckeditor5/a~A}
+				@returns {module:ckeditor5/a~A}
+				Correct link: {@link module:ckeditor5/a~A}
+				Random comment: {priority: 'high'}
+				Invalid link: {module:ckeditor5/a~A}
+				`,
+				meta: { fileName: '', path: '' },
+			}, {
+				comment: '',
+				longname: 'module:ckeditor5/a~A',
+				meta: { fileName: '', path: '' },
+			} ], getTestedModules() );
+
+			linter._lintLinks();
+
+			expect( linter._errors.length ).to.be.equal( 1 );
+			expect( linter._errors[ 0 ].message ).to.match( /Link misses the '@link' part:/ );
+		} );
 	} );
 
 	it( '_lintEvents()', () => {

--- a/packages/jsdoc-plugins/tests/doclet-validator.js
+++ b/packages/jsdoc-plugins/tests/doclet-validator.js
@@ -264,12 +264,27 @@ describe( 'Linter plugin', () => {
 				comment: '',
 				longname: 'module:ckeditor5/a~A',
 				meta: { fileName: '', path: '' },
+			}, {
+				comment: '',
+				longname: 'module:ckeditor5/a~B',
+				meta: { fileName: '', path: '' },
 			} ], getTestedModules() );
 
 			linter._lintLinks();
 
 			expect( linter._errors.length ).to.be.equal( 1 );
 			expect( linter._errors[ 0 ].message ).to.match( /Link misses the '@link' part: \{module:ckeditor5\/a~B\}/ );
+		} );
+
+		it( 'should validate comment without any link', () => {
+			const linter = new DocletValidator( [ {
+				comment: 'Some comment without any valid nor invalid link',
+				meta: { fileName: '', path: '' },
+			} ], getTestedModules() );
+
+			linter._lintLinks();
+
+			expect( linter._errors ).to.deep.equal( [] );
 		} );
 	} );
 

--- a/packages/jsdoc-plugins/tests/doclet-validator.js
+++ b/packages/jsdoc-plugins/tests/doclet-validator.js
@@ -257,7 +257,7 @@ describe( 'Linter plugin', () => {
 				@returns {module:ckeditor5/a~A}
 				Correct link: {@link module:ckeditor5/a~A}
 				Random comment: {priority: 'high'}
-				Invalid link: {module:ckeditor5/a~A}
+				Invalid link: {module:ckeditor5/a~B}
 				`,
 				meta: { fileName: '', path: '' },
 			}, {
@@ -269,7 +269,7 @@ describe( 'Linter plugin', () => {
 			linter._lintLinks();
 
 			expect( linter._errors.length ).to.be.equal( 1 );
-			expect( linter._errors[ 0 ].message ).to.match( /Link misses the '@link' part:/ );
+			expect( linter._errors[ 0 ].message ).to.match( /Link misses the '@link' part: \{module:ckeditor5\/a~B\}/ );
 		} );
 	} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Added missing `@link` part validation to JSDoc validation. Closes #433.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
