### PR TITLE
Make port number configurable for manual tests server.

### DIFF
--- a/packages/ckeditor5-dev-tests/lib/tasks/runmanualtests.js
+++ b/packages/ckeditor5-dev-tests/lib/tasks/runmanualtests.js
@@ -23,6 +23,7 @@ const transformFileOptionToTestGlob = require( '../utils/transformfileoptiontote
  * @param {String} options.themePath A path to the theme the PostCSS theme-importer plugin is supposed to load.
  * @param {String} [options.language] A language passed to `CKEditorWebpackPlugin`.
  * @param {Array.<String>} [options.additionalLanguages] Additional languages passed to `CKEditorWebpackPlugin`.
+ * @param {Number} [options.port] A port number used by the `createManualTestServer`.
  * @returns {Promise}
  */
 module.exports = function runManualTests( options ) {
@@ -57,5 +58,5 @@ module.exports = function runManualTests( options ) {
 			} ),
 			copyAssets( buildDir )
 		] ) )
-		.then( () => createManualTestServer( buildDir ) );
+		.then( () => createManualTestServer( buildDir, options.port ) );
 };

--- a/packages/ckeditor5-dev-tests/lib/utils/manual-tests/createserver.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/manual-tests/createserver.js
@@ -16,12 +16,13 @@ const globSync = require( '../glob' );
  * Basic HTTP server.
  *
  * @param {String} sourcePath Base path where the compiler saved the files.
+ * @param {Number} [port=8125] Port to listen at.
  */
-module.exports = function createManualTestServer( sourcePath ) {
+module.exports = function createManualTestServer( sourcePath, port = 8125 ) {
 	return new Promise( resolve => {
 		const server = http.createServer( ( request, response ) => {
 			onRequest( sourcePath, request, response );
-		} ).listen( 8125 );
+		} ).listen( port );
 
 		// SIGINT isn't caught on Windows in process. However CTRL+C can be catch
 		// by `readline` module. After that we can emit SIGINT to the process manually.
@@ -45,7 +46,7 @@ module.exports = function createManualTestServer( sourcePath ) {
 			process.exit();
 		} );
 
-		logger().info( '[Server] Server running at http://localhost:8125/' );
+		logger().info( `[Server] Server running at http://localhost:${ port }/` );
 	} );
 };
 

--- a/packages/ckeditor5-dev-tests/package.json
+++ b/packages/ckeditor5-dev-tests/package.json
@@ -49,7 +49,8 @@
   },
   "devDependencies": {
     "mockery": "^2.1.0",
-    "proxyquire": "^2.1.0"
+    "proxyquire": "^2.1.0",
+    "sinon-chai": "^3.5.0"
   },
   "engines": {
     "node": ">=8.0.0",

--- a/packages/ckeditor5-dev-tests/tests/tasks/runmanualtests.js
+++ b/packages/ckeditor5-dev-tests/tests/tasks/runmanualtests.js
@@ -226,4 +226,30 @@ describe( 'runManualTests', () => {
 				expect( spies.server.firstCall.args[ 0 ] ).to.equal( 'workspace/build/.manual-tests' );
 			} );
 	} );
+
+	it( 'allows specifying port', () => {
+		spies.transformFileOptionToTestGlob.onFirstCall().returns( [
+			'workspace/packages/ckeditor5-build-classic/tests/**/manual/**/*.js',
+			'workspace/packages/ckeditor4-build-classic/tests/**/manual/**/*.js'
+		] );
+		spies.transformFileOptionToTestGlob.onSecondCall().returns( [
+			'workspace/packages/ckeditor5-editor-classic/tests/manual/**/*.js',
+			'workspace/packages/ckeditor-editor-classic/tests/manual/**/*.js'
+		] );
+
+		const options = {
+			files: [
+				'build-classic',
+				'editor-classic/manual/classic.js'
+			],
+			port: 8888
+		};
+
+		return runManualTests( options )
+			.then( () => {
+				expect( spies.server.calledOnce ).to.equal( true );
+				expect( spies.server.firstCall.args[ 0 ] ).to.equal( 'workspace/build/.manual-tests' );
+				expect( spies.server.firstCall.args[ 1 ] ).to.equal( 8888 );
+			} );
+	} );
 } );

--- a/packages/ckeditor5-dev-tests/tests/utils/manual-tests/createserver.js
+++ b/packages/ckeditor5-dev-tests/tests/utils/manual-tests/createserver.js
@@ -12,13 +12,13 @@ use( sinonChai );
 const http = require( 'http' );
 
 describe( 'createManualTestServer', () => {
-	let sandbox, httpCreateServerStub, createManualTestServer;
+	let sandbox, httpCreateServerStub, createManualTestServer, server;
 
 	beforeEach( () => {
 		sandbox = sinon.createSandbox();
 
 		httpCreateServerStub = sandbox.stub( http, 'createServer' ).callsFake( function stubbedCreateServer( ...theArgs ) {
-			const server = httpCreateServerStub.wrappedMethod( ...theArgs );
+			server = httpCreateServerStub.wrappedMethod( ...theArgs );
 			sandbox.spy( server, 'listen' );
 
 			return server;
@@ -29,6 +29,7 @@ describe( 'createManualTestServer', () => {
 
 	afterEach( () => {
 		sandbox.restore();
+		server.close();
 	} );
 
 	it( 'should start http server', () => {

--- a/packages/ckeditor5-dev-tests/tests/utils/manual-tests/createserver.js
+++ b/packages/ckeditor5-dev-tests/tests/utils/manual-tests/createserver.js
@@ -1,0 +1,51 @@
+/**
+ * @license Copyright (c) 2003-2020, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+'use strict';
+
+const { use, expect } = require( 'chai' );
+const sinon = require( 'sinon' );
+const sinonChai = require( 'sinon-chai' );
+use( sinonChai );
+const http = require( 'http' );
+
+describe( 'createManualTestServer', () => {
+	let sandbox, httpCreateServerStub, createManualTestServer;
+
+	beforeEach( () => {
+		sandbox = sinon.createSandbox();
+
+		httpCreateServerStub = sandbox.stub( http, 'createServer' ).callsFake( function stubbedCreateServer( ...theArgs ) {
+			const server = httpCreateServerStub.wrappedMethod( ...theArgs );
+			sandbox.spy( server, 'listen' );
+
+			return server;
+		} );
+
+		createManualTestServer = require( '../../../lib/utils/manual-tests/createserver' );
+	} );
+
+	afterEach( () => {
+		sandbox.restore();
+	} );
+
+	it( 'should start http server', () => {
+		createManualTestServer( 'workspace/build/.manual-tests' );
+
+		expect( httpCreateServerStub ).to.be.calledOnce;
+	} );
+
+	it( 'should listen on given port', () => {
+		createManualTestServer( 'workspace/build/.manual-tests', 8888 );
+
+		expect( httpCreateServerStub.returnValues[ 0 ].listen ).to.be.calledOnceWith( 8888 );
+	} );
+
+	it( 'should listen on 8125 port if no specific port was given', () => {
+		createManualTestServer( 'workspace/build/.manual-tests' );
+
+		expect( httpCreateServerStub.returnValues[ 0 ].listen ).to.be.calledOnceWith( 8125 );
+	} );
+} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Make port number configurable for manual tests server. Closes #632.

---

### Additional information

It's useful when running multiple servers on the same machine, or when one server hangs for unknown reasons. I also added a test for starting the server without any params.
