### PR TITLE
Add `--expose-gc` to Chrome's flags in Karma launcher configuration.

### DIFF
--- a/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getkarmaconfig.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getkarmaconfig.js
@@ -81,7 +81,7 @@ module.exports = function getKarmaConfig( options ) {
 		customLaunchers: {
 			CHROME_TRAVIS_CI: {
 				base: 'Chrome',
-				flags: [ '--no-sandbox', '--disable-background-timer-throttling' ]
+				flags: [ '--no-sandbox', '--disable-background-timer-throttling', '--js-flags="--expose-gc"' ]
 			},
 			CHROME_LOCAL: {
 				base: 'Chrome',

--- a/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getkarmaconfig.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getkarmaconfig.js
@@ -85,7 +85,7 @@ module.exports = function getKarmaConfig( options ) {
 			},
 			CHROME_LOCAL: {
 				base: 'Chrome',
-				flags: [ '--disable-background-timer-throttling' ]
+				flags: [ '--disable-background-timer-throttling', '--js-flags="--expose-gc"' ]
 			},
 			BrowserStack_Edge: {
 				base: 'BrowserStack',


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Add `'--js-flags="--expose-gc"'` flag to Karma Chrome launcher configuration. See ckeditor/ckeditor5#1341.

---

### Additional information

* This change is required for memory leak tests: https://github.com/ckeditor/ckeditor5-core/pull/155.
