### PR TITLE
Non-scoped packages won't be ignored during the changelog generating

### DIFF
--- a/packages/ckeditor5-dev-env/lib/release-tools/utils/transform-commit/transformcommitforsubpackage.js
+++ b/packages/ckeditor5-dev-env/lib/release-tools/utils/transform-commit/transformcommitforsubpackage.js
@@ -43,9 +43,10 @@ module.exports = function transformCommitForSubPackage( commit, context ) {
 		return;
 	}
 
-	const packageName = context.packageData.name.split( '/' )[ 1 ];
+	const packageName = context.packageData.name;
+	const packageDirectory = packageName.startsWith( '@' ) ? packageName.split( '/' )[ 1 ] : packageName;
 
-	if ( !isValidCommit( files, packageName ) ) {
+	if ( !isValidCommit( files, packageDirectory ) ) {
 		return;
 	}
 

--- a/packages/ckeditor5-dev-env/tests/release-tools/utils/transform-commit/transformcommitforsubpackage.js
+++ b/packages/ckeditor5-dev-env/tests/release-tools/utils/transform-commit/transformcommitforsubpackage.js
@@ -177,5 +177,26 @@ describe( 'dev-env/release-tools/utils/transform-commit', () => {
 			expect( commit.header ).to.equal( 'Merge branch \'master\' of github.com:ckeditor/ckeditor5-dev' );
 			expect( commit.body ).to.equal( null );
 		} );
+
+		it( 'works for packages without scoped name', () => {
+			context = {
+				packageData: {
+					name: 'eslint-config-ckeditor5'
+				}
+			};
+
+			const commit = {
+				hash: 'abcd123'
+			};
+
+			stubs.getChangedFilesForCommit.returns( [
+				'packages/eslint-config-ckeditor5/README.md'
+			] );
+
+			stubs.transformCommitForSubRepository.returnsArg( 0 );
+
+			expect( transformCommitForSubPackage( commit, context ) ).to.equal( commit );
+			expect( stubs.transformCommitForSubRepository.called ).to.equal( true );
+		} );
 	} );
 } );

--- a/packages/ckeditor5-dev-env/tests/release-tools/utils/transform-commit/transformcommitforsubpackage.js
+++ b/packages/ckeditor5-dev-env/tests/release-tools/utils/transform-commit/transformcommitforsubpackage.js
@@ -228,18 +228,19 @@ describe( 'dev-env/release-tools/utils/transform-commit', () => {
 				}
 			};
 
-			const commit = {
-				hash: 'abcd123'
+			const rawCommit = {
+				hash: 'abcd123',
+				notes: []
 			};
 
 			stubs.getChangedFilesForCommit.returns( [
 				'packages/eslint-config-ckeditor5/README.md'
 			] );
 
-			stubs.transformCommitForSubRepository.returnsArg( 0 );
+			const commit = transformCommitForSubPackage( rawCommit, context );
 
-			expect( transformCommitForSubPackage( commit, context ) ).to.equal( commit );
 			expect( stubs.transformCommitForSubRepository.called ).to.equal( true );
+			expect( commit ).to.deep.equal( rawCommit );
 		} );
 	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Non-scoped packages won't be ignored during the changelog generating. Closes #331.