### PR TITLE
Made ckeditor5-dev-tests a general use application

### DIFF
--- a/packages/ckeditor5-dev-tests/lib/tasks/runautomatedtests.js
+++ b/packages/ckeditor5-dev-tests/lib/tasks/runautomatedtests.js
@@ -77,7 +77,9 @@ function createEntryFile( globPatterns, production ) {
 		let hasFiles = false;
 
 		for ( const resolvedPattern of globPatterns[ singlePattern ] ) {
-			const files = glob.sync( resolvedPattern );
+			const files = glob.sync( resolvedPattern, {
+				absolute: resolvedPattern.startsWith( './' )
+			} );
 
 			if ( files.length ) {
 				hasFiles = true;

--- a/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getkarmaconfig.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getkarmaconfig.js
@@ -60,6 +60,7 @@ module.exports = function getKarmaConfig( options ) {
 			files: Object.keys( options.globPatterns ).map( key => options.globPatterns[ key ] ),
 			sourceMap: options.sourceMap,
 			coverage: options.coverage,
+			coveragePaths: options.coveragePaths,
 			themePath: options.themePath,
 			debug: options.debug
 		} ),

--- a/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getwebpackconfig.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getwebpackconfig.js
@@ -21,7 +21,7 @@ module.exports = function getWebpackConfigForAutomatedTests( options ) {
 			rules: [
 				{
 					// test: **/ckeditor5-*/theme/icons/*.svg
-					test: /ckeditor5-[^/\\]+[/\\]theme[/\\]icons[/\\][^/\\]+\.svg$/,
+					test: /\.svg$/,
 					use: [ 'raw-loader' ]
 				},
 				{

--- a/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getwebpackconfig.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getwebpackconfig.js
@@ -80,11 +80,14 @@ module.exports = function getWebpackConfigForAutomatedTests( options ) {
 	}
 
 	if ( options.coverage ) {
+		// Additional coverage paths coming from command line.
+		const coveragePaths = ( options.coveragePaths || [] ).map( relativePath => path.resolve( relativePath ) );
+
 		config.module.rules.unshift(
 			{
 				test: /\.js$/,
 				loader: 'istanbul-instrumenter-loader',
-				include: getPathsToIncludeForCoverage( options.files ),
+				include: getPathsToIncludeForCoverage( options.files ).concat( coveragePaths ),
 				exclude: [
 					new RegExp( `${ escapedPathSep }(lib)${ escapedPathSep }` )
 				],

--- a/packages/ckeditor5-dev-tests/lib/utils/automated-tests/parsearguments.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/automated-tests/parsearguments.js
@@ -26,7 +26,8 @@ module.exports = function parseArguments( args ) {
 			'repositories',
 			'language',
 			'theme-path',
-			'additional-languages'
+			'additional-languages',
+			'coverage-paths'
 		],
 
 		boolean: [
@@ -58,6 +59,7 @@ module.exports = function parseArguments( args ) {
 			language: 'en',
 			watch: false,
 			coverage: false,
+			'coverage-paths': '',
 			verbose: false,
 			'source-map': false,
 			server: false,
@@ -83,13 +85,15 @@ module.exports = function parseArguments( args ) {
 		'identity-file',
 		'theme-path',
 		'karma-config-overrides',
-		'additional-languages'
+		'additional-languages',
+		'coverage-paths'
 	] );
 	splitOptionsToArray( options, [
 		'browsers',
 		'files',
 		'repositories',
-		'additionalLanguages'
+		'additionalLanguages',
+		'coveragePaths'
 	] );
 	parseDebugOption( options );
 	parseRepositoriesOption( options );

--- a/packages/ckeditor5-dev-tests/lib/utils/transformfileoptiontotestglob.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/transformfileoptiontotestglob.js
@@ -7,7 +7,7 @@
 
 /**
  * Converts values of --files argument to proper globs.
- * There are 5 supported types of values now:
+ * These are the supported types of values:
  *
  * 0. the main repository - 'ckeditor5'
  * 1. all packages' files – '*'
@@ -15,6 +15,7 @@
  * 3. everything except the given package – '!engine'
  * 4. path – 'engine/view' -> 'ckeditor5-engine/tests/view/**\/*.js'
  * 5. simplified glob – 'engine/view/**\/*.js' -> 'ckeditor5-engine/tests/view/**\/*.js'
+ * 6. a glob starting with './', which stays as is - './tests/**\/*.js'
  *
  * @param {String} globPattern A path or pattern to determine the tests to execute.
  * @param {Boolean} [isManualTest=false] Whether the tests are manual or automated.
@@ -55,6 +56,11 @@ module.exports = function transformFileOptionToTestGlob( globPattern, isManualTe
  * @returns {String}
  */
 function transformSingleGlobPattern( globPattern, options ) {
+	// 6. Support for direct glob to test files.
+	if ( globPattern.startsWith( './' ) ) {
+		return globPattern;
+	}
+
 	const isManualTest = options.isManualTest || false;
 	const useCKEditorPrefix = options.useCKEditorPrefix || false;
 	const prefix = useCKEditorPrefix ? 'ckeditor' : 'ckeditor5';

--- a/packages/ckeditor5-dev-tests/tests/utils/transformfileoptiontotestglob.js
+++ b/packages/ckeditor5-dev-tests/tests/utils/transformfileoptiontotestglob.js
@@ -134,4 +134,18 @@ describe( 'dev-tests/utils', () => {
 			] );
 		} );
 	} );
+
+	describe( 'keep ./ paths intact', () => {
+		it( 'for automated tests', () => {
+			expect( transformFileOptionToTestGlob( './tests/**/*.js' ) ).to.deep.equal( [
+				'./tests/**/*.js'
+			] );
+		} );
+
+		it( 'for manual tests', () => {
+			expect( transformFileOptionToTestGlob( './tests/**/manual/*.js', true ) ).to.deep.equal( [
+				'./tests/**/manual/*.js'
+			] );
+		} );
+	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Made ckeditor5-dev-tests a general use application. Closes ckeditor/ckeditor5#7196.

---

### Additional information

This implementation is pretty simple, doing mainly the following:

*   Allow `--files` to point to resolved globs, by beginning the with `./`.
*   Introduced `--coverage-paths` to point to additional paths to be included in coverage.

It basically doesn't change the current features, just adding to top of them.

I've been able to successfully use this with arguments like `--files=./tests/unit/**/*.js --coverage-paths=./src`.

This should even allow to enable tests when cloning a single editor plugin, instead of having to deal with the big and fancy `ckeditor5` repo.