### PR TITLE
Merge between stable/release/master should be ignored

### DIFF
--- a/packages/ckeditor5-dev-env/lib/release-tools/utils/transformcommitfactory.js
+++ b/packages/ckeditor5-dev-env/lib/release-tools/utils/transformcommitfactory.js
@@ -77,7 +77,7 @@ module.exports = function transformCommitFactory( options = {} ) {
 		}
 
 		// Ignore the `stable` merge branch.
-		if ( commit.merge === 'Merge branch \'stable\'' ) {
+		if ( isInternalMergeCommit( commit ) ) {
 			return;
 		}
 
@@ -380,6 +380,25 @@ module.exports = function transformCommitFactory( options = {} ) {
 	function escapeNewLines( message ) {
 		// Accept spaces before a sentence because they are ready to be rendered in the changelog template.
 		return message.replace( /^\n+|\s+$/g, '' );
+	}
+
+	function isInternalMergeCommit( commit ) {
+		if ( !commit.merge ) {
+			return false;
+		}
+
+		// Internal merges between branches. When creating a release, synchronising the documentation, etc.
+		// Also merge those branches into the feature branch.
+		if ( commit.merge.match( /^Merge( branch)? '?(master|release|stable)'?( into '?(master|release|stable)'?)?/ ) ) {
+			return true;
+		}
+
+		// Merge `origin/master` into the feature branch.
+		if ( commit.merge.match( /^Merge remote-tracking branch 'origin\/master/ ) ) {
+			return true;
+		}
+
+		return false;
 	}
 };
 

--- a/packages/ckeditor5-dev-env/tests/release-tools/utils/transformcommitfactory.js
+++ b/packages/ckeditor5-dev-env/tests/release-tools/utils/transformcommitfactory.js
@@ -426,7 +426,7 @@ describe( 'dev-env/release-tools/utils', () => {
 			} );
 
 			// See: https://github.com/ckeditor/ckeditor5/issues/7489.
-			describe.only( 'internal merge commits', () => {
+			describe( 'internal merge commits', () => {
 				const mergeCommitsToIgnore = [
 					'Merge branch \'stable\'',
 					'Merge branch \'master\'',

--- a/packages/ckeditor5-dev-env/tests/release-tools/utils/transformcommitfactory.js
+++ b/packages/ckeditor5-dev-env/tests/release-tools/utils/transformcommitfactory.js
@@ -309,31 +309,6 @@ describe( 'dev-env/release-tools/utils', () => {
 				expect( commit.footer ).to.equal( null );
 			} );
 
-			it( 'fixes the commit which does not contain the second line', () => {
-				const rawCommit = {
-					type: null,
-					subject: null,
-					merge: 'Merge branch \'master\' of github.com:ckeditor/ckeditor5-dev',
-					header: '-hash-',
-					body: '575e00bc8ece48826adefe226c4fb1fe071c73a7',
-					footer: null,
-					notes: [],
-					references: [],
-					mentions: [],
-					revert: null
-				};
-
-				const transformCommit = transformCommitFactory( {
-					returnInvalidCommit: true
-				} );
-
-				const commit = transformCommit( rawCommit );
-
-				expect( commit.hash ).to.equal( '575e00bc8ece48826adefe226c4fb1fe071c73a7' );
-				expect( commit.header ).to.equal( 'Merge branch \'master\' of github.com:ckeditor/ckeditor5-dev' );
-				expect( commit.body ).to.equal( null );
-			} );
-
 			it( 'removes [skip ci] from the commit message', () => {
 				const rawCommit = {
 					hash: '684997d0eb2eca76b9e058fb1c3fa00b50059cdc',


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other (env): Merge commits between `stable/release/master` branches will be ignored when generating the changelog. Those generate too much noise. Closes ckeditor/ckeditor5#7489.
