### PR TITLE
"Merge 'stable' branch" commit will be ignored

### DIFF
--- a/packages/ckeditor5-dev-env/lib/release-tools/utils/transform-commit/transformcommitforsubrepository.js
+++ b/packages/ckeditor5-dev-env/lib/release-tools/utils/transform-commit/transformcommitforsubrepository.js
@@ -44,6 +44,11 @@ module.exports = function transformCommitForSubRepository( rawCommit, context = 
 		commit.body = null;
 	}
 
+	// Ignore the `stable` merge branch.
+	if ( commit.merge === 'Merge branch \'stable\'' ) {
+		return;
+	}
+
 	if ( typeof commit.hash === 'string' ) {
 		commit.hash = commit.hash.substring( 0, 7 );
 	}

--- a/packages/ckeditor5-dev-env/tests/release-tools/utils/transform-commit/transformcommitforsubrepository.js
+++ b/packages/ckeditor5-dev-env/tests/release-tools/utils/transform-commit/transformcommitforsubrepository.js
@@ -289,5 +289,23 @@ describe( 'dev-env/release-tools/utils/transform-commit', () => {
 
 			expect( commit.subject ).to.equal( 'README.' );
 		} );
+
+		it( 'always ignores merge "stable" commit', () => {
+			const rawCommit = {
+				type: null,
+				subject: null,
+				merge: 'Merge branch \'stable\'',
+				header: '-hash-',
+				body: '575e00bc8ece48826adefe226c4fb1fe071c73a7',
+				footer: null,
+				notes: [],
+				references: [],
+				mentions: [],
+				revert: null
+			};
+
+			expect( transformCommitForSubRepository( rawCommit ) ).to.equal( undefined );
+			expect( transformCommitForSubRepository( rawCommit, { returnInvalidCommit: true } ) ).to.equal( undefined );
+		} );
 	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: `Merge 'stable' branch` commit will be ignored during generating the changelog. Closes #487.

---

![image](https://user-images.githubusercontent.com/2270764/53865498-9faa9100-3fef-11e9-998c-0d3121b2cf40.png)
