### PR TITLE
Dependency Checker will parse CSS files

### DIFF
--- a/packages/ckeditor5-dev-tests/bin/check-dependencies.js
+++ b/packages/ckeditor5-dev-tests/bin/check-dependencies.js
@@ -232,7 +232,7 @@ function parsePostCSS( fileContent, filePath, dependencies ) {
 			};
 		} )
 		.forEach( importDetails => {
-			// If checked file import another file, check whether imported file exists.
+			// If checked file imports another file, checks whether imported file exists.
 			if ( importDetails.type == 'file' ) {
 				const fileToImport = path.resolve( filePath, '..', importDetails.path );
 

--- a/packages/ckeditor5-dev-tests/bin/check-dependencies.js
+++ b/packages/ckeditor5-dev-tests/bin/check-dependencies.js
@@ -163,7 +163,7 @@ function getInvalidItselfImports( repositoryPath ) {
  *
  * @param {Object} missingPackages The `missing` value from object returned by `depcheck`.
  * @param {String} currentPackage Name of current package.
- * @returns {Object.<String, Array.<String>}
+ * @returns {Object.<String, Array.<String>>}
  */
 function groupMissingPackages( missingPackages, currentPackage ) {
 	delete missingPackages[ currentPackage ];


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Introduced a parser for `*.css` files. Now it will check CSS files and if some package is missing, it will be printed by the dependency checker script. See ckeditor/ckeditor5#1662.
