### PR TITLE
Made the leak detector print the outerHTML of the elements leaked.

### DIFF
--- a/packages/ckeditor5-dev-tests/lib/utils/automated-tests/leaksdetectorafter.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/automated-tests/leaksdetectorafter.js
@@ -7,11 +7,25 @@
 
 // eslint-disable-next-line mocha/no-top-level-hooks
 afterEach( function() {
-	if ( document.body.childElementCount !== this._lastDomElementsCount ) {
-		const leaksCount = document.body.childElementCount - this._lastDomElementsCount;
-		const errorMessage = `${ leaksCount } elements were leaked. Be a good citizen and clean your DOM once you're done with it.`;
+	let leaksCount = 0;
+	const lines = [];
 
-		this._lastDomElementsCount = document.body.childElementCount;
+	Array.from( document.body.children ).forEach( el => {
+		if ( !this._lastDomElements.has( el ) ) {
+			const html = el.outerHTML.length > 80 ?
+				el.outerHTML.substr( 0, 77 ) + '...' :
+				el.outerHTML;
+			lines.push( html );
+			leaksCount++;
+		}
+	} );
+
+	if ( leaksCount ) {
+		const errorMessage = `Elements leaked (${ leaksCount }):\n` +
+			lines.join( '\n' ) + '\n' +
+			'Be a good citizen and clean your DOM once you\'re done with it.';
+
+		this._lastDomElements = null;
 
 		// See https://github.com/ckeditor/ckeditor5-dev/issues/586#issuecomment-571573488.
 		if ( window.production ) {

--- a/packages/ckeditor5-dev-tests/lib/utils/automated-tests/leaksdetectorafter.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/automated-tests/leaksdetectorafter.js
@@ -8,21 +8,17 @@
 // eslint-disable-next-line mocha/no-top-level-hooks
 afterEach( function() {
 	let leaksCount = 0;
-	const lines = [];
-
-	Array.from( document.body.children ).forEach( el => {
-		if ( !this._lastDomElements.has( el ) ) {
-			const html = el.outerHTML.length > 80 ?
-				el.outerHTML.substr( 0, 77 ) + '...' :
-				el.outerHTML;
-			lines.push( html );
-			leaksCount++;
-		}
+	const leakedElementMarkups = Array.from( document.body.children ).filter( el => !this._lastDomElements.has( el ) ).map( el => {
+		const html = el.outerHTML.length > 80 ?
+			el.outerHTML.substr( 0, 77 ) + '...' :
+			el.outerHTML;
+		leaksCount++;
+		return html;
 	} );
 
 	if ( leaksCount ) {
 		const errorMessage = `Elements leaked (${ leaksCount }):\n` +
-			lines.join( '\n' ) + '\n' +
+			leakedElementMarkups.join( '\n' ) + '\n' +
 			'Be a good citizen and clean your DOM once you\'re done with it.';
 
 		this._lastDomElements = null;

--- a/packages/ckeditor5-dev-tests/lib/utils/automated-tests/leaksdetectorbefore.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/automated-tests/leaksdetectorbefore.js
@@ -7,5 +7,5 @@
 
 // eslint-disable-next-line mocha/no-top-level-hooks
 beforeEach( function() {
-	this._lastDomElementsCount = document.body.childElementCount;
+	this._lastDomElements = new WeakSet( document.body.children );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: The leak detector now prints the outerHTML of the elements leaked. Closes #617.

---

### Additional information

The outerHTML is cropped at 80 characters.

The check is a bit more precise now. Instead of just counting the elements, it checks precisely if new elements have been left in the dom after the test case.

With this patch, this is an example of the output I have:

```
ERROR: 'Elements leaked (1):
<div class="ck-filteredlist"><div class="select-menu-header d-flex"><span cla...
Be a good citizen and clean your DOM once you're done with it.'
```