### PR TITLE
Added data-cke attribute to style selector

### DIFF
--- a/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getwebpackconfig.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getwebpackconfig.js
@@ -28,7 +28,15 @@ module.exports = function getWebpackConfigForAutomatedTests( options ) {
 					// test: **/ckeditor5-*/theme/**/*.css
 					test: /\.css$/,
 					use: [
-						'style-loader',
+						{
+							loader: 'style-loader',
+							options: {
+								injectType: 'singletonStyleTag',
+								attributes: {
+									'data-cke': true
+								}
+							}
+						},
 						{
 							loader: 'postcss-loader',
 							options: getPostCssConfig( {

--- a/packages/ckeditor5-dev-tests/lib/utils/manual-tests/getwebpackconfig.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/manual-tests/getwebpackconfig.js
@@ -55,7 +55,13 @@ module.exports = function getWebpackConfigForManualTests( options ) {
 					test: /\.css$/,
 					use: [
 						{
-							loader: 'style-loader'
+							loader: 'style-loader',
+							options: {
+								injectType: 'singletonStyleTag',
+								attributes: {
+									'data-cke': true
+								}
+							}
 						},
 						{
 							loader: 'postcss-loader',


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: The inline `style` element which is being produced by Webpack and delivers styles for the editor will have the `[data-cke="true"]` attribute in order to help find CKEditor 5 styles. See ckeditor/ckeditor5#6454.
