### PR TITLE
All commits will be displayed properly during generating the changelog

### DIFF
--- a/packages/ckeditor5-dev-env/lib/release-tools/tasks/generatechangelogforsinglepackage.js
+++ b/packages/ckeditor5-dev-env/lib/release-tools/tasks/generatechangelogforsinglepackage.js
@@ -11,6 +11,7 @@ const { tools, logger } = require( '@ckeditor/ckeditor5-dev-utils' );
 const cli = require( '../utils/cli' );
 const versionUtils = require( '../utils/versions' );
 const changelogUtils = require( '../utils/changelog' );
+const displayCommits = require( '../utils/displaycommits' );
 const getPackageJson = require( '../utils/getpackagejson' );
 const getNewReleaseType = require( '../utils/getnewreleasetype' );
 const generateChangelogFromCommits = require( '../utils/generatechangelogfromcommits' );
@@ -50,8 +51,10 @@ module.exports = function generateChangelogForSinglePackage( options = {} ) {
 			.then( () => {
 				return getNewReleaseType( transformCommitFunction, { tagName } );
 			} )
-			.then( response => {
-				const newReleaseType = response.releaseType !== 'skip' ? response.releaseType : null;
+			.then( result => {
+				displayCommits( result.commits );
+
+				const newReleaseType = result.releaseType !== 'skip' ? result.releaseType : null;
 
 				return cli.provideVersion( packageJson.version, newReleaseType );
 			} );

--- a/packages/ckeditor5-dev-env/lib/release-tools/tasks/generatechangelogforsubpackages.js
+++ b/packages/ckeditor5-dev-env/lib/release-tools/tasks/generatechangelogforsubpackages.js
@@ -12,6 +12,7 @@ const getNewReleaseType = require( '../utils/getnewreleasetype' );
 const cli = require( '../utils/cli' );
 const versionUtils = require( '../utils/versions' );
 const changelogUtils = require( '../utils/changelog' );
+const displayCommits = require( '../utils/displaycommits' );
 const displaySkippedPackages = require( '../utils/displayskippedpackages' );
 const displayGeneratedChangelogs = require( '../utils/displaygeneratedchangelogs' );
 const executeOnPackages = require( '../utils/executeonpackages' );
@@ -80,8 +81,10 @@ module.exports = function generateChangelogForSubPackages( options ) {
 		log.info( chalk.bold.blue( `Generating changelog for "${ dependencyName }"...` ) );
 
 		return getNewReleaseType( transformCommitFunction, { tagName } )
-			.then( response => {
-				const newReleaseType = response.releaseType !== 'skip' ? response.releaseType : null;
+			.then( result => {
+				displayCommits( result.commits );
+
+				const newReleaseType = result.releaseType !== 'skip' ? result.releaseType : null;
 
 				return cli.provideVersion( packageJson.version, newReleaseType );
 			} )

--- a/packages/ckeditor5-dev-env/lib/release-tools/tasks/generatesummarychangelog.js
+++ b/packages/ckeditor5-dev-env/lib/release-tools/tasks/generatesummarychangelog.js
@@ -13,6 +13,7 @@ const moment = require( 'moment' );
 const { tools, logger } = require( '@ckeditor/ckeditor5-dev-utils' );
 const changelogUtils = require( '../utils/changelog' );
 const cliUtils = require( '../utils/cli' );
+const displayCommits = require( '../utils/displaycommits' );
 const displayGeneratedChangelogs = require( '../utils/displaygeneratedchangelogs' );
 const executeOnPackages = require( '../utils/executeonpackages' );
 const generateChangelogFromCommits = require( '../utils/generatechangelogfromcommits' );
@@ -104,6 +105,8 @@ module.exports = function generateSummaryChangelog( options ) {
 		if ( !newVersion ) {
 			promise = promise.then( () => getNewReleaseType( transformCommitFunction, { tagName } ) )
 				.then( result => {
+					displayCommits( result.commits );
+
 					suggestedBumpFromCommits = result.releaseType === 'internal' ? 'skip' : result.releaseType;
 
 					let newReleaseType;

--- a/packages/ckeditor5-dev-env/lib/release-tools/utils/displaycommits.js
+++ b/packages/ckeditor5-dev-env/lib/release-tools/utils/displaycommits.js
@@ -1,0 +1,37 @@
+const chalk = require( 'chalk' );
+const { logger } = require( '@ckeditor/ckeditor5-dev-utils' );
+const utils = require( './transform-commit/transform-commit-utils' );
+
+// A size of indent for a log. The number is equal to length of the log string:
+// '* 1234567 ', where '1234567' is a short commit id.
+const INDENT_SIZE = 10;
+
+module.exports = function displayCommits( commits ) {
+	const log = logger();
+
+	if ( !commits.length ) {
+		log.info( chalk.italic( 'No commits to display.' ) );
+	}
+
+	for ( const singleCommit of commits ) {
+		const hasCorrectType = utils.availableCommitTypes.has( singleCommit.rawType );
+		const isCommitIncluded = utils.availableCommitTypes.get( singleCommit.rawType );
+
+		let logMessage = `* ${ chalk.yellow( singleCommit.hash ) } "${ utils.truncate( singleCommit.header, 100 ) }" `;
+
+		if ( hasCorrectType && isCommitIncluded ) {
+			logMessage += chalk.green( 'INCLUDED' );
+		} else if ( hasCorrectType && !isCommitIncluded ) {
+			logMessage += chalk.grey( 'SKIPPED' );
+		} else {
+			logMessage += chalk.red( 'INVALID' );
+		}
+
+		// Avoid displaying singleCommit merge twice.
+		if ( singleCommit.merge && singleCommit.merge !== singleCommit.header ) {
+			logMessage += `\n${ ' '.repeat( INDENT_SIZE ) }${ chalk.italic( singleCommit.merge ) }`;
+		}
+
+		log.info( logMessage );
+	}
+};

--- a/packages/ckeditor5-dev-env/lib/release-tools/utils/getnewreleasetype.js
+++ b/packages/ckeditor5-dev-env/lib/release-tools/utils/getnewreleasetype.js
@@ -5,37 +5,27 @@
 
 'use strict';
 
-const chalk = require( 'chalk' );
 const conventionalCommitsParser = require( 'conventional-commits-parser' );
 const conventionalCommitsFilter = require( 'conventional-commits-filter' );
 const gitRawCommits = require( 'git-raw-commits' );
 const concat = require( 'concat-stream' );
-const { logger } = require( '@ckeditor/ckeditor5-dev-utils' );
 const parserOptions = require( './transform-commit/parser-options' );
 const { availableCommitTypes } = require( './transform-commit/transform-commit-utils' );
 const getPackageJson = require( './getpackagejson' );
-const utils = require( './transform-commit/transform-commit-utils' );
-
-module.exports = getNewReleaseType;
-
-// Used for testing purposes.
-getNewReleaseType._displayCommits = _displayCommits;
-
-// A size of indent for a log. The number is equal to length of the log string:
-// '* 1234567 ', where '1234567' is a short commit id.
-const INDENT_SIZE = 10;
 
 /**
  * Returns a type (major, minor, patch) of the next release based on commits.
  *
  * If given package has not changed, suggested version will be equal to 'skip'.
  *
+ * It returns a promise that resolves the `releaseType` and all `commits` that have been checked.
+ *
  * @param {Function} transformCommit
  * @param {Object} options
  * @param {String|null} options.tagName Name of the last created tag for the repository.
- * @returns {Promise}
+ * @returns {Promise.<Object>}
  */
-function getNewReleaseType( transformCommit, options = {} ) {
+module.exports = function getNewReleaseType( transformCommit, options = {} ) {
 	const gitRawCommitsOpts = {
 		format: '%B%n-hash-%n%H',
 		from: options.tagName,
@@ -67,76 +57,48 @@ function getNewReleaseType( transformCommit, options = {} ) {
 					.map( commit => transformCommit( commit, context ) )
 					.filter( commit => commit );
 
-				getNewReleaseType._displayCommits( commits );
-
-				return resolve( { releaseType: _getNewVersionType( commits ) } );
+				return resolve( {
+					releaseType: getNewVersionType( commits ),
+					commits
+				} );
 			} ) );
 	} );
-}
 
-// Returns a type of version for a release based on the commits.
-//
-// @param {Array.<Commit>} commits
-// @returns {String}
-function _getNewVersionType( commits ) {
-	// Repository does not have new changes.
-	if ( !commits.length ) {
-		return 'skip';
-	}
+	// Returns a type of version for a release based on the commits.
+	//
+	// @param {Array.<Commit>} commits
+	// @returns {String}
+	function getNewVersionType( commits ) {
+		// Repository does not have new changes.
+		if ( !commits.length ) {
+			return 'skip';
+		}
 
-	const publicCommits = commits.filter( commit => availableCommitTypes.get( commit.rawType ) );
+		const publicCommits = commits.filter( commit => availableCommitTypes.get( commit.rawType ) );
 
-	if ( !publicCommits.length ) {
-		return 'internal';
-	}
+		if ( !publicCommits.length ) {
+			return 'internal';
+		}
 
-	let newFeatures = false;
+		let newFeatures = false;
 
-	for ( const commit of publicCommits ) {
-		for ( const note of commit.notes ) {
-			if ( note.title === 'BREAKING CHANGES' ) {
-				return 'major';
+		for ( const commit of publicCommits ) {
+			for ( const note of commit.notes ) {
+				if ( note.title === 'BREAKING CHANGES' ) {
+					return 'major';
+				}
+			}
+
+			if ( !newFeatures && commit.rawType === 'Feature' ) {
+				newFeatures = true;
 			}
 		}
 
-		if ( !newFeatures && commit.rawType === 'Feature' ) {
-			newFeatures = true;
-		}
-	}
-
-	// Repository has new features without breaking changes.
-	if ( newFeatures ) {
-		return 'minor';
-	}
-
-	return 'patch';
-}
-
-// Displays all commits on the console.
-//
-// @param {Array.<Commit>} commits
-function _displayCommits( commits ) {
-	const log = logger();
-
-	for ( const singleCommit of commits ) {
-		const hasCorrectType = utils.availableCommitTypes.has( singleCommit.rawType );
-		const isCommitIncluded = utils.availableCommitTypes.get( singleCommit.rawType );
-
-		let logMessage = `* ${ chalk.yellow( singleCommit.hash ) } "${ utils.truncate( singleCommit.header, 100 ) }" `;
-
-		if ( hasCorrectType && isCommitIncluded ) {
-			logMessage += chalk.green( 'INCLUDED' );
-		} else if ( hasCorrectType && !isCommitIncluded ) {
-			logMessage += chalk.grey( 'SKIPPED' );
-		} else {
-			logMessage += chalk.red( 'INVALID' );
+		// Repository has new features without breaking changes.
+		if ( newFeatures ) {
+			return 'minor';
 		}
 
-		// Avoid displaying singleCommit merge twice.
-		if ( singleCommit.merge && singleCommit.merge !== singleCommit.header ) {
-			logMessage += `\n${ ' '.repeat( INDENT_SIZE ) }${ chalk.italic( singleCommit.merge ) }`;
-		}
-
-		log.info( logMessage );
+		return 'patch';
 	}
-}
+};

--- a/packages/ckeditor5-dev-env/lib/release-tools/utils/getnewreleasetype.js
+++ b/packages/ckeditor5-dev-env/lib/release-tools/utils/getnewreleasetype.js
@@ -89,7 +89,7 @@ module.exports = function getNewReleaseType( transformCommit, options = {} ) {
 				}
 			}
 
-			if ( !newFeatures && commit.rawType === 'Feature' ) {
+			if ( commit.rawType === 'Feature' ) {
 				newFeatures = true;
 			}
 		}

--- a/packages/ckeditor5-dev-env/lib/release-tools/utils/getnewreleasetype.js
+++ b/packages/ckeditor5-dev-env/lib/release-tools/utils/getnewreleasetype.js
@@ -5,13 +5,25 @@
 
 'use strict';
 
+const chalk = require( 'chalk' );
 const conventionalCommitsParser = require( 'conventional-commits-parser' );
 const conventionalCommitsFilter = require( 'conventional-commits-filter' );
 const gitRawCommits = require( 'git-raw-commits' );
 const concat = require( 'concat-stream' );
+const { logger } = require( '@ckeditor/ckeditor5-dev-utils' );
 const parserOptions = require( './transform-commit/parser-options' );
 const { availableCommitTypes } = require( './transform-commit/transform-commit-utils' );
 const getPackageJson = require( './getpackagejson' );
+const utils = require( './transform-commit/transform-commit-utils' );
+
+module.exports = getNewReleaseType;
+
+// Used for testing purposes.
+getNewReleaseType._displayCommits = _displayCommits;
+
+// A size of indent for a log. The number is equal to length of the log string:
+// '* 1234567 ', where '1234567' is a short commit id.
+const INDENT_SIZE = 10;
 
 /**
  * Returns a type (major, minor, patch) of the next release based on commits.
@@ -23,7 +35,7 @@ const getPackageJson = require( './getpackagejson' );
  * @param {String|null} options.tagName Name of the last created tag for the repository.
  * @returns {Promise}
  */
-module.exports = function getNewReleaseType( transformCommit, options = {} ) {
+function getNewReleaseType( transformCommit, options = {} ) {
 	const gitRawCommitsOpts = {
 		format: '%B%n-hash-%n%H',
 		from: options.tagName,
@@ -32,7 +44,6 @@ module.exports = function getNewReleaseType( transformCommit, options = {} ) {
 	};
 
 	const context = {
-		displayLogs: true,
 		returnInvalidCommit: true,
 		packageData: getPackageJson()
 	};
@@ -44,8 +55,7 @@ module.exports = function getNewReleaseType( transformCommit, options = {} ) {
 					reject( new Error( 'Given repository is empty.' ) );
 				} else if ( err.message.match( new RegExp( `'${ options.tagName }\\.\\.HEAD': unknown` ) ) ) {
 					reject( new Error(
-						`Cannot find tag "${ options.tagName }" (the latest version from the changelog) ` +
-						'in given repository.'
+						`Cannot find tag "${ options.tagName }" (the latest version from the changelog) in given repository.`
 					) );
 				} else {
 					reject( err );
@@ -57,47 +67,76 @@ module.exports = function getNewReleaseType( transformCommit, options = {} ) {
 					.map( commit => transformCommit( commit, context ) )
 					.filter( commit => commit );
 
-				const releaseType = getNewVersionType( commits );
+				getNewReleaseType._displayCommits( commits );
 
-				return resolve( { releaseType } );
+				return resolve( { releaseType: _getNewVersionType( commits ) } );
 			} ) );
 	} );
+}
 
-	// Returns a type of version for a release based on the commits.
-	//
-	// @param {Array} commits
-	// @returns {String}
-	function getNewVersionType( commits ) {
-		// Repository does not have new changes.
-		if ( !commits.length ) {
-			return 'skip';
-		}
-
-		const publicCommits = commits.filter( commit => availableCommitTypes.get( commit.rawType ) );
-
-		if ( !publicCommits.length ) {
-			return 'internal';
-		}
-
-		let newFeatures = false;
-
-		for ( const commit of publicCommits ) {
-			for ( const note of commit.notes ) {
-				if ( note.title === 'BREAKING CHANGES' ) {
-					return 'major';
-				}
-			}
-
-			if ( !newFeatures && commit.rawType === 'Feature' ) {
-				newFeatures = true;
-			}
-		}
-
-		// Repository has new features without breaking changes.
-		if ( newFeatures ) {
-			return 'minor';
-		}
-
-		return 'patch';
+// Returns a type of version for a release based on the commits.
+//
+// @param {Array.<Commit>} commits
+// @returns {String}
+function _getNewVersionType( commits ) {
+	// Repository does not have new changes.
+	if ( !commits.length ) {
+		return 'skip';
 	}
-};
+
+	const publicCommits = commits.filter( commit => availableCommitTypes.get( commit.rawType ) );
+
+	if ( !publicCommits.length ) {
+		return 'internal';
+	}
+
+	let newFeatures = false;
+
+	for ( const commit of publicCommits ) {
+		for ( const note of commit.notes ) {
+			if ( note.title === 'BREAKING CHANGES' ) {
+				return 'major';
+			}
+		}
+
+		if ( !newFeatures && commit.rawType === 'Feature' ) {
+			newFeatures = true;
+		}
+	}
+
+	// Repository has new features without breaking changes.
+	if ( newFeatures ) {
+		return 'minor';
+	}
+
+	return 'patch';
+}
+
+// Displays all commits on the console.
+//
+// @param {Array.<Commit>} commits
+function _displayCommits( commits ) {
+	const log = logger();
+
+	for ( const singleCommit of commits ) {
+		const hasCorrectType = utils.availableCommitTypes.has( singleCommit.rawType );
+		const isCommitIncluded = utils.availableCommitTypes.get( singleCommit.rawType );
+
+		let logMessage = `* ${ chalk.yellow( singleCommit.hash ) } "${ utils.truncate( singleCommit.header, 100 ) }" `;
+
+		if ( hasCorrectType && isCommitIncluded ) {
+			logMessage += chalk.green( 'INCLUDED' );
+		} else if ( hasCorrectType && !isCommitIncluded ) {
+			logMessage += chalk.grey( 'SKIPPED' );
+		} else {
+			logMessage += chalk.red( 'INVALID' );
+		}
+
+		// Avoid displaying singleCommit merge twice.
+		if ( singleCommit.merge && singleCommit.merge !== singleCommit.header ) {
+			logMessage += `\n${ ' '.repeat( INDENT_SIZE ) }${ chalk.italic( singleCommit.merge ) }`;
+		}
+
+		log.info( logMessage );
+	}
+}

--- a/packages/ckeditor5-dev-env/lib/release-tools/utils/getnewreleasetype.js
+++ b/packages/ckeditor5-dev-env/lib/release-tools/utils/getnewreleasetype.js
@@ -18,7 +18,7 @@ const getPackageJson = require( './getpackagejson' );
  *
  * If given package has not changed, suggested version will be equal to 'skip'.
  *
- * It returns a promise that resolves the `releaseType` and all `commits` that have been checked.
+ * It returns a promise that resolves to the `releaseType` and all `commits` that have been checked.
  *
  * @param {Function} transformCommit
  * @param {Object} options

--- a/packages/ckeditor5-dev-env/lib/release-tools/utils/transform-commit/transformcommitforsubpackage.js
+++ b/packages/ckeditor5-dev-env/lib/release-tools/utils/transform-commit/transformcommitforsubpackage.js
@@ -15,7 +15,6 @@ const getChangedFilesForCommit = require( './getchangedfilesforcommit' );
  *
  * @param {Commit} commit
  * @param {Object} context
- * @param {Boolean} context.displayLogs Whether to display the logs.
  * @param {Object} context.packageData Content from the 'package.json' for given package.
  * @returns {Commit}
  */

--- a/packages/ckeditor5-dev-env/lib/release-tools/utils/transform-commit/transformcommitforsubpackage.js
+++ b/packages/ckeditor5-dev-env/lib/release-tools/utils/transform-commit/transformcommitforsubpackage.js
@@ -13,10 +13,13 @@ const getChangedFilesForCommit = require( './getchangedfilesforcommit' );
  *
  * The commit will be parsed only if its at least one file is located in current processing package.
  *
+ * Returns `undefined` if given commit should not be added to the changelog. This behavior can be changed
+ * using the `context.returnInvalidCommit` option.
+ *
  * @param {Commit} commit
  * @param {Object} context
  * @param {Object} context.packageData Content from the 'package.json' for given package.
- * @returns {Commit}
+ * @returns {Commit|undefined}
  */
 module.exports = function transformCommitForSubPackage( commit, context ) {
 	// Skip the Lerna "Publish" commit.

--- a/packages/ckeditor5-dev-env/lib/release-tools/utils/transform-commit/transformcommitforsubpackage.js
+++ b/packages/ckeditor5-dev-env/lib/release-tools/utils/transform-commit/transformcommitforsubpackage.js
@@ -16,12 +16,17 @@ const getChangedFilesForCommit = require( './getchangedfilesforcommit' );
  * Returns `undefined` if given commit should not be added to the changelog. This behavior can be changed
  * using the `context.returnInvalidCommit` option.
  *
- * @param {Commit} commit
+ * @param {Commit} rawCommit
  * @param {Object} context
  * @param {Object} context.packageData Content from the 'package.json' for given package.
  * @returns {Commit|undefined}
  */
-module.exports = function transformCommitForSubPackage( commit, context ) {
+module.exports = function transformCommitForSubPackage( rawCommit, context ) {
+	// Let's clone the commit. We don't want to modify the reference.
+	const commit = Object.assign( {}, rawCommit, {
+		notes: rawCommit.notes.map( note => Object.assign( {}, note ) )
+	} );
+
 	// Skip the Lerna "Publish" commit.
 	if ( !commit.type && commit.header === 'Publish' && commit.body ) {
 		return;

--- a/packages/ckeditor5-dev-env/lib/release-tools/utils/transform-commit/transformcommitforsubrepository.js
+++ b/packages/ckeditor5-dev-env/lib/release-tools/utils/transform-commit/transformcommitforsubrepository.js
@@ -34,7 +34,7 @@ module.exports = function transformCommitForSubRepository( rawCommit, context = 
 	commit.rawType = commit.type;
 
 	// Whether the commit will be printed in the changelog.
-	const isCommitIncluded = utils.availableCommitTypes.get( commit.type );
+	const isCommitIncluded = utils.availableCommitTypes.get( commit.rawType );
 
 	// Our merge commit always contains two lines:
 	// Merge ...
@@ -67,7 +67,7 @@ module.exports = function transformCommitForSubRepository( rawCommit, context = 
 	}
 
 	// The `type` below will be key for grouping commits.
-	commit.type = utils.getCommitType( commit.type );
+	commit.type = utils.getCommitType( commit.rawType );
 
 	if ( typeof commit.subject === 'string' ) {
 		commit.subject = makeLinks( commit.subject );

--- a/packages/ckeditor5-dev-env/lib/release-tools/utils/transform-commit/transformcommitforsubrepository.js
+++ b/packages/ckeditor5-dev-env/lib/release-tools/utils/transform-commit/transformcommitforsubrepository.js
@@ -23,15 +23,11 @@ const utils = require( './transform-commit-utils' );
  */
 module.exports = function transformCommitForSubRepository( rawCommit, context = {} ) {
 	// Let's clone the commit. We don't want to modify the reference.
-	const commit = Object.assign( {}, rawCommit );
-	commit.notes = [];
-
-	for ( const note of rawCommit.notes ) {
-		commit.notes.push( Object.assign( {}, note ) );
-	}
-
-	// Copy the original `type` of the commit.
-	commit.rawType = commit.type;
+	const commit = Object.assign( {}, rawCommit, {
+		// Copy the original `type` of the commit.
+		rawType: rawCommit.type,
+		notes: rawCommit.notes.map( note => Object.assign( {}, note ) )
+	} );
 
 	// Whether the commit will be printed in the changelog.
 	const isCommitIncluded = utils.availableCommitTypes.get( commit.rawType );

--- a/packages/ckeditor5-dev-env/lib/release-tools/utils/transform-commit/transformcommitforsubrepository.js
+++ b/packages/ckeditor5-dev-env/lib/release-tools/utils/transform-commit/transformcommitforsubrepository.js
@@ -13,10 +13,13 @@ const utils = require( './transform-commit-utils' );
  *   - filters out the commit if it should not be visible in the changelog,
  *   - makes links to issues and organizations on GitHub.
  *
+ * Returns `undefined` if given commit should not be added to the changelog. This behavior can be changed
+ * using the `context.returnInvalidCommit` option.
+ *
  * @param {Commit} rawCommit
  * @param {Object} [context={}]
  * @param {Boolean} [context.returnInvalidCommit=false] Whether invalid commit should be returned.
- * @returns {Commit}
+ * @returns {Commit|undefined}
  */
 module.exports = function transformCommitForSubRepository( rawCommit, context = {} ) {
 	// Let's clone the commit. We don't want to modify the reference.

--- a/packages/ckeditor5-dev-env/lib/release-tools/utils/transform-commit/transformcommitforsubrepository.js
+++ b/packages/ckeditor5-dev-env/lib/release-tools/utils/transform-commit/transformcommitforsubrepository.js
@@ -5,13 +5,7 @@
 
 'use strict';
 
-const chalk = require( 'chalk' );
-const { logger } = require( '@ckeditor/ckeditor5-dev-utils' );
 const utils = require( './transform-commit-utils' );
-
-// A size of indent for a log. The number is equal to length of the log string:
-// '* 1234567 ', where '1234567' is a short commit id.
-const INDENT_SIZE = 10;
 
 /**
  * Parses a single commit:
@@ -19,17 +13,24 @@ const INDENT_SIZE = 10;
  *   - filters out the commit if it should not be visible in the changelog,
  *   - makes links to issues and organizations on GitHub.
  *
- * @param {Commit} commit
- * @param {Object} context
- * @param {Boolean} context.displayLogs Whether to display the logs.
+ * @param {Commit} rawCommit
+ * @param {Object} [context={}]
  * @param {Boolean} [context.returnInvalidCommit=false] Whether invalid commit should be returned.
- * @param {Object} context.packageData Content from the 'package.json' for given package.
  * @returns {Commit}
  */
-module.exports = function transformCommitForSubRepository( commit, context ) {
-	const log = logger( context.displayLogs ? 'info' : 'error' );
+module.exports = function transformCommitForSubRepository( rawCommit, context = {} ) {
+	// Let's clone the commit. We don't want to modify the reference.
+	const commit = Object.assign( {}, rawCommit );
+	commit.notes = [];
 
-	const hasCorrectType = utils.availableCommitTypes.has( commit.type );
+	for ( const note of rawCommit.notes ) {
+		commit.notes.push( Object.assign( {}, note ) );
+	}
+
+	// Copy the original `type` of the commit.
+	commit.rawType = commit.type;
+
+	// Whether the commit will be printed in the changelog.
 	const isCommitIncluded = utils.availableCommitTypes.get( commit.type );
 
 	// Our merge commit always contains two lines:
@@ -48,23 +49,7 @@ module.exports = function transformCommitForSubRepository( commit, context ) {
 		commit.hash = commit.hash.substring( 0, 7 );
 	}
 
-	let logMessage = `* ${ chalk.yellow( commit.hash ) } "${ utils.truncate( commit.header, 100 ) }" `;
-
-	if ( hasCorrectType && isCommitIncluded ) {
-		logMessage += chalk.green( 'INCLUDED' );
-	} else if ( hasCorrectType && !isCommitIncluded ) {
-		logMessage += chalk.grey( 'SKIPPED' );
-	} else {
-		logMessage += chalk.red( 'INVALID' );
-	}
-
-	// Avoid displaying commit merge twice.
-	if ( commit.merge && commit.merge !== commit.header ) {
-		logMessage += `\n${ ' '.repeat( INDENT_SIZE ) }${ commit.merge }`;
-	}
-
-	log.info( logMessage );
-
+	// It's used only for displaying the commit. Changelog generator will filter out the invalid entries.
 	if ( !isCommitIncluded ) {
 		return context.returnInvalidCommit ? commit : undefined;
 	}
@@ -78,15 +63,15 @@ module.exports = function transformCommitForSubRepository( commit, context ) {
 		commit.subject += '.';
 	}
 
-	commit.rawType = commit.type;
+	// The `type` below will be key for grouping commits.
 	commit.type = utils.getCommitType( commit.type );
 
 	if ( typeof commit.subject === 'string' ) {
 		commit.subject = makeLinks( commit.subject );
 	}
 
-	// Remove additional notes from commit's footer.
-	// Additional notes are added to footer. In order to avoid duplication, they should be removed.
+	// Remove additional notes from the commit's footer.
+	// Additional notes are added to the footer. In order to avoid duplication, they should be removed.
 	if ( commit.footer && commit.notes.length ) {
 		commit.footer = commit.footer.split( '\n' )
 			.filter( footerLine => {
@@ -98,6 +83,7 @@ module.exports = function transformCommitForSubRepository( commit, context ) {
 			.trim();
 	}
 
+	// If `body` of the commit is empty but the `footer` isn't, let's swap those.
 	if ( commit.footer && !commit.body ) {
 		commit.body = commit.footer;
 		commit.footer = null;
@@ -141,7 +127,11 @@ function makeLinks( comment ) {
 /**
  * @typedef {Object} Commit
  *
- * @property {String} [type] Type of the commit.
+ * @property {String} rawType Type of the commit without any modifications.
+ *
+ * @property {String} type Type of the commit (it can be modified).
+ *
+ * @property {String} hash The commit SHA-1 id.
  *
  * @property {String} [subject] Subject of the commit.
  *
@@ -153,13 +143,12 @@ function makeLinks( comment ) {
  *
  * @property {Array.<CommitNote>} [notes] Notes for the commit.
  *
- * @property {String} [hash] The commit SHA-1 id.
- *
  */
+
 /**
  * @typedef {Object} CommitNote
  *
- * @property {String} [title] Type of the note.
+ * @property {String} title Type of the note.
  *
- * @property {String} [text] Text of the note.
+ * @property {String} text Text of the note.
  */

--- a/packages/ckeditor5-dev-env/tests/release-tools/tasks/generatechangelogforsinglepackage.js
+++ b/packages/ckeditor5-dev-env/tests/release-tools/tasks/generatechangelogforsinglepackage.js
@@ -23,6 +23,7 @@ describe( 'dev-env/release-tools/tasks', () => {
 					changelogFile: changelogUtils.changelogFile,
 				},
 				getNewReleaseType: sandbox.stub(),
+				displayCommits: sandbox.stub(),
 				logger: {
 					info: sandbox.stub(),
 					warning: sandbox.stub(),
@@ -49,6 +50,7 @@ describe( 'dev-env/release-tools/tasks', () => {
 
 			mockery.registerMock( '../utils/cli', stubs.cli );
 			mockery.registerMock( '../utils/getnewreleasetype', stubs.getNewReleaseType );
+			mockery.registerMock( '../utils/displaycommits', stubs.displayCommits );
 			mockery.registerMock( '../utils/generatechangelogfromcommits', stubs.generateChangelogFromCommits );
 			mockery.registerMock( '../utils/transform-commit/transformcommitforsubrepository', stubs.transformCommit );
 
@@ -101,8 +103,11 @@ describe( 'dev-env/release-tools/tasks', () => {
 		} );
 
 		it( 'generates changelog for version provided by a user', () => {
+			const commits = [ {}, {} ];
+
 			stubs.getNewReleaseType.returns( Promise.resolve( {
-				releaseType: 'minor'
+				releaseType: 'minor',
+				commits
 			} ) );
 			stubs.cli.provideVersion.returns( Promise.resolve( '0.1.0' ) );
 			stubs.versionUtils.getLastFromChangelog.returns( null );
@@ -126,12 +131,18 @@ describe( 'dev-env/release-tools/tasks', () => {
 					expect( stubs.cli.provideVersion.calledOnce ).to.equal( true );
 					expect( stubs.cli.provideVersion.firstCall.args[ 0 ] ).to.equal( '0.0.1' );
 					expect( stubs.cli.provideVersion.firstCall.args[ 1 ] ).to.equal( 'minor' );
+
+					expect( stubs.displayCommits.calledOnce ).to.equal( true );
+					expect( stubs.displayCommits.firstCall.args[ 0 ] ).to.deep.equal( commits );
 				} );
 		} );
 
 		it( 'does not generate if a user provides "skip" as a new version (suggested a "minor" release)', () => {
+			const commits = [ {}, {} ];
+
 			stubs.getNewReleaseType.returns( Promise.resolve( {
-				releaseType: 'minor'
+				releaseType: 'minor',
+				commits
 			} ) );
 
 			stubs.cli.provideVersion.returns( Promise.resolve( 'skip' ) );
@@ -139,12 +150,18 @@ describe( 'dev-env/release-tools/tasks', () => {
 			return generateChangelogForSinglePackage()
 				.then( () => {
 					expect( stubs.generateChangelogFromCommits.called ).to.equal( false );
+
+					expect( stubs.displayCommits.calledOnce ).to.equal( true );
+					expect( stubs.displayCommits.firstCall.args[ 0 ] ).to.deep.equal( commits );
 				} );
 		} );
 
 		it( 'does not generate if a user provides "skip" as a new version (suggested a "skip" release)', () => {
+			const commits = [ {}, {} ];
+
 			stubs.getNewReleaseType.returns( Promise.resolve( {
-				releaseType: 'skip'
+				releaseType: 'skip',
+				commits
 			} ) );
 
 			stubs.cli.provideVersion.returns( Promise.resolve( 'skip' ) );
@@ -152,6 +169,9 @@ describe( 'dev-env/release-tools/tasks', () => {
 			return generateChangelogForSinglePackage()
 				.then( () => {
 					expect( stubs.generateChangelogFromCommits.called ).to.equal( false );
+
+					expect( stubs.displayCommits.calledOnce ).to.equal( true );
+					expect( stubs.displayCommits.firstCall.args[ 0 ] ).to.deep.equal( commits );
 				} );
 		} );
 

--- a/packages/ckeditor5-dev-env/tests/release-tools/tasks/generatechangelogforsubpackages.js
+++ b/packages/ckeditor5-dev-env/tests/release-tools/tasks/generatechangelogforsubpackages.js
@@ -34,6 +34,7 @@ describe( 'dev-env/release-tools/tasks', () => {
 				changelogFile: 'CHANGELOG.md',
 			},
 			getNewReleaseType: sandbox.stub(),
+			displayCommits: sandbox.stub(),
 			logger: {
 				info: sandbox.spy(),
 				warning: sandbox.spy(),
@@ -58,6 +59,7 @@ describe( 'dev-env/release-tools/tasks', () => {
 		mockery.registerMock( '../utils/cli', stubs.cli );
 		mockery.registerMock( '../utils/versions', stubs.versionUtils );
 		mockery.registerMock( '../utils/getnewreleasetype', stubs.getNewReleaseType );
+		mockery.registerMock( '../utils/displaycommits', stubs.displayCommits );
 
 		sandbox.stub( path, 'join' ).callsFake( ( ...chunks ) => chunks.join( '/' ) );
 
@@ -80,6 +82,7 @@ describe( 'dev-env/release-tools/tasks', () => {
 
 	describe( 'generateChangelogForSubPackages()', () => {
 		it( 'generates changelog entries for found sub packages', () => {
+			const commits = [ {}, {} ];
 			const chdirStub = sandbox.stub( process, 'chdir' );
 			sandbox.stub( process, 'cwd' ).returns( '/ckeditor5-dev' );
 
@@ -96,7 +99,7 @@ describe( 'dev-env/release-tools/tasks', () => {
 				version: '1.0.0'
 			} );
 			stubs.versionUtils.getLastFromChangelog.onFirstCall().returns( '1.0.0' );
-			stubs.getNewReleaseType.onFirstCall().returns( Promise.resolve( { releaseType: 'patch' } ) );
+			stubs.getNewReleaseType.onFirstCall().returns( Promise.resolve( { commits, releaseType: 'patch' } ) );
 			stubs.cli.provideVersion.onFirstCall().returns( Promise.resolve( '1.0.1' ) );
 			stubs.generateChangelogFromCommits.onFirstCall().returns( Promise.resolve( '1.0.1' ) );
 
@@ -105,7 +108,7 @@ describe( 'dev-env/release-tools/tasks', () => {
 				version: '2.0.0'
 			} );
 			stubs.versionUtils.getLastFromChangelog.onSecondCall().returns( '2.0.0' );
-			stubs.getNewReleaseType.onSecondCall().returns( Promise.resolve( { releaseType: 'minor' } ) );
+			stubs.getNewReleaseType.onSecondCall().returns( Promise.resolve( { commits, releaseType: 'minor' } ) );
 			stubs.cli.provideVersion.onSecondCall().returns( Promise.resolve( '2.1.0' ) );
 			stubs.generateChangelogFromCommits.onSecondCall().returns( Promise.resolve( '2.1.0' ) );
 
@@ -174,10 +177,15 @@ describe( 'dev-env/release-tools/tasks', () => {
 						newTagName: '@ckeditor/ckeditor5-dev-bar@2.1.0',
 						isInternalRelease: false
 					} );
+
+					expect( stubs.displayCommits.calledTwice ).to.equal( true );
+					expect( stubs.displayCommits.firstCall.args[ 0 ] ).to.deep.equal( commits );
+					expect( stubs.displayCommits.secondCall.args[ 0 ] ).to.deep.equal( commits );
 				} );
 		} );
 
 		it( 'ignores specified packages', () => {
+			const commits = [ {}, {} ];
 			const chdirStub = sandbox.stub( process, 'chdir' );
 			sandbox.stub( process, 'cwd' ).returns( '/ckeditor5-dev' );
 
@@ -195,7 +203,7 @@ describe( 'dev-env/release-tools/tasks', () => {
 				version: '1.0.0'
 			} );
 			stubs.versionUtils.getLastFromChangelog.onFirstCall().returns( '1.0.0' );
-			stubs.getNewReleaseType.onFirstCall().returns( Promise.resolve( { releaseType: 'patch' } ) );
+			stubs.getNewReleaseType.onFirstCall().returns( Promise.resolve( { commits, releaseType: 'patch' } ) );
 			stubs.cli.provideVersion.onFirstCall().returns( Promise.resolve( '1.0.1' ) );
 			stubs.generateChangelogFromCommits.onFirstCall().returns( Promise.resolve( '1.0.1' ) );
 
@@ -225,6 +233,9 @@ describe( 'dev-env/release-tools/tasks', () => {
 						newTagName: '@ckeditor/ckeditor5-dev-foo@1.0.1',
 						isInternalRelease: false
 					} );
+
+					expect( stubs.displayCommits.calledOnce ).to.equal( true );
+					expect( stubs.displayCommits.firstCall.args[ 0 ] ).to.deep.equal( commits );
 				} );
 		} );
 

--- a/packages/ckeditor5-dev-env/tests/release-tools/tasks/generatesummarychangelog.js
+++ b/packages/ckeditor5-dev-env/tests/release-tools/tasks/generatesummarychangelog.js
@@ -59,6 +59,7 @@ describe( 'dev-env/release-tools/tasks', () => {
 			transformCommitFunction: sandbox.stub(),
 			generateChangelogFromCommits: sandbox.stub(),
 			getNewReleaseType: sandbox.stub(),
+			displayCommits: sandbox.stub(),
 			executeOnPackages: sandbox.stub(),
 			moment: {
 				format: sandbox.stub()
@@ -74,6 +75,7 @@ describe( 'dev-env/release-tools/tasks', () => {
 		mockery.registerMock( '../utils/generatechangelogfromcommits', stubs.generateChangelogFromCommits );
 		mockery.registerMock( '../utils/executeonpackages', stubs.executeOnPackages );
 		mockery.registerMock( '../utils/getnewreleasetype', stubs.getNewReleaseType );
+		mockery.registerMock( '../utils/displaycommits', stubs.displayCommits );
 		mockery.registerMock( '../utils/versions', stubs.versionUtils );
 		mockery.registerMock( '../utils/cli', stubs.cliUtils );
 
@@ -101,6 +103,8 @@ describe( 'dev-env/release-tools/tasks', () => {
 
 	describe( 'generateSummaryChangelog()', () => {
 		it( 'generates a summary changelog for single package', () => {
+			const commits = [ {}, {} ];
+
 			stubs.getSubRepositoriesPaths.returns( {
 				matched: new Set( [
 					packagesPaths.alpha
@@ -124,7 +128,7 @@ describe( 'dev-env/release-tools/tasks', () => {
 			stubs.versionUtils.getCurrent.withArgs( packagesPaths.epsilon ).returns( '0.5.0' );
 			stubs.versionUtils.getLastFromChangelog.withArgs( packagesPaths.epsilon ).returns( '1.0.0' );
 
-			stubs.getNewReleaseType.resolves( { releaseType: 'skip' } );
+			stubs.getNewReleaseType.resolves( { commits, releaseType: 'skip' } );
 
 			stubs.cliUtils.provideVersion.resolves( '1.0.0' );
 
@@ -183,6 +187,8 @@ Patch releases (bug fixes, internal changes):
 					const genetatedChangelogMap = stubs.displayGeneratedChangelogs.firstCall.args[ 0 ];
 
 					expect( genetatedChangelogMap.has( '@ckeditor/alpha' ) ).to.equal( true );
+					expect( stubs.displayCommits.calledOnce ).to.equal( true );
+					expect( stubs.displayCommits.firstCall.args[ 0 ] ).to.deep.equal( commits );
 				} );
 		} );
 
@@ -347,6 +353,8 @@ Changelog entries generated from commits.
 		} );
 
 		it( 'allows generating changelog for main repository', () => {
+			const commits = [ {}, {} ];
+
 			stubs.getSubRepositoriesPaths.returns( {
 				matched: new Set(),
 				skipped: new Set( [
@@ -375,7 +383,7 @@ Changelog entries generated from commits.
 			stubs.versionUtils.getCurrent.withArgs( packagesPaths.epsilon ).returns( '0.5.0' );
 			stubs.versionUtils.getLastFromChangelog.withArgs( packagesPaths.epsilon ).returns( '0.5.1' );
 
-			stubs.getNewReleaseType.resolves( { releaseType: 'minor' } );
+			stubs.getNewReleaseType.resolves( { commits, releaseType: 'minor' } );
 
 			stubs.generateChangelogFromCommits.resolves(
 				'## Changelog header (will be removed)\n\n' +
@@ -428,6 +436,9 @@ Changelog entries generated from commits.
 
 					expect( processChidirStub.firstCall.args[ 0 ] ).to.equal( mainPackagePath );
 					expect( processChidirStub.secondCall.args[ 0 ] ).to.equal( testCwd );
+
+					expect( stubs.displayCommits.calledOnce ).to.equal( true );
+					expect( stubs.displayCommits.firstCall.args[ 0 ] ).to.deep.equal( commits );
 				} );
 		} );
 

--- a/packages/ckeditor5-dev-env/tests/release-tools/utils/displaycommits.js
+++ b/packages/ckeditor5-dev-env/tests/release-tools/utils/displaycommits.js
@@ -1,0 +1,179 @@
+/**
+ * @license Copyright (c) 2003-2019, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+'use strict';
+
+const expect = require( 'chai' ).expect;
+const sinon = require( 'sinon' );
+const proxyquire = require( 'proxyquire' );
+const transformCommitForSubRepository = require( '../../../lib/release-tools/utils/transform-commit/transformcommitforsubrepository' );
+
+describe( 'dev-env/release-tools/utils', () => {
+	let displayCommits, sandbox, stubs;
+
+	beforeEach( () => {
+		sandbox = sinon.createSandbox();
+
+		stubs = {
+			logger: {
+				info: sandbox.spy(),
+				warning: sandbox.spy(),
+				error: sandbox.spy()
+			}
+		};
+
+		displayCommits = proxyquire( '../../../lib/release-tools/utils/displaycommits', {
+			'@ckeditor/ckeditor5-dev-utils': {
+				logger() {
+					return stubs.logger;
+				}
+			}
+		} );
+	} );
+
+	afterEach( () => {
+		sandbox.restore();
+	} );
+
+	describe( 'displayCommits()', () => {
+		it( 'attaches valid "external" commit to the changelog', () => {
+			const rawCommit = {
+				hash: '684997d0eb2eca76b9e058fb1c3fa00b50059cdc',
+				header: 'Fix: Simple fix.',
+				type: 'Fix',
+				subject: 'Simple fix.',
+				body: null,
+				footer: null,
+				notes: []
+			};
+
+			const commit = transformCommitForSubRepository( rawCommit );
+
+			displayCommits( [ commit ] );
+
+			expect( stubs.logger.info.calledOnce ).to.equal( true );
+			expect( stubs.logger.info.firstCall.args[ 0 ].includes( 'Fix: Simple fix.' ) ).to.equal( true );
+			expect( stubs.logger.info.firstCall.args[ 0 ].includes( 'INCLUDED' ) ).to.equal( true );
+		} );
+
+		it( 'truncates too long commit\'s subject', () => {
+			const rawCommit = {
+				hash: '684997d0eb2eca76b9e058fb1c3fa00b50059cdc',
+				header: 'Fix: Reference site about Lorem Ipsum, giving information on its origins, as well as ' +
+					'a random Lipsum generator.',
+				type: 'Fix',
+				subject: 'Reference site about Lorem Ipsum, giving information on its origins, as well as ' +
+					'a random Lipsum generator.',
+				body: null,
+				footer: null,
+				notes: []
+			};
+
+			const commit = transformCommitForSubRepository( rawCommit );
+
+			displayCommits( [ commit ] );
+
+			expect( stubs.logger.info.calledOnce ).to.equal( true );
+			expect( stubs.logger.info.firstCall.args[ 0 ].includes(
+				'Fix: Reference site about Lorem Ipsum, giving information on its origins, as well as a random Lip...'
+			) ).to.equal( true );
+			expect( stubs.logger.info.firstCall.args[ 0 ].includes( 'INCLUDED' ) ).to.equal( true );
+		} );
+
+		it( 'does not attach valid "internal" commit to the changelog', () => {
+			const rawCommit = {
+				hash: '684997d0eb2eca76b9e058fb1c3fa00b50059cdc',
+				header: 'Docs: README.',
+				type: 'Docs',
+				subject: 'README.',
+				body: null,
+				footer: null,
+				notes: []
+			};
+
+			const commit = transformCommitForSubRepository( rawCommit, { returnInvalidCommit: true } );
+
+			displayCommits( [ commit ] );
+
+			expect( stubs.logger.info.calledOnce ).to.equal( true );
+			expect( stubs.logger.info.firstCall.args[ 0 ].includes( 'Docs: README.' ) ).to.equal( true );
+			expect( stubs.logger.info.firstCall.args[ 0 ].includes( 'SKIPPED' ) ).to.equal( true );
+		} );
+
+		it( 'does not attach invalid commit to the changelog', () => {
+			const rawCommit = {
+				hash: '684997d0eb2eca76b9e058fb1c3fa00b50059cdc',
+				header: 'Invalid commit.',
+				type: null,
+				subject: null,
+				body: null,
+				footer: null,
+				notes: []
+			};
+
+			const commit = transformCommitForSubRepository( rawCommit, { returnInvalidCommit: true } );
+
+			displayCommits( [ commit ] );
+
+			expect( stubs.logger.info.calledOnce ).to.equal( true );
+			expect( stubs.logger.info.firstCall.args[ 0 ].includes( 'Invalid commit.' ) ).to.equal( true );
+			expect( stubs.logger.info.firstCall.args[ 0 ].includes( 'INVALID' ) ).to.equal( true );
+		} );
+
+		it( 'attaches additional subject for merge commits to the commit list', () => {
+			const rawCommit = {
+				merge: 'Merge pull request #75 from ckeditor/t/64',
+				hash: 'dea35014ab610be0c2150343c6a8a68620cfe5ad',
+				header: 'Feature: Introduced a brand new release tools with a new set of requirements.',
+				type: 'Feature',
+				subject: 'Introduced a brand new release tools with a new set of requirements.',
+				body: null,
+				footer: null,
+				mentions: [],
+				notes: []
+			};
+
+			const commit = transformCommitForSubRepository( rawCommit );
+
+			displayCommits( [ commit ] );
+
+			expect( stubs.logger.info.calledOnce ).to.equal( true );
+			expect( stubs.logger.info.firstCall.args[ 0 ] ).to.be.a( 'string' );
+
+			const logMessageAsArray = stubs.logger.info.firstCall.args[ 0 ].split( '\n' );
+
+			expect( logMessageAsArray[ 0 ].includes(
+				'Feature: Introduced a brand new release tools with a new set of requirements.'
+			) ).to.equal( true );
+			expect( logMessageAsArray[ 0 ].includes( 'INCLUDED' ) ).to.equal( true );
+			expect( logMessageAsArray[ 1 ].includes( 'Merge pull request #75 from ckeditor/t/64' ) ).to.equal( true );
+		} );
+
+		it( 'displays proper log if commit does not contain the second line', () => {
+			const rawCommit = {
+				type: null,
+				subject: null,
+				merge: 'Merge branch \'master\' of github.com:ckeditor/ckeditor5-dev',
+				header: '-hash-',
+				body: '575e00bc8ece48826adefe226c4fb1fe071c73a7',
+				footer: null,
+				notes: [],
+				references: [],
+				mentions: [],
+				revert: null
+			};
+
+			const commit = transformCommitForSubRepository( rawCommit, { returnInvalidCommit: true } );
+
+			displayCommits( [ commit ] );
+
+			// The merge commit displays two lines:
+			// Prefix: Changes.
+			// Merge ...
+			// If the merge commit does not contain the second line, it should display only the one.
+			expect( stubs.logger.info.firstCall.args[ 0 ].split( '\n' ) ).length( 1 );
+		} );
+	} );
+} );

--- a/packages/ckeditor5-dev-env/tests/release-tools/utils/getnewreleasetype.js
+++ b/packages/ckeditor5-dev-env/tests/release-tools/utils/getnewreleasetype.js
@@ -11,11 +11,48 @@ const expect = require( 'chai' ).expect;
 const sinon = require( 'sinon' );
 const proxyquire = require( 'proxyquire' );
 const { tools } = require( '@ckeditor/ckeditor5-dev-utils' );
+const transformCommitForSubRepository = require( '../../../lib/release-tools/utils/transform-commit/transformcommitforsubrepository' );
 
 describe( 'dev-env/release-tools/utils', () => {
-	let tmpCwd, cwd, getNewReleaseType, sandbox, packageJson, stubs;
+	let getNewReleaseType, sandbox, stubs;
+
+	beforeEach( () => {
+		sandbox = sinon.createSandbox();
+
+		stubs = {
+			transformCommit: sandbox.stub().callsFake( commit => {
+				commit.rawType = commit.type;
+				commit.hash = commit.hash.substring( 0, 7 );
+
+				return commit;
+			} ),
+			versionUtils: {
+				getLastFromChangelog: sandbox.stub()
+			},
+			logger: {
+				info: sandbox.spy(),
+				warning: sandbox.spy(),
+				error: sandbox.spy()
+			}
+		};
+
+		getNewReleaseType = proxyquire( '../../../lib/release-tools/utils/getnewreleasetype', {
+			'./versions': stubs.versionUtils,
+			'@ckeditor/ckeditor5-dev-utils': {
+				logger() {
+					return stubs.logger;
+				}
+			}
+		} );
+	} );
+
+	afterEach( () => {
+		sandbox.restore();
+	} );
 
 	describe( 'getNewReleaseType()', () => {
+		let tmpCwd, cwd, packageJson, displayCommits, displayCommitsSpy;
+
 		before( () => {
 			cwd = process.cwd();
 			tmpCwd = fs.mkdtempSync( __dirname + path.sep );
@@ -26,18 +63,8 @@ describe( 'dev-env/release-tools/utils', () => {
 		} );
 
 		beforeEach( () => {
-			sandbox = sinon.createSandbox();
-
-			stubs = {
-				transformCommit: sandbox.stub().callsFake( commit => {
-					commit.rawType = commit.type;
-
-					return commit;
-				} ),
-				versionUtils: {
-					getLastFromChangelog: sandbox.stub()
-				}
-			};
+			displayCommits = getNewReleaseType._displayCommits;
+			getNewReleaseType._displayCommits = displayCommitsSpy = sandbox.spy();
 
 			process.chdir( tmpCwd );
 
@@ -54,17 +81,13 @@ describe( 'dev-env/release-tools/utils', () => {
 			};
 
 			fs.writeFileSync( path.join( tmpCwd, 'package.json' ), JSON.stringify( packageJson, null, '\t' ) );
-
-			getNewReleaseType = proxyquire( '../../../lib/release-tools/utils/getnewreleasetype', {
-				'./versions': stubs.versionUtils
-			} );
 		} );
 
 		afterEach( () => {
+			getNewReleaseType._displayCommits = displayCommits;
+
 			process.chdir( cwd );
 			exec( `rm -rf ${ path.join( tmpCwd, '.git' ) }` );
-
-			sandbox.restore();
 		} );
 
 		it( 'throws an error when repository is empty', () => {
@@ -75,6 +98,22 @@ describe( 'dev-env/release-tools/utils', () => {
 					},
 					err => {
 						expect( err.message ).to.equal( 'Given repository is empty.' );
+					}
+				);
+		} );
+
+		it( 'throws an error when given tag does not exist', () => {
+			exec( 'git commit --allow-empty --message "Fix: Some fix."' );
+
+			return getNewReleaseType( stubs.transformCommit, { tagName: 'v1.1.2' } )
+				.then(
+					() => {
+						throw new Error( 'Supposed to be rejected.' );
+					},
+					err => {
+						expect( err.message ).to.equal(
+							'Cannot find tag "v1.1.2" (the latest version from the changelog) in given repository.'
+						);
 					}
 				);
 		} );
@@ -97,6 +136,7 @@ describe( 'dev-env/release-tools/utils', () => {
 
 			return getNewReleaseType( stubs.transformCommit )
 				.then( response => {
+					expect( displayCommitsSpy.called ).to.equal( true );
 					expect( response.releaseType ).to.equal( 'patch' );
 				} );
 		} );
@@ -107,6 +147,7 @@ describe( 'dev-env/release-tools/utils', () => {
 
 			return getNewReleaseType( stubs.transformCommit )
 				.then( response => {
+					expect( displayCommitsSpy.called ).to.equal( true );
 					expect( response.releaseType ).to.equal( 'patch' );
 				} );
 		} );
@@ -117,6 +158,7 @@ describe( 'dev-env/release-tools/utils', () => {
 
 			return getNewReleaseType( stubs.transformCommit )
 				.then( response => {
+					expect( displayCommitsSpy.called ).to.equal( true );
 					expect( response.releaseType ).to.equal( 'minor' );
 				} );
 		} );
@@ -128,6 +170,7 @@ describe( 'dev-env/release-tools/utils', () => {
 
 			return getNewReleaseType( stubs.transformCommit )
 				.then( response => {
+					expect( displayCommitsSpy.called ).to.equal( true );
 					expect( response.releaseType ).to.equal( 'major' );
 				} );
 		} );
@@ -138,6 +181,7 @@ describe( 'dev-env/release-tools/utils', () => {
 
 			return getNewReleaseType( stubs.transformCommit, { tagName: 'v1.0.0' } )
 				.then( response => {
+					expect( displayCommitsSpy.called ).to.equal( true );
 					expect( response.releaseType ).to.equal( 'skip' );
 				} );
 		} );
@@ -151,6 +195,7 @@ describe( 'dev-env/release-tools/utils', () => {
 
 			return getNewReleaseType( stubs.transformCommit, { tagName: 'v1.0.0' } )
 				.then( response => {
+					expect( displayCommitsSpy.called ).to.equal( true );
 					expect( response.releaseType ).to.equal( 'internal' );
 				} );
 		} );
@@ -173,21 +218,151 @@ describe( 'dev-env/release-tools/utils', () => {
 					expect( stubs.transformCommit.calledThrice ).to.equal( true );
 				} );
 		} );
+	} );
 
-		it( 'throws an error when given tag does not exist', () => {
-			exec( 'git commit --allow-empty --message "Fix: Some fix."' );
+	describe( '_displayCommits()', () => {
+		let displayCommits;
 
-			return getNewReleaseType( stubs.transformCommit, { tagName: 'v1.1.2' } )
-				.then(
-					() => {
-						throw new Error( 'Supposed to be rejected.' );
-					},
-					err => {
-						const message = 'Cannot find tag "v1.1.2" (the latest version' +
-							' from the changelog) in given repository.';
-						expect( err.message ).to.equal( message );
-					}
-				);
+		beforeEach( () => {
+			displayCommits = getNewReleaseType._displayCommits;
+		} );
+
+		it( 'attaches valid "external" commit to the changelog', () => {
+			const rawCommit = {
+				hash: '684997d0eb2eca76b9e058fb1c3fa00b50059cdc',
+				header: 'Fix: Simple fix.',
+				type: 'Fix',
+				subject: 'Simple fix.',
+				body: null,
+				footer: null,
+				notes: []
+			};
+
+			const commit = transformCommitForSubRepository( rawCommit );
+
+			displayCommits( [ commit ] );
+
+			expect( stubs.logger.info.calledOnce ).to.equal( true );
+			expect( stubs.logger.info.firstCall.args[ 0 ].includes( 'Fix: Simple fix.' ) ).to.equal( true );
+			expect( stubs.logger.info.firstCall.args[ 0 ].includes( 'INCLUDED' ) ).to.equal( true );
+		} );
+
+		it( 'truncates too long commit\'s subject', () => {
+			const rawCommit = {
+				hash: '684997d0eb2eca76b9e058fb1c3fa00b50059cdc',
+				header: 'Fix: Reference site about Lorem Ipsum, giving information on its origins, as well as ' +
+				'a random Lipsum generator.',
+				type: 'Fix',
+				subject: 'Reference site about Lorem Ipsum, giving information on its origins, as well as ' +
+				'a random Lipsum generator.',
+				body: null,
+				footer: null,
+				notes: []
+			};
+
+			const commit = transformCommitForSubRepository( rawCommit );
+
+			displayCommits( [ commit ] );
+
+			expect( stubs.logger.info.calledOnce ).to.equal( true );
+			expect( stubs.logger.info.firstCall.args[ 0 ].includes(
+				'Fix: Reference site about Lorem Ipsum, giving information on its origins, as well as a random Lip...'
+			) ).to.equal( true );
+			expect( stubs.logger.info.firstCall.args[ 0 ].includes( 'INCLUDED' ) ).to.equal( true );
+		} );
+
+		it( 'does not attach valid "internal" commit to the changelog', () => {
+			const rawCommit = {
+				hash: '684997d0eb2eca76b9e058fb1c3fa00b50059cdc',
+				header: 'Docs: README.',
+				type: 'Docs',
+				subject: 'README.',
+				body: null,
+				footer: null,
+				notes: []
+			};
+
+			const commit = transformCommitForSubRepository( rawCommit, { returnInvalidCommit: true } );
+
+			displayCommits( [ commit ] );
+
+			expect( stubs.logger.info.calledOnce ).to.equal( true );
+			expect( stubs.logger.info.firstCall.args[ 0 ].includes( 'Docs: README.' ) ).to.equal( true );
+			expect( stubs.logger.info.firstCall.args[ 0 ].includes( 'SKIPPED' ) ).to.equal( true );
+		} );
+
+		it( 'does not attach invalid commit to the changelog', () => {
+			const rawCommit = {
+				hash: '684997d0eb2eca76b9e058fb1c3fa00b50059cdc',
+				header: 'Invalid commit.',
+				type: null,
+				subject: null,
+				body: null,
+				footer: null,
+				notes: []
+			};
+
+			const commit = transformCommitForSubRepository( rawCommit, { returnInvalidCommit: true } );
+
+			displayCommits( [ commit ] );
+
+			expect( stubs.logger.info.calledOnce ).to.equal( true );
+			expect( stubs.logger.info.firstCall.args[ 0 ].includes( 'Invalid commit.' ) ).to.equal( true );
+			expect( stubs.logger.info.firstCall.args[ 0 ].includes( 'INVALID' ) ).to.equal( true );
+		} );
+
+		it( 'attaches additional subject for merge commits to the commit list', () => {
+			const rawCommit = {
+				merge: 'Merge pull request #75 from ckeditor/t/64',
+				hash: 'dea35014ab610be0c2150343c6a8a68620cfe5ad',
+				header: 'Feature: Introduced a brand new release tools with a new set of requirements.',
+				type: 'Feature',
+				subject: 'Introduced a brand new release tools with a new set of requirements.',
+				body: null,
+				footer: null,
+				mentions: [],
+				notes: []
+			};
+
+			const commit = transformCommitForSubRepository( rawCommit );
+
+			displayCommits( [ commit ] );
+
+			expect( stubs.logger.info.calledOnce ).to.equal( true );
+			expect( stubs.logger.info.firstCall.args[ 0 ] ).to.be.a( 'string' );
+
+			const logMessageAsArray = stubs.logger.info.firstCall.args[ 0 ].split( '\n' );
+
+			expect( logMessageAsArray[ 0 ].includes(
+				'Feature: Introduced a brand new release tools with a new set of requirements.'
+			) ).to.equal( true );
+			expect( logMessageAsArray[ 0 ].includes( 'INCLUDED' ) ).to.equal( true );
+			expect( logMessageAsArray[ 1 ].includes( 'Merge pull request #75 from ckeditor/t/64' ) ).to.equal( true );
+		} );
+
+		it( 'displays proper log if commit does not contain the second line', () => {
+			const rawCommit = {
+				type: null,
+				subject: null,
+				merge: 'Merge branch \'master\' of github.com:ckeditor/ckeditor5-dev',
+				header: '-hash-',
+				body: '575e00bc8ece48826adefe226c4fb1fe071c73a7',
+				footer: null,
+				notes: [],
+				references: [],
+				mentions: [],
+				revert: null
+			};
+
+			const commit = transformCommitForSubRepository( rawCommit, { returnInvalidCommit: true } );
+
+			displayCommits( [ commit ] );
+
+			// The merge commit displays two lines:
+			// Prefix: Changes.
+			// Merge ...
+			// If the merge commit does not contain the second line, it should display only the one.
+			expect( stubs.logger.info.firstCall.args[ 0 ].split( '\n' ) ).length( 1 );
 		} );
 	} );
 

--- a/packages/ckeditor5-dev-env/tests/release-tools/utils/getnewreleasetype.js
+++ b/packages/ckeditor5-dev-env/tests/release-tools/utils/getnewreleasetype.js
@@ -11,10 +11,18 @@ const expect = require( 'chai' ).expect;
 const sinon = require( 'sinon' );
 const proxyquire = require( 'proxyquire' );
 const { tools } = require( '@ckeditor/ckeditor5-dev-utils' );
-const transformCommitForSubRepository = require( '../../../lib/release-tools/utils/transform-commit/transformcommitforsubrepository' );
 
 describe( 'dev-env/release-tools/utils', () => {
-	let getNewReleaseType, sandbox, stubs;
+	let getNewReleaseType, sandbox, stubs, tmpCwd, cwd, packageJson;
+
+	before( () => {
+		cwd = process.cwd();
+		tmpCwd = fs.mkdtempSync( __dirname + path.sep );
+	} );
+
+	after( () => {
+		exec( `rm -rf ${ tmpCwd }` );
+	} );
 
 	beforeEach( () => {
 		sandbox = sinon.createSandbox();
@@ -28,11 +36,6 @@ describe( 'dev-env/release-tools/utils', () => {
 			} ),
 			versionUtils: {
 				getLastFromChangelog: sandbox.stub()
-			},
-			logger: {
-				info: sandbox.spy(),
-				warning: sandbox.spy(),
-				error: sandbox.spy()
 			}
 		};
 
@@ -44,52 +47,32 @@ describe( 'dev-env/release-tools/utils', () => {
 				}
 			}
 		} );
+
+		process.chdir( tmpCwd );
+
+		exec( 'git init' );
+
+		if ( process.env.CI ) {
+			exec( 'git config user.email "ckeditor5@ckeditor.com"' );
+			exec( 'git config user.name "CKEditor5 CI"' );
+		}
+
+		packageJson = {
+			name: 'test-package',
+			bugs: 'some-url'
+		};
+
+		fs.writeFileSync( path.join( tmpCwd, 'package.json' ), JSON.stringify( packageJson, null, '\t' ) );
 	} );
 
 	afterEach( () => {
 		sandbox.restore();
+
+		process.chdir( cwd );
+		exec( `rm -rf ${ path.join( tmpCwd, '.git' ) }` );
 	} );
 
 	describe( 'getNewReleaseType()', () => {
-		let tmpCwd, cwd, packageJson, displayCommits, displayCommitsSpy;
-
-		before( () => {
-			cwd = process.cwd();
-			tmpCwd = fs.mkdtempSync( __dirname + path.sep );
-		} );
-
-		after( () => {
-			exec( `rm -rf ${ tmpCwd }` );
-		} );
-
-		beforeEach( () => {
-			displayCommits = getNewReleaseType._displayCommits;
-			getNewReleaseType._displayCommits = displayCommitsSpy = sandbox.spy();
-
-			process.chdir( tmpCwd );
-
-			exec( 'git init' );
-
-			if ( process.env.CI ) {
-				exec( 'git config user.email "ckeditor5@ckeditor.com"' );
-				exec( 'git config user.name "CKEditor5 CI"' );
-			}
-
-			packageJson = {
-				name: 'test-package',
-				bugs: 'some-url'
-			};
-
-			fs.writeFileSync( path.join( tmpCwd, 'package.json' ), JSON.stringify( packageJson, null, '\t' ) );
-		} );
-
-		afterEach( () => {
-			getNewReleaseType._displayCommits = displayCommits;
-
-			process.chdir( cwd );
-			exec( `rm -rf ${ path.join( tmpCwd, '.git' ) }` );
-		} );
-
 		it( 'throws an error when repository is empty', () => {
 			return getNewReleaseType( stubs.transformCommit )
 				.then(
@@ -127,6 +110,8 @@ describe( 'dev-env/release-tools/utils', () => {
 			return getNewReleaseType( stubs.transformCommit )
 				.then( response => {
 					expect( response.releaseType ).to.equal( 'skip' );
+					expect( response.commits ).to.be.an( 'Array' );
+					expect( response.commits.length ).to.equal( 0 );
 				} );
 		} );
 
@@ -136,8 +121,8 @@ describe( 'dev-env/release-tools/utils', () => {
 
 			return getNewReleaseType( stubs.transformCommit )
 				.then( response => {
-					expect( displayCommitsSpy.called ).to.equal( true );
 					expect( response.releaseType ).to.equal( 'patch' );
+					expect( response.commits.length ).to.equal( 2 );
 				} );
 		} );
 
@@ -147,8 +132,8 @@ describe( 'dev-env/release-tools/utils', () => {
 
 			return getNewReleaseType( stubs.transformCommit )
 				.then( response => {
-					expect( displayCommitsSpy.called ).to.equal( true );
 					expect( response.releaseType ).to.equal( 'patch' );
+					expect( response.commits.length ).to.equal( 2 );
 				} );
 		} );
 
@@ -158,8 +143,8 @@ describe( 'dev-env/release-tools/utils', () => {
 
 			return getNewReleaseType( stubs.transformCommit )
 				.then( response => {
-					expect( displayCommitsSpy.called ).to.equal( true );
 					expect( response.releaseType ).to.equal( 'minor' );
+					expect( response.commits.length ).to.equal( 2 );
 				} );
 		} );
 
@@ -170,8 +155,8 @@ describe( 'dev-env/release-tools/utils', () => {
 
 			return getNewReleaseType( stubs.transformCommit )
 				.then( response => {
-					expect( displayCommitsSpy.called ).to.equal( true );
 					expect( response.releaseType ).to.equal( 'major' );
+					expect( response.commits.length ).to.equal( 3 );
 				} );
 		} );
 
@@ -181,8 +166,8 @@ describe( 'dev-env/release-tools/utils', () => {
 
 			return getNewReleaseType( stubs.transformCommit, { tagName: 'v1.0.0' } )
 				.then( response => {
-					expect( displayCommitsSpy.called ).to.equal( true );
 					expect( response.releaseType ).to.equal( 'skip' );
+					expect( response.commits.length ).to.equal( 0 );
 				} );
 		} );
 
@@ -195,8 +180,8 @@ describe( 'dev-env/release-tools/utils', () => {
 
 			return getNewReleaseType( stubs.transformCommit, { tagName: 'v1.0.0' } )
 				.then( response => {
-					expect( displayCommitsSpy.called ).to.equal( true );
 					expect( response.releaseType ).to.equal( 'internal' );
+					expect( response.commits.length ).to.equal( 3 );
 				} );
 		} );
 
@@ -217,152 +202,6 @@ describe( 'dev-env/release-tools/utils', () => {
 					// (3) Docs: Added some notes to README #2.
 					expect( stubs.transformCommit.calledThrice ).to.equal( true );
 				} );
-		} );
-	} );
-
-	describe( '_displayCommits()', () => {
-		let displayCommits;
-
-		beforeEach( () => {
-			displayCommits = getNewReleaseType._displayCommits;
-		} );
-
-		it( 'attaches valid "external" commit to the changelog', () => {
-			const rawCommit = {
-				hash: '684997d0eb2eca76b9e058fb1c3fa00b50059cdc',
-				header: 'Fix: Simple fix.',
-				type: 'Fix',
-				subject: 'Simple fix.',
-				body: null,
-				footer: null,
-				notes: []
-			};
-
-			const commit = transformCommitForSubRepository( rawCommit );
-
-			displayCommits( [ commit ] );
-
-			expect( stubs.logger.info.calledOnce ).to.equal( true );
-			expect( stubs.logger.info.firstCall.args[ 0 ].includes( 'Fix: Simple fix.' ) ).to.equal( true );
-			expect( stubs.logger.info.firstCall.args[ 0 ].includes( 'INCLUDED' ) ).to.equal( true );
-		} );
-
-		it( 'truncates too long commit\'s subject', () => {
-			const rawCommit = {
-				hash: '684997d0eb2eca76b9e058fb1c3fa00b50059cdc',
-				header: 'Fix: Reference site about Lorem Ipsum, giving information on its origins, as well as ' +
-				'a random Lipsum generator.',
-				type: 'Fix',
-				subject: 'Reference site about Lorem Ipsum, giving information on its origins, as well as ' +
-				'a random Lipsum generator.',
-				body: null,
-				footer: null,
-				notes: []
-			};
-
-			const commit = transformCommitForSubRepository( rawCommit );
-
-			displayCommits( [ commit ] );
-
-			expect( stubs.logger.info.calledOnce ).to.equal( true );
-			expect( stubs.logger.info.firstCall.args[ 0 ].includes(
-				'Fix: Reference site about Lorem Ipsum, giving information on its origins, as well as a random Lip...'
-			) ).to.equal( true );
-			expect( stubs.logger.info.firstCall.args[ 0 ].includes( 'INCLUDED' ) ).to.equal( true );
-		} );
-
-		it( 'does not attach valid "internal" commit to the changelog', () => {
-			const rawCommit = {
-				hash: '684997d0eb2eca76b9e058fb1c3fa00b50059cdc',
-				header: 'Docs: README.',
-				type: 'Docs',
-				subject: 'README.',
-				body: null,
-				footer: null,
-				notes: []
-			};
-
-			const commit = transformCommitForSubRepository( rawCommit, { returnInvalidCommit: true } );
-
-			displayCommits( [ commit ] );
-
-			expect( stubs.logger.info.calledOnce ).to.equal( true );
-			expect( stubs.logger.info.firstCall.args[ 0 ].includes( 'Docs: README.' ) ).to.equal( true );
-			expect( stubs.logger.info.firstCall.args[ 0 ].includes( 'SKIPPED' ) ).to.equal( true );
-		} );
-
-		it( 'does not attach invalid commit to the changelog', () => {
-			const rawCommit = {
-				hash: '684997d0eb2eca76b9e058fb1c3fa00b50059cdc',
-				header: 'Invalid commit.',
-				type: null,
-				subject: null,
-				body: null,
-				footer: null,
-				notes: []
-			};
-
-			const commit = transformCommitForSubRepository( rawCommit, { returnInvalidCommit: true } );
-
-			displayCommits( [ commit ] );
-
-			expect( stubs.logger.info.calledOnce ).to.equal( true );
-			expect( stubs.logger.info.firstCall.args[ 0 ].includes( 'Invalid commit.' ) ).to.equal( true );
-			expect( stubs.logger.info.firstCall.args[ 0 ].includes( 'INVALID' ) ).to.equal( true );
-		} );
-
-		it( 'attaches additional subject for merge commits to the commit list', () => {
-			const rawCommit = {
-				merge: 'Merge pull request #75 from ckeditor/t/64',
-				hash: 'dea35014ab610be0c2150343c6a8a68620cfe5ad',
-				header: 'Feature: Introduced a brand new release tools with a new set of requirements.',
-				type: 'Feature',
-				subject: 'Introduced a brand new release tools with a new set of requirements.',
-				body: null,
-				footer: null,
-				mentions: [],
-				notes: []
-			};
-
-			const commit = transformCommitForSubRepository( rawCommit );
-
-			displayCommits( [ commit ] );
-
-			expect( stubs.logger.info.calledOnce ).to.equal( true );
-			expect( stubs.logger.info.firstCall.args[ 0 ] ).to.be.a( 'string' );
-
-			const logMessageAsArray = stubs.logger.info.firstCall.args[ 0 ].split( '\n' );
-
-			expect( logMessageAsArray[ 0 ].includes(
-				'Feature: Introduced a brand new release tools with a new set of requirements.'
-			) ).to.equal( true );
-			expect( logMessageAsArray[ 0 ].includes( 'INCLUDED' ) ).to.equal( true );
-			expect( logMessageAsArray[ 1 ].includes( 'Merge pull request #75 from ckeditor/t/64' ) ).to.equal( true );
-		} );
-
-		it( 'displays proper log if commit does not contain the second line', () => {
-			const rawCommit = {
-				type: null,
-				subject: null,
-				merge: 'Merge branch \'master\' of github.com:ckeditor/ckeditor5-dev',
-				header: '-hash-',
-				body: '575e00bc8ece48826adefe226c4fb1fe071c73a7',
-				footer: null,
-				notes: [],
-				references: [],
-				mentions: [],
-				revert: null
-			};
-
-			const commit = transformCommitForSubRepository( rawCommit, { returnInvalidCommit: true } );
-
-			displayCommits( [ commit ] );
-
-			// The merge commit displays two lines:
-			// Prefix: Changes.
-			// Merge ...
-			// If the merge commit does not contain the second line, it should display only the one.
-			expect( stubs.logger.info.firstCall.args[ 0 ].split( '\n' ) ).length( 1 );
 		} );
 	} );
 

--- a/packages/ckeditor5-dev-env/tests/release-tools/utils/getnewreleasetype.js
+++ b/packages/ckeditor5-dev-env/tests/release-tools/utils/getnewreleasetype.js
@@ -146,6 +146,8 @@ describe( 'dev-env/release-tools/utils', () => {
 			exec( 'git commit --allow-empty --message "Fix: Some fix."' );
 			exec( 'git tag v1.0.0' );
 			exec( 'git commit --allow-empty --message "Docs: Added some notes to README #1."' );
+			exec( 'git commit --allow-empty --message "Docs: Added some notes to README #2."' );
+			exec( 'git commit --allow-empty --message "Docs: Added some notes to README #3."' );
 
 			return getNewReleaseType( stubs.transformCommit, { tagName: 'v1.0.0' } )
 				.then( response => {
@@ -169,23 +171,6 @@ describe( 'dev-env/release-tools/utils', () => {
 					// (2) Other: Nothing.
 					// (3) Docs: Added some notes to README #2.
 					expect( stubs.transformCommit.calledThrice ).to.equal( true );
-				} );
-		} );
-
-		it( 'transforms each commit since the last release until breaking changes commit', () => {
-			exec( 'git commit --allow-empty --message "Fix: Some fix."' );
-			exec( 'git tag v1.0.0' );
-			exec( 'git commit --allow-empty --message "Docs: Added some notes to README #1."' );
-			exec( 'git commit --allow-empty --message "Other: Nothing." --message "BREAKING CHANGES: Bump the major!"' );
-			exec( 'git commit --allow-empty --message "Docs: Added some notes to README #2."' );
-
-			return getNewReleaseType( stubs.transformCommit, { tagName: 'v1.0.0' } )
-				.then( response => {
-					// transformCommit should be called for commits:
-					// (1) Docs: Added some notes to README #1.
-					// (2) Other: Nothing.
-					expect( stubs.transformCommit.calledTwice ).to.equal( true );
-					expect( response.releaseType ).to.equal( 'major' );
 				} );
 		} );
 

--- a/packages/ckeditor5-dev-env/tests/release-tools/utils/transform-commit/transformcommitforsubpackage.js
+++ b/packages/ckeditor5-dev-env/tests/release-tools/utils/transform-commit/transformcommitforsubpackage.js
@@ -132,6 +132,7 @@ describe( 'dev-env/release-tools/utils/transform-commit', () => {
 			stubs.transformCommitForSubRepository.reset();
 			stubs.transformCommitForSubRepository.callsFake( commit => {
 				commit.hash = commit.hash.substring( 0, 7 );
+
 				return commit;
 			} );
 

--- a/packages/ckeditor5-dev-env/tests/release-tools/utils/transform-commit/transformcommitforsubpackage.js
+++ b/packages/ckeditor5-dev-env/tests/release-tools/utils/transform-commit/transformcommitforsubpackage.js
@@ -50,6 +50,8 @@ describe( 'dev-env/release-tools/utils/transform-commit', () => {
 					}
 				}
 			} );
+
+			stubs.transformCommitForSubRepository.returnsArg( 0 );
 		} );
 
 		afterEach( () => {
@@ -59,7 +61,8 @@ describe( 'dev-env/release-tools/utils/transform-commit', () => {
 
 		it( 'rejects the commit if no files were changed', () => {
 			const commit = {
-				hash: 'abcd123'
+				hash: 'abcd123',
+				notes: []
 			};
 
 			stubs.getChangedFilesForCommit.returns( [] );
@@ -70,7 +73,8 @@ describe( 'dev-env/release-tools/utils/transform-commit', () => {
 
 		it( 'rejects the commit when it changed files in other package', () => {
 			const commit = {
-				hash: 'abcd123'
+				hash: 'abcd123',
+				notes: []
 			};
 
 			stubs.getChangedFilesForCommit.returns( [
@@ -104,41 +108,20 @@ describe( 'dev-env/release-tools/utils/transform-commit', () => {
 			expect( stubs.transformCommitForSubRepository.called ).to.equal( false );
 		} );
 
-		it( 'accepts the commit when it has changed files in proper and other packages', () => {
-			const commit = {
-				hash: 'abcd123'
-			};
+		it( 'returns a new instance of object instead od modifying passed one', () => {
+			const notes = [
+				{ title: 'Foo', text: 'Foo-Text' },
+				{ title: 'Bar', text: 'Bar-Text' }
+			];
 
-			stubs.getChangedFilesForCommit.returns( [
-				'packages/ckeditor5-dev-env/README.md',
-				'packages/ckeditor5-dev-tests/README.md'
-			] );
-
-			stubs.transformCommitForSubRepository.returnsArg( 0 );
-
-			expect( transformCommitForSubPackage( commit, context ) ).to.equal( commit );
-			expect( stubs.transformCommitForSubRepository.called ).to.equal( true );
-		} );
-
-		it( 'accepts the commit when it has changed files in proper packages and root of the repository', () => {
-			const commit = {
-				hash: 'abcd123'
-			};
-
-			stubs.getChangedFilesForCommit.returns( [
-				'packages/ckeditor5-dev-env/README.md',
-				'README.md'
-			] );
-
-			stubs.transformCommitForSubRepository.returnsArg( 0 );
-
-			expect( transformCommitForSubPackage( commit, context ) ).to.equal( commit );
-			expect( stubs.transformCommitForSubRepository.called ).to.equal( true );
-		} );
-
-		it( 'accepts the commit when it has changed files for proper package', () => {
-			const commit = {
-				hash: 'abcd123'
+			const rawCommit = {
+				hash: '684997d0eb2eca76b9e058fb1c3fa00b50059cdc',
+				header: 'Fix: Simple fix.',
+				type: 'Fix',
+				subject: 'Simple fix.',
+				body: null,
+				footer: null,
+				notes
 			};
 
 			stubs.getChangedFilesForCommit.returns( [
@@ -146,14 +129,78 @@ describe( 'dev-env/release-tools/utils/transform-commit', () => {
 				'packages/ckeditor5-dev-env/package.json',
 			] );
 
-			stubs.transformCommitForSubRepository.returnsArg( 0 );
+			stubs.transformCommitForSubRepository.reset();
+			stubs.transformCommitForSubRepository.callsFake( commit => {
+				commit.hash = commit.hash.substring( 0, 7 );
+				return commit;
+			} );
 
-			expect( transformCommitForSubPackage( commit, context ) ).to.equal( commit );
+			const commit = transformCommitForSubPackage( rawCommit, context );
+
 			expect( stubs.transformCommitForSubRepository.calledOnce ).to.equal( true );
+
+			// `transformCommitForSubRepository` modifies `hash` of given commit and returns the same object.
+			// `transformCommitForSubPackage` must care about cloning the object before any operation.
+			expect( commit.hash ).to.not.equal( rawCommit.hash );
+
+			// Notes cannot be the same but they should be equal.
+			expect( commit.notes ).to.not.equal( rawCommit.notes );
+			expect( commit.notes ).to.deep.equal( rawCommit.notes );
+		} );
+
+		it( 'accepts the commit when it has changed files in proper and other packages', () => {
+			const rawCommit = {
+				hash: 'abcd123',
+				notes: []
+			};
+
+			stubs.getChangedFilesForCommit.returns( [
+				'packages/ckeditor5-dev-env/README.md',
+				'packages/ckeditor5-dev-tests/README.md'
+			] );
+
+			const commit = transformCommitForSubPackage( rawCommit, context );
+
+			expect( stubs.transformCommitForSubRepository.called ).to.equal( true );
+			expect( commit ).to.deep.equal( rawCommit );
+		} );
+
+		it( 'accepts the commit when it has changed files in proper packages and root of the repository', () => {
+			const rawCommit = {
+				hash: 'abcd123',
+				notes: []
+			};
+
+			stubs.getChangedFilesForCommit.returns( [
+				'README.md',
+				'packages/ckeditor5-dev-env/README.md'
+			] );
+
+			const commit = transformCommitForSubPackage( rawCommit, context );
+
+			expect( stubs.transformCommitForSubRepository.called ).to.equal( true );
+			expect( commit ).to.deep.equal( rawCommit );
+		} );
+
+		it( 'accepts the commit when it has changed files for proper package', () => {
+			const rawCommit = {
+				hash: 'abcd123',
+				notes: []
+			};
+
+			stubs.getChangedFilesForCommit.returns( [
+				'packages/ckeditor5-dev-env/README.md',
+				'packages/ckeditor5-dev-env/package.json',
+			] );
+
+			const commit = transformCommitForSubPackage( rawCommit, context );
+
+			expect( stubs.transformCommitForSubRepository.called ).to.equal( true );
+			expect( commit ).to.deep.equal( rawCommit );
 		} );
 
 		it( 'does not crash if the merge commit does not contain the second line', () => {
-			const commit = {
+			const rawCommit = {
 				type: null,
 				subject: null,
 				merge: 'Merge branch \'master\' of github.com:ckeditor/ckeditor5-dev',
@@ -169,13 +216,8 @@ describe( 'dev-env/release-tools/utils/transform-commit', () => {
 			stubs.getChangedFilesForCommit.returns( [] );
 
 			expect( () => {
-				transformCommitForSubPackage( commit, context );
+				transformCommitForSubPackage( rawCommit, context );
 			} ).to.not.throw( Error );
-
-			expect( stubs.getChangedFilesForCommit.firstCall.args[ 0 ] ).to.equal( '575e00bc8ece48826adefe226c4fb1fe071c73a7' );
-			expect( commit.hash ).to.equal( '575e00bc8ece48826adefe226c4fb1fe071c73a7' );
-			expect( commit.header ).to.equal( 'Merge branch \'master\' of github.com:ckeditor/ckeditor5-dev' );
-			expect( commit.body ).to.equal( null );
 		} );
 	} );
 } );

--- a/packages/ckeditor5-dev-env/tests/release-tools/utils/transform-commit/transformcommitforsubrepository.js
+++ b/packages/ckeditor5-dev-env/tests/release-tools/utils/transform-commit/transformcommitforsubrepository.js
@@ -33,6 +33,11 @@ describe( 'dev-env/release-tools/utils/transform-commit', () => {
 		} );
 
 		it( 'returns a new instance of object instead od modifying passed one', () => {
+			const notes = [
+				{ title: 'Foo', text: 'Foo-Text' },
+				{ title: 'Bar', text: 'Bar-Text' }
+			];
+
 			const rawCommit = {
 				hash: '684997d0eb2eca76b9e058fb1c3fa00b50059cdc',
 				header: 'Fix: Simple fix.',
@@ -40,13 +45,17 @@ describe( 'dev-env/release-tools/utils/transform-commit', () => {
 				subject: 'Simple fix.',
 				body: null,
 				footer: null,
-				notes: []
+				notes
 			};
 
 			const commit = transformCommitForSubRepository( rawCommit );
 
 			// `transformCommit` modifies `hash` of given commit.
 			expect( commit.hash ).to.not.equal( rawCommit.hash );
+
+			// Notes cannot be the same but they should be equal.
+			expect( commit.notes ).to.not.equal( rawCommit.notes );
+			expect( commit.notes ).to.deep.equal( rawCommit.notes );
 		} );
 
 		it( 'returns "undefined" if given commit should not be visible in the changelog', () => {

--- a/packages/ckeditor5-dev-env/tests/release-tools/utils/transform-commit/transformcommitforsubrepository.js
+++ b/packages/ckeditor5-dev-env/tests/release-tools/utils/transform-commit/transformcommitforsubrepository.js
@@ -203,13 +203,6 @@ describe( 'dev-env/release-tools/utils/transform-commit', () => {
 			expect( commit.subject ).to.equal( 'Introduced a brand new release tools with a new set of requirements. ' +
 				'See [#64](https://github.com/ckeditor/ckeditor5-dev/issues/64).' );
 			expect( commit.body ).to.equal( commitDescriptionWithIndents );
-
-			// expect( stubs.logger.info.calledOnce ).to.equal( true );
-			//
-			// expect( stubs.logger.info.firstCall.args[ 0 ].includes(
-			// 	'Feature: Introduced a brand new release tools with a new set of requirements. See #64.'
-			// ) ).to.equal( true );
-			// expect( stubs.logger.info.firstCall.args[ 0 ].includes( 'INCLUDED' ) ).to.equal( true );
 		} );
 
 		it( 'removes references to issues', () => {

--- a/packages/ckeditor5-dev-env/tests/release-tools/utils/transform-commit/transformcommitforsubrepository.js
+++ b/packages/ckeditor5-dev-env/tests/release-tools/utils/transform-commit/transformcommitforsubrepository.js
@@ -8,11 +8,10 @@
 const expect = require( 'chai' ).expect;
 const sinon = require( 'sinon' );
 const mockery = require( 'mockery' );
-const proxyquire = require( 'proxyquire' );
 
 describe( 'dev-env/release-tools/utils/transform-commit', () => {
 	describe( 'transformCommitForSubRepository()', () => {
-		let transformCommitForSubRepository, sandbox, stubs, loggerVerbosity, packageJson;
+		let transformCommitForSubRepository, sandbox;
 
 		beforeEach( () => {
 			sandbox = sinon.createSandbox();
@@ -23,30 +22,8 @@ describe( 'dev-env/release-tools/utils/transform-commit', () => {
 				warnOnUnregistered: false
 			} );
 
-			stubs = {
-				logger: {
-					info: sandbox.spy(),
-					warning: sandbox.spy(),
-					error: sandbox.spy()
-				}
-			};
-
-			packageJson = {
-				name: 'ckeditor5-dev',
-				bugs: 'https://github.com/ckeditor/ckeditor5-dev/issues'
-			};
-
-			transformCommitForSubRepository = proxyquire(
-				'../../../../lib/release-tools/utils/transform-commit/transformcommitforsubrepository',
-				{
-					'@ckeditor/ckeditor5-dev-utils': {
-						logger( verbosity ) {
-							loggerVerbosity = verbosity;
-
-							return stubs.logger;
-						}
-					}
-				}
+			transformCommitForSubRepository = require(
+				'../../../../lib/release-tools/utils/transform-commit/transformcommitforsubrepository'
 			);
 		} );
 
@@ -55,8 +32,57 @@ describe( 'dev-env/release-tools/utils/transform-commit', () => {
 			mockery.disable();
 		} );
 
+		it( 'returns a new instance of object instead od modifying passed one', () => {
+			const rawCommit = {
+				hash: '684997d0eb2eca76b9e058fb1c3fa00b50059cdc',
+				header: 'Fix: Simple fix.',
+				type: 'Fix',
+				subject: 'Simple fix.',
+				body: null,
+				footer: null,
+				notes: []
+			};
+
+			const commit = transformCommitForSubRepository( rawCommit );
+
+			// `transformCommit` modifies `hash` of given commit.
+			expect( commit.hash ).to.not.equal( rawCommit.hash );
+		} );
+
+		it( 'returns "undefined" if given commit should not be visible in the changelog', () => {
+			const rawCommit = {
+				hash: '684997d',
+				header: 'Docs: README.',
+				type: 'Docs',
+				subject: 'README.',
+				body: null,
+				footer: null,
+				notes: []
+			};
+
+			const newCommit = transformCommitForSubRepository( rawCommit );
+
+			expect( newCommit ).to.equal( undefined );
+		} );
+
+		it( 'allows returning invalid commit instead of removing', () => {
+			const rawCommit = {
+				hash: '684997d',
+				header: 'Docs: README.',
+				type: 'Docs',
+				subject: 'README.',
+				body: null,
+				footer: null,
+				notes: []
+			};
+
+			const newCommit = transformCommitForSubRepository( rawCommit, { returnInvalidCommit: true } );
+
+			expect( newCommit ).to.not.equal( undefined );
+		} );
+
 		it( 'groups "BREAKING CHANGES" and "BREAKING CHANGE" as a single group', () => {
-			const commit = {
+			const rawCommit = {
 				hash: '684997d0eb2eca76b9e058fb1c3fa00b50059cdc',
 				header: 'Fix: Simple fix.',
 				type: 'Fix',
@@ -69,90 +95,14 @@ describe( 'dev-env/release-tools/utils/transform-commit', () => {
 				]
 			};
 
-			transformCommitForSubRepository( commit, { displayLogs: true, packageData: packageJson } );
+			const commit = transformCommitForSubRepository( rawCommit );
 
 			expect( commit.notes[ 0 ].title ).to.equal( 'BREAKING CHANGES' );
 			expect( commit.notes[ 1 ].title ).to.equal( 'BREAKING CHANGES' );
 		} );
 
-		it( 'attaches valid "external" commit to the changelog', () => {
-			const commit = {
-				hash: '684997d0eb2eca76b9e058fb1c3fa00b50059cdc',
-				header: 'Fix: Simple fix.',
-				type: 'Fix',
-				subject: 'Simple fix.',
-				body: null,
-				footer: null,
-				notes: []
-			};
-
-			transformCommitForSubRepository( commit, { displayLogs: true, packageData: packageJson } );
-
-			expect( stubs.logger.info.calledOnce ).to.equal( true );
-			expect( stubs.logger.info.firstCall.args[ 0 ].includes( 'Fix: Simple fix.' ) ).to.equal( true );
-			expect( stubs.logger.info.firstCall.args[ 0 ].includes( 'INCLUDED' ) ).to.equal( true );
-		} );
-
-		it( 'truncates too long commit\'s subject', () => {
-			const commit = {
-				hash: '684997d0eb2eca76b9e058fb1c3fa00b50059cdc',
-				header: 'Fix: Reference site about Lorem Ipsum, giving information on its origins, as well as ' +
-				'a random Lipsum generator.',
-				type: 'Fix',
-				subject: 'Reference site about Lorem Ipsum, giving information on its origins, as well as ' +
-				'a random Lipsum generator.',
-				body: null,
-				footer: null,
-				notes: []
-			};
-
-			transformCommitForSubRepository( commit, { displayLogs: true, packageData: packageJson } );
-
-			expect( stubs.logger.info.calledOnce ).to.equal( true );
-			expect( stubs.logger.info.firstCall.args[ 0 ].includes(
-				'Fix: Reference site about Lorem Ipsum, giving information on its origins, as well as a random Lip...'
-			) ).to.equal( true );
-			expect( stubs.logger.info.firstCall.args[ 0 ].includes( 'INCLUDED' ) ).to.equal( true );
-		} );
-
-		it( 'does not attach valid "internal" commit to the changelog', () => {
-			const commit = {
-				hash: '684997d0eb2eca76b9e058fb1c3fa00b50059cdc',
-				header: 'Docs: README.',
-				type: 'Docs',
-				subject: 'README.',
-				body: null,
-				footer: null,
-				notes: []
-			};
-
-			transformCommitForSubRepository( commit, { displayLogs: true, packageData: packageJson } );
-
-			expect( stubs.logger.info.calledOnce ).to.equal( true );
-			expect( stubs.logger.info.firstCall.args[ 0 ].includes( 'Docs: README.' ) ).to.equal( true );
-			expect( stubs.logger.info.firstCall.args[ 0 ].includes( 'SKIPPED' ) ).to.equal( true );
-		} );
-
-		it( 'does not attach invalid commit to the changelog', () => {
-			const commit = {
-				hash: '684997d0eb2eca76b9e058fb1c3fa00b50059cdc',
-				header: 'Invalid commit.',
-				type: null,
-				subject: null,
-				body: null,
-				footer: null,
-				notes: []
-			};
-
-			transformCommitForSubRepository( commit, { displayLogs: true, packageData: packageJson } );
-
-			expect( stubs.logger.info.calledOnce ).to.equal( true );
-			expect( stubs.logger.info.firstCall.args[ 0 ].includes( 'Invalid commit.' ) ).to.equal( true );
-			expect( stubs.logger.info.firstCall.args[ 0 ].includes( 'INVALID' ) ).to.equal( true );
-		} );
-
 		it( 'makes proper links in the commit subject', () => {
-			const commit = {
+			const rawCommit = {
 				hash: '76b9e058fb1c3fa00b50059cdc684997d0eb2eca',
 				header: 'Fix: Simple fix. See ckeditor/ckeditor5#1. Thanks to @CKEditor. Closes #2.',
 				type: 'Fix',
@@ -162,7 +112,7 @@ describe( 'dev-env/release-tools/utils/transform-commit', () => {
 				notes: []
 			};
 
-			transformCommitForSubRepository( commit, { displayLogs: true, packageData: packageJson } );
+			const commit = transformCommitForSubRepository( rawCommit );
 
 			const expectedSubject = 'Simple fix. ' +
 				'See [ckeditor/ckeditor5#1](https://github.com/ckeditor/ckeditor5/issues/1). ' +
@@ -173,7 +123,7 @@ describe( 'dev-env/release-tools/utils/transform-commit', () => {
 		} );
 
 		it( 'makes proper links in the commit body', () => {
-			const commit = {
+			const rawCommit = {
 				hash: '76b9e058fb1c3fa00b50059cdc684997d0eb2eca',
 				header: 'Fix: Simple fix. Closes #2.',
 				type: 'Fix',
@@ -183,7 +133,7 @@ describe( 'dev-env/release-tools/utils/transform-commit', () => {
 				notes: []
 			};
 
-			transformCommitForSubRepository( commit, { displayLogs: true, packageData: packageJson } );
+			const commit = transformCommitForSubRepository( rawCommit );
 
 			// Remember about the indent in commit body.
 			const expectedBody = '  See [ckeditor/ckeditor5#1](https://github.com/ckeditor/ckeditor5/issues/1). ' +
@@ -194,7 +144,7 @@ describe( 'dev-env/release-tools/utils/transform-commit', () => {
 		} );
 
 		it( 'makes proper links in the commit notes', () => {
-			const commit = {
+			const rawCommit = {
 				hash: '76b9e058fb1c3fa00b50059cdc684997d0eb2eca',
 				header: 'Fix: Simple fix. Closes #2.',
 				type: 'Fix',
@@ -213,7 +163,7 @@ describe( 'dev-env/release-tools/utils/transform-commit', () => {
 				]
 			};
 
-			transformCommitForSubRepository( commit, { displayLogs: true, packageData: packageJson } );
+			const commit = transformCommitForSubRepository( rawCommit );
 
 			const expectedFirstNoteText = 'See [ckeditor/ckeditor5#1](https://github.com/ckeditor/ckeditor5/issues/1). ' +
 				'Thanks to [@CKEditor](https://github.com/CKEditor).';
@@ -236,7 +186,7 @@ describe( 'dev-env/release-tools/utils/transform-commit', () => {
 				'  * Used `semver` package for bumping the version (instead of a custom module).',
 			].join( '\n' );
 
-			const commit = {
+			const rawCommit = {
 				header: 'Feature: Introduced a brand new release tools with a new set of requirements. See #64.',
 				hash: 'dea35014ab610be0c2150343c6a8a68620cfe5ad',
 				body: commitDescription.join( '\n' ),
@@ -247,66 +197,23 @@ describe( 'dev-env/release-tools/utils/transform-commit', () => {
 				notes: []
 			};
 
-			transformCommitForSubRepository( commit, { displayLogs: true, packageData: packageJson } );
+			const commit = transformCommitForSubRepository( rawCommit );
 
 			expect( commit.type ).to.equal( 'Features' );
 			expect( commit.subject ).to.equal( 'Introduced a brand new release tools with a new set of requirements. ' +
 				'See [#64](https://github.com/ckeditor/ckeditor5-dev/issues/64).' );
 			expect( commit.body ).to.equal( commitDescriptionWithIndents );
 
-			expect( stubs.logger.info.calledOnce ).to.equal( true );
-
-			expect( stubs.logger.info.firstCall.args[ 0 ].includes(
-				'Feature: Introduced a brand new release tools with a new set of requirements. See #64.'
-			) ).to.equal( true );
-			expect( stubs.logger.info.firstCall.args[ 0 ].includes( 'INCLUDED' ) ).to.equal( true );
-		} );
-
-		it( 'attaches additional subject for merge commits to the commit list', () => {
-			const commit = {
-				merge: 'Merge pull request #75 from ckeditor/t/64',
-				hash: 'dea35014ab610be0c2150343c6a8a68620cfe5ad',
-				header: 'Feature: Introduced a brand new release tools with a new set of requirements.',
-				type: 'Feature',
-				subject: 'Introduced a brand new release tools with a new set of requirements.',
-				body: null,
-				footer: null,
-				mentions: [],
-				notes: []
-			};
-
-			transformCommitForSubRepository( commit, { displayLogs: true, packageData: packageJson } );
-
-			expect( stubs.logger.info.calledOnce ).to.equal( true );
-			expect( stubs.logger.info.firstCall.args[ 0 ] ).to.be.a( 'string' );
-
-			const logMessageAsArray = stubs.logger.info.firstCall.args[ 0 ].split( '\n' );
-
-			expect( logMessageAsArray[ 0 ].includes(
-				'Feature: Introduced a brand new release tools with a new set of requirements.'
-			) ).to.equal( true );
-			expect( logMessageAsArray[ 0 ].includes( 'INCLUDED' ) ).to.equal( true );
-			expect( logMessageAsArray[ 1 ].includes( 'Merge pull request #75 from ckeditor/t/64' ) ).to.equal( true );
-		} );
-
-		it( 'allows hiding the logs', () => {
-			const commit = {
-				hash: '684997d0eb2eca76b9e058fb1c3fa00b50059cdc',
-				header: 'Fix: Simple fix.',
-				type: 'Fix',
-				subject: 'Simple fix.',
-				body: null,
-				footer: null,
-				notes: []
-			};
-
-			transformCommitForSubRepository( commit, { displayLogs: false } );
-
-			expect( loggerVerbosity ).to.equal( 'error' );
+			// expect( stubs.logger.info.calledOnce ).to.equal( true );
+			//
+			// expect( stubs.logger.info.firstCall.args[ 0 ].includes(
+			// 	'Feature: Introduced a brand new release tools with a new set of requirements. See #64.'
+			// ) ).to.equal( true );
+			// expect( stubs.logger.info.firstCall.args[ 0 ].includes( 'INCLUDED' ) ).to.equal( true );
 		} );
 
 		it( 'removes references to issues', () => {
-			const commit = {
+			const rawCommit = {
 				hash: '684997d0eb2eca76b9e058fb1c3fa00b50059cdc',
 				header: 'Fix: Simple fix.',
 				type: 'Fix',
@@ -320,13 +227,13 @@ describe( 'dev-env/release-tools/utils/transform-commit', () => {
 				]
 			};
 
-			transformCommitForSubRepository( commit, { displayLogs: false } );
+			const commit = transformCommitForSubRepository( rawCommit, { displayLogs: false } );
 
 			expect( commit.references ).to.equal( undefined );
 		} );
 
 		it( 'uses commit\'s footer as a commit\'s body when commit does not have additional notes', () => {
-			const commit = {
+			const rawCommit = {
 				hash: 'dea35014ab610be0c2150343c6a8a68620cfe5ad',
 				header: 'Feature: Introduced a brand new release tools with a new set of requirements.',
 				type: 'Feature',
@@ -336,7 +243,7 @@ describe( 'dev-env/release-tools/utils/transform-commit', () => {
 				notes: []
 			};
 
-			transformCommitForSubRepository( commit, { displayLogs: false, packageData: packageJson } );
+			const commit = transformCommitForSubRepository( rawCommit, { displayLogs: false } );
 
 			expect( commit.body ).to.equal(
 				'  Additional description has been parsed as a footer but it should be a body.'
@@ -345,7 +252,7 @@ describe( 'dev-env/release-tools/utils/transform-commit', () => {
 		} );
 
 		it( 'fixes the commit which does not contain the second line', () => {
-			const commit = {
+			const rawCommit = {
 				type: null,
 				subject: null,
 				merge: 'Merge branch \'master\' of github.com:ckeditor/ckeditor5-dev',
@@ -358,58 +265,15 @@ describe( 'dev-env/release-tools/utils/transform-commit', () => {
 				revert: null
 			};
 
-			transformCommitForSubRepository( commit, { displayLogs: true, packageData: packageJson } );
+			const commit = transformCommitForSubRepository( rawCommit, { returnInvalidCommit: true } );
 
 			expect( commit.hash ).to.equal( '575e00b' );
 			expect( commit.header ).to.equal( 'Merge branch \'master\' of github.com:ckeditor/ckeditor5-dev' );
 			expect( commit.body ).to.equal( null );
 		} );
 
-		it( 'displays proper log if commit does not contain the second line', () => {
-			const commit = {
-				type: null,
-				subject: null,
-				merge: 'Merge branch \'master\' of github.com:ckeditor/ckeditor5-dev',
-				header: '-hash-',
-				body: '575e00bc8ece48826adefe226c4fb1fe071c73a7',
-				footer: null,
-				notes: [],
-				references: [],
-				mentions: [],
-				revert: null
-			};
-
-			transformCommitForSubRepository( commit, { displayLogs: true, packageData: packageJson } );
-
-			// The merge commit displays two lines:
-			// Prefix: Changes.
-			// Merge ...
-			// If the merge commit does not contain the second line, it should display only the one.
-			expect( stubs.logger.info.firstCall.args[ 0 ].split( '\n' ) ).length( 1 );
-		} );
-
-		it( 'allows returning invalid commit instead of removing', () => {
-			const commit = {
-				hash: '684997d0eb2eca76b9e058fb1c3fa00b50059cdc',
-				header: 'Docs: README.',
-				type: 'Docs',
-				subject: 'README.',
-				body: null,
-				footer: null,
-				notes: []
-			};
-
-			const newCommit = transformCommitForSubRepository( commit, {
-				displayLogs: false,
-				packageData: packageJson,
-				returnInvalidCommit: true
-			} );
-
-			expect( newCommit ).to.deep.equal( commit );
-		} );
-
 		it( 'removes [skip ci] from the commit message', () => {
-			const commit = {
+			const rawCommit = {
 				hash: '684997d0eb2eca76b9e058fb1c3fa00b50059cdc',
 				header: 'Fix: README. [skip ci]',
 				type: 'Fix',
@@ -419,11 +283,7 @@ describe( 'dev-env/release-tools/utils/transform-commit', () => {
 				notes: []
 			};
 
-			transformCommitForSubRepository( commit, {
-				displayLogs: false,
-				packageData: packageJson,
-				returnInvalidCommit: true
-			} );
+			const commit = transformCommitForSubRepository( rawCommit );
 
 			expect( commit.subject ).to.equal( 'README.' );
 		} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: All commits will be displayed properly during generating the changelog. Closes #488.

---

### Additional information

I refactored a little bit the piece of the code because the next tickets will require it. No more side effect inside the `transformCommit()` function.
