### PR TITLE
i/611: Configured stylelint to enforce CSS indentation using tabs and hsl() colors

### DIFF
--- a/packages/stylelint-config-ckeditor5/.stylelintrc
+++ b/packages/stylelint-config-ckeditor5/.stylelintrc
@@ -2,6 +2,9 @@
 	"extends": "stylelint-config-recommended",
 	"rules": {
 		"at-rule-no-unknown": null,
-		"indentation": "tab"
+		"indentation": "tab",
+		"declaration-property-value-blacklist": {
+			"/color/": ["/^#/", "/^rgb/"]
+		}
 	}
 }

--- a/packages/stylelint-config-ckeditor5/.stylelintrc
+++ b/packages/stylelint-config-ckeditor5/.stylelintrc
@@ -1,6 +1,7 @@
 {
 	"extends": "stylelint-config-recommended",
 	"rules": {
-		"at-rule-no-unknown": null
+		"at-rule-no-unknown": null,
+		"indentation": "tab"
 	}
 }

--- a/packages/stylelint-config-ckeditor5/.stylelintrc
+++ b/packages/stylelint-config-ckeditor5/.stylelintrc
@@ -4,7 +4,8 @@
 		"at-rule-no-unknown": null,
 		"indentation": "tab",
 		"declaration-property-value-blacklist": {
-			"/color/": ["/^#/", "/^rgb/"]
-		}
+			"/.*/": ["/#/", "/rgb/"]
+		},
+		color-named: "never"
 	}
 }


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Configured stylelint to enforce CSS indentation using tabs and hsl() colors. Closes #611.

---

### Additional information

sub-PRs in v5 that fix stylelint errors (they can be merged regardless fo this PR):

* ckeditor5: https://github.com/ckeditor/ckeditor5/pull/6588
* theme-lark: https://github.com/ckeditor/ckeditor5-theme-lark/pull/278
* code-block https://github.com/ckeditor/ckeditor5-code-block/pull/12
* engine https://github.com/ckeditor/ckeditor5-engine/pull/1838
* highlight https://github.com/ckeditor/ckeditor5-highlight/pull/48
* pagebreak https://github.com/ckeditor/ckeditor5-page-break/pull/13
* widget https://github.com/ckeditor/ckeditor5-widget/pull/120

---

Let's make sure we release stylelint-config-ckeditor5 when this is all done (cc @pomek).