### PR TITLE
Adjusted "createGithubRelease()" util to not use deprecated methods

### DIFF
--- a/packages/ckeditor5-dev-env/lib/release-tools/utils/creategithubrelease.js
+++ b/packages/ckeditor5-dev-env/lib/release-tools/utils/creategithubrelease.js
@@ -20,12 +20,8 @@ const GitHubApi = require( '@octokit/rest' );
  */
 module.exports = function createGithubRelease( token, options ) {
 	const github = new GitHubApi( {
-		version: '3.0.0'
-	} );
-
-	github.authenticate( {
-		token,
-		type: 'oauth',
+		version: '3.0.0',
+		auth: `token ${ token }`
 	} );
 
 	const releaseParams = {
@@ -35,13 +31,5 @@ module.exports = function createGithubRelease( token, options ) {
 		body: options.description
 	};
 
-	return new Promise( ( resolve, reject ) => {
-		github.repos.createRelease( releaseParams, ( err, responses ) => {
-			if ( err ) {
-				return reject( err );
-			}
-
-			resolve( responses );
-		} );
-	} );
+	return github.repos.createRelease( releaseParams );
 };


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Adjusted usage of GitHub API inside `createGithubRelease()` util. Closes ckeditor/ckeditor5#1889.
