### PR TITLE
t/489: Enabled ckeditor5-inspector in all manual tests

### DIFF
--- a/packages/ckeditor5-dev-tests/lib/tasks/runmanualtests.js
+++ b/packages/ckeditor5-dev-tests/lib/tasks/runmanualtests.js
@@ -11,6 +11,7 @@ const path = require( 'path' );
 const createManualTestServer = require( '../utils/manual-tests/createserver' );
 const compileManualTestScripts = require( '../utils/manual-tests/compilescripts' );
 const compileManualTestHtmlFiles = require( '../utils/manual-tests/compilehtmlfiles' );
+const copyAssets = require( '../utils/manual-tests/copyassets' );
 const removeDir = require( '../utils/manual-tests/removedir' );
 const transformFileOptionToTestGlob = require( '../utils/transformfileoptiontotestglob' );
 
@@ -30,7 +31,8 @@ module.exports = function runManualTests( options ) {
 		.then( () => removeDir( buildDir ) )
 		.then( () => Promise.all( [
 			compileManualTestScripts( buildDir, manualTestFilesPattern, options.themePath ),
-			compileManualTestHtmlFiles( buildDir, manualTestFilesPattern )
+			compileManualTestHtmlFiles( buildDir, manualTestFilesPattern ),
+			copyAssets( buildDir )
 		] ) )
 		.then( () => createManualTestServer( buildDir ) );
 };

--- a/packages/ckeditor5-dev-tests/lib/utils/manual-tests/attachinspector.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/manual-tests/attachinspector.js
@@ -1,0 +1,24 @@
+/**
+ * @license Copyright (c) 2003-2019, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/* global CKEditorInspector, window */
+
+/*
+ * This script attaches the inspector (https://github.com/ckeditor/ckeditor5-inspector) to
+ * all editors created in manual tests and referred under the global `window.editor` property.
+ */
+( () => {
+	let editor = null;
+
+	Object.defineProperty( window, 'editor', {
+		set: value => {
+			editor = value;
+
+			CKEditorInspector.attach( 'editor', editor );
+		},
+		get: () => editor
+	} );
+} )();
+

--- a/packages/ckeditor5-dev-tests/lib/utils/manual-tests/compilehtmlfiles.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/manual-tests/compilehtmlfiles.js
@@ -85,6 +85,8 @@ function compileHtmlFile( buildDir, sourceFilePathBase, viewTemplate ) {
 	// Attach script file to the view.
 	const scriptTag =
 		'<body class="manual-test-container">' +
+			'<script src="/assets/inspector.js"></script>' +
+			'<script src="/assets/attachinspector.js"></script>' +
 			`<script src="/${ absoluteJSFilePath }"></script>` +
 		'</body>';
 

--- a/packages/ckeditor5-dev-tests/lib/utils/manual-tests/copyassets.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/manual-tests/copyassets.js
@@ -1,0 +1,30 @@
+/**
+ * @license Copyright (c) 2003-2019, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/* jshint node: true, strict: true */
+
+const path = require( 'path' );
+const fs = require( 'fs-extra' );
+
+const assets = [
+	path.join( __dirname, 'attachinspector.js' ),
+	require.resolve( '@ckeditor/ckeditor5-inspector' )
+];
+
+/*
+ * Create the "assets" directory containing global, noncompilable files shared across all manual tests.
+ *
+ *		build/.manual-tests
+ *		├── assets
+ *		│   ├── ...
+ *		│   └── ...
+ *		...
+ */
+module.exports = function copyAssets( buildDir ) {
+	for ( const assetPath of assets ) {
+		const outputFilePath = path.join( buildDir, 'assets', path.basename( assetPath ) );
+		fs.copySync( assetPath, outputFilePath );
+	}
+};

--- a/packages/ckeditor5-dev-tests/package.json
+++ b/packages/ckeditor5-dev-tests/package.json
@@ -8,7 +8,7 @@
     "@babel/core": "^7.0.0",
     "@ckeditor/ckeditor5-dev-utils": "^12.0.0",
     "@ckeditor/ckeditor5-dev-webpack-plugin": "^8.0.0",
-    "@ckeditor/ckeditor5-inspector": "^0.0.1",
+    "@ckeditor/ckeditor5-inspector": "^1.0.0",
     "babel-core": "^6.26.0",
     "babel-loader": "^8.0.2",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.26.0",

--- a/packages/ckeditor5-dev-tests/package.json
+++ b/packages/ckeditor5-dev-tests/package.json
@@ -8,6 +8,7 @@
     "@babel/core": "^7.0.0",
     "@ckeditor/ckeditor5-dev-utils": "^12.0.0",
     "@ckeditor/ckeditor5-dev-webpack-plugin": "^8.0.0",
+    "@ckeditor/ckeditor5-inspector": "^0.0.1",
     "babel-core": "^6.26.0",
     "babel-loader": "^8.0.2",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.26.0",

--- a/packages/ckeditor5-dev-tests/tests/tasks/runmanualtests.js
+++ b/packages/ckeditor5-dev-tests/tests/tasks/runmanualtests.js
@@ -27,6 +27,7 @@ describe( 'runManualTests', () => {
 			htmlFileCompiler: sandbox.spy( () => Promise.resolve() ),
 			scriptCompiler: sandbox.spy( () => Promise.resolve() ),
 			removeDir: sandbox.spy( () => Promise.resolve() ),
+			copyAssets: sandbox.spy(),
 			transformFileOptionToTestGlob: sandbox.stub()
 		};
 
@@ -34,6 +35,7 @@ describe( 'runManualTests', () => {
 		mockery.registerMock( '../utils/manual-tests/compilehtmlfiles', spies.htmlFileCompiler );
 		mockery.registerMock( '../utils/manual-tests/compilescripts', spies.scriptCompiler );
 		mockery.registerMock( '../utils/manual-tests/removedir', spies.removeDir );
+		mockery.registerMock( '../utils/manual-tests/copyassets', spies.copyAssets );
 		mockery.registerMock( '../utils/transformfileoptiontotestglob', spies.transformFileOptionToTestGlob );
 
 		sandbox.stub( path, 'join' ).callsFake( ( ...chunks ) => chunks.join( '/' ) );

--- a/packages/ckeditor5-dev-tests/tests/utils/manual-tests/compilehtmlfiles.js
+++ b/packages/ckeditor5-dev-tests/tests/utils/manual-tests/compilehtmlfiles.js
@@ -134,7 +134,11 @@ describe( 'compileHtmlFiles', () => {
 				'<div>template html content</div>',
 				'<div class="manual-test-sidebar"><a href="/" class="manual-test-root-link">&larr; Back to the list</a><h2>Markdown header</h2></div>',
 				'<div>html file content</div>',
-				`<body class="manual-test-container"><script src="${ path.sep + path.join( 'path', 'to', 'manual', 'file.js' ) }"></script></body>`
+				'<body class="manual-test-container">' +
+					'<script src="/assets/inspector.js"></script>' +
+					'<script src="/assets/attachinspector.js"></script>' +
+					`<script src="${ path.sep + path.join( 'path', 'to', 'manual', 'file.js' ) }"></script>` +
+				'</body>'
 			].join( '\n' )
 		);
 		/* eslint-enable max-len */
@@ -167,7 +171,11 @@ describe( 'compileHtmlFiles', () => {
 				'<div>template html content</div>',
 				'<div class="manual-test-sidebar"><a href="/" class="manual-test-root-link">&larr; Back to the list</a><h2>Markdown header</h2></div>',
 				'<div>html file content</div>',
-				`<body class="manual-test-container"><script src="${ path.sep + path.join( 'path', 'to', 'manual', 'file.abc.js' ) }"></script></body>`
+				'<body class="manual-test-container">' +
+					'<script src="/assets/inspector.js"></script>' +
+					'<script src="/assets/attachinspector.js"></script>' +
+					`<script src="${ path.sep + path.join( 'path', 'to', 'manual', 'file.abc.js' ) }"></script>` +
+				'</body>'
 			].join( '\n' )
 		);
 		/* eslint-enable max-len */
@@ -255,8 +263,11 @@ describe( 'compileHtmlFiles', () => {
 				'<div>template html content</div>',
 				'<div class="manual-test-sidebar"><a href="/" class="manual-test-root-link">&larr; Back to the list</a><h2>Markdown header</h2></div>',
 				'<div>html file content</div>',
-				`<body class="manual-test-container"><script src="${ path.sep +
-				path.join( 'path', 'to', 'manual', 'file.js' ) }"></script></body>`
+				'<body class="manual-test-container">' +
+					'<script src="/assets/inspector.js"></script>' +
+					'<script src="/assets/attachinspector.js"></script>' +
+					`<script src="${ path.sep + path.join( 'path', 'to', 'manual', 'file.js' ) }"></script>` +
+				'</body>'
 			].join( '\n' )
 		);
 		/* eslint-enable max-len */
@@ -295,7 +306,11 @@ describe( 'compileHtmlFiles', () => {
 				'<div>template html content</div>',
 				'<div class="manual-test-sidebar"><a href="/" class="manual-test-root-link">&larr; Back to the list</a><h2>Markdown header</h2></div>',
 				'<div>html file content</div>',
-				`<body class="manual-test-container"><script src="/${ path.join( 'path', 'to', 'manual', 'file.js' ) }"></script></body>`
+				'<body class="manual-test-container">' +
+					'<script src="/assets/inspector.js"></script>' +
+					'<script src="/assets/attachinspector.js"></script>' +
+					`<script src="/${ path.join( 'path', 'to', 'manual', 'file.js' ) }"></script>` +
+				'</body>'
 			].join( '\n' )
 		);
 		/* eslint-enable max-len */


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))


Feature: Enabled ckeditor5-inspector in all manual tests. Closes #489.

---

### Additional information

NOTE: Awaits release of [ckeditor5-inspector](https://github.com/ckeditor/ckeditor5-inspector) on npm.
