### PR TITLE
Add ECMA version option to acorn parser options.

### DIFF
--- a/packages/ckeditor5-dev-utils/lib/translations/findoriginalstrings.js
+++ b/packages/ckeditor5-dev-utils/lib/translations/findoriginalstrings.js
@@ -12,6 +12,7 @@ const logger = require( '../logger' )();
 module.exports = function findOriginalStrings( source ) {
 	const ast = acorn.parse( source, {
 		sourceType: 'module',
+		ecmaVersion: '2018'
 	} );
 
 	const originalStrings = [];

--- a/packages/ckeditor5-dev-utils/lib/translations/translatesource.js
+++ b/packages/ckeditor5-dev-utils/lib/translations/translatesource.js
@@ -26,7 +26,8 @@ module.exports = function translateSource( source, sourceFile, translateString )
 		sourceType: 'module',
 		ranges: true,
 		onComment: comments,
-		onToken: tokens
+		onToken: tokens,
+		ecmaVersion: '2018'
 	} );
 
 	let changesInCode = false;


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Add ECMA version option to acorn parser options. Closes #534.

---

### Additional information

* Lack of ECMA specification caused problems with the usage of RegExp extensions: https://github.com/ckeditor/ckeditor5-utils/pull/292#discussion_r304822251
