### PR TITLE
Support for running manual tests from the main repository

### DIFF
--- a/packages/ckeditor5-dev-tests/bin/test-manual.js
+++ b/packages/ckeditor5-dev-tests/bin/test-manual.js
@@ -18,7 +18,7 @@ if ( options.files.length === 0 ) {
 	// Checks whether the test command was called from the main repository.
 	// If so then take all packages files to tests.
 	if ( require( path.join( cwd, 'package.json' ) ).name === 'ckeditor5' ) {
-		options.files = [ '*' ];
+		options.files = [ '*', '/' ];
 	} else {
 	// In other case take files from the current package.
 		options.files = [ '/' ];

--- a/packages/ckeditor5-dev-tests/lib/utils/getrelativefilepath.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/getrelativefilepath.js
@@ -10,6 +10,8 @@
  * a build directory, once all packages are gathered together.
  *
  * In order to do that, everything up to `ckeditor5?-packageName` is removed:
+ * /work/space/ckeditor5/tests/manual/foo.js -> ckeditor5/tests/manual/foo.js
+ * /work/space/ckeditor/tests/manual/foo.js -> ckeditor/tests/manual/foo.js
  * /work/space/ckeditor5-foo/tests/manual/foo.js -> ckeditor5-foo/tests/manual/foo.js
  * /work/space/ckeditor-foo/tests/manual/foo.js -> ckeditor-foo/tests/manual/foo.js
  *
@@ -17,7 +19,9 @@
  * @returns {String}
  */
 module.exports = function getRelativeFilePath( filePath ) {
-	return filePath.replace( /^.+[/\\]ckeditor(5)?-/, ( ...match ) => {
-		return match[ 1 ] ? 'ckeditor5-' : 'ckeditor-';
+	return filePath.replace( /^.+[/\\]ckeditor(5)?(-)?/, ( ...match ) => {
+		const ckeditor = match[ 1 ] ? 'ckeditor5' : 'ckeditor';
+
+		return match[ 2 ] ? `${ ckeditor }-` : ckeditor;
 	} );
 };

--- a/packages/ckeditor5-dev-tests/tests/utils/getrelativefilepath.js
+++ b/packages/ckeditor5-dev-tests/tests/utils/getrelativefilepath.js
@@ -42,6 +42,14 @@ describe( 'dev-tests/utils', () => {
 				);
 				/* eslint-enable max-len */
 			} );
+
+			it( 'returns a proper path for "ckeditor-" prefix', () => {
+				checkPath( '/work/space/ckeditor-foo/tests/manual/foo.js', 'ckeditor-foo/tests/manual/foo.js' );
+			} );
+
+			it( 'returns a proper path to from the main (root) package', () => {
+				checkPath( '/work/space/ckeditor5/tests/manual/foo.js', 'ckeditor5/tests/manual/foo.js' );
+			} );
 		} );
 
 		describe( 'Windows paths', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Support for running manual tests from the main repository. See ckeditor/ckeditor5#2054.

In order to run manual tests for main package only, use `yarn run manual -f /`. By default, all tests (including the main package) are compiled.