### PR TITLE
Removed the BrowserStack integration from ckeditor5-dev repository

### DIFF
--- a/packages/ckeditor5-dev-tests/README.md
+++ b/packages/ckeditor5-dev-tests/README.md
@@ -54,16 +54,6 @@ You can also use the bin script for testing a package:
 * `browsers` - Browsers which will be used to run the tests. Also available as an alias: `-b`.
 * `reporter` - Mocha reporter – either `mocha` (default) or `dots` (less verbose one).
 
-#### BrowserStack
-
-You can use BrowserStack to execute the tests on different browsers. At this moment we have defined 2 browsers:
-
-1. Edge 16 - Windows 10 (`BrowserStack_Edge`)
-1. Safari 11 - OS X High Sierra (`BrowserStack_Safari`)
-
-In order to run BrowserStack, you need to specify the environment variables: `BROWSER_STACK_USERNAME` and `BROWSER_STACK_ACCESS_KEY`.
-By default, the tests will be executed on Chrome that is installed on your machine. You can use an option `--browsers` to specify the browsers.
-
 #### Examples
 
 Test the `ckeditor5-enter` and `ckeditor5-paragraph` packages and generate code coverage report:
@@ -95,18 +85,6 @@ Test all installed packages except one (or more):
 ```bash
 $ npm t -- --files='!(engine)'
 $ npm t -- --files='!(engine|ui)'
-```
-
-Test the `ckeditor5-engine` using BrowserStack on Edge:
-
-```bash
-$ BROWSER_STACK_USERNAME=[...] BROWSER_STACK_ACCESS_KEY=[...] npm test -- --files engine --browsers=BrowserStack_Edge
-```
-
-Test the `ckeditor5-image` and `ckeditor5-ui` using BrowserStack on Safari and Edge:
-
-```bash
-$ BROWSER_STACK_USERNAME=[...] BROWSER_STACK_ACCESS_KEY=[...] npm test -- --files image,ui --browsers=BrowserStack_Safari,BrowserStack_Edge
 ```
 
 ### Rules for converting `--files` option to glob pattern:

--- a/packages/ckeditor5-dev-tests/bin/test-travis.sh
+++ b/packages/ckeditor5-dev-tests/bin/test-travis.sh
@@ -19,4 +19,4 @@ yarn run lint && \
 ${ROOT_BIN}/ckeditor5-dev-tests-check-dependencies && \
 cd ${CKEDITOR5_TEST_ENVIRONMENT} && \
 node --max_old_space_size=4096 $ROOT_BIN/ckeditor5-dev-tests --files=$PACKAGE_NAME --coverage --reporter=dots --browsers=Chrome && \
-node --max_old_space_size=4096 $ROOT_BIN/ckeditor5-dev-tests --files=$PACKAGE_NAME --reporter=dots --browsers=Firefox,BrowserStack_Edge,BrowserStack_Safari
+node --max_old_space_size=4096 $ROOT_BIN/ckeditor5-dev-tests --files=$PACKAGE_NAME --reporter=dots --browsers=Firefox

--- a/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getkarmaconfig.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getkarmaconfig.js
@@ -86,19 +86,6 @@ module.exports = function getKarmaConfig( options ) {
 			CHROME_LOCAL: {
 				base: 'Chrome',
 				flags: [ '--disable-background-timer-throttling', '--js-flags="--expose-gc"' ]
-			},
-			BrowserStack_Edge: {
-				base: 'BrowserStack',
-				os: 'Windows',
-				os_version: '10',
-				browser: 'edge',
-				browser_version: '17.0'
-			},
-			BrowserStack_Safari: {
-				base: 'BrowserStack',
-				os: 'OS X',
-				os_version: 'Mojave',
-				browser: 'safari'
 			}
 		},
 
@@ -126,17 +113,6 @@ module.exports = function getKarmaConfig( options ) {
 	if ( options.verbose ) {
 		karmaConfig.webpackMiddleware.noInfo = false;
 		delete karmaConfig.webpackMiddleware.stats;
-	}
-
-	if ( shouldEnableBrowserStack() ) {
-		karmaConfig.browserStack = {
-			username: process.env.BROWSER_STACK_USERNAME,
-			accessKey: process.env.BROWSER_STACK_ACCESS_KEY,
-			build: getBuildName(),
-			project: 'ckeditor5'
-		};
-
-		karmaConfig.reporters = [ 'dots', 'BrowserStack' ];
 	}
 
 	if ( options.coverage ) {
@@ -176,51 +152,11 @@ function getBrowsers( options ) {
 		return null;
 	}
 
-	const browsers = options.browsers
-		.map( browser => {
-			if ( browser !== 'Chrome' ) {
-				return browser;
-			}
+	return options.browsers.map( browser => {
+		if ( browser !== 'Chrome' ) {
+			return browser;
+		}
 
-			return process.env.TRAVIS ? 'CHROME_TRAVIS_CI' : 'CHROME_LOCAL';
-		} );
-
-	if ( shouldEnableBrowserStack() ) {
-		return browsers;
-	}
-
-	// If the BrowserStack is disabled, all browsers that start with a prefix "BrowserStack" should be filtered out.
-	// See: https://github.com/ckeditor/ckeditor5-dev/issues/358 and https://github.com/ckeditor/ckeditor5-dev/issues/402.
-	return browsers.filter( browser => !browser.startsWith( 'BrowserStack' ) );
-}
-
-// Formats name of the build for BrowserStack. It merges repository name and current timestamp.
-// If env variable `TRAVIS_REPO_SLUG` is not available, the function returns `undefined`.
-//
-// @returns {String|undefined}
-function getBuildName() {
-	const repoSlug = process.env.TRAVIS_REPO_SLUG;
-
-	if ( !repoSlug ) {
-		return;
-	}
-
-	const repositoryName = repoSlug.split( '/' )[ 1 ].replace( /-/g, '_' );
-	const date = new Date().getTime();
-
-	return `${ repositoryName } ${ date }`;
-}
-
-function shouldEnableBrowserStack() {
-	if ( !process.env.BROWSER_STACK_USERNAME ) {
-		return false;
-	}
-
-	if ( !process.env.BROWSER_STACK_ACCESS_KEY ) {
-		return false;
-	}
-
-	// If the repository slugs are different, the pull request comes from the community (forked repository).
-	// For such builds, BrowserStack will be disabled. Read more: https://github.com/ckeditor/ckeditor5-dev/issues/358.
-	return ( process.env.TRAVIS_EVENT_TYPE !== 'pull_request' || process.env.TRAVIS_PULL_REQUEST_SLUG === process.env.TRAVIS_REPO_SLUG );
+		return process.env.TRAVIS ? 'CHROME_TRAVIS_CI' : 'CHROME_LOCAL';
+	} );
 }

--- a/packages/ckeditor5-dev-tests/lib/utils/automated-tests/parsearguments.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/automated-tests/parsearguments.js
@@ -44,8 +44,7 @@ module.exports = function parseArguments( args ) {
 			coverage: false,
 			verbose: false,
 			'source-map': false,
-			server: false,
-			browserStack: false
+			server: false
 		}
 	};
 	const options = minimist( args, minimistConfig );

--- a/packages/ckeditor5-dev-tests/package.json
+++ b/packages/ckeditor5-dev-tests/package.json
@@ -24,7 +24,6 @@
     "glob": "^7.1.3",
     "istanbul-instrumenter-loader": "^3.0.0",
     "karma": "^3.0.0",
-    "karma-browserstack-launcher": "^1.3.0",
     "karma-chai": "^0.1.0",
     "karma-chrome-launcher": "^2.2.0",
     "karma-coverage": "^1.1.1",

--- a/packages/ckeditor5-dev-tests/tests/utils/automated-tests/getkarmaconfig.js
+++ b/packages/ckeditor5-dev-tests/tests/utils/automated-tests/getkarmaconfig.js
@@ -10,7 +10,7 @@ const { expect } = require( 'chai' );
 const sinon = require( 'sinon' );
 const path = require( 'path' );
 
-describe( 'getKarmaConfig', () => {
+describe( 'getKarmaConfig()', () => {
 	let getKarmaConfig, sandbox;
 	const originalEnv = process.env;
 
@@ -70,80 +70,5 @@ describe( 'getKarmaConfig', () => {
 		expect( karmaConfig ).to.have.own.property( 'reporters' );
 		expect( karmaConfig ).to.have.own.property( 'browsers' );
 		expect( karmaConfig ).to.have.own.property( 'singleRun', true );
-	} );
-
-	describe( 'BrowserStack integration', () => {
-		beforeEach( () => {
-			process.env.BROWSER_STACK_USERNAME = 'username';
-			process.env.BROWSER_STACK_ACCESS_KEY = 'access-key';
-		} );
-
-		// BROWSER_STACK_USERNAME=username BROWSER_STACK_ACCESS_KEY=access-key yarn run test --files=autoformat
-		it( 'should be enabled when tests were called on a dev machine', () => {
-			// Removes the Travis variables. It protects tests on Travis where the env variables are set by default.
-			process.env.TRAVIS_EVENT_TYPE = null;
-			process.env.TRAVIS_REPO_SLUG = null;
-			process.env.TRAVIS_PULL_REQUEST_SLUG = null;
-
-			const karmaConfig = getKarmaConfig( { reporter: 'mocha', globPatterns: {}, browsers: [ 'BrowserStack_Edge' ] } );
-
-			expect( karmaConfig.browserStack ).to.not.be.a( 'undefined' );
-			expect( karmaConfig.browsers ).to.deep.equal( [
-				'BrowserStack_Edge'
-			] );
-		} );
-
-		// A team member made a commit. Travis should use BrowserStack.
-		it( 'should be enabled for commit build on Travis', () => {
-			process.env.TRAVIS = true;
-			process.env.TRAVIS_EVENT_TYPE = 'push';
-
-			const karmaConfig = getKarmaConfig( { reporter: 'mocha', globPatterns: {}, browsers: [ 'BrowserStack_Edge' ] } );
-
-			expect( karmaConfig.browserStack ).to.not.be.a( 'undefined' );
-			expect( karmaConfig.browsers ).to.deep.equal( [
-				'BrowserStack_Edge'
-			] );
-		} );
-
-		// A team member made a pull request. Travis should use BrowserStack.
-		it( 'should be enabled for pull request build on Travis', () => {
-			process.env.TRAVIS = true;
-			process.env.TRAVIS_EVENT_TYPE = 'pull_request';
-			process.env.TRAVIS_PULL_REQUEST_SLUG = 'ckeditor/ckeditor-foo';
-			process.env.TRAVIS_REPO_SLUG = 'ckeditor/ckeditor-foo';
-
-			const karmaConfig = getKarmaConfig( { reporter: 'mocha', globPatterns: {}, browsers: [ 'BrowserStack_Edge' ] } );
-
-			expect( karmaConfig.browserStack ).to.not.be.a( 'undefined' );
-			expect( karmaConfig.browsers ).to.deep.equal( [
-				'BrowserStack_Edge'
-			] );
-		} );
-
-		// A community member made a pull request. Travis should not use BrowserStack.
-		it( 'should be disabled for pull request build on Travis that comes from community', () => {
-			process.env.TRAVIS = true;
-			process.env.TRAVIS_EVENT_TYPE = 'pull_request';
-			process.env.TRAVIS_PULL_REQUEST_SLUG = 'ckeditor-forked/ckeditor-foo';
-			process.env.TRAVIS_REPO_SLUG = 'ckeditor/ckeditor-foo';
-
-			// Encrypted environment variables are not available to pull requests from forks due to
-			// the security risk of exposing such information to unknown code.
-			delete process.env.BROWSER_STACK_USERNAME;
-			delete process.env.BROWSER_STACK_ACCESS_KEY;
-
-			const karmaConfig = getKarmaConfig( {
-				reporter: 'mocha',
-				globPatterns: {},
-				browsers: [ 'BrowserStack_Edge', 'Firefox', 'Chrome', 'BrowserStack_Safari' ]
-			} );
-
-			expect( karmaConfig.browserStack ).to.be.a( 'undefined' );
-			expect( karmaConfig.browsers ).to.deep.equal( [
-				'Firefox',
-				'CHROME_TRAVIS_CI'
-			] );
-		} );
 	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Removed the BrowserStack integration from `ckeditor5-dev` repository. See ckeditor/ckeditor5#1742.
