### PR TITLE
Load `.rtf` files via 'raw-loader' for automated tests.

### DIFF
--- a/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getwebpackconfig.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getwebpackconfig.js
@@ -41,7 +41,7 @@ module.exports = function getWebpackConfigForAutomatedTests( options ) {
 					]
 				},
 				{
-					test: /\.(txt|html)$/,
+					test: /\.(txt|html|rtf)$/,
 					use: [ 'raw-loader' ]
 				}
 			]


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: The `.rtf` files are now loaded via `raw-loader`. Closes #448.

---

### Additional information

None.
