### PR TITLE
Allows releasing packages from the non-master branch

### DIFF
--- a/packages/ckeditor5-dev-env/lib/release-tools/tasks/bumpversions.js
+++ b/packages/ckeditor5-dev-env/lib/release-tools/tasks/bumpversions.js
@@ -36,6 +36,7 @@ const BREAK_RELEASE_MESSAGE = 'You aborted updating versions. Why? Oh why?!';
  * @param {Boolean} [options.dryRun=false] If set on true, all changes will be printed on the screen. Changes produced by commands like
  * `npm version` will be reverted. Every called command will be displayed.
  * @param {Boolean} [options.skipMainRepository=false] If set on true, package found in "cwd" will be skipped.
+ * @param {String} [options.releaseBranch='master'] A name of the branch that should be used for releasing packages.
  * @returns {Promise}
  */
 module.exports = function bumpVersions( options ) {
@@ -53,6 +54,7 @@ module.exports = function bumpVersions( options ) {
 
 	const mainRepositoryVersion = versions.getLastFromChangelog( options.cwd );
 	const mainChangelog = changelog.getChangesForVersion( mainRepositoryVersion );
+	const releaseBranch = options.releaseBranch || 'master';
 
 	logDryRun( '⚠️  DRY RUN mode ⚠️' );
 	logDryRun( 'All changes made by this script will be reverted automatically.' );
@@ -250,6 +252,7 @@ module.exports = function bumpVersions( options ) {
 		const releaseDetails = packages.get( mainPackageJson.name );
 
 		const errors = validatePackageToRelease( {
+			branch: releaseBranch,
 			changes: releaseDetails.changes,
 			version: releaseDetails.version
 		} );

--- a/packages/ckeditor5-dev-env/lib/release-tools/utils/validatepackagetorelease.js
+++ b/packages/ckeditor5-dev-env/lib/release-tools/utils/validatepackagetorelease.js
@@ -12,17 +12,19 @@ const { tools } = require( '@ckeditor/ckeditor5-dev-utils' );
  * @param {String} options.version Version of the current release.
  * @param {String} options.changes Changelog entries for the current release.
  * @param {Boolean} [options.ignoreBranchCheck=false] If set on true, branch checking will be skipped.
+ * @param {String} [options.branch='master'] A name of the branch that should be used for releasing packages.
  * @returns {Array.<String>}
  */
 module.exports = function validatePackageToRelease( options ) {
 	const errors = [];
+	const branch = options.branch || 'master';
 
 	// Check whether the repository is ready for the release.
 	const status = exec( 'git status -sb', { verbosity: 'error' } ).trim();
 
 	if ( !options.ignoreBranchCheck ) {
 		// Check whether current branch is "master".
-		if ( !status.startsWith( '## master...origin/master' ) ) {
+		if ( !status.startsWith( `## ${ branch }...origin/${ branch }` ) ) {
 			errors.push( 'Not on master.' );
 		}
 	}

--- a/packages/ckeditor5-dev-env/lib/release-tools/utils/validatepackagetorelease.js
+++ b/packages/ckeditor5-dev-env/lib/release-tools/utils/validatepackagetorelease.js
@@ -25,7 +25,7 @@ module.exports = function validatePackageToRelease( options ) {
 	if ( !options.ignoreBranchCheck ) {
 		// Check whether current branch is "master".
 		if ( !status.startsWith( `## ${ branch }...origin/${ branch }` ) ) {
-			errors.push( 'Not on master.' );
+			errors.push( `Not on ${ branch } branch.` );
 		}
 	}
 

--- a/packages/ckeditor5-dev-env/tests/release-tools/utils/validatepackagetorelease.js
+++ b/packages/ckeditor5-dev-env/tests/release-tools/utils/validatepackagetorelease.js
@@ -92,5 +92,27 @@ describe( 'dev-env/release-tools/utils', () => {
 
 			expect( errors.length ).to.equal( 0 );
 		} );
+
+		it( 'uses non-master branch for releasing if specified', () => {
+			stubs.devUtils.tools.shExec.returns( '## release...origin/release' );
+
+			const errors = validatePackageToRelease( { branch: 'release', changes: 'Some changes.', version: '1.0.0' } );
+
+			expect( errors ).to.be.an( 'Array' );
+			expect( errors.length ).to.equal( 0 );
+		} );
+
+		it( 'allows skipping the branch check (even if specified)', () => {
+			stubs.devUtils.tools.shExec.returns( '## develop...origin/develop' );
+
+			const errors = validatePackageToRelease( {
+				branch: 'release',
+				changes: 'Some changes.',
+				version: '1.0.0',
+				ignoreBranchCheck: true
+			} );
+
+			expect( errors.length ).to.equal( 0 );
+		} );
 	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature (env): Allows releasing packages from the non-master branch. Closes ckeditor/ckeditor5#7271.

Task `bumpVersions()` accepts `options.releaseBranch` (by default is `'master'`) which defined the branch using for releasing.
