### PR TITLE
Fix dependency version in eslint-config-ckeditor5 package.

### DIFF
--- a/packages/eslint-config-ckeditor5/package.json
+++ b/packages/eslint-config-ckeditor5/package.json
@@ -12,7 +12,7 @@
   ],
   "main": ".eslintrc.js",
   "dependencies": {
-    "eslint-plugin-ckeditor5-rules": "^1.0.0"
+    "eslint-plugin-ckeditor5-rules": "^0.0.1"
   },
   "peerDependencies": {
     "eslint": ">=3.0.0"


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Use proper dependency version in eslint-config-ckeditor5 package. Closes #457.

---

### Additional information

* Still NPM package should be released for `eslint-plugin-ckeditor5-rules`
