### PR TITLE
Forked repositories should be cloned properly on CI

### DIFF
--- a/packages/ckeditor5-dev-tests/bin/prepare-mrgit-json.js
+++ b/packages/ckeditor5-dev-tests/bin/prepare-mrgit-json.js
@@ -29,6 +29,6 @@ tools.updateJSONFile( path.join( TEST_DIR_PATH, 'mrgit.json' ), () => {
 		// Specify a repository that provides the package specified as `packageName` and which should be cloned.
 		// Forked repositories should be able to execute the test scenario as well.
 		// See: https://github.com/ckeditor/ckeditor5-dev/issues/542.
-		repository: process.env.TRAVIS_REPO_SLUG
+		repository: process.env.TRAVIS_PULL_REQUEST_SLUG || process.env.TRAVIS_REPO_SLUG
 	} );
 } );

--- a/packages/ckeditor5-dev-tests/bin/prepare-mrgit-json.js
+++ b/packages/ckeditor5-dev-tests/bin/prepare-mrgit-json.js
@@ -25,6 +25,10 @@ tools.updateJSONFile( path.join( TEST_DIR_PATH, 'mrgit.json' ), () => {
 		packageName: originalPackageJson.name,
 		// For PR build we want to get the latest commit from given PR instead of Merge Commit.
 		// See: https://github.com/ckeditor/ckeditor5-dev/issues/484
-		commit: process.env.TRAVIS_PULL_REQUEST_SHA || process.env.TRAVIS_COMMIT
+		commit: process.env.TRAVIS_PULL_REQUEST_SHA || process.env.TRAVIS_COMMIT,
+		// Specify a repository that provides the package specified as `packageName` and which should be cloned.
+		// Forked repositories should be able to execute the test scenario as well.
+		// See: https://github.com/ckeditor/ckeditor5-dev/issues/542.
+		repository: process.env.TRAVIS_REPO_SLUG
 	} );
 } );

--- a/packages/ckeditor5-dev-tests/lib/bin/createmrgitjsoncontent.js
+++ b/packages/ckeditor5-dev-tests/lib/bin/createmrgitjsoncontent.js
@@ -8,8 +8,9 @@
  *
  * @param {Object} packageJson Parsed package.json.
  * @param {Object} [options]
- * @param {String} options.name The name of package that `options.commit` will be specified as a version to check out.
+ * @param {String} options.name The name of the package that `options.commit` or `options.repository` will be modified.
  * @param {String} options.commit The specified commit.
+ * @param {String} options.repository The specified repository.
  */
 module.exports = function createMrGitJsonContent( packageJson, options ) {
 	const mrgitJson = {
@@ -45,9 +46,20 @@ module.exports = function createMrGitJsonContent( packageJson, options ) {
 		return mrgitJson;
 	}
 
-	// For testing package we need to use a specified commit instead of the latest master.
+	// Do not modify value of the repository if specified package belongs to our ecosystem.
+	if ( options.repository === mrgitJson.dependencies[ options.packageName ] ) {
+		delete options.repository;
+	}
+
+	// If `options.repository` is defined, use that value as a repository that should be cloned.
+	const repository = options.repository ? options.repository : mrgitJson.dependencies[ options.packageName ];
+
+	// If `options.commit` is defined, use that value as a commit which cloned repository should be checked out.
+	const commit = options.commit ? '#' + options.commit : '';
+
+	// If the package is defined, let's modify those values.
 	if ( mrgitJson.dependencies[ options.packageName ] ) {
-		mrgitJson.dependencies[ options.packageName ] = mrgitJson.dependencies[ options.packageName ] + '#' + options.commit;
+		mrgitJson.dependencies[ options.packageName ] = repository + commit;
 	}
 
 	return mrgitJson;

--- a/packages/ckeditor5-dev-tests/tests/bin/createmrgitjsoncontent.js
+++ b/packages/ckeditor5-dev-tests/tests/bin/createmrgitjsoncontent.js
@@ -105,4 +105,131 @@ describe( 'dev-tests/bin/create-mrgit-json', () => {
 			packages: 'packages/'
 		} );
 	} );
+
+	it( 'does not modify anything because required "packageName" is not specified', () => {
+		const mrgitJson = createMrGitJsonContent( {
+			dependencies: {
+				'@ckeditor/ckeditor5-core': '^0.8.1',
+				'@ckeditor/ckeditor5-engine': '0.10.0'
+			},
+			devDependencies: {
+				'@ckeditor/ckeditor5-basic-styles': '^0.8.1'
+			}
+		}, {
+			packageName: '@ckeditor/ckeditor5-utils',
+			commit: 'abcd1234'
+		} );
+
+		expect( mrgitJson ).to.deep.equal( {
+			dependencies: {
+				'@ckeditor/ckeditor5-core': 'ckeditor/ckeditor5-core',
+				'@ckeditor/ckeditor5-engine': 'ckeditor/ckeditor5-engine',
+				'@ckeditor/ckeditor5-basic-styles': 'ckeditor/ckeditor5-basic-styles'
+			},
+			packages: 'packages/'
+		} );
+	} );
+
+	describe( 'forked repository', () => {
+		it( 'allows using forked repository (without specifying a commit)', () => {
+			const mrgitJson = createMrGitJsonContent( {
+				dependencies: {
+					'@ckeditor/ckeditor5-core': '^0.8.1',
+					'@ckeditor/ckeditor5-engine': '0.10.0'
+				},
+				devDependencies: {
+					'@ckeditor/ckeditor5-basic-styles': '^0.8.1'
+				}
+			}, {
+				packageName: '@ckeditor/ckeditor5-core',
+				repository: 'foo/bar'
+			} );
+
+			expect( mrgitJson ).to.deep.equal( {
+				dependencies: {
+					'@ckeditor/ckeditor5-core': 'foo/bar',
+					'@ckeditor/ckeditor5-engine': 'ckeditor/ckeditor5-engine',
+					'@ckeditor/ckeditor5-basic-styles': 'ckeditor/ckeditor5-basic-styles'
+				},
+				packages: 'packages/'
+			} );
+		} );
+
+		it( 'allows using forked repository (with setting a proper commit)', () => {
+			const mrgitJson = createMrGitJsonContent( {
+				dependencies: {
+					'@ckeditor/ckeditor5-core': '^0.8.1',
+					'@ckeditor/ckeditor5-engine': '0.10.0'
+				},
+				devDependencies: {
+					'@ckeditor/ckeditor5-basic-styles': '^0.8.1'
+				}
+			}, {
+				packageName: '@ckeditor/ckeditor5-core',
+				repository: 'foo/bar',
+				commit: 'abcd1234'
+			} );
+
+			expect( mrgitJson ).to.deep.equal( {
+				dependencies: {
+					'@ckeditor/ckeditor5-core': 'foo/bar#abcd1234',
+					'@ckeditor/ckeditor5-engine': 'ckeditor/ckeditor5-engine',
+					'@ckeditor/ckeditor5-basic-styles': 'ckeditor/ckeditor5-basic-styles'
+				},
+				packages: 'packages/'
+			} );
+		} );
+
+		it( 'does not modify anything because required "packageName" is not specified', () => {
+			const mrgitJson = createMrGitJsonContent( {
+				dependencies: {
+					'@ckeditor/ckeditor5-core': '^0.8.1',
+					'@ckeditor/ckeditor5-engine': '0.10.0'
+				},
+				devDependencies: {
+					'@ckeditor/ckeditor5-basic-styles': '^0.8.1'
+				}
+			}, {
+				packageName: '@ckeditor/ckeditor5-utils',
+				repository: 'foo/bar'
+			} );
+
+			expect( mrgitJson ).to.deep.equal( {
+				dependencies: {
+					'@ckeditor/ckeditor5-core': 'ckeditor/ckeditor5-core',
+					'@ckeditor/ckeditor5-engine': 'ckeditor/ckeditor5-engine',
+					'@ckeditor/ckeditor5-basic-styles': 'ckeditor/ckeditor5-basic-styles'
+				},
+				packages: 'packages/'
+			} );
+		} );
+
+		it( 'removes `options.repository` value if the repository belongs to our ecosystem', () => {
+			const options = {
+				packageName: '@ckeditor/ckeditor5-core',
+				repository: 'ckeditor/ckeditor5-core'
+			};
+
+			const mrgitJson = createMrGitJsonContent( {
+				dependencies: {
+					'@ckeditor/ckeditor5-core': '^0.8.1',
+					'@ckeditor/ckeditor5-engine': '0.10.0'
+				},
+				devDependencies: {
+					'@ckeditor/ckeditor5-basic-styles': '^0.8.1'
+				}
+			}, options );
+
+			expect( mrgitJson ).to.deep.equal( {
+				dependencies: {
+					'@ckeditor/ckeditor5-core': 'ckeditor/ckeditor5-core',
+					'@ckeditor/ckeditor5-engine': 'ckeditor/ckeditor5-engine',
+					'@ckeditor/ckeditor5-basic-styles': 'ckeditor/ckeditor5-basic-styles'
+				},
+				packages: 'packages/'
+			} );
+
+			expect( options.repository ).to.be.undefined;
+		} );
+	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Forked repositories should be cloned properly on CI. Closes #542.
