### PR TITLE
Remove debug option for theme importer from manual tests webpack configuration.

### DIFF
--- a/packages/ckeditor5-dev-tests/lib/utils/manual-tests/getwebpackconfig.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/manual-tests/getwebpackconfig.js
@@ -56,8 +56,7 @@ module.exports = function getWebpackConfigForManualTests( entryObject, buildDir,
 							loader: 'postcss-loader',
 							options: getPostCssConfig( {
 								themeImporter: {
-									themePath,
-									debug: true
+									themePath
 								},
 								sourceMap: true
 							} )


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Remove debug option for theme importer from manual tests webpack configuration. Closes ckeditor/ckeditor5#1654.

---

### Additional information

* Hides confusing logs.
