### PR TITLE
Execute stylelint task on CI

### DIFF
--- a/packages/ckeditor5-dev-tests/bin/test-travis.sh
+++ b/packages/ckeditor5-dev-tests/bin/test-travis.sh
@@ -16,6 +16,7 @@ CKEDITOR5_TEST_ENVIRONMENT=$(cat ${PACKAGE_ROOT}/.ckeditor5_test_environment)
 
 # Linter and dependency checker tasks must be executed from the original package.
 yarn run lint && \
+yarn run stylelint && \
 ${ROOT_BIN}/ckeditor5-dev-tests-check-dependencies && \
 cd ${CKEDITOR5_TEST_ENVIRONMENT} && \
 node --max_old_space_size=4096 $ROOT_BIN/ckeditor5-dev-tests --files=$PACKAGE_NAME --coverage --reporter=dots --browsers=Chrome --disallow-console-use && \


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Execute the `stylelint` task on CI. Closes #578.

Working build: https://travis-ci.org/ckeditor/ckeditor5-heading/builds/617103672