### PR TITLE
Fixed PR builds in testing env

### DIFF
--- a/packages/ckeditor5-dev-tests/bin/prepare-mgit-json.js
+++ b/packages/ckeditor5-dev-tests/bin/prepare-mgit-json.js
@@ -23,6 +23,8 @@ tools.updateJSONFile( path.join( TEST_DIR_PATH, 'mgit.json' ), () => {
 
 	return createMgitJsonContent( testingPackageJson, {
 		packageName: originalPackageJson.name,
-		commit: process.env.TRAVIS_COMMIT
+		// For PR build we want to get the latest commit from given PR instead of Merge Commit.
+		// See: https://github.com/ckeditor/ckeditor5-dev/issues/484
+		commit: process.env.TRAVIS_PULL_REQUEST_SHA || process.env.TRAVIS_COMMIT
 	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Pull requests builds will use proper commit SHA-1. Instead of testing the merge commit which does not exist in the git tree, it will use the latest commit from a branch that a user wants to merge. Closes #484.

---

### Additional information

Testing PR and builds – https://github.com/ckeditor/ckeditor5-paragraph/pull/42.
