### PR TITLE
Code coverage is also stored as a JSON file

### DIFF
--- a/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getkarmaconfig.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getkarmaconfig.js
@@ -142,6 +142,10 @@ module.exports = function getKarmaConfig( options ) {
 					dir: coverageDir,
 					type: 'html'
 				},
+				{
+					dir: coverageDir,
+					type: 'json'
+				},
 				// Generates "lcov.info" file. It's used by external code coverage services.
 				{
 					type: 'lcovonly',


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Code coverage is also stored as a JSON file. Closes #615.