### PR TITLE
Workaround for a bug related to `/` in Git bash (Win)

### DIFF
--- a/packages/ckeditor5-dev-tests/README.md
+++ b/packages/ckeditor5-dev-tests/README.md
@@ -54,7 +54,7 @@ You can also use the bin script for testing a package:
 * `browsers` - Browsers which will be used to run the tests. Also available as an alias: `-b`.
 * `reporter` - Mocha reporter – either `mocha` (default) or `dots` (less verbose one).
 * `disallow-console-use` - Whether to throw an error when one of the console methods (e.g. `console.log()`) is executed.
-* `root-only` - Whether to run tests only for root repository. Equivalent of `--files /`.
+* `only-root` - Whether to run tests only for root repository. Equivalent of `--files /`.
 * `include-root` - Whether to append root repository to tests matched by `--files`.
 
 #### Examples

--- a/packages/ckeditor5-dev-tests/README.md
+++ b/packages/ckeditor5-dev-tests/README.md
@@ -54,6 +54,8 @@ You can also use the bin script for testing a package:
 * `browsers` - Browsers which will be used to run the tests. Also available as an alias: `-b`.
 * `reporter` - Mocha reporter – either `mocha` (default) or `dots` (less verbose one).
 * `disallow-console-use` - Whether to throw an error when one of the console methods (e.g. `console.log()`) is executed.
+* `root-only` - Whether to run tests only for root repository. Equivalent of `--files /`.
+* `include-root` - Whether to append root repository to tests matched by `--files`.
 
 #### Examples
 

--- a/packages/ckeditor5-dev-tests/lib/utils/automated-tests/parsearguments.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/automated-tests/parsearguments.js
@@ -82,22 +82,13 @@ module.exports = function parseArguments( args ) {
 		delete options[ alias ];
 	}
 
-	
-	if ( process.platform === 'win32' ) {
-		const exePath = process.env.EXEPATH;
+	// Due to issues with `/` in Git bash (on Windows environments), we needed to introduce an additional CLI parameter.
+	// See: https://github.com/ckeditor/ckeditor5-dev/issues/558#issuecomment-534008612
+	if ( options[ 'include-root' ] && !options.files.includes( '/' ) ) {
+		options.files.push( '/' );
 
-		options.files = options.files.map( file => {
-			if ( normalizePath( file ) === normalizePath( exePath ) ) {
-				return '/';
-			}
-
-			return file;
-		} );
+		delete options[ 'include-root' ];
 	}
 
 	return options;
 };
-
-function normalizePath( file ) {
-	return file.replace(/\\/g, '/').replace(/\/$/, '');
-}

--- a/packages/ckeditor5-dev-tests/lib/utils/automated-tests/parsearguments.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/automated-tests/parsearguments.js
@@ -93,7 +93,7 @@ module.exports = function parseArguments( args ) {
 	}
 
 	// `--only-root` means that we want to compile manual tests from the main repository only.
-	// E.g.: `yarn run manual --include-root` => `yarn run manual -f /`
+	// E.g.: `yarn run manual --only-root` => `yarn run manual -f /`
 	if ( options[ 'only-root' ] ) {
 		options.files = [ '/' ];
 

--- a/packages/ckeditor5-dev-tests/lib/utils/automated-tests/parsearguments.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/automated-tests/parsearguments.js
@@ -51,6 +51,7 @@ module.exports = function parseArguments( args ) {
 			'disallow-console-use': false
 		}
 	};
+
 	const options = minimist( args, minimistConfig );
 
 	options.disallowConsoleUse = options[ 'disallow-console-use' ];
@@ -77,7 +78,7 @@ module.exports = function parseArguments( args ) {
 	options.themePath = options.themePath ? options.themePath : null;
 
 	// Delete all aliases because we don't want to use them in the code.
-	// They are useful when calling command but useless after that.
+	// They are useful when calling a command but useless after that.
 	for ( const alias of Object.keys( minimistConfig.alias ) ) {
 		delete options[ alias ];
 	}

--- a/packages/ckeditor5-dev-tests/lib/utils/automated-tests/parsearguments.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/automated-tests/parsearguments.js
@@ -82,7 +82,7 @@ module.exports = function parseArguments( args ) {
 		delete options[ alias ];
 	}
 
-	// Due to issues with `/` in Git bash (on Windows environments), we needed to introduce an additional CLI parameter.
+	// Due to issues with `/` in Git bash (on Windows environments), we needed to introduce more CLI parameters.
 	// See: https://github.com/ckeditor/ckeditor5-dev/issues/558#issuecomment-534008612
 	// `--include-root` appends `/` to the `--files` list.
 	// E.g.: `yarn run manual -f core --include-root` => `yarn run manual -f core,/`

--- a/packages/ckeditor5-dev-tests/lib/utils/automated-tests/parsearguments.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/automated-tests/parsearguments.js
@@ -84,10 +84,20 @@ module.exports = function parseArguments( args ) {
 
 	// Due to issues with `/` in Git bash (on Windows environments), we needed to introduce an additional CLI parameter.
 	// See: https://github.com/ckeditor/ckeditor5-dev/issues/558#issuecomment-534008612
+	// `--include-root` appends `/` to the `--files` list.
+	// E.g.: `yarn run manual -f core --include-root` => `yarn run manual -f core,/`
 	if ( options[ 'include-root' ] && !options.files.includes( '/' ) ) {
 		options.files.push( '/' );
 
 		delete options[ 'include-root' ];
+	}
+
+	// `--only-root` means that we want to compile manual tests from the main repository only.
+	// E.g.: `yarn run manual --include-root` => `yarn run manual -f /`
+	if ( options[ 'only-root' ] ) {
+		options.files = [ '/' ];
+
+		delete options[ 'only-root' ];
 	}
 
 	return options;

--- a/packages/ckeditor5-dev-tests/lib/utils/automated-tests/parsearguments.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/automated-tests/parsearguments.js
@@ -82,5 +82,22 @@ module.exports = function parseArguments( args ) {
 		delete options[ alias ];
 	}
 
+	
+	if ( process.platform === 'win32' ) {
+		const exePath = process.env.EXEPATH;
+
+		options.files = options.files.map( file => {
+			if ( normalizePath( file ) === normalizePath( exePath ) ) {
+				return '/';
+			}
+
+			return file;
+		} );
+	}
+
 	return options;
 };
+
+function normalizePath( file ) {
+	return file.replace(/\\/g, '/').replace(/\/$/, '');
+}

--- a/packages/ckeditor5-dev-tests/tests/utils/automated-tests/parsearguments.js
+++ b/packages/ckeditor5-dev-tests/tests/utils/automated-tests/parsearguments.js
@@ -1,0 +1,133 @@
+/**
+ * @license Copyright (c) 2003-2019, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+'use strict';
+
+const mockery = require( 'mockery' );
+const { expect } = require( 'chai' );
+const sinon = require( 'sinon' );
+
+describe( 'parseArguments()', () => {
+	let parseArguments, sandbox;
+
+	beforeEach( () => {
+		sandbox = sinon.createSandbox();
+
+		mockery.enable( {
+			warnOnReplace: false,
+			warnOnUnregistered: false
+		} );
+
+		parseArguments = require( '../../../lib/utils/automated-tests/parsearguments' );
+	} );
+
+	afterEach( () => {
+		sandbox.restore();
+		mockery.disable();
+	} );
+
+	it( 'returns an empty files list if --files was not specified', () => {
+		const options = parseArguments( [] );
+
+		expect( options.files ).to.deep.equal( [] );
+	} );
+
+	it( 'returns as array values specified in --files', () => {
+		const options = parseArguments( [
+			'--files',
+			'core,engine'
+		] );
+
+		expect( options.files ).to.deep.equal( [ 'core', 'engine' ] );
+	} );
+
+	it( 'should enable debug options by default', () => {
+		const options = parseArguments( [] );
+
+		expect( options.debug ).to.deep.equal( [ 'CK_DEBUG' ] );
+	} );
+
+	it( 'allows specifying additional debug flags', () => {
+		const options = parseArguments( [
+			'--debug',
+			'engine,ui'
+		] );
+
+		expect( options.debug ).to.deep.equal( [ 'CK_DEBUG', 'CK_DEBUG_ENGINE', 'CK_DEBUG_UI' ] );
+	} );
+
+	it( 'allows disabling debug option (--debug false)', () => {
+		const options = parseArguments( [
+			'--debug',
+			'false'
+		] );
+
+		expect( options.debug ).to.deep.equal( [] );
+	} );
+
+	it( 'allows disabling debug option (--no-debug)', () => {
+		const options = parseArguments( [
+			'--no-debug'
+		] );
+
+		expect( options.debug ).to.deep.equal( [] );
+	} );
+
+	describe( 'workaround for "/" in Git Bash (Windows)', () => {
+		it( 'adds the main repository when --include-root was used', () => {
+			const options = parseArguments( [
+				'--include-root'
+			] );
+
+			expect( options.files ).to.deep.equal( [ '/' ] );
+		} );
+
+		it( 'removes "include-root" from "options" object', () => {
+			const options = parseArguments( [
+				'--include-root'
+			] );
+
+			expect( options[ 'include-root' ] ).to.be.undefined;
+		} );
+
+		it( 'does not duplicate the main repository when --include-root was used', () => {
+			const options = parseArguments( [
+				'--files',
+				'/',
+				'--include-root'
+			] );
+
+			expect( options.files ).to.deep.equal( [ '/' ] );
+		} );
+
+		it( 'merges --include-root and values specified in --files', () => {
+			const options = parseArguments( [
+				'--files',
+				'core,engine',
+				'--include-root'
+			] );
+
+			expect( options.files ).to.deep.equal( [ 'core', 'engine', '/' ] );
+		} );
+
+		it( 'ignores values specified in --files when --only-root was used', () => {
+			const options = parseArguments( [
+				'--files',
+				'core,engine',
+				'--only-root'
+			] );
+
+			expect( options.files ).to.deep.equal( [ '/' ] );
+		} );
+
+		it( 'removes "only-root" from "options" object', () => {
+			const options = parseArguments( [
+				'--only-root'
+			] );
+
+			expect( options[ 'only-root' ] ).to.be.undefined;
+		} );
+	} );
+} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Introduced two new CLI parameters: `--include-root` and `--only-root` that allow specifying whether the main repository should be added to test file query or tests from the main repository should be compiled only. It's a workaround due to bug in Git Bash (on Windows environment) that does not allow to use `'/'` as value for an option in CLI.  Closes #558.
