### PR TITLE
t/450: Added meta "viewport" to the manual test template

### DIFF
--- a/packages/ckeditor5-dev-tests/lib/utils/manual-tests/template.html
+++ b/packages/ckeditor5-dev-tests/lib/utils/manual-tests/template.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
 	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<title>Manual Test</title>
 	<style>
 		.manual-test-list-container,


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Added meta "viewport" to the manual test template to make testing on mobiles easier. Closes #450.
