### PR TITLE
Add support for the `translationsOutputFile` option allowing specifying target bundle for translations

### DIFF
--- a/packages/ckeditor5-dev-env/lib/translations/createpotfiles.js
+++ b/packages/ckeditor5-dev-env/lib/translations/createpotfiles.js
@@ -20,8 +20,8 @@ const corePackageName = 'ckeditor5-core';
  * and context files and saves them as POT files in the `build/.transifex` directory.
  *
  * @param {Object} options
- * @param {String[]} options.sourceFiles An array of source files that contain messages to translate.
- * @param {String[]} options.packagePaths An array of paths to packages, which will be used to find message contexts.
+ * @param {Array.<String>} options.sourceFiles An array of source files that contain messages to translate.
+ * @param {Array.<String>} options.packagePaths An array of paths to packages, which will be used to find message contexts.
  * @param {String} options.corePackagePath A path to the ckeditor5-core package.
  * @param {Logger} [logger] A logger.
  */
@@ -71,7 +71,7 @@ module.exports = function createPotFiles( {
  * Traverses all packages and returns a map of all found language contexts
  * (file content and file name).
  *
- * @param {String[]} packagePaths An array of paths to packages, which will be used to find message contexts.
+ * @param {Array.<String>} packagePaths An array of paths to packages, which will be used to find message contexts.
  * @returns {Map.<String, Context>}
  */
 function getPackageContexts( packagePaths, corePackagePath ) {
@@ -241,7 +241,7 @@ function createPotFileHeader() {
  *
  * @param {String} filePath
  * @param {String} fileContent
- * @returns {Message[]}
+ * @returns {Array.<Message>}
  */
 function getSourceMessagesFromFile( { filePath, fileContent, logger } ) {
 	const packageMatch = filePath.match( /([^/\\]+)[/\\]src[/\\]/ );
@@ -260,7 +260,7 @@ function getSourceMessagesFromFile( { filePath, fileContent, logger } ) {
 /**
  * Creates a POT file from the given i18n messages.
  *
- * @param {Message[]} messages
+ * @param {Array.<Message>} messages
  * @returns {String}
  */
 function createPotFileContent( messages ) {

--- a/packages/ckeditor5-dev-utils/lib/translations/multiplelanguagetranslationservice.js
+++ b/packages/ckeditor5-dev-utils/lib/translations/multiplelanguagetranslationservice.js
@@ -190,7 +190,7 @@ module.exports = class MultipleLanguageTranslationService extends EventEmitter {
 	 * @fires error
 	 * @param {Object} options
 	 * @param {String} options.outputDirectory Output directory for the translation files relative to the output.
-	 * @param {String[]} options.compilationAssetNames Original asset names from the compiler (e.g. Webpack).
+	 * @param {Array.<String>} options.compilationAssetNames Original asset names from the compiler (e.g. Webpack).
 	 * @returns {Array.<Object>} Returns new and modified assets that will be added to original ones.
 	 */
 	getAssets( { outputDirectory, compilationAssetNames } ) {
@@ -238,7 +238,7 @@ module.exports = class MultipleLanguageTranslationService extends EventEmitter {
 	/**
 	 * @param {Object} options
 	 * @param {String} options.outputDirectory Output directory for the translation files relative to the output.
-	 * @param {String[]} options.compilationAssetNames Original asset names from the compiler (e.g. Webpack).
+	 * @param {Array.<String>} options.compilationAssetNames Original asset names from the compiler (e.g. Webpack).
 	 */
 	_getAssetsWithTranslationsBundledToTheOutputFile( { outputDirectory, compilationAssetNames } ) {
 		const assetName = match( this._translationsOutputFile, compilationAssetNames );
@@ -325,7 +325,7 @@ module.exports = class MultipleLanguageTranslationService extends EventEmitter {
 	 *
 	 * @private
 	 * @param {String} language The target language
-	 * @param {String[]} sortedMessageIds An array of sorted message ids.
+	 * @param {Array.<String>} sortedMessageIds An array of sorted message ids.
 	 * @returns {Object.<String,String|String[]>}
 	 */
 	_getTranslations( language, sortedMessageIds ) {
@@ -392,7 +392,7 @@ module.exports = class MultipleLanguageTranslationService extends EventEmitter {
 /**
  *
  * @param {String|((name: string) => boolean)|RegExp} predicate
- * @param {String[]} options
+ * @param {Array.<String>} options
  * @returns {String|undefined}
  */
 function match( predicate, options ) {

--- a/packages/ckeditor5-dev-utils/lib/translations/multiplelanguagetranslationservice.js
+++ b/packages/ckeditor5-dev-utils/lib/translations/multiplelanguagetranslationservice.js
@@ -393,7 +393,7 @@ module.exports = class MultipleLanguageTranslationService extends EventEmitter {
 };
 
 /**
- * @param {String|((name: string) => boolean)|RegExp} predicate
+ * @param {String|Function|RegExp} predicate
  * @param {Array.<String>} options
  * @returns {String|undefined}
  */

--- a/packages/ckeditor5-dev-utils/lib/translations/multiplelanguagetranslationservice.js
+++ b/packages/ckeditor5-dev-utils/lib/translations/multiplelanguagetranslationservice.js
@@ -251,14 +251,12 @@ module.exports = class MultipleLanguageTranslationService extends EventEmitter {
 			.map( asset => asset.outputBody )
 			.join( '' );
 
-		if ( typeof this._translationsOutputFile === 'string' ) {
-			return [ {
-				outputBody: translationsBundle,
-				outputPath: assetName || this._translationsOutputFile,
-				// Concat with an existing asset if it exists.
-				shouldConcat: compilationAssetNames.some( assetName => assetName === this._translationsOutputFile )
-			} ];
-		}
+		return [ {
+			outputBody: translationsBundle,
+			outputPath: assetName || this._translationsOutputFile,
+			// Concat with an existing asset if it exists.
+			shouldConcat: compilationAssetNames.some( name => name === assetName )
+		} ];
 	}
 
 	/**

--- a/packages/ckeditor5-dev-utils/lib/translations/multiplelanguagetranslationservice.js
+++ b/packages/ckeditor5-dev-utils/lib/translations/multiplelanguagetranslationservice.js
@@ -25,7 +25,9 @@ module.exports = class MultipleLanguageTranslationService extends EventEmitter {
 	 * about multiple JS assets and will output translations for the main language to all found assets.
 	 * @param {Boolean} [options.buildAllTranslationsToSeparateFiles] When set to `true` the service will output all translations
 	 * to separate files.
-	 * @param {String|Function|RegExp} [options.translationsOutputFile]
+	 * @param {String|Function|RegExp} [options.translationsOutputFile] An option allowing outputting all translation file
+	 * to the given file. If a file specified by a path (string) does not exist, then it will be created. Otherwise, translations
+	 * will be outputted to the file.
 	 */
 	constructor( {
 		mainLanguage,

--- a/packages/ckeditor5-dev-utils/lib/translations/multiplelanguagetranslationservice.js
+++ b/packages/ckeditor5-dev-utils/lib/translations/multiplelanguagetranslationservice.js
@@ -239,6 +239,7 @@ module.exports = class MultipleLanguageTranslationService extends EventEmitter {
 	 * @param {Object} options
 	 * @param {String} options.outputDirectory Output directory for the translation files relative to the output.
 	 * @param {Array.<String>} options.compilationAssetNames Original asset names from the compiler (e.g. Webpack).
+	 * @returns {Array.<Object>} Returns an array with one asset that
 	 */
 	_getAssetsWithTranslationsBundledToTheOutputFile( { outputDirectory, compilationAssetNames } ) {
 		const assetName = match( this._translationsOutputFile, compilationAssetNames );
@@ -390,7 +391,6 @@ module.exports = class MultipleLanguageTranslationService extends EventEmitter {
 };
 
 /**
- *
  * @param {String|((name: string) => boolean)|RegExp} predicate
  * @param {Array.<String>} options
  * @returns {String|undefined}
@@ -410,6 +410,6 @@ function match( predicate, options ) {
 
 	throw new Error(
 		'The CKEditorWebpackPlugin matching function got an unsupported type of a predicate.' +
-		`Got ${ predicate } (${ typeof predicate } ) where supported values are only 'string', 'regexp' and 'function'`
+		`Got '${ predicate }' (${ typeof predicate } ) where supported values are only 'string', 'regexp' and 'function'.`
 	);
 }

--- a/packages/ckeditor5-dev-utils/lib/translations/multiplelanguagetranslationservice.js
+++ b/packages/ckeditor5-dev-utils/lib/translations/multiplelanguagetranslationservice.js
@@ -212,9 +212,11 @@ module.exports = class MultipleLanguageTranslationService extends EventEmitter {
 		} else if ( compilationAssetNames.length > 1 && !this._addMainLanguageTranslationsToAllAssets ) {
 			this.emit( 'error', [
 				'Too many JS assets has been found during the compilation. ' +
-				'You should add translation assets directly to the application from the `translations` directory or ' +
-				'use the `addMainLanguageTranslationsToAllAssets` option to add translations for the main language to all assets ' +
-				'or use the `buildAllTranslationsToSeparateFiles` if you want to add translation files on your own.'
+				'You should use one of the following options to specify the strategy:\n' +
+				'- use `addMainLanguageTranslationsToAllAssets` to add translations for the main language to all assets,' +
+				'- use `buildAllTranslationsToSeparateFiles` to add translation files via `<script>` tags in HTML file,' +
+				'- use `translationsOutputFile` to append translation to the existing file or create a new asset.' +
+				'For more details visit https://github.com/ckeditor/ckeditor5-dev/tree/master/packages/ckeditor5-dev-webpack-plugin.'
 			].join( '\n' ) );
 
 			compilationAssetNames = [];

--- a/packages/ckeditor5-dev-utils/tests/translations/multiplelanguagetranslationservice.js
+++ b/packages/ckeditor5-dev-utils/tests/translations/multiplelanguagetranslationservice.js
@@ -636,12 +636,9 @@ describe( 'translations', () => {
 				} );
 
 				sinon.assert.calledOnce( errorSpy );
-				sinon.assert.alwaysCalledWithExactly( errorSpy, [
-					'Too many JS assets has been found during the compilation. ' +
-					'You should add translation assets directly to the application from the `translations` directory or ' +
-					'use the `addMainLanguageTranslationsToAllAssets` option to add translations for the main language to all assets ' +
-					'or use the `buildAllTranslationsToSeparateFiles` if you want to add translation files on your own.'
-				].join( '\n' ) );
+				expect( errorSpy.getCalls()[ 0 ] ).to.match(
+					/Too many JS assets has been found during the compilation./
+				);
 
 				expect( assets ).to.have.length( 1 );
 				expect( assets[ 0 ] ).to.have.property( 'outputPath', path.join( 'lang', 'pl.js' ) );

--- a/packages/ckeditor5-dev-utils/tests/translations/multiplelanguagetranslationservice.js
+++ b/packages/ckeditor5-dev-utils/tests/translations/multiplelanguagetranslationservice.js
@@ -720,7 +720,7 @@ describe( 'translations', () => {
 				expect( assets ).to.have.length( 0 );
 			} );
 
-			it( 'should emit all files to a file specified by the `translationsOutputFile` option when it is specified', () => {
+			it( 'should emit all files to a file specified by the `translationsOutputFile` option when it is specified (as string)', () => {
 				const translationService = new MultipleLanguageTranslationService( {
 					mainLanguage: 'pl',
 					additionalLanguages: [],
@@ -757,6 +757,96 @@ describe( 'translations', () => {
 				expect( assets ).to.have.length( 1 );
 
 				expect( assets[ 0 ] ).to.have.property( 'outputPath', 'foo/bar' );
+				expect( assets[ 0 ] ).to.have.property( 'outputBody' );
+				expect( assets[ 0 ].outputBody ).to.have.length.greaterThan( 0 );
+
+				expect( warningSpy ).to.have.not.be.called;
+				expect( errorSpy ).to.have.not.be.called;
+			} );
+
+			it( 'should emit all files to a file specified by the `translationsOutputFile` option when it is specified (as regexp)', () => {
+				const translationService = new MultipleLanguageTranslationService( {
+					mainLanguage: 'pl',
+					additionalLanguages: [],
+					translationsOutputFile: /app\.js/
+				} );
+
+				const errorSpy = sinon.spy();
+				const warningSpy = sinon.spy();
+
+				translationService.on( 'error', errorSpy );
+				translationService.on( 'warning', warningSpy );
+
+				translationService._foundMessageIds = new Set( [
+					'Cancel',
+					'Save'
+				] );
+
+				translationService._translationDictionaries = {
+					pl: {
+						Cancel: [ 'Anuluj' ],
+						Save: [ 'Zapisz' ]
+					}
+				};
+
+				translationService._pluralFormsRules = { pl: 'plural=(() => 0)' };
+
+				const assets = translationService.getAssets( {
+					outputDirectory: 'lang',
+					compilationAssetNames: [
+						'app.js',
+						'bar.js'
+					]
+				} );
+
+				expect( assets ).to.have.length( 1 );
+
+				expect( assets[ 0 ] ).to.have.property( 'outputPath', 'app.js' );
+				expect( assets[ 0 ] ).to.have.property( 'outputBody' );
+				expect( assets[ 0 ].outputBody ).to.have.length.greaterThan( 0 );
+
+				expect( warningSpy ).to.have.not.be.called;
+				expect( errorSpy ).to.have.not.be.called;
+			} );
+
+			it( 'should emit all files to a file specified by the `translationsOutputFile` option when it is specified (as func.)', () => {
+				const translationService = new MultipleLanguageTranslationService( {
+					mainLanguage: 'pl',
+					additionalLanguages: [],
+					translationsOutputFile: name => /app\.js/.test( name )
+				} );
+
+				const errorSpy = sinon.spy();
+				const warningSpy = sinon.spy();
+
+				translationService.on( 'error', errorSpy );
+				translationService.on( 'warning', warningSpy );
+
+				translationService._foundMessageIds = new Set( [
+					'Cancel',
+					'Save'
+				] );
+
+				translationService._translationDictionaries = {
+					pl: {
+						Cancel: [ 'Anuluj' ],
+						Save: [ 'Zapisz' ]
+					}
+				};
+
+				translationService._pluralFormsRules = { pl: 'plural=(() => 0)' };
+
+				const assets = translationService.getAssets( {
+					outputDirectory: 'lang',
+					compilationAssetNames: [
+						'app.js',
+						'bar.js'
+					]
+				} );
+
+				expect( assets ).to.have.length( 1 );
+
+				expect( assets[ 0 ] ).to.have.property( 'outputPath', 'app.js' );
 				expect( assets[ 0 ] ).to.have.property( 'outputBody' );
 				expect( assets[ 0 ].outputBody ).to.have.length.greaterThan( 0 );
 

--- a/packages/ckeditor5-dev-webpack-plugin/README.md
+++ b/packages/ckeditor5-dev-webpack-plugin/README.md
@@ -61,6 +61,10 @@ A pattern which is used for determining if a package may contain translations (P
 
 A pattern which is used for determining if a file may contain messages to translate. Defaults to `/[/\\]ckeditor5-[^/\\]+[/\\]src[/\\].+\.js$/`.
 
+### `translationsOutputFile`
+
+[TODO]
+
 ### `corePackagePattern`
 
 (internal)

--- a/packages/ckeditor5-dev-webpack-plugin/README.md
+++ b/packages/ckeditor5-dev-webpack-plugin/README.md
@@ -63,7 +63,7 @@ A pattern which is used for determining if a file may contain messages to transl
 
 ### `translationsOutputFile`
 
-[TODO]
+An option that allows specifying the target file to which all translations will be outputted. This option supports a string, regular expression and a function. If no asset exists with the name, it will be created automatically and filled with translations.
 
 ### `corePackagePattern`
 

--- a/packages/ckeditor5-dev-webpack-plugin/lib/index.js
+++ b/packages/ckeditor5-dev-webpack-plugin/lib/index.js
@@ -31,24 +31,13 @@ const MultipleLanguageTranslationService = require( '@ckeditor/ckeditor5-dev-uti
  */
 module.exports = class CKEditorWebpackPlugin {
 	/**
-	 * @param {Object} [options] Plugin options.
-	 * @param {String} options.language The main language for internationalization - translations for that language
-	 * will be added to the bundle(s).
-	 * @param {Array.<String>|'all'} [options.additionalLanguages] Additional languages. Build is optimized when this option is not set.
-	 * When `additionalLanguages` is set to 'all' then script will be looking for all languages and according translations during
-	 * the compilation.
-	 * @param {String} [options.outputDirectory='translations'] The output directory for the emitted translation files,
-	 * should be relative to the webpack context.
-	 * @param {Boolean} [options.strict] An option that make the plugin throw when the error is found during the compilation.
-	 * @param {Boolean} [options.verbose] An option that make this plugin log all warnings into the console.
-	 * @param {Boolean} [options.addMainLanguageTranslationsToAllAssets] An option that allows outputting translations to more than one
-	 * JS asset.
-	 * @param {Boolean} [options.buildAllTranslationsToSeparateFiles] An option that makes all translations output to separate files.
-	 * @param {String} [options.sourceFilesPattern] An option that allows override the default pattern for CKEditor 5 source files.
-	 * @param {String} [options.packageNamesPattern] An option that allows override the default pattern for CKEditor 5 package names.
-	 * @param {String} [options.corePackagePattern] An option that allows override the default CKEditor 5 core package pattern.
+	 * @param {CKEditorWebpackPluginOptions} [options] Plugin options.
 	 */
-	constructor( options = {} ) {
+	constructor( options ) {
+		if ( !options ) {
+			throw new Error( 'The `CKEditorWebpackPlugin` plugin requires an object.' );
+		}
+
 		this.options = {
 			language: options.language,
 			additionalLanguages: options.additionalLanguages,
@@ -57,17 +46,19 @@ module.exports = class CKEditorWebpackPlugin {
 			verbose: !!options.verbose,
 			addMainLanguageTranslationsToAllAssets: !!options.addMainLanguageTranslationsToAllAssets,
 			buildAllTranslationsToSeparateFiles: !!options.buildAllTranslationsToSeparateFiles,
-			sourceFilesPattern: options.sourceFileRegexp || /[/\\]ckeditor5-[^/\\]+[/\\]src[/\\].+\.js$/,
+			sourceFilesPattern: options.sourceFilesPattern || /[/\\]ckeditor5-[^/\\]+[/\\]src[/\\].+\.js$/,
 			packageNamesPattern: options.packageNamesPattern || /[/\\]ckeditor5-[^/\\]+[/\\]/,
 			corePackagePattern: options.corePackagePattern || /[/\\]ckeditor5-core/,
-			corePackageSampleResourcePath: options.corePackageSampleResourcePath || '@ckeditor/ckeditor5-core/src/editor/editor.js'
+			corePackageSampleResourcePath: options.corePackageSampleResourcePath || '@ckeditor/ckeditor5-core/src/editor/editor.js',
+			translationsOutputFile: options.translationsOutputFile
 		};
 	}
 
 	apply( compiler ) {
 		if ( !this.options.language ) {
 			console.warn( chalk.yellow(
-				'Warning: The `language` option is required for CKEditorWebpackPlugin plugin.'
+				'The `language` option is required by the `CKEditorWebpackPlugin` plugin.' +
+				'If you do not want to localize the CKEditor 5 code do not add this plugin to your webpack configuration.'
 			) );
 
 			return;
@@ -100,9 +91,33 @@ module.exports = class CKEditorWebpackPlugin {
 			compileAllLanguages,
 			additionalLanguages,
 			addMainLanguageTranslationsToAllAssets,
-			buildAllTranslationsToSeparateFiles
+			buildAllTranslationsToSeparateFiles,
+			translationsOutputFile: this.options.translationsOutputFile
 		} );
 
 		serveTranslations( compiler, this.options, translationService );
 	}
 };
+
+/**
+ * @typedef {Object} CKEditorWebpackPluginOptions CKEditorWebpackPluginOptions options.
+ *
+ * @property {String} language The main language for internationalization - translations for that language
+ * will be added to the bundle(s).
+ * @property {Array.<String>|'all'} [additionalLanguages] Additional languages. Build is optimized when this option is not set.
+ * When `additionalLanguages` is set to 'all' then script will be looking for all languages and according translations during
+ * the compilation.
+ * @property {String} [outputDirectory='translations'] The output directory for the emitted translation files,
+ * should be relative to the webpack context.
+ * @property {Boolean} [strict] An option that make the plugin throw when the error is found during the compilation.
+ * @property {Boolean} [verbose] An option that make this plugin log all warnings into the console.
+ * @property {Boolean} [addMainLanguageTranslationsToAllAssets] An option that allows outputting translations to more than one
+ * JS asset.
+ * @property {String} corePackageSampleResourcePath
+ * @property {Boolean} [buildAllTranslationsToSeparateFiles] An option that makes all translations output to separate files.
+ * @property {String} [sourceFilesPattern] An option that allows override the default pattern for CKEditor 5 source files.
+ * @property {String} [packageNamesPattern] An option that allows override the default pattern for CKEditor 5 package names.
+ * @property {String} [corePackagePattern] An option that allows override the default CKEditor 5 core package pattern.
+ * @property {String|Function|RegExp} [translationsOutputFile] An option allowing outputting all translation file to the given file.
+ * If a file specified by a path (string) does not exist, then it will be created. Otherwise, translations will be outputted to the file.
+ */

--- a/packages/ckeditor5-dev-webpack-plugin/lib/index.js
+++ b/packages/ckeditor5-dev-webpack-plugin/lib/index.js
@@ -113,7 +113,7 @@ module.exports = class CKEditorWebpackPlugin {
  * @property {Boolean} [verbose] An option that make this plugin log all warnings into the console.
  * @property {Boolean} [addMainLanguageTranslationsToAllAssets] An option that allows outputting translations to more than one
  * JS asset.
- * @property {String} corePackageSampleResourcePath
+ * @property {String} [corePackageSampleResourcePath] TODO
  * @property {Boolean} [buildAllTranslationsToSeparateFiles] An option that makes all translations output to separate files.
  * @property {String} [sourceFilesPattern] An option that allows override the default pattern for CKEditor 5 source files.
  * @property {String} [packageNamesPattern] An option that allows override the default pattern for CKEditor 5 package names.

--- a/packages/ckeditor5-dev-webpack-plugin/lib/index.js
+++ b/packages/ckeditor5-dev-webpack-plugin/lib/index.js
@@ -31,7 +31,7 @@ const MultipleLanguageTranslationService = require( '@ckeditor/ckeditor5-dev-uti
  */
 module.exports = class CKEditorWebpackPlugin {
 	/**
-	 * @param {CKEditorWebpackPluginOptions} [options] Plugin options.
+	 * @param {CKEditorWebpackPluginOptions} options Plugin options.
 	 */
 	constructor( options ) {
 		if ( !options ) {

--- a/packages/ckeditor5-dev-webpack-plugin/lib/servetranslations.js
+++ b/packages/ckeditor5-dev-webpack-plugin/lib/servetranslations.js
@@ -92,6 +92,7 @@ module.exports = function serveTranslations( compiler, options, translationServi
 			const generatedAssets = translationService.getAssets( {
 				outputDirectory: options.outputDirectory,
 				compilationAssetNames: Object.keys( compilation.assets )
+					.filter( name => name.endsWith( '.js' ) )
 			} );
 
 			const allFiles = chunks.reduce( ( acc, chunk ) => [ ...acc, ...chunk.files ], [] );

--- a/packages/ckeditor5-dev-webpack-plugin/tests/index.js
+++ b/packages/ckeditor5-dev-webpack-plugin/tests/index.js
@@ -104,7 +104,8 @@ describe( 'webpack-plugin/CKEditorWebpackPlugin', () => {
 						compileAllLanguages: false,
 						additionalLanguages: [],
 						buildAllTranslationsToSeparateFiles: false,
-						addMainLanguageTranslationsToAllAssets: false
+						addMainLanguageTranslationsToAllAssets: false,
+						translationsOutputFile: undefined
 					}
 				);
 			} );
@@ -128,7 +129,8 @@ describe( 'webpack-plugin/CKEditorWebpackPlugin', () => {
 						compileAllLanguages: false,
 						additionalLanguages: [ 'en' ],
 						buildAllTranslationsToSeparateFiles: false,
-						addMainLanguageTranslationsToAllAssets: false
+						addMainLanguageTranslationsToAllAssets: false,
+						translationsOutputFile: undefined
 					}
 				);
 			} );
@@ -152,7 +154,8 @@ describe( 'webpack-plugin/CKEditorWebpackPlugin', () => {
 						compileAllLanguages: true,
 						additionalLanguages: [],
 						buildAllTranslationsToSeparateFiles: false,
-						addMainLanguageTranslationsToAllAssets: false
+						addMainLanguageTranslationsToAllAssets: false,
+						translationsOutputFile: undefined
 					}
 				);
 

--- a/packages/ckeditor5-dev-webpack-plugin/tests/index.js
+++ b/packages/ckeditor5-dev-webpack-plugin/tests/index.js
@@ -60,18 +60,6 @@ describe( 'webpack-plugin/CKEditorWebpackPlugin', () => {
 	} );
 
 	describe( 'apply()', () => {
-		it( 'should log a warning and do nothing if language is not specified', () => {
-			const ckeditorWebpackPlugin = new CKEditorWebpackPlugin( {} );
-			ckeditorWebpackPlugin.apply( {} );
-
-			sinon.assert.calledOnce( console.warn );
-			expect( console.warn.getCall( 0 ).args[ 0 ] ).to.match(
-				/Warning: The `language` option is required for CKEditorWebpackPlugin plugin\./
-			);
-
-			sinon.assert.notCalled( stubs.serveTranslations );
-		} );
-
 		it( 'should call serveTranslations() if the options are correct', () => {
 			const options = {
 				language: 'pl'

--- a/packages/jsdoc-plugins/lib/doclet.jsdoc
+++ b/packages/jsdoc-plugins/lib/doclet.jsdoc
@@ -42,7 +42,7 @@
  *
  * @property {String} [classdesc] Description for the class.
  *
- * @property {String[]} [see] `@see {}` tag contents.
+ * @property {Array.<String>} [see] `@see {}` tag contents.
  *
  * @property {Array.<Parameter>} [params] Event and function params.
  *


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Add support for the `translationsOutputFile` option for `CKEditorWebpackPlugin` allowing specifying the target bundle for translations. Closes ckeditor/ckeditor5#7688.

---

### Additional information

*   The `CKEditorWebpackPlugin` won't longer complain when no asset will be available during the build
*   Requires ckeditor/ckeditor5#7755.