### PR TITLE
Add support for advanced structures of messages inside `t()` calls

### DIFF
--- a/packages/ckeditor5-dev-utils/lib/translations/findmessages.js
+++ b/packages/ckeditor5-dev-utils/lib/translations/findmessages.js
@@ -53,10 +53,10 @@ module.exports = function findMessages( source, sourceFile, onMessageFound, onEr
 
 		const firstArgument = node.arguments[ 0 ];
 
-		findMessageInArgument( firstArgument );
+		findMessagesInExpression( firstArgument );
 	}
 
-	function findMessageInArgument( node ) {
+	function findMessagesInExpression( node ) {
 		// Matches t( { string: 'foo' } ) and t( { 'string': 'foo' } ).
 		// (also `plural` and `id` properties)
 		if ( node.type === 'ObjectExpression' ) {
@@ -99,8 +99,8 @@ module.exports = function findMessages( source, sourceFile, onMessageFound, onEr
 
 		// Matches t( foo ? 'bar' : { string: 'baz', plural: 'biz' } );
 		if ( node.type === 'ConditionalExpression' ) {
-			findMessageInArgument( node.consequent );
-			findMessageInArgument( node.alternate );
+			findMessagesInExpression( node.consequent );
+			findMessagesInExpression( node.alternate );
 
 			return;
 		}


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Added support for advanced structures of messages inside `t()` calls. Closes #622.

---

### Additional information

More information in the issue.