### PR TITLE
The changelog generator now produces a commented out blog post placeholder by default

### DIFF
--- a/packages/ckeditor5-dev-env/lib/release-tools/templates/template.hbs
+++ b/packages/ckeditor5-dev-env/lib/release-tools/templates/template.hbs
@@ -8,7 +8,7 @@ Internal changes only (updated dependencies, documentation, etc.).
 {{#if highlightsPlaceholder}}
 ### Release highlights
 
-TODO: Add a link to the blog post.
+<!-- TODO: Add a link to the blog post. -->
 
 {{/if}}
 {{#if collaborationFeatures}}

--- a/packages/ckeditor5-dev-env/tests/release-tools/utils/generatechangelog.js
+++ b/packages/ckeditor5-dev-env/tests/release-tools/utils/generatechangelog.js
@@ -639,7 +639,7 @@ describe( 'dev-env/release-tools/utils', () => {
 							'### Release highlights'
 						);
 						expect( changesAsArray[ 2 ] ).to.equal(
-							'TODO: Add a link to the blog post.'
+							'<!-- TODO: Add a link to the blog post. -->'
 						);
 						expect( changesAsArray[ 3 ] ).to.equal(
 							'### Features'
@@ -820,7 +820,7 @@ describe( 'dev-env/release-tools/utils', () => {
 							'### Release highlights'
 						);
 						expect( changesAsArray[ 2 ] ).to.equal(
-							'TODO: Add a link to the blog post.'
+							'<!-- TODO: Add a link to the blog post. -->'
 						);
 						expect( changesAsArray[ 3 ] ).to.equal(
 							'### Collaboration features'


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature (env): The changelog generator now produces a commented out blog post placeholder by default. Closes ckeditor/ckeditor5#7954.

---

### Additional information

Didn't check the unit tests, I'll rely on CI here 🤞