### PR TITLE
Change the `space-before-function-paren` rule to preserve spaces before async arrow functions

### DIFF
--- a/packages/eslint-config-ckeditor5/.eslintrc.js
+++ b/packages/eslint-config-ckeditor5/.eslintrc.js
@@ -8,7 +8,7 @@
 module.exports = {
 	extends: 'eslint:recommended',
 	parserOptions: {
-		ecmaVersion: 6,
+		ecmaVersion: 2018,
 		sourceType: 'module'
 	},
 	env: {

--- a/packages/eslint-config-ckeditor5/.eslintrc.js
+++ b/packages/eslint-config-ckeditor5/.eslintrc.js
@@ -230,7 +230,11 @@ module.exports = {
 		],
 		'space-before-function-paren': [
 			'error',
-			'never'
+			{
+				anonymous: 'never',
+				named: 'never',
+				asyncArrow: 'always'
+			}
 		],
 		'space-infix-ops': 'error',
 		'space-in-parens': [


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Updated `ecmaVersion` from `es6` to `es2018` (`es9`). Changed the `space-before-function-paren` rule to preserve spaces before async arrow functions. Closes #521.

---

### Additional information

BREAKING CHANGE: During async arrow function linting, the space before the parenthesis will be required, unlike in the past.

The correct code style after this change:

```
const fn = function x() {};
const anonymousFn = function() {};

const arrowFn = () => {};

const asyncArrowFn = async () => {};
const asyncAnonymousFn = async function() {};
const asyncFn = async function y() {};
```
