### PR TITLE
Enable "no-unused-expressions" ESLint rule.

### DIFF
--- a/packages/eslint-config-ckeditor5/.eslintrc.js
+++ b/packages/eslint-config-ckeditor5/.eslintrc.js
@@ -71,8 +71,7 @@ module.exports = {
 		'no-return-assign': 'error',
 		'no-self-compare': 'error',
 		'no-sequences': 'error',
-		// We can't use it because of https://github.com/eslint/eslint/issues/2102
-		// 'no-unused-expressions': 'error',
+		'no-unused-expressions': 'error', // See rule overrides for tests files.
 		'no-useless-call': 'error',
 		'no-useless-concat': 'error',
 		'no-useless-escape': 'error',
@@ -308,5 +307,13 @@ module.exports = {
 		'mocha/no-pending-tests': 'error',
 		'mocha/no-sibling-hooks': 'error',
 		'mocha/no-top-level-hooks': 'error'
-	}
+	},
+	'overrides': [
+		{
+			'files': [ '**/tests/**/*.js' ],
+			'rules': {
+				'no-unused-expressions': 'off'
+			}
+		}
+	]
 };


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Enable "no-unused-expressions" ESLint rule. Closes ckeditor/ckeditor5#7843.

