### PR TITLE
Added fixing code snippets for parameter, return, and property descriptions

### DIFF
--- a/packages/jsdoc-plugins/lib/doclet.jsdoc
+++ b/packages/jsdoc-plugins/lib/doclet.jsdoc
@@ -14,7 +14,7 @@
  *
  * @property {Type} [type] A type of the member.
  *
- * @property {ReturnData[]} [returns] The metadata for the function or method return type and description.
+ * @property {Array.<ReturnData>} [returns] The metadata for the function or method return type and description.
  *
  * @property {String} memberof Where the doclet belongs to (parent of the symbol).
  *
@@ -44,7 +44,7 @@
  *
  * @property {String[]} [see] `@see {}` tag contents.
  *
- * @property {Array.<Object>} [params] Event and function params.
+ * @property {Array.<Parameter>} [params] Event and function params.
  *
  * @property {'instance'|'inner'|'static'|'global'} [scope]
  *
@@ -83,7 +83,7 @@
  *
  * @property {Type} type
  *
- * @property {String} description
+ * @property {String} [description]
  *
  * @property {Boolean} [inherited] [A custom  property used by the relation fixer]
  */
@@ -100,5 +100,15 @@
  * @property {Type} type Type of the return statement. I.e. what the function should return.
  * It's gathered from the text after the `@returns` tag.
  *
- * @property {String} description Description for the return statement (after the `@returns` tag and type).
+ * @property {String} [description] Description for the return statement (after the `@returns` tag and type).
+ */
+
+/**
+ * @typedef {Object} Parameter
+ *
+ * @property {Type} type Type of the parameter.
+ *
+ * @property {String} name Name of the paramter.
+ *
+ * @property {String} [description] Description of the parameter.
  */

--- a/packages/jsdoc-plugins/lib/fix-code-snippets.js
+++ b/packages/jsdoc-plugins/lib/fix-code-snippets.js
@@ -10,13 +10,40 @@
  */
 exports.handlers = {
 	parseComplete: e => {
-		for ( const doclet of e.doclets ) {
+		/** @type {Array.<Doclet>} */
+		const doclets = e.doclets;
+
+		for ( const doclet of doclets ) {
 			if ( doclet.description ) {
 				doclet.description = fixDescription( doclet.description );
 			}
 
 			if ( doclet.classdesc ) {
 				doclet.classdesc = fixDescription( doclet.classdesc );
+			}
+
+			if ( doclet.params ) {
+				for ( const param of doclet.params ) {
+					if ( param.description ) {
+						param.description = fixDescription( param.description );
+					}
+				}
+			}
+
+			if ( doclet.returns ) {
+				for ( const returnObject of doclet.returns ) {
+					if ( returnObject.description ) {
+						returnObject.description = fixDescription( returnObject.description );
+					}
+				}
+			}
+
+			if ( doclet.properties ) {
+				for ( const property of doclet.properties ) {
+					if ( property.description ) {
+						property.description = fixDescription( property.description );
+					}
+				}
 			}
 		}
 	}

--- a/packages/jsdoc-plugins/tests/fix-code-snippets.js
+++ b/packages/jsdoc-plugins/tests/fix-code-snippets.js
@@ -116,4 +116,79 @@ describe( 'jsdoc-plugins/fix-code-snippets', () => {
 			'<pre><code>foo\nbar</code></pre>'
 		);
 	} );
+
+	it( 'should fix property descriptions', () => {
+		const doclet = {
+			properties: [ {
+				name: 'foo',
+				description: '<pre><code>\tfoo\n\tbar</code></pre>'
+			}, {
+				name: 'bar',
+				description: '<pre><code>\tfoo\n\tbar</code></pre>'
+			}, {
+				name: 'baz'
+				// The `baz` property has no description.
+			} ]
+		};
+
+		fixCodeSnippets.handlers.parseComplete( { doclets: [ doclet ] } );
+
+		expect( doclet.properties[ 0 ].description ).to.equal(
+			'<pre><code>foo\nbar</code></pre>'
+		);
+
+		expect( doclet.properties[ 1 ].description ).to.equal(
+			'<pre><code>foo\nbar</code></pre>'
+		);
+	} );
+
+	it( 'should fix descriptions of the return tags', () => {
+		const doclet = {
+			returns: [ {
+				type: 'String',
+				description: '<pre><code>\tfoo\n\tbar</code></pre>'
+			}, {
+				type: 'Array',
+				description: '<pre><code>\tfoo\n\tbar</code></pre>'
+			}, {
+				type: 'Boolean'
+				// Third return overload has no description.
+			} ]
+		};
+
+		fixCodeSnippets.handlers.parseComplete( { doclets: [ doclet ] } );
+
+		expect( doclet.returns[ 0 ].description ).to.equal(
+			'<pre><code>foo\nbar</code></pre>'
+		);
+
+		expect( doclet.returns[ 1 ].description ).to.equal(
+			'<pre><code>foo\nbar</code></pre>'
+		);
+	} );
+
+	it( 'should fix descriptions of parameters', () => {
+		const doclet = {
+			params: [ {
+				name: 'foo',
+				description: '<pre><code>\tfoo\n\tbar</code></pre>'
+			}, {
+				name: 'bar',
+				description: '<pre><code>\tfoo\n\tbar</code></pre>'
+			}, {
+				name: 'baz'
+				// The `baz` parameter has no description.
+			} ]
+		};
+
+		fixCodeSnippets.handlers.parseComplete( { doclets: [ doclet ] } );
+
+		expect( doclet.params[ 0 ].description ).to.equal(
+			'<pre><code>foo\nbar</code></pre>'
+		);
+
+		expect( doclet.params[ 1 ].description ).to.equal(
+			'<pre><code>foo\nbar</code></pre>'
+		);
+	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Added fixing code snippets for parameter, return, and property descriptions. Closes ckeditor/ckeditor5#7742.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
