### PR TITLE
Fix files pattern for coverage when running without --files parameter.

### DIFF
--- a/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getwebpackconfig.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getwebpackconfig.js
@@ -109,12 +109,14 @@ function getPathsToIncludeForCoverage( globs ) {
 				const packageName = matchCKEditor5[ 1 ]
 					// A special case when --files='!engine' or --files='!engine|ui' was passed.
 					// Convert it to /ckeditor5-(?!engine)[^/]\/src\//.
-					.replace( /ckeditor5-!\(([^)]+)\)\*/, 'ckeditor5-(?!$1)[^' + escapedPathSep + ']+' );
+					.replace( /ckeditor5-!\(([^)]+)\)\*/, 'ckeditor5-(?!$1)[^' + escapedPathSep + ']+' )
+					.replace( 'ckeditor5-*', 'ckeditor5-[a-z]+' );
 
 				return new RegExp( packageName + escapedPathSep + 'src' + escapedPathSep );
 			} else if ( matchCKEditor ) {
 				const packageName = matchCKEditor[ 1 ]
-					.replace( /ckeditor-!\(([^)]+)\)\*/, 'ckeditor-(?!$1)[^' + escapedPathSep + ']+' );
+					.replace( /ckeditor-!\(([^)]+)\)\*/, 'ckeditor-(?!$1)[^' + escapedPathSep + ']+' )
+					.replace( 'ckeditor-*', 'ckeditor-[a-z]+' );
 
 				return new RegExp( packageName + escapedPathSep + 'src' + escapedPathSep );
 			}


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: RegExp pattern for coverage files now properly matches all ckeditor- and ckeditor5- projects. Closes #584.

---

### Additional information

It turned out that the RegExp created for all files was wrong. When no `--files` directive was passed the pattern was:
```
/ckeditor5-*\/src/
```

which doesn't catch packages names because `*` is a quantifier for `-` character.

The proper one is like:
```
/ckeditor5-[a-z-]+\/src/
```
ps.: dunno if we gonna have plugins like `ckeditor5-image-2` but I think that for now, we're safe :P