### PR TITLE
Changelog generator - "skip" breaks the process

### DIFF
--- a/packages/ckeditor5-dev-env/lib/release-tools/tasks/generatechangelogforsinglepackage.js
+++ b/packages/ckeditor5-dev-env/lib/release-tools/tasks/generatechangelogforsinglepackage.js
@@ -175,8 +175,7 @@ module.exports = function generateChangelogForSinglePackage( options = {} ) {
 				return;
 			}
 
-			log.error( err.stack );
-			process.exitCode = -1;
+			throw err;
 		} );
 
 	function logProcess( message ) {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: When typed "skip" as a new version, the changelog generator should abort the process instead of writing invalid entries to the changelog file. Closes ckeditor/ckeditor5#7402.
