### PR TITLE
Manual tests were crashing after setting window.editor to null

### DIFF
--- a/packages/ckeditor5-dev-tests/lib/utils/manual-tests/attachinspector.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/manual-tests/attachinspector.js
@@ -16,7 +16,9 @@
 		set: value => {
 			editor = value;
 
-			CKEditorInspector.attach( 'editor', editor );
+			if ( editor ) {
+				CKEditorInspector.attach( 'editor', editor );
+			}
 		},
 		get: () => editor
 	} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Manual tests were crashing after setting `window.editor` to `null`. Closes #502.