### PR TITLE
Removed scoped BC notes from commit's footer

### DIFF
--- a/packages/ckeditor5-dev-env/lib/release-tools/utils/transformcommitfactory.js
+++ b/packages/ckeditor5-dev-env/lib/release-tools/utils/transformcommitfactory.js
@@ -110,7 +110,7 @@ module.exports = function transformCommitFactory( options = {} ) {
 						// For each footer line checks whether the line starts with note prefix.
 						// If so, this footer line should be removed.
 						const noteToRemove = commitsNotes.find( note => {
-							return footerLine == `${ note.title }: ${ note.text }`;
+							return footerLine.startsWith( note.title ) && footerLine.endsWith( note.text );
 						} );
 
 						// In order to avoid checking the same note, remove it.
@@ -121,7 +121,7 @@ module.exports = function transformCommitFactory( options = {} ) {
 						return !noteToRemove;
 					} )
 					.join( '\n' )
-					.trim();
+					.trim() || null;
 			}
 
 			// If `body` of the commit is empty but the `footer` isn't, let's swap those.
@@ -314,7 +314,7 @@ module.exports = function transformCommitFactory( options = {} ) {
 	 *
 	 * E.g.:
 	 *   - input: `Fix (engine): Fixed...
-	 *   - output: { rawType: 'Fix', scope: [ 'engine'] }
+	 *   - output: { rawType: 'Fix', scope: [ 'engine' ] }
 	 *
 	 * For commits with no scope, `null` will be returned instead of the array (as `scope`).
 	 *
@@ -348,7 +348,7 @@ module.exports = function transformCommitFactory( options = {} ) {
 	 *
 	 * E.g.:
 	 *   - input: `(engine): Removed...
-	 *   - output: { text: 'Removed...', scope: [ 'engine'] }
+	 *   - output: { text: 'Removed...', scope: [ 'engine' ] }
 	 *
 	 * For notes with no scope, `null` will be returned instead of the array (as `scope`).
 	 *

--- a/packages/ckeditor5-dev-env/tests/release-tools/utils/transformcommitfactory.js
+++ b/packages/ckeditor5-dev-env/tests/release-tools/utils/transformcommitfactory.js
@@ -443,6 +443,32 @@ describe( 'dev-env/release-tools/utils', () => {
 				expect( commit.notes ).to.deep.equal( notes );
 			} );
 
+			// See: https://github.com/ckeditor/ckeditor5/issues/7495.
+			it( 'removes duplicated scoped notes from the footer', () => {
+				const rawCommit = {
+					type: 'Other (table)',
+					subject: 'Extracted `TableMouse` plugin from `TableSelection` plugin. Closes #6757.',
+					merge: 'Merge pull request #7355 from ckeditor/i/6757',
+					header: 'Other (table): Extracted `TableMouse` plugin from `TableSelection` plugin. Closes #6757.',
+					body: null,
+					footer: 'MINOR BREAKING CHANGE (table): The `TableNavigation` plugin renamed to `TableKeyboard`.',
+					notes: [
+						{
+							title: 'MINOR BREAKING CHANGE',
+							text: '(table): The `TableNavigation` plugin renamed to `TableKeyboard`.'
+						}
+					],
+					references: [],
+					mentions: [],
+					revert: null,
+					hash: '4d2f5f9b9f298601b332f304da66333c52673cb8'
+				};
+
+				const commit = transformCommit( rawCommit );
+
+				expect( commit.footer ).to.equal( null );
+			} );
+
 			describe( '"Closes" references - merging into single entry', () => {
 				it( 'works for #id pattern', () => {
 					const rawCommit = {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix (env): Scoped breaking changes notes won't be duplicated in the commit's footer. Closes ckeditor/ckeditor5#7495.

---

### Additional information

A commit used in the test is the same as what caused the problem.
