### PR TITLE
Added support for the `"` character in translation messages and contexts

### DIFF
--- a/packages/ckeditor5-dev-env/lib/translations/collect-utils.js
+++ b/packages/ckeditor5-dev-env/lib/translations/collect-utils.js
@@ -186,9 +186,9 @@ const utils = {
 		return translationObjects.map( translationObject => {
 			// Note that order is important.
 			return [
-				`msgctxt "${ translationObject.ctxt }"`,
-				`msgid "${ translationObject.id }"`,
-				`msgstr "${ translationObject.str }"`
+				`msgctxt ${ JSON.stringify( translationObject.ctxt ) }`,
+				`msgid ${ JSON.stringify( translationObject.id ) }`,
+				`msgstr ${ JSON.stringify( translationObject.str ) }`
 			].map( x => x + '\n' ).join( '' );
 		} ).join( '\n' );
 	},

--- a/packages/ckeditor5-dev-env/tests/translations/collect-utils.js
+++ b/packages/ckeditor5-dev-env/tests/translations/collect-utils.js
@@ -263,6 +263,20 @@ msgstr "util"
 			);
 			/* eslint-enable indent */
 		} );
+
+		it( 'should support the `"` character', () => {
+			const context = { content: { '"foo"': '"bar"' } };
+			const poContent = utils.createPotFileContent( context );
+
+			/* eslint-disable indent */
+			expect( poContent ).to.be.equal(
+`msgctxt "\\"bar\\""
+msgid "\\"foo\\""
+msgstr "\\"foo\\""
+`
+			);
+			/* eslint-enable indent */
+		} );
 	} );
 
 	describe( 'createPotFileHeader', () => {

--- a/packages/ckeditor5-dev-utils/tests/translations/singlelanguagetranslationservice.js
+++ b/packages/ckeditor5-dev-utils/tests/translations/singlelanguagetranslationservice.js
@@ -132,6 +132,18 @@ describe( 'translations', () => {
 				sinon.assert.calledOnce( spy );
 				sinon.assert.calledWithExactly( spy, 'First t() call argument should be a string literal in file.js.' );
 			} );
+
+			it( 'should handle correctly the special characters', () => {
+				const translationService = new SingleLanguageTranslationService( 'pl' );
+				const source = 't( \'Cancel\' )';
+
+				translationService._dictionary.Cancel = 'foo"\'';
+
+				const result = translationService.translateSource( source, 'file.js' );
+
+				// eslint-disable-next-line quotes
+				expect( result ).to.equal( `t('foo"\\'');` );
+			} );
 		} );
 
 		describe( 'getAssets()', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Added support for the `"` character in translation messages and contexts. Closes #523.

---

### Additional information

I need to ensure that the `"` characters won't break during building the editor with the CKEditor5 webpack plugin.

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
