### PR TITLE
Added ErrorEvent and PromiseRejectionEvent types to JSDoc validator

### DIFF
--- a/packages/jsdoc-plugins/lib/validator/types.js
+++ b/packages/jsdoc-plugins/lib/validator/types.js
@@ -36,6 +36,8 @@ const BASIC_TYPES = [
 	'FocusEvent',
 	'ClientRect',
 	'Window',
+	'ErrorEvent',
+	'PromiseRejectionEvent',
 
 	// Web APIs
 	'File',


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Added `ErrorEvent` and `PromiseRejectionEvent` types to the JSDoc validator. Part of ckeditor/ckeditor5-watchdog#3.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
