### PR TITLE
Support for `--repositories` option

### DIFF
--- a/packages/ckeditor5-dev-tests/README.md
+++ b/packages/ckeditor5-dev-tests/README.md
@@ -46,14 +46,18 @@ You can also use the bin script for testing a package:
 
 #### CLI options
 
-* `watch` - Whether to watch the files and executing tests whenever any file changes. Also available as an alias: `-w`.
-* `source-map` - Whether to generate the source maps. Also available as an alias: `-s`.
-* `coverage` - Whether to generate code coverage. Also available as an alias: `-c`.
-* `verbose` - Whether to informs about Webpack's work. Also available as an alias: `-v`.
-* `files` - Specify file(s) to test. Also available as an alias: `-f`.
 * `browsers` - Browsers which will be used to run the tests. Also available as an alias: `-b`.
-* `reporter` - Mocha reporter – either `mocha` (default) or `dots` (less verbose one).
+* `coverage` - Whether to generate code coverage. Also available as an alias: `-c`.
+* `debug` - Allows specifying custom debug flags. For example, the `--debug engine` option uncomments the `// @if CK_DEBUG_ENGINE //` lines in the code. By default `--debug` is set to true even if you did not specify it. This enables the base set of debug logs (`// @if CK_DEBUG //`) which should always be enabled in the testing environment. You can completely turn off the debug mode by setting the `--debug false` option or `--no-debug`.
+* `files` - Package names, directories or files to tests. Also available as an alias: `-f`.
+* `language` – Specifies a language that will be used while building tests. By default it is `en`.
 * `production` - Run strictest set of checks. E.g. it fails test run when there are [console calls](https://github.com/ckeditor/ckeditor5/issues/1996) or [DOM leaks](https://github.com/ckeditor/ckeditor5/issues/6002).
+* `repositories` - The names of repositories where the tool should look for packages. Those repositories should be cloned into the `external/` directory in the root directory of the project. It allows omitting specifying all packages names' as `--files` option because those names will be read by the tool automatically. 
+* `reporter` - Mocha reporter – either `mocha` (default) or `dots` (less verbose one).
+* `server` - Whether to run the server without opening any browser.
+* `source-map` - Whether to generate the source maps. Also available as an alias: `-s`.
+* `verbose` - Whether to informs about Webpack's work. Also available as an alias: `-v`.
+* `watch` - Whether to watch the files and executing tests whenever any file changes. Also available as an alias: `-w`.
 
 #### Examples
 

--- a/packages/ckeditor5-dev-tests/README.md
+++ b/packages/ckeditor5-dev-tests/README.md
@@ -52,7 +52,7 @@ You can also use the bin script for testing a package:
 * `files` - Package names, directories or files to tests. Also available as an alias: `-f`.
 * `language` – Specifies a language that will be used while building tests. By default it is `en`.
 * `production` - Run strictest set of checks. E.g. it fails test run when there are [console calls](https://github.com/ckeditor/ckeditor5/issues/1996) or [DOM leaks](https://github.com/ckeditor/ckeditor5/issues/6002).
-* `repositories` - The names of repositories where the tool should look for packages. Those repositories should be cloned into the `external/` directory in the root directory of the project. It allows omitting specifying all packages names' as `--files` option because those names will be read by the tool automatically. 
+* `repositories` (`-r`) - Specifies names of repositories containing packages that should be tested. Those repositories should be cloned into the `external/` directory in the root directory of the project. It's a shortcut of the `--files` option as these repository packages' names will be read by the tool automatically. 
 * `reporter` - Mocha reporter – either `mocha` (default) or `dots` (less verbose one).
 * `server` - Whether to run the server without opening any browser.
 * `source-map` - Whether to generate the source maps. Also available as an alias: `-s`.

--- a/packages/ckeditor5-dev-tests/lib/utils/automated-tests/parsearguments.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/automated-tests/parsearguments.js
@@ -171,7 +171,7 @@ module.exports = function parseArguments( args ) {
 			if ( tools.isDirectory( externalRepositoryPath ) ) {
 				addPackagesToCollection( files, path.join( externalRepositoryPath, 'packages' ) );
 			} else {
-				log.warning( `Did not find repository "${ repositoryName }" in the root repository or the "external/" directory.` );
+				log.warning( `Did not find the repository "${ repositoryName }" in the root repository or the "external/" directory.` );
 			}
 		}
 
@@ -179,7 +179,7 @@ module.exports = function parseArguments( args ) {
 
 		function addPackagesToCollection( collection, directoryPath ) {
 			for ( const directory of tools.getDirectories( directoryPath ) ) {
-				collection.add( directory.replace( /ckeditor5?-/, '' ) );
+				collection.add( directory.replace( /^ckeditor5?-/, '' ) );
 			}
 		}
 	}

--- a/packages/ckeditor5-dev-tests/lib/utils/automated-tests/parsearguments.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/automated-tests/parsearguments.js
@@ -207,7 +207,7 @@ module.exports = function parseArguments( args ) {
 	function toCamelCase( value ) {
 		return value.split( '-' )
 			.map( ( item, index ) => {
-				if ( !index ) {
+				if ( index == 0 ) {
 					return item.toLowerCase();
 				}
 

--- a/packages/ckeditor5-dev-tests/tests/utils/automated-tests/parsearguments.js
+++ b/packages/ckeditor5-dev-tests/tests/utils/automated-tests/parsearguments.js
@@ -5,73 +5,317 @@
 
 'use strict';
 
-const mockery = require( 'mockery' );
+const path = require( 'path' );
 const { expect } = require( 'chai' );
 const sinon = require( 'sinon' );
+const proxyquire = require( 'proxyquire' );
 
 describe( 'parseArguments()', () => {
-	let parseArguments, sandbox;
+	let parseArguments, sandbox, stubs;
 
 	beforeEach( () => {
 		sandbox = sinon.createSandbox();
 
-		mockery.enable( {
-			warnOnReplace: false,
-			warnOnUnregistered: false
-		} );
+		stubs = {
+			cwd: sandbox.stub( process, 'cwd' ),
+			tools: {
+				isDirectory: sandbox.stub(),
+				readPackageName: sandbox.stub(),
+				getDirectories: sandbox.stub()
+			},
+			logger: {
+				warning: sandbox.stub()
+			},
+			pathJoin: sandbox.stub( path, 'join' ).callsFake( ( ...chunks ) => chunks.join( '/' ) )
+		};
 
-		parseArguments = require( '../../../lib/utils/automated-tests/parsearguments' );
+		parseArguments = proxyquire( '../../../lib/utils/automated-tests/parsearguments', {
+			'@ckeditor/ckeditor5-dev-utils': {
+				logger() {
+					return stubs.logger;
+				},
+				tools: stubs.tools
+			}
+		} );
 	} );
 
 	afterEach( () => {
 		sandbox.restore();
-		mockery.disable();
 	} );
 
-	it( 'returns an empty files list if --files was not specified', () => {
-		const options = parseArguments( [] );
-
-		expect( options.files ).to.deep.equal( [] );
-	} );
-
-	it( 'returns as array values specified in --files', () => {
+	it( 'replaces kebab-case strings with camelCase values', () => {
 		const options = parseArguments( [
-			'--files',
-			'core,engine'
+			'--source-map',
+			'true',
+			'--identity-file',
+			'/home/.secret/file.key',
+			'--theme-path',
+			'/path/to/theme/package',
+			'--additional-languages',
+			'de,fr'
 		] );
 
-		expect( options.files ).to.deep.equal( [ 'core', 'engine' ] );
+		expect( options[ 'source-map' ] ).to.be.undefined;
+		expect( options[ 'identity-file' ] ).to.be.undefined;
+		expect( options[ 'theme-path' ] ).to.be.undefined;
+		expect( options[ 'additional-languages' ] ).to.be.undefined;
+
+		expect( options.sourceMap ).to.equal( true );
+		expect( options.identityFile ).to.equal( '/home/.secret/file.key' );
+		expect( options.themePath ).to.equal( '/path/to/theme/package' );
+		expect( options.additionalLanguages ).to.deep.equal( [ 'de', 'fr' ] );
 	} );
 
-	it( 'should enable debug options by default', () => {
-		const options = parseArguments( [] );
-
-		expect( options.debug ).to.deep.equal( [ 'CK_DEBUG' ] );
-	} );
-
-	it( 'allows specifying additional debug flags', () => {
+	it( 'deletes all aliases keys from returned object', () => {
 		const options = parseArguments( [
-			'--debug',
-			'engine,ui'
+			'-b',
+			'Chrome,Firefox',
+			'-c',
+			'true',
+			'-d',
+			'engine',
+			'-f',
+			'core',
+			'-i',
+			'/home/.secret/file.key',
+			'-r',
+			'custom-monorepo',
+			'-s',
+			'true',
+			'-v',
+			'false',
+			'-w',
+			true
 		] );
 
-		expect( options.debug ).to.deep.equal( [ 'CK_DEBUG', 'CK_DEBUG_ENGINE', 'CK_DEBUG_UI' ] );
+		for ( const key of [ 'b', 'c', 'd', 'f', 'i', 'r', 's', 'v', 'w' ] ) {
+			expect( options[ key ], `Checked "${ key }"` ).to.be.undefined;
+		}
+
+		expect( options.coverage ).to.equal( true );
+		expect( options.verbose ).to.equal( false );
+		expect( options.browsers ).to.deep.equal( [ 'Chrome', 'Firefox' ] );
+		expect( options.debug ).to.deep.equal( [ 'CK_DEBUG', 'CK_DEBUG_ENGINE' ] );
+		expect( options.files ).to.deep.equal( [ 'core' ] );
+		expect( options.repositories ).to.deep.equal( [ 'custom-monorepo' ] );
+		expect( options.sourceMap ).to.equal( true );
+		expect( options.identityFile ).to.equal( '/home/.secret/file.key' );
 	} );
 
-	it( 'allows disabling debug option (--debug false)', () => {
-		const options = parseArguments( [
-			'--debug',
-			'false'
-		] );
+	describe( 'files', () => {
+		it( 'returns an empty array when the --files option was not specified', () => {
+			const options = parseArguments( [] );
 
-		expect( options.debug ).to.deep.equal( [] );
+			expect( options.files ).to.deep.equal( [] );
+		} );
+
+		it( 'returns an array values specified as --files', () => {
+			const options = parseArguments( [
+				'--files',
+				'core,engine'
+			] );
+
+			expect( options.files ).to.deep.equal( [ 'core', 'engine' ] );
+		} );
 	} );
 
-	it( 'allows disabling debug option (--no-debug)', () => {
-		const options = parseArguments( [
-			'--no-debug'
-		] );
+	describe( 'debug', () => {
+		it( 'should enable debug options by default', () => {
+			const options = parseArguments( [] );
 
-		expect( options.debug ).to.deep.equal( [] );
+			expect( options.debug ).to.deep.equal( [ 'CK_DEBUG' ] );
+		} );
+
+		it( 'allows specifying additional debug flags', () => {
+			const options = parseArguments( [
+				'--debug',
+				'engine,ui'
+			] );
+
+			expect( options.debug ).to.deep.equal( [ 'CK_DEBUG', 'CK_DEBUG_ENGINE', 'CK_DEBUG_UI' ] );
+		} );
+
+		it( 'allows disabling debug option (--debug false)', () => {
+			const options = parseArguments( [
+				'--debug',
+				'false'
+			] );
+
+			expect( options.debug ).to.deep.equal( [] );
+		} );
+
+		it( 'allows disabling debug option (--no-debug)', () => {
+			const options = parseArguments( [
+				'--no-debug'
+			] );
+
+			expect( options.debug ).to.deep.equal( [] );
+		} );
+	} );
+
+	describe( 'repositories', () => {
+		it( 'returns an empty array when the --repositories option was not specified', () => {
+			const options = parseArguments( [] );
+
+			expect( options.repositories ).to.deep.equal( [] );
+		} );
+
+		it(
+			'returns an array of packages to tests when `--repositories` is specified ' +
+			'(root directory check)',
+			() => {
+				stubs.cwd.returns( '/home/project' );
+
+				stubs.tools.isDirectory.withArgs( '/home/project/external' ).returns( false );
+				stubs.tools.readPackageName.withArgs( '/home/project' ).returns( 'ckeditor5' );
+				stubs.tools.getDirectories.withArgs( '/home/project/packages' ).returns( [
+					'ckeditor5-core',
+					'ckeditor5-engine'
+				] );
+
+				const options = parseArguments( [
+					'--repositories',
+					'ckeditor5'
+				] );
+
+				expect( options.files ).to.deep.equal( [ 'core', 'engine' ] );
+
+				expect( stubs.logger.warning.callCount ).to.equal( 1 );
+				expect( stubs.logger.warning.firstCall.args[ 0 ] ).to.equal(
+					'The `external/` directory does not exist. Only the root repository will be checked.'
+				);
+			}
+		);
+
+		it(
+			'returns an array of packages to tests when `--repositories` is specified ' +
+			'(external directory check)',
+			() => {
+				stubs.cwd.returns( '/home/project' );
+
+				stubs.tools.isDirectory.withArgs( '/home/project/external' ).returns( true );
+				stubs.tools.isDirectory.withArgs( '/home/project/external/ckeditor5' ).returns( true );
+
+				stubs.tools.readPackageName.withArgs( '/home/project' ).returns( 'foo' );
+				stubs.tools.getDirectories.withArgs( '/home/project/external/ckeditor5/packages' ).returns( [
+					'ckeditor5-core',
+					'ckeditor5-engine'
+				] );
+
+				const options = parseArguments( [
+					'--repositories',
+					'ckeditor5'
+				] );
+
+				expect( options.files ).to.deep.equal( [ 'core', 'engine' ] );
+
+				expect( stubs.logger.warning.callCount ).to.equal( 0 );
+			}
+		);
+
+		it(
+			'returns an array of packages to tests when `--repositories` is specified ' +
+			'(external directory check, specified repository does not exist)',
+			() => {
+				stubs.cwd.returns( '/home/project' );
+
+				stubs.tools.isDirectory.withArgs( '/home/project/external' ).returns( true );
+				stubs.tools.isDirectory.withArgs( '/home/project/external/ckeditor5' ).returns( false );
+
+				stubs.tools.readPackageName.withArgs( '/home/project' ).returns( 'foo' );
+
+				const options = parseArguments( [
+					'--repositories',
+					'ckeditor5'
+				] );
+
+				expect( options.files ).to.deep.equal( [] );
+
+				expect( stubs.logger.warning.callCount ).to.equal( 1 );
+				expect( stubs.logger.warning.firstCall.args[ 0 ] ).to.equal(
+					'Did not find the repository "ckeditor5" in the root repository or the "external/" directory.'
+				);
+			}
+		);
+
+		it(
+			'returns an array of packages (unique list) to tests when `--repositories` is specified ' +
+			'(root directory check + `--files` specified)',
+			() => {
+				stubs.cwd.returns( '/home/project' );
+
+				stubs.tools.isDirectory.withArgs( '/home/project/external' ).returns( true );
+
+				stubs.tools.readPackageName.withArgs( '/home/project' ).returns( 'ckeditor5' );
+				stubs.tools.getDirectories.withArgs( '/home/project/packages' ).returns( [
+					'ckeditor5-core',
+					'ckeditor5-engine',
+					'ckeditor5-utils'
+				] );
+
+				const options = parseArguments( [
+					'--repositories',
+					'ckeditor5',
+					'--files',
+					'core'
+				] );
+
+				expect( options.files ).to.deep.equal( [ 'core', 'engine', 'utils' ] );
+			}
+		);
+
+		it(
+			'returns an array of packages to tests when `--repositories` is specified ' +
+			'(root and external directories check)',
+			() => {
+				stubs.cwd.returns( '/home/project' );
+
+				stubs.tools.isDirectory.withArgs( '/home/project/external' ).returns( true );
+				stubs.tools.isDirectory.withArgs( '/home/project/external/foo' ).returns( true );
+				stubs.tools.isDirectory.withArgs( '/home/project/external/bar' ).returns( true );
+				stubs.tools.readPackageName.withArgs( '/home/project' ).returns( 'ckeditor5' );
+				stubs.tools.getDirectories.withArgs( '/home/project/packages' ).returns( [
+					'ckeditor5-core',
+					'ckeditor5-engine'
+				] );
+				stubs.tools.getDirectories.withArgs( '/home/project/external/foo/packages' ).returns( [
+					'ckeditor5-foo-1',
+					'ckeditor5-foo-2'
+				] );
+				stubs.tools.getDirectories.withArgs( '/home/project/external/bar/packages' ).returns( [
+					'ckeditor5-bar-1',
+					'ckeditor5-bar-2'
+				] );
+
+				const options = parseArguments( [
+					'--repositories',
+					'ckeditor5,foo,bar'
+				] );
+
+				expect( options.files ).to.deep.equal( [ 'core', 'engine', 'foo-1', 'foo-2', 'bar-1', 'bar-2' ] );
+			}
+		);
+
+		it(
+			'returns an array of packages to tests when `--repositories` is specified ' +
+			'(removes "ckeditor-" prefix)',
+			() => {
+				stubs.cwd.returns( '/home/project' );
+
+				stubs.tools.isDirectory.withArgs( '/home/project/external' ).returns( false );
+				stubs.tools.readPackageName.withArgs( '/home/project' ).returns( 'ckeditor5' );
+				stubs.tools.getDirectories.withArgs( '/home/project/packages' ).returns( [
+					'ckeditor-core',
+					'ckeditor-engine'
+				] );
+
+				const options = parseArguments( [
+					'--repositories',
+					'ckeditor5'
+				] );
+
+				expect( options.files ).to.deep.equal( [ 'core', 'engine' ] );
+			}
+		);
 	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature (tests): Introduced the `--repositories` (also known as `-r`) that allows specifying a name of a repository (or repositories, separated by a comma, similar to the `--files` option) where the tool should look for packages that should be tested. Thanks to that, you do not have to specify all packages of a repository that was cloned into the `external/` directory. Closes ckeditor/ckeditor5#7889.

An example. For the following tree:

```
packages/
    ...
    ckeditor5-xyz
external/
    custom-repository/
        packages/
            ckeditor5-foo/
            ckeditor5-bar/
```

Executing a test command:

```
yarn run test --repositories custom-repository
``` 

will be translated to: 

```
yarn run test --files foo,bar
```

The `--repositories` option can be mixed with the `--files` option. The following command:

```
yarn run test -f xyz -r custom-repository
```

Will be resolved as:

```
yarn run test -f xyz,foo,bar
```

---

### Additional information

When merging, copy the full message with examples.
