### PR TITLE
Provide changes required for env unification

### DIFF
--- a/packages/ckeditor5-dev-docs/lib/index.js
+++ b/packages/ckeditor5-dev-docs/lib/index.js
@@ -51,6 +51,7 @@ async function build( config ) {
 	const jsDocConfig = {
 		plugins: [
 			require.resolve( 'jsdoc/plugins/markdown' ),
+			require.resolve( '@ckeditor/jsdoc-plugins/lib/purge-private-api-docs' ),
 			require.resolve( '@ckeditor/jsdoc-plugins/lib/export-fixer/export-fixer' ),
 			require.resolve( '@ckeditor/jsdoc-plugins/lib/custom-tags/error' ),
 			require.resolve( '@ckeditor/jsdoc-plugins/lib/custom-tags/observable' ),

--- a/packages/ckeditor5-dev-tests/lib/tasks/runmanualtests.js
+++ b/packages/ckeditor5-dev-tests/lib/tasks/runmanualtests.js
@@ -24,6 +24,7 @@ const transformFileOptionToTestGlob = require( '../utils/transformfileoptiontote
  * @param {String} [options.language] A language passed to `CKEditorWebpackPlugin`.
  * @param {Array.<String>} [options.additionalLanguages] Additional languages passed to `CKEditorWebpackPlugin`.
  * @param {Number} [options.port] A port number used by the `createManualTestServer`.
+ * @param {String} [options.identityFile] A file that provides secret keys used in the test scripts.
  * @returns {Promise}
  */
 module.exports = function runManualTests( options ) {
@@ -38,6 +39,7 @@ module.exports = function runManualTests( options ) {
 	const themePath = options.themePath || null;
 	const language = options.language;
 	const additionalLanguages = options.additionalLanguages;
+	const identityFile = normalizeIdentityFile( options.identityFile );
 
 	return Promise.resolve()
 		.then( () => removeDir( buildDir ) )
@@ -48,7 +50,8 @@ module.exports = function runManualTests( options ) {
 				themePath,
 				language,
 				additionalLanguages,
-				debug: options.debug
+				debug: options.debug,
+				identityFile
 			} ),
 			compileManualTestHtmlFiles( {
 				buildDir,
@@ -60,3 +63,21 @@ module.exports = function runManualTests( options ) {
 		] ) )
 		.then( () => createManualTestServer( buildDir, options.port ) );
 };
+
+/**
+ * @param {String|null} identityFile
+ * @returns {String|null}
+ */
+function normalizeIdentityFile( identityFile ) {
+	if ( !identityFile ) {
+		return null;
+	}
+
+	// Passed an absolute path.
+	if ( path.isAbsolute( identityFile ) ) {
+		return identityFile;
+	}
+
+	// Passed a relative path. Merge it with the current working directory.
+	return path.join( process.cwd(), identityFile );
+}

--- a/packages/ckeditor5-dev-tests/lib/utils/automated-tests/parsearguments.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/automated-tests/parsearguments.js
@@ -37,7 +37,8 @@ module.exports = function parseArguments( args ) {
 			v: 'verbose',
 			f: 'files',
 			b: 'browsers',
-			d: 'debug'
+			d: 'debug',
+			i: 'identity-file'
 		},
 
 		default: {
@@ -49,7 +50,8 @@ module.exports = function parseArguments( args ) {
 			verbose: false,
 			'source-map': false,
 			server: false,
-			production: false
+			production: false,
+			'identity-file': null
 		}
 	};
 
@@ -57,6 +59,7 @@ module.exports = function parseArguments( args ) {
 
 	options.karmaConfigOverrides = options[ 'karma-config-overrides' ];
 	options.sourceMap = options[ 'source-map' ];
+	options.identityFile = options[ 'identity-file' ];
 	options.browsers = options.browsers.split( ',' );
 
 	if ( typeof options.files === 'string' ) {

--- a/packages/ckeditor5-dev-tests/lib/utils/manual-tests/compilehtmlfiles.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/manual-tests/compilehtmlfiles.js
@@ -37,7 +37,10 @@ module.exports = function compileHtmlFiles( options ) {
 		return [
 			...arr,
 			...globSync( manualTestPattern )
+				// Accept only files saved in the `/manual/` directory.
 				.filter( manualTestFile => manualTestFile.includes( path.sep + 'manual' + path.sep ) )
+				// But do not parse manual tests utils saved in the `/manual/_utils/` directory.
+				.filter( manualTestFile => !manualTestFile.includes( path.sep + 'manual' + path.sep + '_utils' + path.sep ) )
 				.map( jsFile => setExtension( jsFile, 'md' ) )
 		];
 	}, [] );

--- a/packages/ckeditor5-dev-tests/lib/utils/manual-tests/compilescripts.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/manual-tests/compilescripts.js
@@ -20,6 +20,7 @@ const getRelativeFilePath = require( '../getrelativefilepath' );
  * @param {String} options.themePath A path to the theme the PostCSS theme-importer plugin is supposed to load.
  * @param {String} options.language A language passed to `CKEditorWebpackPlugin`.
  * @param {Array.<String>} [options.additionalLanguages] Additional languages passed to `CKEditorWebpackPlugin`.
+ * @param {String} [options.identityFile] A file that provides secret keys used in the test scripts.
  * @returns {Promise}
  */
 module.exports = function compileManualTestScripts( options ) {
@@ -41,7 +42,8 @@ module.exports = function compileManualTestScripts( options ) {
 		themePath: options.themePath,
 		language: options.language,
 		additionalLanguages: options.additionalLanguages,
-		debug: options.debug
+		debug: options.debug,
+		identityFile: options.identityFile
 	} );
 
 	return runWebpack( webpackConfig );

--- a/packages/ckeditor5-dev-tests/lib/utils/manual-tests/compilescripts.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/manual-tests/compilescripts.js
@@ -27,7 +27,10 @@ module.exports = function compileManualTestScripts( options ) {
 		return [
 			...arr,
 			...globSync( manualTestPattern )
+				// Accept only files saved in the `/manual/` directory.
 				.filter( manualTestFile => manualTestFile.includes( path.sep + 'manual' + path.sep ) )
+				// But do not parse manual tests utils saved in the `/manual/_utils/` directory.
+				.filter( manualTestFile => !manualTestFile.includes( path.sep + 'manual' + path.sep + '_utils' + path.sep ) )
 		];
 	}, [] );
 

--- a/packages/ckeditor5-dev-tests/lib/utils/manual-tests/createserver.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/manual-tests/createserver.js
@@ -67,7 +67,9 @@ function onRequest( sourcePath, request, response ) {
 
 	// In other cases - return a static file.
 	try {
-		const content = fs.readFileSync( path.join( sourcePath, request.url ) );
+		// Remove the query part of the request.
+		const url = request.url.replace( /\?.+$/, '' );
+		const content = fs.readFileSync( path.join( sourcePath, url ) );
 
 		response.end( content, 'utf-8' );
 	} catch ( error ) {

--- a/packages/ckeditor5-dev-tests/lib/utils/manual-tests/getwebpackconfig.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/manual-tests/getwebpackconfig.js
@@ -9,6 +9,7 @@ const path = require( 'path' );
 const WebpackNotifierPlugin = require( './webpacknotifierplugin' );
 const { getPostCssConfig } = require( '@ckeditor/ckeditor5-dev-utils' ).styles;
 const CKEditorWebpackPlugin = require( '@ckeditor/ckeditor5-dev-webpack-plugin' );
+const webpack = require( 'webpack' );
 
 /**
  * @param {Object} options
@@ -17,9 +18,12 @@ const CKEditorWebpackPlugin = require( '@ckeditor/ckeditor5-dev-webpack-plugin' 
  * @param {String} options.themePath
  * @param {String} [options.language]
  * @param {Array.<String>} [options.additionalLanguages]
+ * @param {String|null} [options.identityFile]
  * @returns {Object}
  */
 module.exports = function getWebpackConfigForManualTests( options ) {
+	const definitions = Object.assign( {}, getDefinitionsFromFile( options.identityFile ) );
+
 	return {
 		mode: 'development',
 
@@ -43,7 +47,8 @@ module.exports = function getWebpackConfigForManualTests( options ) {
 				language: options.language,
 				additionalLanguages: options.additionalLanguages,
 				addMainLanguageTranslationsToAllAssets: true
-			} )
+			} ),
+			new webpack.DefinePlugin( definitions )
 		],
 
 		module: {
@@ -97,3 +102,21 @@ module.exports = function getWebpackConfigForManualTests( options ) {
 		}
 	};
 };
+
+/**
+ * @param {String|null} definitionSource
+ * @returns {Object}
+ */
+function getDefinitionsFromFile( definitionSource ) {
+	if ( !definitionSource ) {
+		return {};
+	}
+
+	try {
+		return require( definitionSource );
+	} catch ( err ) {
+		console.error( err.message );
+
+		return {};
+	}
+}

--- a/packages/ckeditor5-dev-tests/lib/utils/manual-tests/getwebpackconfig.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/manual-tests/getwebpackconfig.js
@@ -113,7 +113,15 @@ function getDefinitionsFromFile( definitionSource ) {
 	}
 
 	try {
-		return require( definitionSource );
+		const definitions = require( definitionSource );
+
+		const stringifiedDefinitions = {};
+
+		for ( const definitionName in definitions ) {
+			stringifiedDefinitions[ definitionName ] = JSON.stringify( definitions[ definitionName ] );
+		}
+
+		return stringifiedDefinitions;
 	} catch ( err ) {
 		console.error( err.message );
 

--- a/packages/ckeditor5-dev-tests/lib/utils/manual-tests/template.html
+++ b/packages/ckeditor5-dev-tests/lib/utils/manual-tests/template.html
@@ -3,7 +3,6 @@
 <head>
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
-	<!-- <meta http-equiv="Content-Security-Policy" content="default-src 'none'; connect-src 'self' https://cksource.com http://*.cke-cs.com wss://33333.cke-cs.com https://33333.cke-cs.com; script-src 'self' https://cksource.com; img-src * data:; style-src 'self' 'unsafe-inline'; frame-src *"> -->
 	<title>Manual Test</title>
 	<style>
 		.manual-test-list-container,

--- a/packages/ckeditor5-dev-tests/lib/utils/manual-tests/template.html
+++ b/packages/ckeditor5-dev-tests/lib/utils/manual-tests/template.html
@@ -3,7 +3,7 @@
 <head>
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
-	<meta http-equiv="Content-Security-Policy" content="default-src 'none'; connect-src 'self' https://cksource.com http://*.cke-cs.com; script-src 'self' https://cksource.com; img-src * data:; style-src 'self' 'unsafe-inline'; frame-src *">
+	<!-- <meta http-equiv="Content-Security-Policy" content="default-src 'none'; connect-src 'self' https://cksource.com http://*.cke-cs.com wss://33333.cke-cs.com https://33333.cke-cs.com; script-src 'self' https://cksource.com; img-src * data:; style-src 'self' 'unsafe-inline'; frame-src *"> -->
 	<title>Manual Test</title>
 	<style>
 		.manual-test-list-container,

--- a/packages/ckeditor5-dev-tests/lib/utils/manual-tests/template.html
+++ b/packages/ckeditor5-dev-tests/lib/utils/manual-tests/template.html
@@ -3,6 +3,7 @@
 <head>
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<meta http-equiv="Content-Security-Policy" content="default-src 'none'; connect-src 'self' https://cksource.com http://*.cke-cs.com; script-src 'self' https://cksource.com; img-src * data:; style-src 'self' 'unsafe-inline'; frame-src *">
 	<title>Manual Test</title>
 	<style>
 		.manual-test-list-container,

--- a/packages/ckeditor5-dev-tests/tests/tasks/runmanualtests.js
+++ b/packages/ckeditor5-dev-tests/tests/tasks/runmanualtests.js
@@ -85,7 +85,8 @@ describe( 'runManualTests', () => {
 					themePath: null,
 					language: undefined,
 					additionalLanguages: undefined,
-					debug: undefined
+					debug: undefined,
+					identityFile: null
 				} );
 
 				expect( spies.server.calledOnce ).to.equal( true );
@@ -150,7 +151,8 @@ describe( 'runManualTests', () => {
 					themePath: 'path/to/theme',
 					language: undefined,
 					additionalLanguages: undefined,
-					debug: [ 'CK_DEBUG' ]
+					debug: [ 'CK_DEBUG' ],
+					identityFile: null
 				} );
 
 				expect( spies.server.calledOnce ).to.equal( true );
@@ -219,7 +221,8 @@ describe( 'runManualTests', () => {
 					themePath: 'path/to/theme',
 					language: 'pl',
 					additionalLanguages: [ 'ar', 'en' ],
-					debug: [ 'CK_DEBUG' ]
+					debug: [ 'CK_DEBUG' ],
+					identityFile: null
 				} );
 
 				expect( spies.server.calledOnce ).to.equal( true );
@@ -250,6 +253,86 @@ describe( 'runManualTests', () => {
 				expect( spies.server.calledOnce ).to.equal( true );
 				expect( spies.server.firstCall.args[ 0 ] ).to.equal( 'workspace/build/.manual-tests' );
 				expect( spies.server.firstCall.args[ 1 ] ).to.equal( 8888 );
+			} );
+	} );
+
+	it( 'allows specifying identity file (absolute path)', () => {
+		spies.transformFileOptionToTestGlob.onFirstCall().returns( [
+			'workspace/packages/ckeditor5-build-classic/tests/**/manual/**/*.js',
+			'workspace/packages/ckeditor4-build-classic/tests/**/manual/**/*.js'
+		] );
+		spies.transformFileOptionToTestGlob.onSecondCall().returns( [
+			'workspace/packages/ckeditor5-editor-classic/tests/manual/**/*.js',
+			'workspace/packages/ckeditor-editor-classic/tests/manual/**/*.js'
+		] );
+
+		const options = {
+			files: [
+				'build-classic',
+				'editor-classic/manual/classic.js'
+			],
+			identityFile: '/absolute/path/to/secrets.js'
+		};
+
+		return runManualTests( options )
+			.then( () => {
+				expect( spies.server.calledOnce ).to.equal( true );
+				expect( spies.server.firstCall.args[ 0 ] ).to.equal( 'workspace/build/.manual-tests' );
+
+				expect( spies.scriptCompiler.firstCall.args[ 0 ] ).to.deep.equal( {
+					buildDir: 'workspace/build/.manual-tests',
+					patterns: [
+						'workspace/packages/ckeditor5-build-classic/tests/**/manual/**/*.js',
+						'workspace/packages/ckeditor4-build-classic/tests/**/manual/**/*.js',
+						'workspace/packages/ckeditor5-editor-classic/tests/manual/**/*.js',
+						'workspace/packages/ckeditor-editor-classic/tests/manual/**/*.js'
+					],
+					themePath: null,
+					language: undefined,
+					debug: undefined,
+					additionalLanguages: undefined,
+					identityFile: '/absolute/path/to/secrets.js'
+				} );
+			} );
+	} );
+
+	it( 'allows specifying identity file (relative path)', () => {
+		spies.transformFileOptionToTestGlob.onFirstCall().returns( [
+			'workspace/packages/ckeditor5-build-classic/tests/**/manual/**/*.js',
+			'workspace/packages/ckeditor4-build-classic/tests/**/manual/**/*.js'
+		] );
+		spies.transformFileOptionToTestGlob.onSecondCall().returns( [
+			'workspace/packages/ckeditor5-editor-classic/tests/manual/**/*.js',
+			'workspace/packages/ckeditor-editor-classic/tests/manual/**/*.js'
+		] );
+
+		const options = {
+			files: [
+				'build-classic',
+				'editor-classic/manual/classic.js'
+			],
+			identityFile: 'path/to/secrets.js'
+		};
+
+		return runManualTests( options )
+			.then( () => {
+				expect( spies.server.calledOnce ).to.equal( true );
+				expect( spies.server.firstCall.args[ 0 ] ).to.equal( 'workspace/build/.manual-tests' );
+
+				expect( spies.scriptCompiler.firstCall.args[ 0 ] ).to.deep.equal( {
+					buildDir: 'workspace/build/.manual-tests',
+					patterns: [
+						'workspace/packages/ckeditor5-build-classic/tests/**/manual/**/*.js',
+						'workspace/packages/ckeditor4-build-classic/tests/**/manual/**/*.js',
+						'workspace/packages/ckeditor5-editor-classic/tests/manual/**/*.js',
+						'workspace/packages/ckeditor-editor-classic/tests/manual/**/*.js'
+					],
+					themePath: null,
+					language: undefined,
+					debug: undefined,
+					additionalLanguages: undefined,
+					identityFile: 'workspace/path/to/secrets.js'
+				} );
 			} );
 	} );
 } );

--- a/packages/ckeditor5-dev-tests/tests/utils/manual-tests/compilehtmlfiles.js
+++ b/packages/ckeditor5-dev-tests/tests/utils/manual-tests/compilehtmlfiles.js
@@ -266,7 +266,10 @@ describe( 'compileHtmlFiles', () => {
 		};
 
 		patternFiles = {
-			[ path.join( 'manualTestPattern', '*.js' ) ]: [ path.join( 'path', 'to', 'manual', 'file.js' ) ],
+			[ path.join( 'manualTestPattern', '*.js' ) ]: [
+				path.join( 'path', 'to', 'manual', 'file.js' ),
+				path.join( 'path', 'to', 'manual', '_utils', 'secretplugin.js' )
+			],
 			[ path.join( 'anotherPattern', '*.js' ) ]: [ path.join( 'path', 'to', 'another', 'file.js' ) ],
 			[ path.join( 'path', 'to', 'manual', '**', '*.!(js|html|md)' ) ]: [ 'static-file.png' ]
 		};

--- a/packages/ckeditor5-dev-tests/tests/utils/manual-tests/compilescripts.js
+++ b/packages/ckeditor5-dev-tests/tests/utils/manual-tests/compilescripts.js
@@ -73,7 +73,8 @@ describe( 'compileManualTestScripts', () => {
 					'ckeditor5-foo/manual/file1': 'ckeditor5-foo/manual/file1',
 					'ckeditor5-foo/manual/file2': 'ckeditor5-foo/manual/file2'
 				},
-				debug: [ 'CK_DEBUG' ]
+				debug: [ 'CK_DEBUG' ],
+				identityFile: undefined
 			} );
 
 			expect( stubs.webpack.calledOnce ).to.equal( true );
@@ -199,6 +200,48 @@ describe( 'compileManualTestScripts', () => {
 			expect( stubs.getRelativeFilePath.calledOnce ).to.equal( true );
 			expect( stubs.getRelativeFilePath.firstCall.args[ 0 ] )
 				.to.equal( 'ckeditor5-build-classic\\tests\\manual\\ckeditor.js' );
+		} );
+	} );
+
+	it( 'should pass identity file to Webpack configuration factory', () => {
+		stubs.glob.returns( [ 'ckeditor5-foo/manual/file1', 'ckeditor5-foo/manual/file2' ] );
+		const identityFile = '/foo/bar.js';
+
+		return compileManualTestScripts( {
+			buildDir: 'buildDir',
+			patterns: [ 'manualTestPattern' ],
+			themePath: 'path/to/theme',
+			language: 'en',
+			additionalLanguages: [ 'pl', 'ar' ],
+			debug: [ 'CK_DEBUG' ],
+			identityFile
+		} ).then( () => {
+			expect( stubs.getWebpackConfig.calledOnce ).to.equal( true );
+
+			expect( stubs.getWebpackConfig.firstCall.args[ 0 ] ).to.deep.equal( {
+				buildDir: 'buildDir',
+				themePath: 'path/to/theme',
+				language: 'en',
+				additionalLanguages: [ 'pl', 'ar' ],
+				entries: {
+					'ckeditor5-foo/manual/file1': 'ckeditor5-foo/manual/file1',
+					'ckeditor5-foo/manual/file2': 'ckeditor5-foo/manual/file2'
+				},
+				debug: [ 'CK_DEBUG' ],
+				identityFile
+			} );
+
+			expect( stubs.webpack.calledOnce ).to.equal( true );
+			expect( stubs.webpack.firstCall.args[ 0 ] ).to.deep.equal( {
+				buildDir: 'buildDir',
+				entries: {
+					'ckeditor5-foo/manual/file1': 'ckeditor5-foo/manual/file1',
+					'ckeditor5-foo/manual/file2': 'ckeditor5-foo/manual/file2'
+				}
+			} );
+
+			expect( stubs.glob.calledOnce ).to.equal( true );
+			expect( stubs.glob.firstCall.args[ 0 ] ).to.equal( 'manualTestPattern' );
 		} );
 	} );
 } );

--- a/packages/ckeditor5-dev-tests/tests/utils/manual-tests/compilescripts.js
+++ b/packages/ckeditor5-dev-tests/tests/utils/manual-tests/compilescripts.js
@@ -149,13 +149,14 @@ describe( 'compileManualTestScripts', () => {
 		);
 	} );
 
-	it( 'compiles only manual test files', () => {
+	it( 'compiles only manual test files (ignores utils and files outside the manual directory)', () => {
 		const manualTestScriptsPatterns = [
 			'ckeditor5-build-classic/tests/**/*.js'
 		];
 
 		stubs.glob.onFirstCall().returns( [
 			'ckeditor5-build-classic/tests/manual/ckeditor.js',
+			'ckeditor5-build-classic/tests/manual/_utils/secretplugin.js',
 			'ckeditor5-build-classic/tests/ckeditor.js'
 		] );
 

--- a/packages/jsdoc-plugins/lib/purge-private-api-docs.js
+++ b/packages/jsdoc-plugins/lib/purge-private-api-docs.js
@@ -38,6 +38,8 @@ module.exports = {
 				if ( doclet.meta && doclet.meta.path ) {
 					if ( isPrivatePackageFile( doclet.meta.path ) ) {
 						delete doclet.meta;
+
+						doclet.skipSource = true;
 					}
 				}
 			}

--- a/packages/jsdoc-plugins/lib/purge-private-api-docs.js
+++ b/packages/jsdoc-plugins/lib/purge-private-api-docs.js
@@ -1,0 +1,73 @@
+// A plugin for JSDoc that should purge non-public API docs.
+// Public API docs should contain the `@publicApi` tag below the `@module` tag.
+
+const path = require( 'path' );
+const fs = require( 'fs' );
+
+module.exports = {
+	handlers: {
+		/**
+		 * @see http://usejsdoc.org/about-plugins.html#event-beforeparse
+		 * @param {any} evt
+		 */
+		beforeParse( evt ) {
+			// Skip public packages.
+			if ( !isPrivatePackageFile( evt.filename ) ) {
+				return;
+			}
+
+			// Do not emit any JSDoc doclet if the `@publicApi` tag is missing in that file.
+			if ( !evt.source.includes( '@publicApi' ) ) {
+				evt.source = '';
+
+				return;
+			}
+
+			// Do not emit any JSDoc doclet if the '@module' tag is missing and log a warning.
+			if ( !evt.source.includes( '@module' ) ) {
+				evt.source = '';
+
+				const filename = path.relative( process.cwd(), evt.filename );
+
+				console.warn( `File ${ filename } did not start with '@module' tag and hence it will be ignored while building docs.` );
+			}
+		}
+	},
+
+	/**
+	 * See http://usejsdoc.org/about-plugins.html#tag-definition.
+	 *
+	 * @param {any} dictionary
+	 */
+	defineTags( dictionary ) {
+		dictionary.defineTag( 'publicApi', {
+			mustHaveValue: false,
+			canHaveType: false,
+			canHaveName: false,
+
+			/**
+			 * @param {any} doclet
+			 * @param {any} tag
+			 */
+			onTagged( doclet ) {
+				Object.assign( doclet, {
+					publicApi: true
+				} );
+			}
+		} );
+	}
+};
+
+function isPrivatePackageFile( fileName ) {
+	let dirName = path.dirname( fileName );
+
+	while ( true ) {
+		const pathToPackageJson = path.join( dirName, 'package.json' );
+
+		if ( fs.existsSync( pathToPackageJson ) ) {
+			return !!JSON.parse( fs.readFileSync( pathToPackageJson ).toString() ).private;
+		}
+
+		dirName = path.dirname( dirName );
+	}
+}

--- a/packages/jsdoc-plugins/lib/purge-private-api-docs.js
+++ b/packages/jsdoc-plugins/lib/purge-private-api-docs.js
@@ -31,6 +31,16 @@ module.exports = {
 
 				console.warn( `File ${ filename } did not start with '@module' tag and hence it will be ignored while building docs.` );
 			}
+		},
+
+		processingComplete( evt ) {
+			for ( const doclet of evt.doclets ) {
+				if ( doclet.meta && doclet.meta.path ) {
+					if ( isPrivatePackageFile( doclet.meta.path ) ) {
+						delete doclet.meta;
+					}
+				}
+			}
 		}
 	},
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature (tests): Manual test server accepts a new flag: `--identity-file` (alias: `-i`) that allows defining global constants in manual tests.

Other (tests): Manual test script will not search for tests in the `./manual/_utils` directory. If any of a manual test requires additional utils to work, those can be placed in the `_utils` directory.

Feature (jsdoc-plugins): Introduced a plugin that hides the package documentation if in the package's `package.json` file the `private` key is set to `true`. However, by adding the `@publicApi` annotation, you can mark blocks of the code that should not be hidden.

---

### Additional information

* A new `purge-private-api-docs` JSDoc plugin was introduced to remove private docs not ready to be public.
