### PR TITLE
Commit and note groups should be sorted properly

### DIFF
--- a/packages/ckeditor5-dev-env/lib/release-tools/utils/getwriteroptions.js
+++ b/packages/ckeditor5-dev-env/lib/release-tools/utils/getwriteroptions.js
@@ -8,7 +8,7 @@
 const fs = require( 'fs' );
 const path = require( 'path' );
 const templatePath = path.join( __dirname, '..', 'templates' );
-const { typesOrder } = require( './transformcommitutils' );
+const { getTypeOrder } = require( './transformcommitutils' );
 
 /**
  * @param {Function|Object} transform
@@ -18,16 +18,16 @@ module.exports = function getWriterOptions( transform ) {
 	return {
 		transform,
 		groupBy: 'type',
-		commitGroupsSort( a, b ) {
-			return typesOrder[ a.title ] - typesOrder[ b.title ];
-		},
+		commitGroupsSort: sortFunction,
 		commitsSort: [ 'subject' ],
-		noteGroupsSort( a, b ) {
-			return typesOrder[ a.title ] - typesOrder[ b.title ];
-		},
+		noteGroupsSort: sortFunction,
 		mainTemplate: fs.readFileSync( path.join( templatePath, 'template.hbs' ), 'utf-8' ),
 		headerPartial: fs.readFileSync( path.join( templatePath, 'header.hbs' ), 'utf-8' ),
 		commitPartial: fs.readFileSync( path.join( templatePath, 'commit.hbs' ), 'utf-8' ),
 		footerPartial: fs.readFileSync( path.join( templatePath, 'footer.hbs' ), 'utf-8' )
 	};
 };
+
+function sortFunction( a, b ) {
+	return getTypeOrder( a.title ) - getTypeOrder( b.title );
+}

--- a/packages/ckeditor5-dev-env/lib/release-tools/utils/transformcommitutils.js
+++ b/packages/ckeditor5-dev-env/lib/release-tools/utils/transformcommitutils.js
@@ -7,7 +7,7 @@
 
 const getPackageJson = require( './getpackagejson' );
 
-const transformcommitutils = {
+const transformCommitUtils = {
 	/**
 	 * A regexp for extracting additional changelog entries from the single commit.
 	 * Prefixes of the commit must be synchronized the `getCommitType()` util.
@@ -44,6 +44,22 @@ const transformcommitutils = {
 	},
 
 	/**
+	 * Returns an order of a message in the changelog.
+	 *
+	 * @param {String} title
+	 * @returns {Number}
+	 */
+	getTypeOrder( title ) {
+		for ( const typeTitle of Object.keys( transformCommitUtils.typesOrder ) ) {
+			if ( title.startsWith( typeTitle ) ) {
+				return transformCommitUtils.typesOrder[ typeTitle ];
+			}
+		}
+
+		return 10;
+	},
+
+	/**
 	 * Replaces reference to the user (`@name`) with a link to the user's profile.
 	 *
 	 * @param {String} comment
@@ -72,7 +88,7 @@ const transformcommitutils = {
 				return `[${ maybeRepository }#${ issueId }](https://github.com/${ maybeRepository }/issues/${ issueId })`;
 			}
 
-			const repositoryUrl = transformcommitutils.getRepositoryUrl();
+			const repositoryUrl = transformCommitUtils.getRepositoryUrl();
 
 			// But if doesn't, let's add it.
 			return `[#${ issueId }](${ repositoryUrl }/issues/${ issueId })`;
@@ -144,4 +160,4 @@ const transformcommitutils = {
 	}
 };
 
-module.exports = transformcommitutils;
+module.exports = transformCommitUtils;

--- a/packages/ckeditor5-dev-env/tests/release-tools/utils/getwriteroptions.js
+++ b/packages/ckeditor5-dev-env/tests/release-tools/utils/getwriteroptions.js
@@ -39,5 +39,69 @@ describe( 'dev-env/release-tools/utils', () => {
 			expect( writerOptions.commitGroupsSort ).to.be.a( 'function' );
 			expect( writerOptions.noteGroupsSort ).to.be.a( 'function' );
 		} );
+
+		it( 'sorts notes properly', () => {
+			const writerOptions = getWriterOptions( transformSpy );
+
+			const noteGroups = [
+				{ title: 'BREAKING CHANGES', notes: [] },
+				{ title: 'MINOR BREAKING CHANGES', notes: [] },
+				{ title: 'MAJOR BREAKING CHANGES', notes: [] }
+			];
+
+			expect( noteGroups.sort( writerOptions.noteGroupsSort ) ).to.deep.equal( [
+				{ title: 'MAJOR BREAKING CHANGES', notes: [] },
+				{ title: 'MINOR BREAKING CHANGES', notes: [] },
+				{ title: 'BREAKING CHANGES', notes: [] }
+			] );
+		} );
+
+		it( 'sorts notes properly (titles with emojis)', () => {
+			const writerOptions = getWriterOptions( transformSpy );
+
+			const noteGroups = [
+				{ title: 'BREAKING CHANGES [ℹ](url)', notes: [] },
+				{ title: 'MINOR BREAKING CHANGES [ℹ](url)', notes: [] },
+				{ title: 'MAJOR BREAKING CHANGES [ℹ](url)', notes: [] }
+			];
+
+			expect( noteGroups.sort( writerOptions.noteGroupsSort ) ).to.deep.equal( [
+				{ title: 'MAJOR BREAKING CHANGES [ℹ](url)', notes: [] },
+				{ title: 'MINOR BREAKING CHANGES [ℹ](url)', notes: [] },
+				{ title: 'BREAKING CHANGES [ℹ](url)', notes: [] }
+			] );
+		} );
+
+		it( 'sorts groups properly', () => {
+			const writerOptions = getWriterOptions( transformSpy );
+
+			const commitGroups = [
+				{ title: 'Other changes', commits: [] },
+				{ title: 'Features', commits: [] },
+				{ title: 'Bug fixes', commits: [] }
+			];
+
+			expect( commitGroups.sort( writerOptions.commitGroupsSort ) ).to.deep.equal( [
+				{ title: 'Features', commits: [] },
+				{ title: 'Bug fixes', commits: [] },
+				{ title: 'Other changes', commits: [] }
+			] );
+		} );
+
+		it( 'sorts groups properly (titles with emojis)', () => {
+			const writerOptions = getWriterOptions( transformSpy );
+
+			const commitGroups = [
+				{ title: 'Other changes [ℹ](url)', commits: [] },
+				{ title: 'Features [ℹ](url)', commits: [] },
+				{ title: 'Bug fixes [ℹ](url)', commits: [] }
+			];
+
+			expect( commitGroups.sort( writerOptions.commitGroupsSort ) ).to.deep.equal( [
+				{ title: 'Features [ℹ](url)', commits: [] },
+				{ title: 'Bug fixes [ℹ](url)', commits: [] },
+				{ title: 'Other changes [ℹ](url)', commits: [] }
+			] );
+		} );
 	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix (env): Commit and note groups should be sorted properly. Closes ckeditor/ckeditor5#7496.
