### PR TITLE
t/ckeditor5/335: Enabled Content Security Policy settings in all manual tests 

### DIFF
--- a/packages/ckeditor5-dev-tests/lib/utils/manual-tests/template.html
+++ b/packages/ckeditor5-dev-tests/lib/utils/manual-tests/template.html
@@ -3,6 +3,7 @@
 <head>
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<meta http-equiv="Content-Security-Policy" content="default-src 'none'; connect-src 'self' https://cksource.com http://*.cke-cs.com; script-src 'self' https://cksource.com; img-src * data:; style-src 'self' 'unsafe-inline'; frame-src *">
 	<title>Manual Test</title>
 	<style>
 		.manual-test-list-container,


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Enabled Content Security Policy settings in all manual tests (see ckeditor/ckeditor5#335).

---

Requires:

* https://github.com/ckeditor/ckeditor5-ckfinder/pull/36 changes in tests
* https://github.com/ckeditor/ckeditor5-theme-lark/pull/218 changes in tests