### PR TITLE
Added a proxy for static assets resources

### DIFF
--- a/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getkarmaconfig.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getkarmaconfig.js
@@ -41,8 +41,16 @@ module.exports = function getKarmaConfig( options ) {
 		// Frameworks to use. Available frameworks: https://npmjs.org/browse/keyword/karma-adapter
 		frameworks: [ 'mocha', 'chai', 'sinon' ],
 
+		// Files saved in directory `ckeditor5/packages/ckeditor5-utils/tests/_assets/` are available under: http://0.0.0.0:9876/assets/
+		proxies: {
+			'/assets/': '/base/packages/ckeditor5-utils/tests/_assets/'
+		},
+
 		// List of files/patterns to load in the browser.
-		files: [ options.entryFile ],
+		files: [
+			options.entryFile,
+			{ pattern: 'packages/ckeditor5-utils/tests/_assets/**/*', watched: false, included: false, served: true, nocache: false }
+		],
 
 		// Preprocess matching files before serving them to the browser.
 		// Available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor

--- a/packages/ckeditor5-dev-tests/tests/utils/automated-tests/getkarmaconfig.js
+++ b/packages/ckeditor5-dev-tests/tests/utils/automated-tests/getkarmaconfig.js
@@ -71,4 +71,29 @@ describe( 'getKarmaConfig()', () => {
 		expect( karmaConfig ).to.have.own.property( 'browsers' );
 		expect( karmaConfig ).to.have.own.property( 'singleRun', true );
 	} );
+
+	it( 'should define proxies to static assets resources', () => {
+		const karmaConfig = getKarmaConfig( {
+			files: [ '*' ],
+			reporter: 'mocha',
+			sourceMap: false,
+			coverage: false,
+			browsers: [ 'Chrome' ],
+			watch: false,
+			verbose: false,
+			themePath: 'workspace/path/to/theme.css',
+			entryFile: 'workspace/entry-file.js',
+			globPatterns: {
+				'*': 'workspace/packages/ckeditor5-*/tests/**/*.js'
+			}
+		} );
+
+		expect( karmaConfig ).to.have.own.property( 'proxies' );
+		expect( karmaConfig.proxies ).to.have.own.property( '/assets/' );
+
+		expect( karmaConfig.files ).to.be.an( 'array' );
+		expect( karmaConfig.files.length ).to.equal( 2 );
+		expect( karmaConfig.files[ 0 ] ).to.equal( 'workspace/entry-file.js' );
+		expect( karmaConfig.files[ 1 ].pattern ).to.equal( 'packages/ckeditor5-utils/tests/_assets/**/*' );
+	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Added a proxy for static assets resources. Closes #139.

---

### Additional information

* Assets must be saved in `tests/_assets/` directory in the `@ckeditor/ckeditor5-utils` package.
* 13 repositories require changes in tests (modifying an image `[src]` attribute):

    ![image](https://user-images.githubusercontent.com/2270764/62190166-ffc01c00-b370-11e9-9ca2-870966c47760.png)

* The default asset: https://github.com/ckeditor/ckeditor5-utils/commit/7059a734c0c0529ec9ca7b129acc1c5d671ded28?short_path=6fe1ae4#diff-6fe1ae49b762910e195699e1e712cb30 (this file is specified in all changed tests)
* MrGit command for managing changes:

    ```console
    mrgit --scope='@ckeditor/ckeditor5-@(alignment|block-quote|build-*|core|heading|highlight|media-embed|typing|ui)' exec 'git status -sb'
    ```
