### PR TITLE
Introduced support for "@skipsource" annotation

### DIFF
--- a/packages/ckeditor5-dev-docs/lib/index.js
+++ b/packages/ckeditor5-dev-docs/lib/index.js
@@ -54,6 +54,7 @@ async function build( config ) {
 			require.resolve( '@ckeditor/jsdoc-plugins/lib/export-fixer/export-fixer' ),
 			require.resolve( '@ckeditor/jsdoc-plugins/lib/custom-tags/error' ),
 			require.resolve( '@ckeditor/jsdoc-plugins/lib/custom-tags/observable' ),
+			require.resolve( '@ckeditor/jsdoc-plugins/lib/custom-tags/skipsource' ),
 			require.resolve( '@ckeditor/jsdoc-plugins/lib/observable-event-provider' ),
 			require.resolve( '@ckeditor/jsdoc-plugins/lib/longname-fixer/longname-fixer' ),
 			require.resolve( '@ckeditor/jsdoc-plugins/lib/fix-code-snippets' ),

--- a/packages/jsdoc-plugins/README.md
+++ b/packages/jsdoc-plugins/README.md
@@ -9,6 +9,7 @@ The list of generic plugins:
 * `lib/validator/validator.js` - validates if references to types used in params lists or property types are defined elsewhere, whether links point to existing properties/classes/modules, etc.
 * `lib/export-fixer/export-fixer.js` - fixes an error with `export default` syntax
 * `lib/custom-tags/error.js` - provides support for the custom `@error` tag
+* `lib/custom-tags/skipsource.js` - provides support for the custom `@skipsource` tag
 * `lib/relation-fixer.js` - fixes problem with inheritance (extends child classes with properties from parent classes)
 * `lib/longname-fixer/longname-fixer.js` - enables short notation in links
 * `lib/utils/doclet-logger.js` - enables logging output into the `<CWD>/docs/api/output.json`

--- a/packages/jsdoc-plugins/lib/custom-tags/skipsource.js
+++ b/packages/jsdoc-plugins/lib/custom-tags/skipsource.js
@@ -1,0 +1,17 @@
+/**
+ * @license Copyright (c) 2003-2020, CKSource - Frederico Knabben. All rights reserved.
+ * Licensed under the terms of the MIT License (see LICENSE.md).
+ */
+
+'use strict';
+
+module.exports = {
+	// See http://usejsdoc.org/about-plugins.html#tag-definitions.
+	defineTags( dictionary ) {
+		dictionary.defineTag( 'skipsource', {
+			onTagged( doclet ) {
+				doclet.skipSource = true;
+			}
+		} );
+	}
+};


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature (jsdoc-plugins): Support for the `@skipsource` annotation.

Internal (docs): Added the plugin that supports the `@skipsource` annotation.

---

### Additional information

By adding the `@skipsource` annotation you can hide `See source` link in API docs produced by Umberto.
