### PR TITLE
Avoid hook to be called in mini-css-extract-plugin context

### DIFF
--- a/packages/ckeditor5-dev-webpack-plugin/lib/servetranslations.js
+++ b/packages/ckeditor5-dev-webpack-plugin/lib/servetranslations.js
@@ -89,6 +89,10 @@ module.exports = function serveTranslations( compiler, options, translationServi
 		// At the end of the compilation add assets generated from the PO files.
 		// Use `optimize-chunk-assets` instead of `emit` to emit assets before the `webpack.BannerPlugin`.
 		compilation.hooks.optimizeChunkAssets.tap( 'CKEditor5Plugin', chunks => {
+			if(chunks.length === 1 && chunks[0].name === 'mini-css-extract-plugin') {
+				return 
+			}
+			
 			const generatedAssets = translationService.getAssets( {
 				outputDirectory: options.outputDirectory,
 				compilationAssetNames: Object.keys( compilation.assets )


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Avoids "optimizeChunkAssets" hook to be executed in mini-css-extract-plugin context
---

### Additional information

I'm using this plugin to build ckeditor along with my app in one big webpack config. This pull request avoids "optimizeChunkAssets" hook to be executed when mini-css-extract-plugin is invoked in production to extract css from my chunks. It's producing innumerous warnings on console output for each locale, like:

Conflict: Multiple assets emit different content to the same filename ckeditor5-trans/de.js