### PR TITLE
Link package inside its node_module's directory for tests.

### DIFF
--- a/packages/ckeditor5-dev-tests/bin/install-dependencies.sh
+++ b/packages/ckeditor5-dev-tests/bin/install-dependencies.sh
@@ -19,3 +19,6 @@ $NPM_BIN/mgit sync --recursive --resolver-path=$(pwd)/node_modules/@ckeditor/cke
 echo -e "\npackages/**\n" >> .gitignore
 
 yarn install
+
+# Links current package to node_modules dependencies (see #470).
+$NPM_BIN/ckeditor5-dev-tests-link-package-to-node-modules

--- a/packages/ckeditor5-dev-tests/bin/link-package-to-node-modules.js
+++ b/packages/ckeditor5-dev-tests/bin/link-package-to-node-modules.js
@@ -1,0 +1,16 @@
+#!/usr/bin/env node
+
+/**
+ * @license Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+'use strict';
+
+const path = require( 'path' );
+const cwd = process.cwd();
+const { tools } = require( '@ckeditor/ckeditor5-dev-utils' );
+
+const packageName = require( path.join( cwd, 'package.json' ) ).name;
+
+tools.linkDirectories( '../..', `node_modules/${ packageName }` );

--- a/packages/ckeditor5-dev-tests/package.json
+++ b/packages/ckeditor5-dev-tests/package.json
@@ -65,7 +65,8 @@
     "ckeditor5-dev-tests-add-workspace-to-package-json": "./bin/add-workspace-to-package-json.js",
     "ckeditor5-dev-tests-install-dependencies": "./bin/install-dependencies.sh",
     "ckeditor5-dev-tests-save-revision": "./bin/save-revision.js",
-    "ckeditor5-dev-tests-check-dependencies": "./bin/check-dependencies.js"
+    "ckeditor5-dev-tests-check-dependencies": "./bin/check-dependencies.js",
+    "ckeditor5-dev-tests-link-package-to-node-modules": "./bin/link-package-to-node-modules.js"
   },
   "author": "CKSource (http://cksource.com/)",
   "license": "GPL-2.0-or-later",


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Link package inside its node_module's directory for tests. Closes #470.

---

### Additional information

For testing I did:
- clone the `ckeditor5-paragraph` repo
- `cd` into the created `ckeditor/ckeditor5-papragraph` directory
- run `yarn add ckeditor5-dev-test mgit2`
- run the `./node_modules/.bin/ckeditor5-dev-tests-create-mgit-json`
- run the `./node_modules/.bin/ckeditor5-dev-tests-add-workspace-to-package-json`
- run the `./node_modules/.bin/mgit sync --recursive --resolver-path=$(pwd)/node_modules/@ckeditor/ckeditor5-dev-tests/lib/mgit-resolver.js`
- run the `yarn install`
- run the test: `node --max_old_space_size=4096 node_modules/.bin/ckeditor5-dev-tests --coverage --reporter=dots --browsers=Chrome`

The test is failing with cannot add plugin twice (or simialar). The `./node_modules/` dir will contain `@ckeditor/ckeditor5-paragraph` directory from github.

The fix changes the steps so that:
- the `ckeditor5-dev-tests-add-workspace-to-package-json` does not add the `'*'` directory.
- after the `yarn install` and before running the test the  `./node_modules/.bin/ckeditor5-dev-tests-link-package-to-node-modules` is run.

After that the `node_modules/@ckeditor/ckeditor5-paragraph` sould link to `../..` which is the `ckeditor5-paragraph` main directory thus preventing circular dependencies when running test. The test for `ckeditor5-paragraph` should run smoothly after that.

Also you can `npm link` the `@ckeditor/ckeditor5-dev-tests` package and run the `/node_modules/.bin/ckeditor5-dev-tests-install-dependencies` script.