### PR TITLE
mrgit will handle "ckeditor-" packages on CI

### DIFF
--- a/packages/ckeditor5-dev-tests/lib/bin/createmrgitjsoncontent.js
+++ b/packages/ckeditor5-dev-tests/lib/bin/createmrgitjsoncontent.js
@@ -24,7 +24,7 @@ module.exports = function createMrGitJsonContent( packageJson, options ) {
 		const dependencyVersion = dependencies[ dependencyName ];
 
 		if (
-			!dependencyName.startsWith( '@ckeditor/ckeditor5' ) &&
+			!dependencyName.match( /^@ckeditor\/ckeditor5?/ ) &&
 			!dependencyVersion.includes( 'cksource/ckeditor' )
 		) {
 			continue;

--- a/packages/ckeditor5-dev-tests/lib/mrgit-resolver.js
+++ b/packages/ckeditor5-dev-tests/lib/mrgit-resolver.js
@@ -18,7 +18,7 @@ module.exports = function resolver( packageName, options ) {
 	let repositoryUrl = options.dependencies[ packageName ];
 
 	if ( !repositoryUrl ) {
-		if ( packageName.match( /^@ckeditor\/ckeditor5-(?!dev)/ ) ) {
+		if ( packageName.match( /^@ckeditor\/ckeditor5?-(?!dev)/ ) ) {
 			repositoryUrl = packageName.slice( 1 );
 		} else {
 			return null;

--- a/packages/ckeditor5-dev-tests/tests/bin/createmrgitjsoncontent.js
+++ b/packages/ckeditor5-dev-tests/tests/bin/createmrgitjsoncontent.js
@@ -41,6 +41,27 @@ describe( 'dev-tests/bin/create-mrgit-json', () => {
 		} );
 	} );
 
+	it( 'should work with "ckeditor-" prefix', () => {
+		const mrgitJson = createMrGitJsonContent( {
+			dependencies: {
+				'@ckeditor/ckeditor-core': '^0.8.1',
+				'@ckeditor/ckeditor-engine': '0.10.0'
+			},
+			devDependencies: {
+				'@ckeditor/ckeditor5-basic-styles': '^0.8.1'
+			}
+		} );
+
+		expect( mrgitJson ).to.deep.equal( {
+			dependencies: {
+				'@ckeditor/ckeditor-core': 'ckeditor/ckeditor-core',
+				'@ckeditor/ckeditor-engine': 'ckeditor/ckeditor-engine',
+				'@ckeditor/ckeditor5-basic-styles': 'ckeditor/ckeditor5-basic-styles'
+			},
+			packages: 'packages/'
+		} );
+	} );
+
 	it( 'should return an object with hashed dependency versions for hashed github versions of dependencies', () => {
 		const mrgitJson = createMrGitJsonContent( {
 			dependencies: {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Mr. Git will handle "ckeditor-" packages on CI.

---

### Additional information

After learning mrgit how to handle "ckeditor-" packages, I was finally able to execute tests using the same script that Travis:

![image](https://user-images.githubusercontent.com/2270764/64593681-c4246300-d3ae-11e9-8eef-41579ec60da3.png)

