### PR TITLE
Merged multiple "Updated translations" commits into one 

### DIFF
--- a/packages/ckeditor5-dev-env/lib/release-tools/utils/generatechangelogfromcommits.js
+++ b/packages/ckeditor5-dev-env/lib/release-tools/utils/generatechangelogfromcommits.js
@@ -117,13 +117,13 @@ function groupUpdatedTranslationsCommits( changelog ) {
 	const removedEntries = [];
 
 	// An array that contains changelog without duplicated entries.
-	const uniqueEntries = changelogAsArray.filter( row => {
-		if ( !row.startsWith( UPDATED_TRANSLATION_COMMIT ) ) {
+	const uniqueEntries = changelogAsArray.filter( line => {
+		if ( !line.startsWith( UPDATED_TRANSLATION_COMMIT ) ) {
 			return true;
 		}
 
 		if ( foundUpdatedTranslationCommit ) {
-			removedEntries.push( row );
+			removedEntries.push( line );
 
 			return false;
 		}
@@ -133,13 +133,13 @@ function groupUpdatedTranslationsCommits( changelog ) {
 		return true;
 	} );
 
-	return uniqueEntries.map( row => {
-		if ( !row.startsWith( UPDATED_TRANSLATION_COMMIT ) ) {
-			return row;
+	return uniqueEntries.map( line => {
+		if ( !line.startsWith( UPDATED_TRANSLATION_COMMIT ) ) {
+			return line;
 		}
 
-		return row + ' ' + removedEntries.map( row => {
-			return row.match( /(\(\[.{7}\]\([^)]+\)\))/ )[ 1 ];
+		return line + ' ' + removedEntries.map( entry => {
+			return entry.match( /(\(\[.{7}\]\([^)]+\)\))/ )[ 1 ];
 		} ).join( ' ' );
 	} ).join( '\n' );
 }

--- a/packages/ckeditor5-dev-env/tests/release-tools/utils/generatechangelogfromcommits-integration.js
+++ b/packages/ckeditor5-dev-env/tests/release-tools/utils/generatechangelogfromcommits-integration.js
@@ -99,12 +99,12 @@ describe( 'dev-env/release-tools/utils', () => {
 		} );
 
 		it( 'title of the next release should be a link which compares current version with the previous one', () => {
-			exec( 'git commit --allow-empty --message "Internal: An initial commit."' );
+			makeCommit( 'Internal: An initial commit.' );
 
 			return makeInitialRelease()
 				.then( () => {
-					exec( 'git commit --allow-empty --message "Internal: An initial commit."' );
-					exec( 'git commit --allow-empty --message "Feature: Some amazing feature. Closes #1."' );
+					makeCommit( 'Internal: An initial commit.' );
+					makeCommit( 'Feature: Some amazing feature. Closes #1.' );
 
 					return generateChangelog( '0.1.0' );
 				} )
@@ -119,8 +119,7 @@ describe( 'dev-env/release-tools/utils', () => {
 		it( 'handles a commit which does not end with a dot', () => {
 			return makeInitialRelease()
 				.then( () => {
-					exec( 'git commit --allow-empty ' +
-						'--message "Feature: Another feature. Closes #2"' );
+					makeCommit( 'Feature: Another feature. Closes #2' );
 
 					return generateChangelog( '0.1.0' );
 				} )
@@ -143,9 +142,7 @@ describe( 'dev-env/release-tools/utils', () => {
 			it( 'does not hoist issues from the commit body', () => {
 				return makeInitialRelease()
 					.then( () => {
-						exec( 'git commit --allow-empty ' +
-							'--message "Feature: Another feature. Closes #2." ' +
-							'--message "This PR also closes #3 and #4."' );
+						makeCommit( 'Feature: Another feature. Closes #2.', 'This PR also closes #3 and #4.' );
 
 						return generateChangelog( '0.1.0' );
 					} )
@@ -169,10 +166,11 @@ describe( 'dev-env/release-tools/utils', () => {
 			it( 'does not hoist issues from the commit body for merge commit', () => {
 				return makeInitialRelease()
 					.then( () => {
-						exec( 'git commit --allow-empty ' +
-							'--message "Merge pull request #5 from ckeditor/t/4" ' +
-							'--message "Fix: Amazing fix. Closes #5." ' +
-							'--message "The PR also finally closes #3 and #4. So good!"' );
+						makeCommit(
+							'Merge pull request #5 from ckeditor/t/4',
+							'Fix: Amazing fix. Closes #5.',
+							'The PR also finally closes #3 and #4. So good!'
+						);
 
 						return generateChangelog( '0.1.1' );
 					} )
@@ -196,12 +194,13 @@ describe( 'dev-env/release-tools/utils', () => {
 			it( 'does not hoist issues from the commit body with additional notes for merge commit', () => {
 				return makeInitialRelease()
 					.then( () => {
-						exec( 'git commit --allow-empty ' +
-							'--message "Merge pull request #7 from ckeditor/t/6" ' +
-							'--message "Other: Some docs improvements. Closes #6." ' +
-							'--message "Did you see the #3 and #4?" ' +
-							'--message "NOTE: Please read #1." ' +
-							'--message "BREAKING CHANGES: Some breaking change." ' );
+						makeCommit(
+							'Merge pull request #7 from ckeditor/t/6',
+							'Other: Some docs improvements. Closes #6.',
+							'Did you see the #3 and #4?',
+							'NOTE: Please read #1.',
+							'BREAKING CHANGES: Some breaking change.'
+						);
 
 						return generateChangelog( '0.2.0' );
 					} )
@@ -233,11 +232,12 @@ describe( 'dev-env/release-tools/utils', () => {
 			it( 'does not hoist issues from the commit body with additional notes', () => {
 				return makeInitialRelease()
 					.then( () => {
-						exec( 'git commit --allow-empty ' +
-							'--message "Feature: Issues will not be hoisted. Closes #8." ' +
-							'--message "All details have been described in #1." ' +
-							'--message "NOTE: Please read #1." ' +
-							'--message "BREAKING CHANGES: Some breaking change." ' );
+						makeCommit(
+							'Feature: Issues will not be hoisted. Closes #8.',
+							'All details have been described in #1.',
+							'NOTE: Please read #1.',
+							'BREAKING CHANGES: Some breaking change.'
+						);
 
 						return generateChangelog( '0.2.0' );
 					} )
@@ -272,9 +272,9 @@ describe( 'dev-env/release-tools/utils', () => {
 			it( 'works with merge commit which is not a pull request #1', () => {
 				return makeInitialRelease()
 					.then( () => {
-						exec( 'git commit --allow-empty ' +
-							'--message "Merge t/ckeditor5-link/52 into master" ' +
-							'--message "Fix: Foo."'
+						makeCommit(
+							'Merge t/ckeditor5-link/52 into master',
+							'Fix: Foo.'
 						);
 
 						return generateChangelog( '0.1.0' );
@@ -297,9 +297,9 @@ describe( 'dev-env/release-tools/utils', () => {
 			it( 'works with merge commit which is not a pull request #2', () => {
 				return makeInitialRelease()
 					.then( () => {
-						exec( 'git commit --allow-empty ' +
-							'--message "Merge branch t/ckedtor5-engine/660 to master" ' +
-							'--message "Fix: Foo."'
+						makeCommit(
+							'Merge branch t/ckedtor5-engine/660 to master',
+							'Fix: Foo.'
 						);
 
 						return generateChangelog( '0.1.0' );
@@ -325,9 +325,7 @@ describe( 'dev-env/release-tools/utils', () => {
 			it( 'works with prefix "Fixes"', () => {
 				return makeInitialRelease()
 					.then( () => {
-						exec( 'git commit --allow-empty ' +
-							'--message "Fixes: Foo Bar."'
-						);
+						makeCommit( 'Fixes: Foo Bar.' );
 
 						return generateChangelog( '0.0.2' );
 					} )
@@ -349,9 +347,7 @@ describe( 'dev-env/release-tools/utils', () => {
 			it( 'works with prefix "Fixed"', () => {
 				return makeInitialRelease()
 					.then( () => {
-						exec( 'git commit --allow-empty ' +
-							'--message "Fixed: Foo Bar."'
-						);
+						makeCommit( 'Fixed: Foo Bar.' );
 
 						return generateChangelog( '0.0.2' );
 					} )
@@ -427,7 +423,7 @@ describe( 'dev-env/release-tools/utils', () => {
 			it( 'changelog should contain 2 blank lines for changelog with internal changes', () => {
 				return makeInitialRelease()
 					.then( () => {
-						exec( 'git commit --allow-empty --message "Docs: Updated README."' );
+						makeCommit( 'Docs: Updated README.' );
 
 						return generateChangelog( '0.0.2' );
 					} )
@@ -453,9 +449,7 @@ describe( 'dev-env/release-tools/utils', () => {
 			it( 'attaches additional description for "Bug fixes" section', () => {
 				return makeInitialRelease()
 					.then( () => {
-						exec( 'git commit --allow-empty ' +
-							'--message "Fix: Foo Bar."'
-						);
+						makeCommit( 'Fix: Foo Bar.' );
 
 						return generateChangelog( '0.0.2', { additionalNotes: true } );
 					} )
@@ -480,17 +474,19 @@ Besides changes in the dependencies, this version also contains the following bu
 			it( 'forces generating changelog as "internal" even if commits were made', () => {
 				return makeInitialRelease()
 					.then( () => {
-						exec( 'git commit --allow-empty ' +
-							'--message "Feature: Issues will not be hoisted. Closes #8." ' +
-							'--message "All details have been described in #1." ' +
-							'--message "NOTE: Please read #1." ' +
-							'--message "BREAKING CHANGES: Some breaking change." ' );
+						makeCommit(
+							'Feature: Issues will not be hoisted. Closes #8.',
+							'All details have been described in #1.',
+							'NOTE: Please read #1.',
+							'BREAKING CHANGES: Some breaking change.'
+						);
 
-						exec( 'git commit --allow-empty ' +
-							'--message "Feature: Issues will not be hoisted. Closes #8." ' +
-							'--message "All details have been described in #1." ' +
-							'--message "NOTE: Please read #1." ' +
-							'--message "BREAKING CHANGES: Some breaking change." ' );
+						makeCommit(
+							'Feature: Issues will not be hoisted. Closes #8.',
+							'All details have been described in #1.',
+							'NOTE: Please read #1.',
+							'BREAKING CHANGES: Some breaking change.'
+						);
 
 						return generateChangelog( '0.1.0', { isInternalRelease: true } );
 					} )
@@ -504,7 +500,7 @@ Besides changes in the dependencies, this version also contains the following bu
 			it( 'does not generate links to commits and release', () => {
 				return makeInitialRelease()
 					.then( () => {
-						exec( 'git commit --allow-empty --message "Feature: Some amazing feature."' );
+						makeCommit( 'Feature: Some amazing feature.' );
 
 						return generateChangelog( '0.1.0', { skipLinks: true } );
 					} )
@@ -544,6 +540,10 @@ Besides changes in the dependencies, this version also contains the following bu
 		return normalizeStrings( _getChangesForVersion( version ) );
 	}
 
+	function makeCommit( ...messages ) {
+		return exec( 'git commit --allow-empty ' + messages.map( m => `--message "${ m }"` ).join( ' ' ) );
+	}
+
 	function exec( command ) {
 		return tools.shExec( command, { verbosity: 'error' } );
 	}
@@ -578,7 +578,7 @@ Besides changes in the dependencies, this version also contains the following bu
 	// Almost all testes (except the initial release) require the initial release because we're checking
 	// how the changelog looks between releases.
 	function makeInitialRelease() {
-		exec( 'git commit --allow-empty --message "Internal: An initial commit."' );
+		makeCommit( 'Internal: An initial commit.' );
 
 		return generateChangelog( '0.0.1', { isFirstRelease: true } )
 			.then( () => {
@@ -586,7 +586,7 @@ Besides changes in the dependencies, this version also contains the following bu
 
 				exec( `npm version ${ version } --no-git-tag-version` );
 				exec( 'git add package.json' );
-				exec( `git commit --message "Release: v${ version }."` );
+				makeCommit( `Release: v${ version }.` );
 				exec( `git tag v${ version }` );
 			} );
 	}

--- a/packages/ckeditor5-dev-env/tests/release-tools/utils/generatechangelogfromcommits-integration.js
+++ b/packages/ckeditor5-dev-env/tests/release-tools/utils/generatechangelogfromcommits-integration.js
@@ -524,6 +524,94 @@ Besides changes in the dependencies, this version also contains the following bu
 					} );
 			} );
 		} );
+
+		describe( 'grouping "Updated translation" commits as the single entry', () => {
+			it( 'works fine when translations have been updated few times (and nothing more has been changed)', () => {
+				return makeInitialRelease()
+					.then( () => {
+						makeCommit( 'Other: Updated translations. [skip ci]' );
+						makeCommit( 'Other: Updated translations. [skip ci]' );
+						makeCommit( 'Other: Updated translations. [skip ci]' );
+
+						return generateChangelog( '0.0.2' );
+					} )
+					.then( () => {
+						const latestChangelog = replaceCommitIds( getChangesForVersion( '0.0.2' ) );
+
+						/* eslint-disable max-len */
+						const expectedChangelog = normalizeStrings( `
+### Other changes
+
+* Updated translations. ([XXXXXXX](https://github.com/ckeditor/ckeditor5-test-package/commit/XXXXXXX)) ([XXXXXXX](https://github.com/ckeditor/ckeditor5-test-package/commit/XXXXXXX)) ([XXXXXXX](https://github.com/ckeditor/ckeditor5-test-package/commit/XXXXXXX))
+` );
+						/* eslint-enable max-len */
+
+						expect( latestChangelog ).to.equal( expectedChangelog.trim() );
+					} );
+			} );
+
+			it( 'works fine for complex iteration', () => {
+				return makeInitialRelease()
+					.then( () => {
+						makeCommit( 'Feature: Another feature. Closes #2' );
+						makeCommit( 'Other: Updated translations. [skip ci]' );
+						makeCommit(
+							'Feature: Issues will not be hoisted. Closes #8.',
+							'All details have been described in #1.',
+							'NOTE: Please read #1.',
+							'BREAKING CHANGES: Some breaking change.'
+						);
+						makeCommit( 'Other: Updated translations. [skip ci]' );
+						makeCommit(
+							'Merge t/ckeditor5-link/52 into master',
+							'Fix: Foo Bar. Closes #9.'
+						);
+						makeCommit( 'Other: Updated translations. [skip ci]' );
+						makeCommit(
+							'Fix: Amazing fix. Closes #5.',
+							'The PR also finally closes #3 and #4. So good!'
+						);
+						makeCommit( 'Other: Updated translations.' );
+
+						return generateChangelog( '1.0.0' );
+					} )
+					.then( () => {
+						const latestChangelog = replaceCommitIds( getChangesForVersion( '1.0.0' ) );
+
+						/* eslint-disable max-len */
+						const expectedChangelog = normalizeStrings( `
+### Features
+
+* Another feature. Closes [#2](https://github.com/ckeditor/ckeditor5-test-package/issues/2). ([XXXXXXX](https://github.com/ckeditor/ckeditor5-test-package/commit/XXXXXXX))
+* Issues will not be hoisted. Closes [#8](https://github.com/ckeditor/ckeditor5-test-package/issues/8). ([XXXXXXX](https://github.com/ckeditor/ckeditor5-test-package/commit/XXXXXXX))
+
+  All details have been described in [#1](https://github.com/ckeditor/ckeditor5-test-package/issues/1).
+
+### Bug fixes
+
+* Amazing fix. Closes [#5](https://github.com/ckeditor/ckeditor5-test-package/issues/5). ([XXXXXXX](https://github.com/ckeditor/ckeditor5-test-package/commit/XXXXXXX))
+
+  The PR also finally closes [#3](https://github.com/ckeditor/ckeditor5-test-package/issues/3) and [#4](https://github.com/ckeditor/ckeditor5-test-package/issues/4). So good!
+* Foo Bar. Closes [#9](https://github.com/ckeditor/ckeditor5-test-package/issues/9). ([XXXXXXX](https://github.com/ckeditor/ckeditor5-test-package/commit/XXXXXXX))
+
+### Other changes
+
+* Updated translations. ([XXXXXXX](https://github.com/ckeditor/ckeditor5-test-package/commit/XXXXXXX)) ([XXXXXXX](https://github.com/ckeditor/ckeditor5-test-package/commit/XXXXXXX)) ([XXXXXXX](https://github.com/ckeditor/ckeditor5-test-package/commit/XXXXXXX)) ([XXXXXXX](https://github.com/ckeditor/ckeditor5-test-package/commit/XXXXXXX))
+
+### BREAKING CHANGES
+
+* Some breaking change.
+
+### NOTE
+
+* Please read [#1](https://github.com/ckeditor/ckeditor5-test-package/issues/1).
+` );
+						/* eslint-enable max-len */
+
+						expect( latestChangelog ).to.equal( expectedChangelog.trim() );
+					} );
+			} );
+		} );
 	} );
 
 	// Because of the Windows end of the line, we need to normalize them.


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Multiple "Updated translations." commits will be merged into a single entry in the changelog. Closes #486.