### PR TITLE
Automatic DOM leak detection for unit tests

### DIFF
--- a/packages/ckeditor5-dev-tests/README.md
+++ b/packages/ckeditor5-dev-tests/README.md
@@ -53,7 +53,7 @@ You can also use the bin script for testing a package:
 * `files` - Specify file(s) to test. Also available as an alias: `-f`.
 * `browsers` - Browsers which will be used to run the tests. Also available as an alias: `-b`.
 * `reporter` - Mocha reporter – either `mocha` (default) or `dots` (less verbose one).
-* `disallow-console-use` - Whether to throw an error when one of the console methods (e.g. `console.log()`) is executed.
+* `production` - Run strictest set of checks. E.g. it fails test run when there are [console calls](https://github.com/ckeditor/ckeditor5/issues/1996) or [DOM leaks](https://github.com/ckeditor/ckeditor5/issues/6002).
 
 #### Examples
 

--- a/packages/ckeditor5-dev-tests/bin/test-travis.sh
+++ b/packages/ckeditor5-dev-tests/bin/test-travis.sh
@@ -19,5 +19,5 @@ yarn run lint && \
 yarn run stylelint && \
 ${ROOT_BIN}/ckeditor5-dev-tests-check-dependencies && \
 cd ${CKEDITOR5_TEST_ENVIRONMENT} && \
-node --max_old_space_size=4096 $ROOT_BIN/ckeditor5-dev-tests --files=$PACKAGE_NAME --coverage --reporter=dots --browsers=Chrome --disallow-console-use && \
-node --max_old_space_size=4096 $ROOT_BIN/ckeditor5-dev-tests --files=$PACKAGE_NAME --reporter=dots --browsers=Firefox --disallow-console-use
+node --max_old_space_size=4096 $ROOT_BIN/ckeditor5-dev-tests --files=$PACKAGE_NAME --coverage --reporter=dots --browsers=Chrome --production && \
+node --max_old_space_size=4096 $ROOT_BIN/ckeditor5-dev-tests --files=$PACKAGE_NAME --reporter=dots --browsers=Firefox --production

--- a/packages/ckeditor5-dev-tests/lib/tasks/runautomatedtests.js
+++ b/packages/ckeditor5-dev-tests/lib/tasks/runautomatedtests.js
@@ -32,15 +32,16 @@ const ENTRY_FILE_PATH = path.join( process.cwd(), 'build', '.automated-tests', '
 
 module.exports = function runAutomatedTests( options ) {
 	return Promise.resolve().then( () => {
-		if ( !options.disallowConsoleUse ) {
+		if ( !options.production ) {
 			console.warn( chalk.yellow(
-				'⚠ Console use is allowed. Use `--disallow-console-use` to disallow console use.'
+				'⚠ You\'re running tests in dev mode - some error protections are loose. Use the `--protection` flag' +
+				'to use strictest verification methods.'
 			) );
 		}
 
 		const globPatterns = transformFilesToTestGlob( options.files );
 
-		createEntryFile( globPatterns, options.disallowConsoleUse );
+		createEntryFile( globPatterns, options.production );
 
 		const optionsForKarma = Object.assign( {}, options, {
 			entryFile: ENTRY_FILE_PATH,
@@ -65,7 +66,7 @@ function transformFilesToTestGlob( files ) {
 	return globMap;
 }
 
-function createEntryFile( globPatterns, disallowConsoleUse ) {
+function createEntryFile( globPatterns, production ) {
 	mkdirp.sync( path.dirname( ENTRY_FILE_PATH ) );
 	karmaLogger.setupFromConfig( { logLevel: 'INFO' } );
 
@@ -96,12 +97,16 @@ function createEntryFile( globPatterns, disallowConsoleUse ) {
 		throw new Error( 'Not found files to tests. Specified patterns are invalid.' );
 	}
 
+	allFiles.push( path.join( __dirname, '..', 'utils', 'automated-tests', 'leaksdetector.js' ).replace( /\\/g, '/' ) );
+
 	const entryFileContent = allFiles
 		.map( file => 'import "' + file + '";' );
 
-	if ( disallowConsoleUse ) {
+	if ( production ) {
 		entryFileContent.unshift( `
 const originalWarn = console.warn;
+
+window.production = true;
 
 beforeEach( () => {
 	Object.keys( console )

--- a/packages/ckeditor5-dev-tests/lib/tasks/runautomatedtests.js
+++ b/packages/ckeditor5-dev-tests/lib/tasks/runautomatedtests.js
@@ -34,7 +34,7 @@ module.exports = function runAutomatedTests( options ) {
 	return Promise.resolve().then( () => {
 		if ( !options.production ) {
 			console.warn( chalk.yellow(
-				'⚠ You\'re running tests in dev mode - some error protections are loose. Use the `--protection` flag' +
+				'⚠ You\'re running tests in dev mode - some error protections are loose. Use the `--protection` flag ' +
 				'to use strictest verification methods.'
 			) );
 		}

--- a/packages/ckeditor5-dev-tests/lib/tasks/runautomatedtests.js
+++ b/packages/ckeditor5-dev-tests/lib/tasks/runautomatedtests.js
@@ -34,7 +34,7 @@ module.exports = function runAutomatedTests( options ) {
 	return Promise.resolve().then( () => {
 		if ( !options.production ) {
 			console.warn( chalk.yellow(
-				'⚠ You\'re running tests in dev mode - some error protections are loose. Use the `--protection` flag ' +
+				'⚠ You\'re running tests in dev mode - some error protections are loose. Use the `--production` flag ' +
 				'to use strictest verification methods.'
 			) );
 		}

--- a/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getkarmaconfig.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getkarmaconfig.js
@@ -48,6 +48,7 @@ module.exports = function getKarmaConfig( options ) {
 
 		// List of files/patterns to load in the browser.
 		files: [
+			'test-setup.js',
 			options.entryFile,
 			{ pattern: 'packages/ckeditor5-utils/tests/_assets/**/*', watched: false, included: false, served: true, nocache: false }
 		],

--- a/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getkarmaconfig.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getkarmaconfig.js
@@ -48,7 +48,6 @@ module.exports = function getKarmaConfig( options ) {
 
 		// List of files/patterns to load in the browser.
 		files: [
-			'tests/_utils/leakdetector.js',
 			options.entryFile,
 			{ pattern: 'packages/ckeditor5-utils/tests/_assets/**/*', watched: false, included: false, served: true, nocache: false }
 		],

--- a/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getkarmaconfig.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getkarmaconfig.js
@@ -48,7 +48,7 @@ module.exports = function getKarmaConfig( options ) {
 
 		// List of files/patterns to load in the browser.
 		files: [
-			'test-setup.js',
+			'tests/_utils/leakdetector.js',
 			options.entryFile,
 			{ pattern: 'packages/ckeditor5-utils/tests/_assets/**/*', watched: false, included: false, served: true, nocache: false }
 		],

--- a/packages/ckeditor5-dev-tests/lib/utils/automated-tests/leaksdetector.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/automated-tests/leaksdetector.js
@@ -1,0 +1,29 @@
+/**
+ * @license Copyright (c) 2003-2020, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/* global window, document */
+
+( function() {
+	let lastDomElementsCount;
+
+	beforeEach( () => {
+		lastDomElementsCount = document.body.childElementCount;
+	} );
+
+	afterEach( () => {
+		if ( document.body.childElementCount !== lastDomElementsCount ) {
+			const leaksCount = document.body.childElementCount - lastDomElementsCount;
+			const errorMessage = `${ leaksCount } elements were leaked. Be a good citizen and clean your DOM once you're done with it.`;
+
+			lastDomElementsCount = document.body.childElementCount;
+
+			if ( window.production ) {
+				throw new Error( errorMessage );
+			} else {
+				console.error( errorMessage );
+			}
+		}
+	} );
+}() );

--- a/packages/ckeditor5-dev-tests/lib/utils/automated-tests/leaksdetector.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/automated-tests/leaksdetector.js
@@ -19,6 +19,7 @@
 
 			lastDomElementsCount = document.body.childElementCount;
 
+			// See https://github.com/ckeditor/ckeditor5-dev/issues/586#issuecomment-571573488.
 			if ( window.production ) {
 				throw new Error( errorMessage );
 			} else {

--- a/packages/ckeditor5-dev-tests/lib/utils/automated-tests/parsearguments.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/automated-tests/parsearguments.js
@@ -27,7 +27,7 @@ module.exports = function parseArguments( args ) {
 			'source-map',
 			'verbose',
 			'server',
-			'disallow-console-use'
+			'production'
 		],
 
 		alias: {
@@ -49,14 +49,13 @@ module.exports = function parseArguments( args ) {
 			verbose: false,
 			'source-map': false,
 			server: false,
-			'disallow-console-use': false
+			production: false
 		}
 	};
 
 	const options = minimist( args, minimistConfig );
 
 	options.karmaConfigOverrides = options[ 'karma-config-overrides' ];
-	options.disallowConsoleUse = options[ 'disallow-console-use' ];
 	options.sourceMap = options[ 'source-map' ];
 	options.browsers = options.browsers.split( ',' );
 

--- a/packages/ckeditor5-dev-tests/tests/tasks/runautomatedtests.js
+++ b/packages/ckeditor5-dev-tests/tests/tasks/runautomatedtests.js
@@ -17,6 +17,8 @@ describe( 'runAutomatedTests', () => {
 	const codeMakingConsoleUseThrowErrors = `
 const originalWarn = console.warn;
 
+window.production = true;
+
 beforeEach( () => {
 	Object.keys( console )
 		.filter( methodOrProperty => typeof console[ methodOrProperty ] === 'function' )
@@ -106,7 +108,7 @@ beforeEach( () => {
 			files: [
 				'basic-styles'
 			],
-			disallowConsoleUse: true
+			production: true
 		};
 
 		stubs.transformFileOptionToTestGlob.returns( [
@@ -145,7 +147,7 @@ beforeEach( () => {
 	} );
 
 	it( 'throws when files are not specified', () => {
-		return runAutomatedTests( { disallowConsoleUse: true } )
+		return runAutomatedTests( { production: true } )
 			.then(
 				() => {
 					throw new Error( 'Expected to be rejected.' );
@@ -162,7 +164,7 @@ beforeEach( () => {
 				'basic-foo',
 				'bar-core',
 			],
-			disallowConsoleUse: true
+			production: true
 		};
 
 		stubs.transformFileOptionToTestGlob.onFirstCall().returns( [
@@ -194,12 +196,12 @@ beforeEach( () => {
 			);
 	} );
 
-	it( 'should warn when the `disallowConsoleUse` option is set to `false`', () => {
+	it( 'should warn when the `production` option is set to `false`', () => {
 		const options = {
 			files: [
 				'basic-styles'
 			],
-			disallowConsoleUse: false
+			production: false
 		};
 
 		const consoleWarnStub = sandbox.stub( console, 'warn' );
@@ -225,17 +227,18 @@ beforeEach( () => {
 				sinon.assert.calledOnce( consoleWarnStub );
 				sinon.assert.calledWith(
 					consoleWarnStub,
-					chalk.yellow( '⚠ Console use is allowed. Use `--disallow-console-use` to disallow console use.' )
+					chalk.yellow( '⚠ You\'re running tests in dev mode - some error protections are loose. ' +
+						'Use the `--protection` flag to use strictest verification methods.' )
 				);
 			} );
 	} );
 
-	it( 'should not add the code making console use throw an error when the `disallowConsoleUse` option is set to false', () => {
+	it( 'should not add the code making console use throw an error when the `production` option is set to false', () => {
 		const options = {
 			files: [
 				'basic-styles'
 			],
-			disallowConsoleUse: false
+			production: false
 		};
 
 		sandbox.stub( console, 'warn' );
@@ -262,12 +265,12 @@ beforeEach( () => {
 			} );
 	} );
 
-	it( 'should add the code making console use throw an error when the `disallowConsoleUse` option is set to true', () => {
+	it( 'should add the code making console use throw an error when the `production` option is set to true', () => {
 		const options = {
 			files: [
 				'basic-styles'
 			],
-			disallowConsoleUse: true
+			production: true
 		};
 
 		stubs.transformFileOptionToTestGlob.returns( [

--- a/packages/ckeditor5-dev-tests/tests/tasks/runautomatedtests.js
+++ b/packages/ckeditor5-dev-tests/tests/tasks/runautomatedtests.js
@@ -228,7 +228,7 @@ beforeEach( () => {
 				sinon.assert.calledWith(
 					consoleWarnStub,
 					chalk.yellow( '⚠ You\'re running tests in dev mode - some error protections are loose. ' +
-						'Use the `--protection` flag to use strictest verification methods.' )
+						'Use the `--production` flag to use strictest verification methods.' )
 				);
 			} );
 	} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Introduced automatic DOM leak detection for unit tests. Closes #586.

MAJOR BREAKING CHANGE: `--disallow-console-use` flag was removed, use `--production` instead.

---

### Additional information

See https://github.com/ckeditor/ckeditor5-dev/issues/586#issuecomment-571573488 for some notes.