### PR TITLE
JSDoc validator found errors, mark the entire process with proper exit code

### DIFF
--- a/packages/jsdoc-plugins/lib/validator/validator.js
+++ b/packages/jsdoc-plugins/lib/validator/validator.js
@@ -21,6 +21,11 @@ exports.handlers = {
 		// Prints only first 50 errors to stdout.
 		printErrors( errors, 50 );
 
+		// Mark the process as ended with error.
+		if ( errors.length ) {
+			process.exitCode = 1;
+		}
+
 		if ( process.env.JSDOC_VALIDATE_ONLY ) {
 			process.exit();
 		}

--- a/packages/jsdoc-plugins/lib/validator/validator.js
+++ b/packages/jsdoc-plugins/lib/validator/validator.js
@@ -14,6 +14,7 @@ const logger = require( 'jsdoc/util/logger' );
 
 exports.handlers = {
 	processingComplete( e ) {
+		const isValidateOnly = process.env.JSDOC_VALIDATE_ONLY;
 		const validator = new DocletValidator( e.doclets );
 
 		const errors = validator.findErrors();
@@ -24,9 +25,13 @@ exports.handlers = {
 		// Mark the process as ended with error.
 		if ( errors.length ) {
 			process.exitCode = 1;
+
+			if ( isValidateOnly ) {
+				return logger.fatal( 'Aborted due to errors.' );
+			}
 		}
 
-		if ( process.env.JSDOC_VALIDATE_ONLY ) {
+		if ( isValidateOnly ) {
 			process.exit();
 		}
 	}
@@ -54,8 +59,4 @@ function printErrors( errors, maxSize ) {
 	}
 
 	process.stderr.write( errorMessages.join( '\n' ) );
-
-	if ( process.env.JSDOC_VALIDATE_ONLY ) {
-		logger.fatal( 'Aborted due to errors.' );
-	}
 }


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: JSDoc validator will end with proper exit code if, during the validation, any error occurred. Closes #550.