### PR TITLE
t/529: Feature: Enabled `CKEditorWebpackPlugin` in `getWebpackConfigForManualTes...

### DIFF
--- a/packages/ckeditor5-dev-tests/lib/tasks/runmanualtests.js
+++ b/packages/ckeditor5-dev-tests/lib/tasks/runmanualtests.js
@@ -19,19 +19,34 @@ const transformFileOptionToTestGlob = require( '../utils/transformfileoptiontote
  * Main function that runs manual tests.
  *
  * @param {Object} options
- * @param {Array.<String>} options.files
+ * @param {Array.<String>} options.files Glob patterns specifying which tests to run.
+ * @param {String} options.themePath A path to the theme the PostCSS theme-importer plugin is supposed to load.
+ * @param {String} [options.language] A language passed to `CKEditorWebpackPlugin`.
+ * @param {Array.<String>} [options.additionalLanguages] Additional languages passed to `CKEditorWebpackPlugin`.
  * @returns {Promise}
  */
 module.exports = function runManualTests( options ) {
 	const buildDir = path.join( process.cwd(), 'build', '.manual-tests' );
 	const files = ( options.files && options.files.length ) ? options.files : [ '*' ];
-	const manualTestFilesPattern = files.map( file => transformFileOptionToTestGlob( file, true ) );
+	const patterns = files.map( file => transformFileOptionToTestGlob( file, true ) );
+	const additionalLanguages = options.additionalLanguages ? options.additionalLanguages.split( ',' ) : null;
 
 	return Promise.resolve()
 		.then( () => removeDir( buildDir ) )
 		.then( () => Promise.all( [
-			compileManualTestScripts( buildDir, manualTestFilesPattern, options.themePath ),
-			compileManualTestHtmlFiles( buildDir, manualTestFilesPattern ),
+			compileManualTestScripts( {
+				buildDir,
+				patterns,
+				themePath: options.themePath || null,
+				language: options.language || 'en',
+				additionalLanguages
+			} ),
+			compileManualTestHtmlFiles( {
+				buildDir,
+				patterns,
+				language: options.language || 'en',
+				additionalLanguages
+			} ),
 			copyAssets( buildDir )
 		] ) )
 		.then( () => createManualTestServer( buildDir ) );

--- a/packages/ckeditor5-dev-tests/lib/tasks/runmanualtests.js
+++ b/packages/ckeditor5-dev-tests/lib/tasks/runmanualtests.js
@@ -22,13 +22,14 @@ const transformFileOptionToTestGlob = require( '../utils/transformfileoptiontote
  * @param {Array.<String>} options.files Glob patterns specifying which tests to run.
  * @param {String} options.themePath A path to the theme the PostCSS theme-importer plugin is supposed to load.
  * @param {String} [options.language] A language passed to `CKEditorWebpackPlugin`.
- * @param {Array.<String>} [options.additionalLanguages] Additional languages passed to `CKEditorWebpackPlugin`.
+ * @param {String} [options.additionalLanguages] Additional languages passed to `CKEditorWebpackPlugin`.
  * @returns {Promise}
  */
 module.exports = function runManualTests( options ) {
 	const buildDir = path.join( process.cwd(), 'build', '.manual-tests' );
 	const files = ( options.files && options.files.length ) ? options.files : [ '*' ];
 	const patterns = files.map( file => transformFileOptionToTestGlob( file, true ) );
+	const language = options.language || 'en';
 	const additionalLanguages = options.additionalLanguages ? options.additionalLanguages.split( ',' ) : null;
 
 	return Promise.resolve()
@@ -38,13 +39,13 @@ module.exports = function runManualTests( options ) {
 				buildDir,
 				patterns,
 				themePath: options.themePath || null,
-				language: options.language || 'en',
+				language,
 				additionalLanguages
 			} ),
 			compileManualTestHtmlFiles( {
 				buildDir,
 				patterns,
-				language: options.language || 'en',
+				language,
 				additionalLanguages
 			} ),
 			copyAssets( buildDir )

--- a/packages/ckeditor5-dev-tests/lib/tasks/runmanualtests.js
+++ b/packages/ckeditor5-dev-tests/lib/tasks/runmanualtests.js
@@ -22,15 +22,16 @@ const transformFileOptionToTestGlob = require( '../utils/transformfileoptiontote
  * @param {Array.<String>} options.files Glob patterns specifying which tests to run.
  * @param {String} options.themePath A path to the theme the PostCSS theme-importer plugin is supposed to load.
  * @param {String} [options.language] A language passed to `CKEditorWebpackPlugin`.
- * @param {String} [options.additionalLanguages] Additional languages passed to `CKEditorWebpackPlugin`.
+ * @param {Array.<String>} [options.additionalLanguages] Additional languages passed to `CKEditorWebpackPlugin`.
  * @returns {Promise}
  */
 module.exports = function runManualTests( options ) {
 	const buildDir = path.join( process.cwd(), 'build', '.manual-tests' );
 	const files = ( options.files && options.files.length ) ? options.files : [ '*' ];
 	const patterns = files.map( file => transformFileOptionToTestGlob( file, true ) );
-	const language = options.language || 'en';
-	const additionalLanguages = options.additionalLanguages ? options.additionalLanguages.split( ',' ) : null;
+	const themePath = options.themePath || null;
+	const language = options.language;
+	const additionalLanguages = options.additionalLanguages;
 
 	return Promise.resolve()
 		.then( () => removeDir( buildDir ) )
@@ -38,7 +39,7 @@ module.exports = function runManualTests( options ) {
 			compileManualTestScripts( {
 				buildDir,
 				patterns,
-				themePath: options.themePath || null,
+				themePath,
 				language,
 				additionalLanguages
 			} ),

--- a/packages/ckeditor5-dev-tests/lib/utils/automated-tests/parsearguments.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/automated-tests/parsearguments.js
@@ -56,6 +56,10 @@ module.exports = function parseArguments( args ) {
 		options.files = options.files.split( ',' );
 	}
 
+	options.language = options.language || 'en';
+	options.additionalLanguages = options.additionalLanguages ? options.additionalLanguages.split( ',' ) : null;
+	options.themePath = options.themePath ? options.themePath : null;
+
 	// Delete all aliases because we don't want to use them in the code.
 	// They are useful when calling command but useless after that.
 	for ( const alias of Object.keys( minimistConfig.alias ) ) {

--- a/packages/ckeditor5-dev-tests/lib/utils/manual-tests/compilescripts.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/manual-tests/compilescripts.js
@@ -14,13 +14,16 @@ const getWebpackConfigForManualTests = require( './getwebpackconfig' );
 const getRelativeFilePath = require( '../getrelativefilepath' );
 
 /**
- * @param {String} buildDir A path where compiled files will be saved.
- * @param {Array.<String>} manualTestScriptsPatterns An array of patterns that resolve manual test scripts.
- * @param {String} themePath A path to the theme the PostCSS theme-importer plugin is supposed to load.
+ * @param {Object} options
+ * @param {String} options.buildDir A path where compiled files will be saved.
+ * @param {Array.<String>} options.patterns An array of patterns that resolve manual test scripts.
+ * @param {String} options.themePath A path to the theme the PostCSS theme-importer plugin is supposed to load.
+ * @param {String} options.language A language passed to `CKEditorWebpackPlugin`.
+ * @param {Array.<String>} [options.additionalLanguages] Additional languages passed to `CKEditorWebpackPlugin`.
  * @returns {Promise}
  */
-module.exports = function compileManualTestScripts( buildDir, manualTestScriptsPatterns, themePath ) {
-	const entryFiles = manualTestScriptsPatterns.reduce( ( arr, manualTestPattern ) => {
+module.exports = function compileManualTestScripts( options ) {
+	const entryFiles = options.patterns.reduce( ( arr, manualTestPattern ) => {
 		return [
 			...arr,
 			...globSync( manualTestPattern )
@@ -29,7 +32,13 @@ module.exports = function compileManualTestScripts( buildDir, manualTestScriptsP
 	}, [] );
 
 	const entries = getWebpackEntryPoints( entryFiles );
-	const webpackConfig = getWebpackConfigForManualTests( entries, buildDir, themePath );
+	const webpackConfig = getWebpackConfigForManualTests( {
+		entries,
+		buildDir: options.buildDir,
+		themePath: options.themePath,
+		language: options.language,
+		additionalLanguages: options.additionalLanguages
+	} );
 
 	return runWebpack( webpackConfig );
 };

--- a/packages/ckeditor5-dev-tests/lib/utils/manual-tests/getwebpackconfig.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/manual-tests/getwebpackconfig.js
@@ -8,13 +8,18 @@
 const path = require( 'path' );
 const WebpackNotifierPlugin = require( './webpacknotifierplugin' );
 const { getPostCssConfig } = require( '@ckeditor/ckeditor5-dev-utils' ).styles;
+const CKEditorWebpackPlugin = require( '@ckeditor/ckeditor5-dev-webpack-plugin' );
 
 /**
- * @param {Object} entryObject
- * @param {String} buildDir
+ * @param {Object} options
+ * @param {Object} options.entries
+ * @param {String} options.buildDir
+ * @param {String} options.themePath
+ * @param {String} [options.language]
+ * @param {Array.<String>} [options.additionalLanguages]
  * @returns {Object}
  */
-module.exports = function getWebpackConfigForManualTests( entryObject, buildDir, themePath ) {
+module.exports = function getWebpackConfigForManualTests( options ) {
 	return {
 		mode: 'development',
 
@@ -25,14 +30,19 @@ module.exports = function getWebpackConfigForManualTests( entryObject, buildDir,
 
 		watch: true,
 
-		entry: entryObject,
+		entry: options.entries,
 
 		output: {
-			path: buildDir
+			path: options.buildDir
 		},
 
 		plugins: [
-			new WebpackNotifierPlugin()
+			new WebpackNotifierPlugin(),
+			new CKEditorWebpackPlugin( {
+				// See https://ckeditor.com/docs/ckeditor5/latest/features/ui-language.html
+				language: options.language,
+				additionalLanguages: options.additionalLanguages
+			} )
 		],
 
 		module: {
@@ -56,7 +66,7 @@ module.exports = function getWebpackConfigForManualTests( entryObject, buildDir,
 							loader: 'postcss-loader',
 							options: getPostCssConfig( {
 								themeImporter: {
-									themePath
+									themePath: options.themePath
 								},
 								sourceMap: true
 							} )

--- a/packages/ckeditor5-dev-tests/tests/tasks/runmanualtests.js
+++ b/packages/ckeditor5-dev-tests/tests/tasks/runmanualtests.js
@@ -66,8 +66,8 @@ describe( 'runManualTests', () => {
 				expect( spies.htmlFileCompiler.firstCall.args[ 0 ] ).to.deep.equal( {
 					buildDir: 'workspace/build/.manual-tests',
 					patterns: [ testsToExecute ],
-					language: 'en',
-					additionalLanguages: null
+					language: undefined,
+					additionalLanguages: undefined
 				} );
 
 				expect( spies.scriptCompiler.calledOnce ).to.equal( true );
@@ -75,8 +75,8 @@ describe( 'runManualTests', () => {
 					buildDir: 'workspace/build/.manual-tests',
 					patterns: [ testsToExecute ],
 					themePath: null,
-					language: 'en',
-					additionalLanguages: null
+					language: undefined,
+					additionalLanguages: undefined
 				} );
 
 				expect( spies.server.calledOnce ).to.equal( true );
@@ -117,8 +117,8 @@ describe( 'runManualTests', () => {
 				expect( spies.htmlFileCompiler.firstCall.args[ 0 ] ).to.deep.equal( {
 					buildDir: 'workspace/build/.manual-tests',
 					patterns: testsToExecute,
-					language: 'en',
-					additionalLanguages: null
+					language: undefined,
+					additionalLanguages: undefined
 				} );
 
 				expect( spies.scriptCompiler.calledOnce ).to.equal( true );
@@ -126,8 +126,8 @@ describe( 'runManualTests', () => {
 					buildDir: 'workspace/build/.manual-tests',
 					patterns: testsToExecute,
 					themePath: 'path/to/theme',
-					language: 'en',
-					additionalLanguages: null
+					language: undefined,
+					additionalLanguages: undefined
 				} );
 
 				expect( spies.server.calledOnce ).to.equal( true );
@@ -151,7 +151,10 @@ describe( 'runManualTests', () => {
 			],
 			themePath: 'path/to/theme',
 			language: 'pl',
-			additionalLanguages: 'ar,en'
+			additionalLanguages: [
+				'ar',
+				'en'
+			]
 		};
 
 		return runManualTests( options )

--- a/packages/ckeditor5-dev-tests/tests/tasks/runmanualtests.js
+++ b/packages/ckeditor5-dev-tests/tests/tasks/runmanualtests.js
@@ -63,20 +63,28 @@ describe( 'runManualTests', () => {
 				expect( spies.transformFileOptionToTestGlob.firstCall.args[ 1 ] ).to.equal( true );
 
 				expect( spies.htmlFileCompiler.calledOnce ).to.equal( true );
-				expect( spies.htmlFileCompiler.firstCall.args[ 0 ] ).to.equal( 'workspace/build/.manual-tests' );
-				expect( spies.htmlFileCompiler.firstCall.args[ 1 ] ).to.deep.equal( [ testsToExecute ] );
+				expect( spies.htmlFileCompiler.firstCall.args[ 0 ] ).to.deep.equal( {
+					buildDir: 'workspace/build/.manual-tests',
+					patterns: [ testsToExecute ],
+					language: 'en',
+					additionalLanguages: null
+				} );
 
 				expect( spies.scriptCompiler.calledOnce ).to.equal( true );
-				expect( spies.scriptCompiler.firstCall.args[ 0 ] ).to.equal( 'workspace/build/.manual-tests' );
-				expect( spies.scriptCompiler.firstCall.args[ 1 ] ).to.deep.equal( [ testsToExecute ] );
-				expect( spies.scriptCompiler.firstCall.args[ 2 ] ).to.be.undefined;
+				expect( spies.scriptCompiler.firstCall.args[ 0 ] ).to.deep.equal( {
+					buildDir: 'workspace/build/.manual-tests',
+					patterns: [ testsToExecute ],
+					themePath: null,
+					language: 'en',
+					additionalLanguages: null
+				} );
 
 				expect( spies.server.calledOnce ).to.equal( true );
 				expect( spies.server.firstCall.args[ 0 ] ).to.equal( 'workspace/build/.manual-tests' );
 			} );
 	} );
 
-	it( 'run specified manual tests', () => {
+	it( 'runs specified manual tests', () => {
 		testsToExecute = [
 			'workspace/packages/ckeditor5-build-classic/tests/**/manual/**/*.js',
 			'workspace/packages/ckeditor5-editor-classic/tests/manual/**/*.js'
@@ -106,13 +114,74 @@ describe( 'runManualTests', () => {
 				expect( spies.transformFileOptionToTestGlob.secondCall.args[ 1 ] ).to.equal( true );
 
 				expect( spies.htmlFileCompiler.calledOnce ).to.equal( true );
-				expect( spies.htmlFileCompiler.firstCall.args[ 0 ] ).to.equal( 'workspace/build/.manual-tests' );
-				expect( spies.htmlFileCompiler.firstCall.args[ 1 ] ).to.deep.equal( testsToExecute );
+				expect( spies.htmlFileCompiler.firstCall.args[ 0 ] ).to.deep.equal( {
+					buildDir: 'workspace/build/.manual-tests',
+					patterns: testsToExecute,
+					language: 'en',
+					additionalLanguages: null
+				} );
 
 				expect( spies.scriptCompiler.calledOnce ).to.equal( true );
-				expect( spies.scriptCompiler.firstCall.args[ 0 ] ).to.equal( 'workspace/build/.manual-tests' );
-				expect( spies.scriptCompiler.firstCall.args[ 1 ] ).to.deep.equal( testsToExecute );
-				expect( spies.scriptCompiler.firstCall.args[ 2 ] ).to.deep.equal( 'path/to/theme' );
+				expect( spies.scriptCompiler.firstCall.args[ 0 ] ).to.deep.equal( {
+					buildDir: 'workspace/build/.manual-tests',
+					patterns: testsToExecute,
+					themePath: 'path/to/theme',
+					language: 'en',
+					additionalLanguages: null
+				} );
+
+				expect( spies.server.calledOnce ).to.equal( true );
+				expect( spies.server.firstCall.args[ 0 ] ).to.equal( 'workspace/build/.manual-tests' );
+			} );
+	} );
+
+	it( 'allows specifying language and additionalLanguages (to CKEditorWebpackPlugin)', () => {
+		testsToExecute = [
+			'workspace/packages/ckeditor5-build-classic/tests/**/manual/**/*.js',
+			'workspace/packages/ckeditor5-editor-classic/tests/manual/**/*.js'
+		];
+
+		spies.transformFileOptionToTestGlob.onFirstCall().returns( testsToExecute[ 0 ] );
+		spies.transformFileOptionToTestGlob.onSecondCall().returns( testsToExecute[ 1 ] );
+
+		const options = {
+			files: [
+				'build-classic',
+				'editor-classic/manual/classic.js'
+			],
+			themePath: 'path/to/theme',
+			language: 'pl',
+			additionalLanguages: 'ar,en'
+		};
+
+		return runManualTests( options )
+			.then( () => {
+				expect( spies.removeDir.calledOnce ).to.equal( true );
+				expect( spies.removeDir.firstCall.args[ 0 ] ).to.equal( 'workspace/build/.manual-tests' );
+
+				expect( spies.transformFileOptionToTestGlob.calledTwice ).to.equal( true );
+				expect( spies.transformFileOptionToTestGlob.firstCall.args[ 0 ] ).to.equal( 'build-classic' );
+				expect( spies.transformFileOptionToTestGlob.firstCall.args[ 1 ] ).to.equal( true );
+				expect( spies.transformFileOptionToTestGlob.secondCall.args[ 0 ] )
+					.to.equal( 'editor-classic/manual/classic.js' );
+				expect( spies.transformFileOptionToTestGlob.secondCall.args[ 1 ] ).to.equal( true );
+
+				expect( spies.htmlFileCompiler.calledOnce ).to.equal( true );
+				expect( spies.htmlFileCompiler.firstCall.args[ 0 ] ).to.deep.equal( {
+					buildDir: 'workspace/build/.manual-tests',
+					patterns: testsToExecute,
+					language: 'pl',
+					additionalLanguages: [ 'ar', 'en' ],
+				} );
+
+				expect( spies.scriptCompiler.calledOnce ).to.equal( true );
+				expect( spies.scriptCompiler.firstCall.args[ 0 ] ).to.deep.equal( {
+					buildDir: 'workspace/build/.manual-tests',
+					patterns: testsToExecute,
+					themePath: 'path/to/theme',
+					language: 'pl',
+					additionalLanguages: [ 'ar', 'en' ]
+				} );
 
 				expect( spies.server.calledOnce ).to.equal( true );
 				expect( spies.server.firstCall.args[ 0 ] ).to.equal( 'workspace/build/.manual-tests' );

--- a/packages/ckeditor5-dev-tests/tests/utils/manual-tests/compilehtmlfiles.js
+++ b/packages/ckeditor5-dev-tests/tests/utils/manual-tests/compilehtmlfiles.js
@@ -122,7 +122,11 @@ describe( 'compileHtmlFiles', () => {
 			[ path.join( 'path', 'to', 'manual', '**', '*.!(js|html|md)' ) ]: [ 'static-file.png' ]
 		};
 
-		compileHtmlFiles( 'buildDir', [ path.join( 'manualTestPattern', '*.js' ) ] );
+		compileHtmlFiles( {
+			buildDir: 'buildDir',
+			language: 'en',
+			patterns: [ path.join( 'manualTestPattern', '*.js' ) ]
+		} );
 
 		sinon.assert.calledWithExactly( stubs.commonmark.parse, '## Markdown header' );
 		sinon.assert.calledWithExactly( stubs.fs.ensureDirSync, 'buildDir' );
@@ -150,6 +154,34 @@ describe( 'compileHtmlFiles', () => {
 		);
 	} );
 
+	it( 'should compile files with options#language specified', () => {
+		compileHtmlFiles( {
+			buildDir: 'buildDir',
+			language: 'en',
+			additionalLanguages: [ 'pl', 'ar' ],
+			patterns: [ path.join( 'manualTestPattern', '*.js' ) ]
+		} );
+
+		/* eslint-disable max-len */
+		sinon.assert.calledWithExactly(
+			stubs.fs.outputFileSync,
+			path.join( 'buildDir', 'path', 'to', 'manual', 'file.html' ), [
+				'<div>template html content</div>',
+				'<div class="manual-test-sidebar"><a href="/" class="manual-test-root-link">&larr; Back to the list</a><h2>Markdown header</h2></div>',
+				'<div>html file content</div>',
+				'<body class="manual-test-container">' +
+					'<script src="/assets/inspector.js"></script>' +
+					'<script src="/assets/attachinspector.js"></script>' +
+					'<script src="/translations/en.js"></script>' +
+					'<script src="/translations/pl.js"></script>' +
+					'<script src="/translations/ar.js"></script>' +
+					`<script src="${ path.sep + path.join( 'path', 'to', 'manual', 'file.js' ) }"></script>` +
+				'</body>'
+			].join( '\n' )
+		);
+		/* eslint-enable max-len */
+	} );
+
 	it( 'should work with files containing dots in their names', () => {
 		files = {
 			[ path.join( fakeDirname, 'template.html' ) ]: '<div>template html content</div>',
@@ -162,7 +194,10 @@ describe( 'compileHtmlFiles', () => {
 			[ path.join( 'path', 'to', 'manual', '**', '*.!(js|html|md)' ) ]: []
 		};
 
-		compileHtmlFiles( 'buildDir', [ path.join( 'manualTestPattern', '*.js' ) ] );
+		compileHtmlFiles( {
+			buildDir: 'buildDir',
+			patterns: [ path.join( 'manualTestPattern', '*.js' ) ]
+		} );
 
 		/* eslint-disable max-len */
 		sinon.assert.calledWith(
@@ -197,10 +232,13 @@ describe( 'compileHtmlFiles', () => {
 			[ path.join( 'path', 'to', 'another', 'manual', '**', '*.!(js|html|md)' ) ]: []
 		};
 
-		compileHtmlFiles( 'buildDir', [
-			path.join( 'manualTestPattern', '*.js' ),
-			path.join( 'anotherPattern', '*.js' )
-		] );
+		compileHtmlFiles( {
+			buildDir: 'buildDir',
+			patterns: [
+				path.join( 'manualTestPattern', '*.js' ),
+				path.join( 'anotherPattern', '*.js' )
+			]
+		} );
 
 		sinon.assert.calledWithExactly( stubs.chokidar.watch, path.join( 'path', 'to', 'manual', 'file.md' ), { ignoreInitial: true } );
 		sinon.assert.calledWithExactly( stubs.chokidar.watch, path.join( 'path', 'to', 'manual', 'file.html' ), { ignoreInitial: true } );
@@ -227,10 +265,13 @@ describe( 'compileHtmlFiles', () => {
 			[ path.join( 'path', 'to', 'manual', '**', '*.!(js|html|md)' ) ]: [ 'static-file.png' ]
 		};
 
-		compileHtmlFiles( 'buildDir', [
-			path.join( 'manualTestPattern', '*.js' ),
-			path.join( 'anotherPattern', '*.js' )
-		] );
+		compileHtmlFiles( {
+			buildDir: 'buildDir',
+			patterns: [
+				path.join( 'manualTestPattern', '*.js' ),
+				path.join( 'anotherPattern', '*.js' )
+			]
+		} );
 
 		sinon.assert.calledWithExactly( stubs.chokidar.watch, path.join( 'path', 'to', 'manual', 'file.md' ), { ignoreInitial: true } );
 		sinon.assert.calledWithExactly( stubs.chokidar.watch, path.join( 'path', 'to', 'manual', 'file.html' ), { ignoreInitial: true } );
@@ -251,7 +292,12 @@ describe( 'compileHtmlFiles', () => {
 			[ path.join( 'path', 'to', 'manual', '**', '*.!(js|html|md)' ) ]: [ 'some.file.md' ]
 		};
 
-		compileHtmlFiles( 'buildDir', [ path.join( 'manualTestPattern', '*.js' ) ] );
+		compileHtmlFiles( {
+			buildDir: 'buildDir',
+			patterns: [
+				path.join( 'manualTestPattern', '*.js' )
+			]
+		} );
 
 		sinon.assert.calledWithExactly( stubs.commonmark.parse, '## Markdown header' );
 		sinon.assert.calledWithExactly( stubs.fs.ensureDirSync, 'buildDir' );
@@ -294,7 +340,10 @@ describe( 'compileHtmlFiles', () => {
 			'path\\to\\manual\\file.html': '<div>html file content</div>'
 		};
 
-		compileHtmlFiles( 'buildDir', [ path.join( 'manualTestPattern', '*.js' ) ] );
+		compileHtmlFiles( {
+			buildDir: 'buildDir',
+			patterns: [ path.join( 'manualTestPattern', '*.js' ) ]
+		} );
 
 		sinon.assert.calledWithExactly( stubs.commonmark.parse, '## Markdown header' );
 		sinon.assert.calledWithExactly( stubs.fs.ensureDirSync, 'buildDir' );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Enabled `CKEditorWebpackPlugin` in `getWebpackConfigForManualTests()`. Allowed configuring `language` and `additionalLanguages`. Closes #529.

----

I refactored some code in this PR switching from separate arguments to `options` object because some helpers got too many arguments. Also added some missing docs.

Sample usage:

```
yarn manual --files=utils --language=en --additionalLanguages=ar,pl
```