### PR TITLE
Release tool will not crash when publishing a package for the first time

### DIFF
--- a/packages/ckeditor5-dev-env/lib/release-tools/tasks/bumpversions.js
+++ b/packages/ckeditor5-dev-env/lib/release-tools/tasks/bumpversions.js
@@ -68,7 +68,7 @@ module.exports = function bumpVersions( options ) {
 		.then( () => {
 			process.chdir( cwd );
 
-			logProcess( `Finished updating versions of ${ chalk.underline( pathsCollection.matched.size ) } packages.` );
+			logProcess( `Finished updating versions of ${ chalk.underline( pathsCollection.matched.size ) } package(s).` );
 			logDryRun( 'Because of the DRY RUN mode, nothing has been changed. All changes were reverted.' );
 		} )
 		.catch( err => {

--- a/packages/ckeditor5-dev-env/lib/release-tools/tasks/releasesubrepositories.js
+++ b/packages/ckeditor5-dev-env/lib/release-tools/tasks/releasesubrepositories.js
@@ -247,7 +247,7 @@ module.exports = function releaseSubRepositories( options ) {
 			releaseDetails.shouldReleaseOnNpm = npmVersion !== releaseDetails.version;
 
 			if ( releaseDetails.shouldReleaseOnNpm ) {
-				logDryRun( 'Package will be released.' );
+				log.info( '✅  Added to release.' );
 
 				releasesOnNpm.add( repositoryPath );
 			} else {
@@ -314,11 +314,11 @@ module.exports = function releaseSubRepositories( options ) {
 					releaseDetails.shouldReleaseOnGithub = githubVersion !== releaseDetails.version;
 
 					if ( releaseDetails.shouldReleaseOnGithub ) {
-						logDryRun( 'Package will be published.' );
+						log.info( '✅  Added to release.' );
 
 						releasesOnGithub.add( repositoryPath );
 					} else {
-						log.info( '❌  Nothing to publish.' );
+						log.info( '❌  Nothing to release.' );
 					}
 				} )
 				.catch( err => {

--- a/packages/ckeditor5-dev-env/lib/release-tools/tasks/releasesubrepositories.js
+++ b/packages/ckeditor5-dev-env/lib/release-tools/tasks/releasesubrepositories.js
@@ -273,7 +273,7 @@ module.exports = function releaseSubRepositories( options ) {
 					return null;
 				}
 
-				throw new Error( err );
+				throw err;
 			}
 		}
 	}


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Release tool will not crash when publishing a package for the first time. Closes #491.
