### PR TITLE
Adjusted the changelog generator to match to planned changes related to merging issue trackers

### DIFF
--- a/packages/ckeditor5-dev-env/lib/release-tools/utils/transform-commit/transform-commit-utils.js
+++ b/packages/ckeditor5-dev-env/lib/release-tools/utils/transform-commit/transform-commit-utils.js
@@ -79,7 +79,7 @@ const transformCommitUtils = {
 			const packageJson = getPackageJson();
 
 			// Due to merging our issue trackers, `packageJson.bugs` will point to the same place for every package.
-			// We cannot relay on this value anymore. See: https://github.com/ckeditor/ckeditor5/issues/1988.
+			// We cannot rely on this value anymore. See: https://github.com/ckeditor/ckeditor5/issues/1988.
 			// Instead of we can take a value from `packageJson.repository` and adjust it to match to our requirements.
 			let issuesUrl = ( typeof packageJson.repository === 'object' ) ? packageJson.repository.url : packageJson.repository;
 

--- a/packages/ckeditor5-dev-env/lib/release-tools/utils/transform-commit/transform-commit-utils.js
+++ b/packages/ckeditor5-dev-env/lib/release-tools/utils/transform-commit/transform-commit-utils.js
@@ -77,13 +77,26 @@ const transformCommitUtils = {
 			}
 
 			const packageJson = getPackageJson();
-			const issuesUrl = ( typeof packageJson.bugs === 'object' ) ? packageJson.bugs.url : packageJson.bugs;
+
+			// Due to merging our issue trackers, `packageJson.bugs` will point to the same place for every package.
+			// We cannot relay on this value anymore. See: https://github.com/ckeditor/ckeditor5/issues/1988.
+			// Instead of we can take a value from `packageJson.repository` and adjust it to match to our requirements.
+			let issuesUrl = ( typeof packageJson.repository === 'object' ) ? packageJson.repository.url : packageJson.repository;
 
 			if ( !issuesUrl ) {
-				throw new Error( `The package.json for "${ packageJson.name }" must contain the "bugs" property.` );
+				throw new Error( `The package.json for "${ packageJson.name }" must contain the "repository" property.` );
 			}
 
-			return `[#${ issueId }](${ issuesUrl }/${ issueId })`;
+			// If the value ends with ".git", we need to remove it.
+			issuesUrl = issuesUrl.replace( /\.git$/, '' );
+
+			// If the value contains "/issues" suffix, we don't need to add it.
+			if ( issuesUrl.match( /\/issues/ ) ) {
+				return `[#${ issueId }](${ issuesUrl }/${ issueId })`;
+			}
+
+			// But if doesn't, let's add it.
+			return `[#${ issueId }](${ issuesUrl }/issues/${ issueId })`;
 		} );
 	},
 

--- a/packages/ckeditor5-dev-env/tests/release-tools/utils/generatechangelogfromcommits-integration.js
+++ b/packages/ckeditor5-dev-env/tests/release-tools/utils/generatechangelogfromcommits-integration.js
@@ -39,8 +39,7 @@ describe( 'dev-env/release-tools/utils', () => {
 
 			const packageJson = {
 				name: '@ckeditor/ckeditor5-test-package',
-				bugs: `${ url }/issues`,
-				repository: url
+				repository: `${ url }`
 			};
 
 			fs.writeFileSync(

--- a/packages/ckeditor5-dev-env/tests/release-tools/utils/transform-commit/transform-commit-utils.js
+++ b/packages/ckeditor5-dev-env/tests/release-tools/utils/transform-commit/transform-commit-utils.js
@@ -90,30 +90,76 @@ describe( 'dev-env/release-tools/utils/transform-commit', () => {
 		} );
 
 		describe( 'linkToGithubIssue()', () => {
-			it( 'throws an error if package.json does not contain the "bugs" property', () => {
+			it( 'throws an error if package.json does not contain the "repository" property', () => {
 				stubs.getPackageJson.returns( {
 					name: 'test-package'
 				} );
 
 				expect( () => transformCommit.linkToGithubIssue( '#123' ) )
-					.to.throw( Error, 'The package.json for "test-package" must contain the "bugs" property.' );
+					.to.throw( Error, 'The package.json for "test-package" must contain the "repository" property.' );
 			} );
 
-			it( 'replaces "#ID" with a link to GitHub issue (packageJson.bugs as a string)', () => {
+			it( 'replaces "#ID" with a link to GitHub issue (packageJson.repository as a string)', () => {
 				stubs.getPackageJson.returns( {
 					name: 'test-package',
-					bugs: '/issues'
+					repository: 'https://github.com/ckeditor/ckeditor5-dev'
 				} );
 
 				expect( transformCommit.linkToGithubIssue( 'Some issue #1.' ) )
-					.to.equal( 'Some issue [#1](/issues/1).' );
+					.to.equal( 'Some issue [#1](https://github.com/ckeditor/ckeditor5-dev/issues/1).' );
 			} );
 
-			it( 'replaces "#ID" with a link to GitHub issue (packageJson.bugs as an object)', () => {
+			it( 'replaces "#ID" with a link to GitHub issue (packageJson.repository as a string, contains "/issues")', () => {
 				stubs.getPackageJson.returns( {
 					name: 'test-package',
-					bugs: {
-						url: 'https://github.com/ckeditor/ckeditor5-dev/issues'
+					repository: 'https://github.com/ckeditor/ckeditor5-dev/issues'
+				} );
+
+				expect( transformCommit.linkToGithubIssue( 'Some issue #1.' ) )
+					.to.equal( 'Some issue [#1](https://github.com/ckeditor/ckeditor5-dev/issues/1).' );
+			} );
+
+			it( 'replaces "#ID" with a link to GitHub issue (packageJson.repository as a string, ends with ".git")', () => {
+				stubs.getPackageJson.returns( {
+					name: 'test-package',
+					repository: 'https://github.com/ckeditor/ckeditor5-dev.git'
+				} );
+
+				expect( transformCommit.linkToGithubIssue( 'Some issue #1.' ) )
+					.to.equal( 'Some issue [#1](https://github.com/ckeditor/ckeditor5-dev/issues/1).' );
+			} );
+
+			it( 'replaces "#ID" with a link to GitHub issue (packageJson.repository as an object)', () => {
+				stubs.getPackageJson.returns( {
+					name: 'test-package',
+					repository: {
+						url: 'https://github.com/ckeditor/ckeditor5-dev'
+					}
+				} );
+
+				expect( transformCommit.linkToGithubIssue( 'Some issue #1.' ) )
+					.to.equal( 'Some issue [#1](https://github.com/ckeditor/ckeditor5-dev/issues/1).' );
+			} );
+
+			it( 'replaces "#ID" with a link to GitHub issue (packageJson.repository as an object, contains "/issues")', () => {
+				stubs.getPackageJson.returns( {
+					name: 'test-package',
+					repository: {
+						url: 'https://github.com/ckeditor/ckeditor5-dev/issues',
+						type: 'git'
+					}
+				} );
+
+				expect( transformCommit.linkToGithubIssue( 'Some issue #1.' ) )
+					.to.equal( 'Some issue [#1](https://github.com/ckeditor/ckeditor5-dev/issues/1).' );
+			} );
+
+			it( 'replaces "#ID" with a link to GitHub issue (packageJson.repository as an object, ends with ".git")', () => {
+				stubs.getPackageJson.returns( {
+					name: 'test-package',
+					repository: {
+						url: 'https://github.com/ckeditor/ckeditor5-dev.git',
+						type: 'git'
 					}
 				} );
 

--- a/packages/ckeditor5-dev-env/tests/release-tools/utils/transform-commit/transformcommitforsubrepository.js
+++ b/packages/ckeditor5-dev-env/tests/release-tools/utils/transform-commit/transformcommitforsubrepository.js
@@ -11,7 +11,7 @@ const mockery = require( 'mockery' );
 
 describe( 'dev-env/release-tools/utils/transform-commit', () => {
 	describe( 'transformCommitForSubRepository()', () => {
-		let transformCommitForSubRepository, sandbox;
+		let transformCommitForSubRepository, sandbox, stubs;
 
 		beforeEach( () => {
 			sandbox = sinon.createSandbox();
@@ -21,6 +21,16 @@ describe( 'dev-env/release-tools/utils/transform-commit', () => {
 				warnOnReplace: false,
 				warnOnUnregistered: false
 			} );
+
+			stubs = {
+				getPackageJson: () => {
+					return {
+						repository: 'https://github.com/ckeditor/ckeditor5-dev'
+					};
+				}
+			};
+
+			mockery.registerMock( '../getpackagejson', stubs.getPackageJson );
 
 			transformCommitForSubRepository = require(
 				'../../../../lib/release-tools/utils/transform-commit/transformcommitforsubrepository'


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Adjusted the changelog generator to match to planned changes related to merging issue trackers. Closes ckeditor/ckeditor5#1988.

BREAKING CHANGE: Due to merging our issue trackers, `pkgJson.bugs` will point to the same place for every package. We cannot rely on this value anymore. See ckeditor/ckeditor5#1988. Instead of we can take a value from `pkgJson.repository` and adjust it to match to our requirements.

---

### Additional information

This PR won't change anything in our project because we already have defined `pkgJson.repository` for each package but if somebody uses the tool and he hasn't defined the value, the tool will throw an ugly error and that's why I marked it as BC.
