### PR TITLE
Change order of loaders in the webpack configuration for unit tests

### DIFF
--- a/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getwebpackconfig.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getwebpackconfig.js
@@ -72,7 +72,7 @@ module.exports = function getWebpackConfigForAutomatedTests( options ) {
 	}
 
 	if ( options.coverage ) {
-		config.module.rules.push(
+		config.module.rules.unshift(
 			{
 				test: /\.js$/,
 				loader: 'istanbul-instrumenter-loader',


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Changed order of loaders in the webpack configuration for unit tests. Closes #https://github.com/ckeditor/ckeditor5/issues/5771.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
