### PR TITLE
Use Edge 17.0 for BrowserStack tests.

### DIFF
--- a/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getkarmaconfig.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getkarmaconfig.js
@@ -91,7 +91,8 @@ module.exports = function getKarmaConfig( options ) {
 				base: 'BrowserStack',
 				os: 'Windows',
 				os_version: '10',
-				browser: 'edge'
+				browser: 'edge',
+				browser_version: '17.0'
 			},
 			BrowserStack_Safari: {
 				base: 'BrowserStack',


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Enforce Edge 17 in BrowserStack tests.

---

### Additional information

* :crossed_fingers: 
