### PR TITLE
Changelog for monorepo - use the same version for all packages

### DIFF
--- a/packages/ckeditor5-dev-env/lib/release-tools/tasks/generatechangelogformonorepository.js
+++ b/packages/ckeditor5-dev-env/lib/release-tools/tasks/generatechangelogformonorepository.js
@@ -20,6 +20,7 @@ const generateChangelog = require( '../utils/generatechangelog' );
 const getPackageJson = require( '../utils/getpackagejson' );
 const getPackagesPaths = require( '../utils/getpackagespaths' );
 const getCommits = require( '../utils/getcommits' );
+const getNewVersionType = require( '../utils/getnewversiontype' );
 const getWriterOptions = require( '../utils/getwriteroptions' );
 const { getRepositoryUrl } = require( '../utils/transformcommitutils' );
 const transformCommitFactory = require( '../utils/transformcommitfactory' );
@@ -154,7 +155,14 @@ module.exports = function generateChangelogForMonoRepository( options ) {
 				return currentHighest;
 			}, [ null, '0.0.0' ] );
 
-		return cli.provideNewVersionForMonoRepository( highestVersion, packageHighestVersion, { indentLevel: 1 } )
+		let bumpType = getNewVersionType( allCommits );
+
+		// When made commits are not public, bump the `patch` version.
+		if ( bumpType === 'internal' ) {
+			bumpType = 'patch';
+		}
+
+		return cli.provideNewVersionForMonoRepository( highestVersion, packageHighestVersion, bumpType, { indentLevel: 1 } )
 			.then( version => {
 				nextVersion = version;
 

--- a/packages/ckeditor5-dev-env/lib/release-tools/utils/cli.js
+++ b/packages/ckeditor5-dev-env/lib/release-tools/utils/cli.js
@@ -202,17 +202,23 @@ const cli = {
 	 *
 	 * @param {String} version
 	 * @param {String} foundPackage
+	 * @param {String} bumpType
 	 * @param {Object} [options={}]
 	 * @param {Number} [options.indentLevel=0] The indent level.
 	 * @returns {Promise.<String>}
 	 */
-	provideNewVersionForMonoRepository( version, foundPackage, options = {} ) {
+	provideNewVersionForMonoRepository( version, foundPackage, bumpType, options = {} ) {
 		const indentLevel = options.indentLevel || 0;
+		const suggestedVersion = semver.inc( version, bumpType );
+
+		const message = 'Type the new version ' +
+			`(current highest: "${ version }" found in "${ chalk.underline( foundPackage ) }", suggested: "${ suggestedVersion }"):`;
 
 		const versionQuestion = {
 			type: 'input',
 			name: 'version',
-			message: `Type the new version (current highest: "${ version }" found in "${ chalk.underline( foundPackage ) }"):`,
+			default: suggestedVersion,
+			message,
 
 			filter( input ) {
 				return input.trim();

--- a/packages/ckeditor5-dev-env/lib/release-tools/utils/cli.js
+++ b/packages/ckeditor5-dev-env/lib/release-tools/utils/cli.js
@@ -206,16 +206,13 @@ const cli = {
 	 * @param {Number} [options.indentLevel=0] The indent level.
 	 * @returns {Promise.<String>}
 	 */
-	provideNewMajorReleaseVersion( version, foundPackage, options = {} ) {
-		const newVersion = semver.inc( version, 'major' );
+	provideNewVersionForMonoRepository( version, foundPackage, options = {} ) {
 		const indentLevel = options.indentLevel || 0;
 
 		const versionQuestion = {
 			type: 'input',
 			name: 'version',
-			default: newVersion,
-			message: `Type the new version (suggested: "${ newVersion }", current highest: “${ version }" ` +
-				`found in "${ chalk.underline( foundPackage ) }"):`,
+			message: `Type the new version (current highest: "${ version }" found in "${ chalk.underline( foundPackage ) }"):`,
 
 			filter( input ) {
 				return input.trim();
@@ -294,31 +291,6 @@ const cli = {
 						return options;
 					} );
 			} );
-	},
-
-	/**
-	 * Asks a user for a confirmation for major breaking release.
-	 *
-	 * @param {Boolean} haveMajorBreakingChangeCommits Whether the answer for the question should be "Yes".
-	 * @param {Object} [options={}]
-	 * @param {Number} [options.indentLevel=0] The indent level.
-	 * @returns {Promise.<Boolean>}
-	 */
-	confirmMajorBreakingChangeRelease( haveMajorBreakingChangeCommits, options = {} ) {
-		const indentLevel = options.indentLevel || 0;
-		const confirmQuestion = {
-			message: [
-				'If at least one of those changes is really a major breaking change, this will be a major release.',
-				'Should it be the major release?'
-			].join( ' ' ),
-			type: 'confirm',
-			name: 'confirm',
-			prefix: getPrefix( indentLevel ),
-			default: haveMajorBreakingChangeCommits
-		};
-
-		return inquirer.prompt( [ confirmQuestion ] )
-			.then( answers => answers.confirm );
 	}
 };
 

--- a/packages/ckeditor5-dev-env/lib/release-tools/utils/getnewversiontype.js
+++ b/packages/ckeditor5-dev-env/lib/release-tools/utils/getnewversiontype.js
@@ -9,7 +9,7 @@
  * Proposes new version based on commits.
  *
  * @param {Array.<Commit>} commits
- * @returns {String}
+ * @returns {String|null}
  */
 module.exports = function getNewVersionType( commits ) {
 	// No commits = no changes.

--- a/packages/ckeditor5-dev-env/tests/release-tools/utils/cli.js
+++ b/packages/ckeditor5-dev-env/tests/release-tools/utils/cli.js
@@ -304,18 +304,30 @@ describe( 'dev-env/release-tools/utils', () => {
 
 		describe( 'provideNewVersionForMonoRepository()', () => {
 			it( 'bumps major version', () => {
-				userAnswer = '2.0.0';
-
-				return cli.provideNewVersionForMonoRepository( '1.0.0', '@ckeditor/foo' )
+				return cli.provideNewVersionForMonoRepository( '1.0.0', '@ckeditor/foo', 'major' )
 					.then( newVersion => {
 						expect( newVersion ).to.equal( '2.0.0' );
 					} );
 			} );
 
-			it( 'does not suggest a new version', () => {
-				return cli.provideNewVersionForMonoRepository( '1.0.0', '@ckeditor/foo' )
+			it( 'bumps minor version', () => {
+				return cli.provideNewVersionForMonoRepository( '1.0.0', '@ckeditor/foo', 'minor' )
+					.then( newVersion => {
+						expect( newVersion ).to.equal( '1.1.0' );
+					} );
+			} );
+
+			it( 'bumps patch version', () => {
+				return cli.provideNewVersionForMonoRepository( '1.0.0', '@ckeditor/foo', 'patch' )
+					.then( newVersion => {
+						expect( newVersion ).to.equal( '1.0.1' );
+					} );
+			} );
+
+			it( 'suggest new version', () => {
+				return cli.provideNewVersionForMonoRepository( '1.0.0', '@ckeditor/foo', 'minor' )
 					.then( () => {
-						expect( questionItems[ 0 ].default ).to.equal( undefined );
+						expect( questionItems[ 0 ].default ).to.equal( '1.1.0' );
 					} );
 			} );
 

--- a/packages/ckeditor5-dev-env/tests/release-tools/utils/cli.js
+++ b/packages/ckeditor5-dev-env/tests/release-tools/utils/cli.js
@@ -302,16 +302,25 @@ describe( 'dev-env/release-tools/utils', () => {
 			} );
 		} );
 
-		describe( 'provideNewMajorReleaseVersion()', () => {
+		describe( 'provideNewVersionForMonoRepository()', () => {
 			it( 'bumps major version', () => {
-				return cli.provideNewMajorReleaseVersion( '1.0.0', '@ckeditor/foo' )
+				userAnswer = '2.0.0';
+
+				return cli.provideNewVersionForMonoRepository( '1.0.0', '@ckeditor/foo' )
 					.then( newVersion => {
 						expect( newVersion ).to.equal( '2.0.0' );
 					} );
 			} );
 
+			it( 'does not suggest a new version', () => {
+				return cli.provideNewVersionForMonoRepository( '1.0.0', '@ckeditor/foo' )
+					.then( () => {
+						expect( questionItems[ 0 ].default ).to.equal( undefined );
+					} );
+			} );
+
 			it( 'removes spaces from provided version', () => {
-				return cli.provideNewMajorReleaseVersion( '1.0.0', '@ckeditor/foo' )
+				return cli.provideNewVersionForMonoRepository( '1.0.0', '@ckeditor/foo' )
 					.then( () => {
 						const { filter } = questionItems[ 0 ];
 
@@ -322,7 +331,7 @@ describe( 'dev-env/release-tools/utils', () => {
 			} );
 
 			it( 'validates the provided version', () => {
-				return cli.provideNewMajorReleaseVersion( '1.0.0', '@ckeditor/foo' )
+				return cli.provideNewVersionForMonoRepository( '1.0.0', '@ckeditor/foo' )
 					.then( () => {
 						const { validate } = questionItems[ 0 ];
 
@@ -391,18 +400,6 @@ describe( 'dev-env/release-tools/utils', () => {
 							npm: true,
 							github: false
 						} );
-					} );
-			} );
-		} );
-
-		describe( 'confirmMajorBreakingChangeRelease()', () => {
-			it( 'user can disagree with the proposed value', () => {
-				return cli.confirmMajorBreakingChangeRelease( true )
-					.then( () => {
-						const question = questionItems[ 0 ];
-
-						expect( question.message ).to.match( /Should it be the major release\?/ );
-						expect( question.type ).to.equal( 'confirm' );
 					} );
 			} );
 		} );


### PR DESCRIPTION
The changelog generator will use the same version for all packages in the mono repository project.

### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other (env): The changelog generator for mono repository will use the same version for all packages. On the screen, a user will see all changes: `MAJOR BREAKING CHANGES`, `MINOR BREAKING CHANGES`, and all commits since the last release. The user must review it and provide the version. Closes ckeditor/ckeditor5#7323.

MAJOR BREAKING CHANGES (env): Task `generateChangelogForMonoRepository()` will generate the changelog uses the same version for all packages.
