### PR TITLE
Fixed code coverage matching for Windows

### DIFF
--- a/packages/ckeditor5-dev-tests/lib/utils/transformfileoptiontotestglob.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/transformfileoptiontotestglob.js
@@ -21,14 +21,12 @@
  * @returns {String}
  */
 module.exports = function transformFileOptionToTestGlob( fileOption, isManualTest = false ) {
-	const path = require( 'path' );
 	const globSep = '/';
-	const cwdChunks = process.cwd().split( path.sep );
-	const packagesPathChunks = cwdChunks.concat( [ 'packages' ] );
+	const cwdChunks = process.cwd().split( require( 'path' ).sep );
 	const chunks = fileOption.split( globSep );
 	const packageName = chunks.shift();
 	const globSuffix = [ 'tests', '**' ];
-	let returnChunks = [];
+	let returnChunks = cwdChunks.concat( [ 'packages' ] );
 
 	if ( isManualTest ) {
 		globSuffix.push( 'manual', '**' );
@@ -42,19 +40,17 @@ module.exports = function transformFileOptionToTestGlob( fileOption, isManualTes
 	} else if ( chunks.length === 0 ) {
 		// 1.
 		if ( packageName == '*' ) {
-			returnChunks = packagesPathChunks.concat( [ 'ckeditor5-*' ], globSuffix );
-		}
-
-		// 3.
-		if ( packageName.startsWith( '!' ) ) {
-			returnChunks = packagesPathChunks.concat( [ 'ckeditor5-!(' + packageName.slice( 1 ) + ')*' ], globSuffix );
+			returnChunks.push( 'ckeditor5-*', ...globSuffix );
+		} else if ( packageName.startsWith( '!' ) ) {
+			// 3.
+			returnChunks.push( 'ckeditor5-!(' + packageName.slice( 1 ) + ')*', ...globSuffix );
 		} else {
 			// 2.
-			returnChunks = packagesPathChunks.concat( [ 'ckeditor5-' + packageName ], globSuffix );
+			returnChunks.push( 'ckeditor5-' + packageName, ...globSuffix );
 		}
 	} else {
 		// 5.
-		returnChunks = packagesPathChunks.concat( [ 'ckeditor5-' + packageName, 'tests' ], chunks );
+		returnChunks.push( 'ckeditor5-' + packageName, 'tests', ...chunks );
 
 		if ( !chunks[ chunks.length - 1 ].endsWith( '.js' ) ) {
 			// 4.

--- a/packages/ckeditor5-dev-tests/lib/utils/transformfileoptiontotestglob.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/transformfileoptiontotestglob.js
@@ -21,47 +21,49 @@
  * @returns {String}
  */
 module.exports = function transformFileOptionToTestGlob( fileOption, isManualTest = false ) {
+	const pathJoin = ( ...pathParts ) => pathParts.join( '/' );
 	const path = require( 'path' );
-	const nodeModulesPath = path.join( process.cwd(), 'packages' );
-
+	const globSep = '/';
+	const globCwd = process.cwd().split( path.sep ).join( globSep );
+	const nodeModulesPath = pathJoin( globCwd, 'packages' );
 	const chunks = fileOption.split( '/' );
 	const packageName = chunks.shift();
-	let globSuffix = path.join( 'tests', '**' );
+	let globSuffix = pathJoin( 'tests', '**' );
 
 	if ( isManualTest ) {
-		globSuffix += path.sep + path.join( 'manual', '**' );
+		globSuffix += globSep + pathJoin( 'manual', '**' );
 	}
 
-	globSuffix += path.sep + '*.js';
+	globSuffix += globSep + '*.js';
 
 	// 0.
 	if ( fileOption === '/' ) {
-		return path.join( process.cwd(), globSuffix );
+		return pathJoin( globCwd, globSuffix );
 	}
 
 	// 1. 2. 3.
 	if ( chunks.length === 0 ) {
 		// 1.
 		if ( packageName == '*' ) {
-			return path.join( nodeModulesPath, 'ckeditor5-*', globSuffix );
+			return pathJoin( nodeModulesPath, 'ckeditor5-*', globSuffix );
 		}
 
 		// 3.
 		if ( packageName.startsWith( '!' ) ) {
-			return path.join( nodeModulesPath, 'ckeditor5-!(' + packageName.slice( 1 ) + ')*', globSuffix );
+			return pathJoin( nodeModulesPath, 'ckeditor5-!(' + packageName.slice( 1 ) + ')*', globSuffix );
 		}
 
 		// 2.
-		return path.join( nodeModulesPath, 'ckeditor5-' + packageName, globSuffix );
+		return pathJoin( nodeModulesPath, 'ckeditor5-' + packageName, globSuffix );
 	}
 
-	let glob = chunks.join( path.sep );
+	let glob = chunks.join( globSep );
 
 	// 4.
 	if ( !glob.endsWith( '.js' ) ) {
-		glob = path.join( glob, '**', '*.js' );
+		glob = pathJoin( glob, '**', '*.js' );
 	}
 
 	// 5.
-	return path.join( nodeModulesPath, 'ckeditor5-' + packageName, 'tests', glob );
+	return pathJoin( nodeModulesPath, 'ckeditor5-' + packageName, 'tests', glob );
 };

--- a/packages/ckeditor5-dev-tests/lib/utils/transformfileoptiontotestglob.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/transformfileoptiontotestglob.js
@@ -21,49 +21,49 @@
  * @returns {String}
  */
 module.exports = function transformFileOptionToTestGlob( fileOption, isManualTest = false ) {
-	const pathJoin = ( ...pathParts ) => pathParts.join( '/' );
 	const path = require( 'path' );
 	const globSep = '/';
+	const globJoin = ( ...pathParts ) => pathParts.join( globSep );
 	const globCwd = process.cwd().split( path.sep ).join( globSep );
-	const nodeModulesPath = pathJoin( globCwd, 'packages' );
-	const chunks = fileOption.split( '/' );
+	const packagesPath = globJoin( globCwd, 'packages' );
+	const chunks = fileOption.split( globSep );
 	const packageName = chunks.shift();
-	let globSuffix = pathJoin( 'tests', '**' );
+	let globSuffix = globJoin( 'tests', '**' );
 
 	if ( isManualTest ) {
-		globSuffix += globSep + pathJoin( 'manual', '**' );
+		globSuffix += globSep + globJoin( 'manual', '**' );
 	}
 
 	globSuffix += globSep + '*.js';
 
 	// 0.
 	if ( fileOption === '/' ) {
-		return pathJoin( globCwd, globSuffix );
+		return globJoin( globCwd, globSuffix );
 	}
 
 	// 1. 2. 3.
 	if ( chunks.length === 0 ) {
 		// 1.
 		if ( packageName == '*' ) {
-			return pathJoin( nodeModulesPath, 'ckeditor5-*', globSuffix );
+			return globJoin( packagesPath, 'ckeditor5-*', globSuffix );
 		}
 
 		// 3.
 		if ( packageName.startsWith( '!' ) ) {
-			return pathJoin( nodeModulesPath, 'ckeditor5-!(' + packageName.slice( 1 ) + ')*', globSuffix );
+			return globJoin( packagesPath, 'ckeditor5-!(' + packageName.slice( 1 ) + ')*', globSuffix );
 		}
 
 		// 2.
-		return pathJoin( nodeModulesPath, 'ckeditor5-' + packageName, globSuffix );
+		return globJoin( packagesPath, 'ckeditor5-' + packageName, globSuffix );
 	}
 
 	let glob = chunks.join( globSep );
 
 	// 4.
 	if ( !glob.endsWith( '.js' ) ) {
-		glob = pathJoin( glob, '**', '*.js' );
+		glob = globJoin( glob, '**', '*.js' );
 	}
 
 	// 5.
-	return pathJoin( nodeModulesPath, 'ckeditor5-' + packageName, 'tests', glob );
+	return globJoin( packagesPath, 'ckeditor5-' + packageName, 'tests', glob );
 };


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Fixed code coverage matching for Windows. Closes #509.

---

### Additional information

`/` is always used as a separator for glob matchers, no matter the platform.

It would be nice to cover this fix with tests, this would require either setting a CI on appveyor.com or mocking path.sep. Either way I needed the fix asap, and need to switch to other tasks.