### PR TITLE
CKEditor 5 CI works with ckeditor- prefix

### DIFF
--- a/packages/ckeditor5-dev-tests/bin/test-travis.sh
+++ b/packages/ckeditor5-dev-tests/bin/test-travis.sh
@@ -9,7 +9,7 @@ PACKAGE_ROOT=$(pwd)
 # Path to the exeutable in CWD.
 ROOT_BIN=${PACKAGE_ROOT}/node_modules/.bin
 
-PACKAGE_NAME=$(node -e "console.log( require( process.cwd() + '/package.json' ).name.replace( '@ckeditor/ckeditor5-', '' ) )");
+PACKAGE_NAME=$(node -e "console.log( require( process.cwd() + '/package.json' ).name.replace( /@ckeditor\/ckeditor5?-/, '' ) )");
 
 # The `.ckeditor5_test_environment` file is created by the "install-dependencies" script.
 CKEDITOR5_TEST_ENVIRONMENT=$(cat ${PACKAGE_ROOT}/.ckeditor5_test_environment)


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Fixed a script that extracts a package name from a current testing package. Now it uses a regular expression and works with `ckeditor-` prefix as well.
