### PR TITLE
Manual test server will parse builds

### DIFF
--- a/packages/ckeditor5-dev-tests/lib/utils/getrelativefilepath.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/getrelativefilepath.js
@@ -5,23 +5,31 @@
 
 'use strict';
 
+const path = require( 'path' );
+
 /**
  * Get a path to a source file which will uniquely identify this file in
  * a build directory, once all packages are gathered together.
  *
- * In order to do that, everything up to `ckeditor5?-packageName` is removed:
- * /work/space/ckeditor5/tests/manual/foo.js -> ckeditor5/tests/manual/foo.js
- * /work/space/ckeditor/tests/manual/foo.js -> ckeditor/tests/manual/foo.js
- * /work/space/ckeditor5-foo/tests/manual/foo.js -> ckeditor5-foo/tests/manual/foo.js
- * /work/space/ckeditor-foo/tests/manual/foo.js -> ckeditor-foo/tests/manual/foo.js
+ * E.g.:
+ *   - /work/space/ckeditor5/tests/manual/foo.js -> ckeditor5/tests/manual/foo.js
+ *   - /work/space/ckeditor/tests/manual/foo.js -> ckeditor/tests/manual/foo.js
+ *   - /work/space/packages/ckeditor5-foo/tests/manual/foo.js -> ckeditor5-foo/tests/manual/foo.js
+ *   - /work/space/packages/ckeditor-foo/tests/manual/foo.js -> ckeditor-foo/tests/manual/foo.js
  *
  * @param {String} filePath
+ * @param {String} [cwd=process.cwd()]
  * @returns {String}
  */
-module.exports = function getRelativeFilePath( filePath ) {
-	return filePath.replace( /^.+[/\\]ckeditor(5)?(-)?/, ( ...match ) => {
-		const ckeditor = match[ 1 ] ? 'ckeditor5' : 'ckeditor';
+module.exports = function getRelativeFilePath( filePath, cwd = process.cwd() ) {
+	// The path ends with the directory separator.
+	const relativePath = filePath.replace( cwd, '' ).slice( 1 );
 
-		return match[ 2 ] ? `${ ckeditor }-` : ckeditor;
-	} );
+	// A package.
+	if ( relativePath.startsWith( 'packages' ) ) {
+		return relativePath.replace( 'packages', '' ).slice( 1 );
+	}
+
+	// The main repository.
+	return path.join( 'ckeditor5', relativePath );
 };

--- a/packages/ckeditor5-dev-tests/tests/utils/getrelativefilepath.js
+++ b/packages/ckeditor5-dev-tests/tests/utils/getrelativefilepath.js
@@ -5,6 +5,8 @@
 
 'use strict';
 
+const path = require( 'path' );
+const sinon = require( 'sinon' );
 const { expect } = require( 'chai' );
 
 describe( 'dev-tests/utils', () => {
@@ -15,71 +17,123 @@ describe( 'dev-tests/utils', () => {
 	} );
 
 	describe( 'getRelativeFilePath()', () => {
+		let sandbox;
+
+		beforeEach( () => {
+			sandbox = sinon.createSandbox();
+		} );
+
+		afterEach( () => {
+			sandbox.restore();
+		} );
+
 		describe( 'Unix paths', () => {
+			beforeEach( () => {
+				sandbox.stub( path, 'join' ).callsFake( ( ...args ) => args.join( '/' ) );
+			} );
+
 			it( 'returns path which starts with package name (simple check)', () => {
-				checkPath( '/work/space/ckeditor5-foo/tests/manual/foo.js', 'ckeditor5-foo/tests/manual/foo.js' );
+				sandbox.stub( process, 'cwd' ).returns( '/Users/foo' );
+
+				checkPath( '/Users/foo/packages/ckeditor5-foo/tests/manual/foo.js', 'ckeditor5-foo/tests/manual/foo.js' );
 			} );
 
 			it( 'returns path which starts with package name (workspace directory looks like package name)', () => {
+				sandbox.stub( process, 'cwd' ).returns( '/Users/foo/ckeditor5-workspace/ckeditor5' );
+
 				checkPath(
 					'/Users/foo/ckeditor5-workspace/ckeditor5/packages/ckeditor5-foo/tests/manual/foo.js',
 					'ckeditor5-foo/tests/manual/foo.js'
 				);
 			} );
 
-			it( 'returns path which starts with package name (nested dependencies)', () => {
-				checkPath(
-					'/home/foo/ckeditor5/packages/ckeditor5-build-classic/node_modules/@ckeditor/ckeditor5-foo/tests/manual/foo.js',
-					'ckeditor5-foo/tests/manual/foo.js'
-				);
-			} );
-
-			it( 'returns path which starts with package name (combined workspace looks like package and nested dependencies)', () => {
-				/* eslint-disable max-len */
-				checkPath(
-					'/Users/foo/ckeditor5-workspace/ckeditor5/ckeditor5-build-classic/node_modules/@ckeditor/ckeditor5-foo/tests/manual/foo.js',
-					'ckeditor5-foo/tests/manual/foo.js'
-				);
-				/* eslint-enable max-len */
-			} );
-
 			it( 'returns a proper path for "ckeditor-" prefix', () => {
-				checkPath( '/work/space/ckeditor-foo/tests/manual/foo.js', 'ckeditor-foo/tests/manual/foo.js' );
+				sandbox.stub( process, 'cwd' ).returns( '/work/space' );
+
+				checkPath( '/work/space/packages/ckeditor-foo/tests/manual/foo.js', 'ckeditor-foo/tests/manual/foo.js' );
+			} );
+
+			it( 'returns a proper path for "ckeditor-" prefix and "ckeditor.js" file', () => {
+				sandbox.stub( process, 'cwd' ).returns( '/work/space' );
+
+				checkPath( '/work/space/packages/ckeditor-foo/tests/manual/ckeditor.js', 'ckeditor-foo/tests/manual/ckeditor.js' );
 			} );
 
 			it( 'returns a proper path to from the main (root) package', () => {
-				checkPath( '/work/space/ckeditor5/tests/manual/foo.js', 'ckeditor5/tests/manual/foo.js' );
+				sandbox.stub( process, 'cwd' ).returns( '/work/space' );
+				checkPath( '/work/space/packages/ckeditor5/tests/manual/foo.js', 'ckeditor5/tests/manual/foo.js' );
+			} );
+
+			it( 'returns a proper path for "ckeditor5.js" file', () => {
+				sandbox.stub( process, 'cwd' ).returns( '/work/space' );
+				checkPath(
+					'/work/space/packages/ckeditor5-build-a/tests/manual/ckeditor5.js',
+					'ckeditor5-build-a/tests/manual/ckeditor5.js'
+				);
+			} );
+
+			it( 'returns a proper path for "ckeditor.js" file', () => {
+				sandbox.stub( process, 'cwd' ).returns( '/work/space' );
+				checkPath(
+					'/work/space/packages/ckeditor5-build-a/tests/manual/ckeditor.js',
+					'ckeditor5-build-a/tests/manual/ckeditor.js' );
 			} );
 		} );
 
 		describe( 'Windows paths', () => {
+			beforeEach( () => {
+				sandbox.stub( path, 'join' ).callsFake( ( ...args ) => args.join( '\\' ) );
+			} );
+
 			it( 'returns path which starts with package name (simple check)', () => {
-				checkPath( 'C:\\work\\space\\ckeditor5-foo\\tests\\manual\\foo.js', 'ckeditor5-foo\\tests\\manual\\foo.js' );
+				sandbox.stub( process, 'cwd' ).returns( 'C:\\work\\space' );
+
+				checkPath( 'C:\\work\\space\\packages\\ckeditor5-foo\\tests\\manual\\foo.js', 'ckeditor5-foo\\tests\\manual\\foo.js' );
 			} );
 
 			it( 'returns path which starts with package name (workspace directory looks like package name)', () => {
+				sandbox.stub( process, 'cwd' ).returns( 'C:\\Document and settings\\foo\\ckeditor5-workspace\\ckeditor5' );
+
 				checkPath(
 					'C:\\Document and settings\\foo\\ckeditor5-workspace\\ckeditor5\\packages\\ckeditor5-foo\\tests\\manual\\foo.js',
 					'ckeditor5-foo\\tests\\manual\\foo.js'
 				);
 			} );
 
-			it( 'returns path which starts with package name (nested dependencies)', () => {
-				/* eslint-disable max-len */
-				checkPath(
-					'C:\\Document and settings\\ckeditor5\\packages\\ckeditor5-build-classic\\node_modules\\@ckeditor\\ckeditor5-foo\\tests\\manual\\foo.js',
-					'ckeditor5-foo\\tests\\manual\\foo.js'
-				);
-				/* eslint-enable max-len */
+			it( 'returns a proper path for "ckeditor-" prefix', () => {
+				sandbox.stub( process, 'cwd' ).returns( 'C:\\work\\space' );
+
+				checkPath( 'C:\\work\\space\\packages\\ckeditor-foo\\tests\\manual\\foo.js', 'ckeditor-foo\\tests\\manual\\foo.js' );
 			} );
 
-			it( 'returns path which starts with package name (combined workspace looks like package and nested dependencies)', () => {
-				/* eslint-disable max-len */
+			it( 'returns a proper path for "ckeditor-" prefix and "ckeditor.js" file', () => {
+				sandbox.stub( process, 'cwd' ).returns( 'C:\\work\\space' );
+
 				checkPath(
-					'C:\\Users\\foo\\ckeditor5-workspace\\ckeditor5\\ckeditor5-build-classic\\node_modules\\@ckeditor\\ckeditor5-foo\\tests\\manual\\foo.js',
-					'ckeditor5-foo\\tests\\manual\\foo.js'
+					'C:\\work\\space\\packages\\ckeditor-foo\\tests\\manual\\ckeditor.js',
+					'ckeditor-foo\\tests\\manual\\ckeditor.js'
 				);
-				/* eslint-enable max-len */
+			} );
+
+			it( 'returns a proper path to from the main (root) package', () => {
+				sandbox.stub( process, 'cwd' ).returns( 'C:\\work\\space' );
+				checkPath( 'C:\\work\\space\\tests\\manual\\foo.js', 'ckeditor5\\tests\\manual\\foo.js' );
+			} );
+
+			it( 'returns a proper path for "ckeditor5.js" file', () => {
+				sandbox.stub( process, 'cwd' ).returns( 'C:\\work\\space' );
+				checkPath(
+					'C:\\work\\space\\packages\\ckeditor5-build-a\\tests\\manual\\ckeditor5.js',
+					'ckeditor5-build-a\\tests\\manual\\ckeditor5.js'
+				);
+			} );
+
+			it( 'returns a proper path for "ckeditor.js" file', () => {
+				sandbox.stub( process, 'cwd' ).returns( 'C:\\work\\space' );
+				checkPath(
+					'C:\\work\\space\\packages\\ckeditor5-build-a\\tests\\manual\\ckeditor.js',
+					'ckeditor5-build-a\\tests\\manual\\ckeditor.js'
+				);
 			} );
 		} );
 	} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix (tests): The `getRelativeFilePath()` util will return proper paths for CKEditor 5 builds. Closes ckeditor/ckeditor5#7280. Closes ckeditor/ckeditor5#7093.
