### PR TITLE
`getNewVersionType()` will suggest proper version for "BREAKING CHANGES"

### DIFF
--- a/packages/ckeditor5-dev-env/lib/release-tools/tasks/generatechangelogforsinglepackage.js
+++ b/packages/ckeditor5-dev-env/lib/release-tools/tasks/generatechangelogforsinglepackage.js
@@ -18,7 +18,7 @@ const getNewVersionType = require( '../utils/getnewversiontype' );
 const getCommits = require( '../utils/getcommits' );
 const getWriterOptions = require( '../utils/getwriteroptions' );
 const { getRepositoryUrl } = require( '../utils/transformcommitutils' );
-const transformCommitForSubRepositoryFactory = require( '../utils/transformcommitfactory' );
+const transformCommitFactory = require( '../utils/transformcommitfactory' );
 
 const SKIP_GENERATE_CHANGELOG = 'Typed "skip" as a new version. Aborting.';
 
@@ -37,6 +37,8 @@ const SKIP_GENERATE_CHANGELOG = 'Typed "skip" as a new version. Aborting.';
  *
  * @param {Boolean} [options.collaborationFeatures=false] Whether to add a note about collaboration features.
  *
+ * @param {String} [options.releaseBranch='master'] A name of the branch that should be used for releasing packages.
+ *
  * @returns {Promise}
  */
 module.exports = function generateChangelogForSinglePackage( options = {} ) {
@@ -45,12 +47,13 @@ module.exports = function generateChangelogForSinglePackage( options = {} ) {
 
 	logProcess( chalk.bold( `Generating changelog for "${ chalk.underline( pkgJson.name ) }"...` ) );
 
-	const transformCommit = transformCommitForSubRepositoryFactory();
+	const transformCommit = transformCommitFactory();
 
 	logProcess( 'Collecting all commits since the last release...' );
 
 	const commitOptions = {
-		from: options.from ? options.from : 'v' + pkgJson.version
+		from: options.from ? options.from : 'v' + pkgJson.version,
+		releaseBranch: options.releaseBranch
 	};
 
 	// Initial release.

--- a/packages/ckeditor5-dev-env/lib/release-tools/utils/getnewversiontype.js
+++ b/packages/ckeditor5-dev-env/lib/release-tools/utils/getnewversiontype.js
@@ -29,7 +29,7 @@ module.exports = function getNewVersionType( commits ) {
 
 	for ( const commit of publicCommits ) {
 		for ( const note of commit.notes ) {
-			if ( note.title === 'MAJOR BREAKING CHANGES' ) {
+			if ( note.title === 'MAJOR BREAKING CHANGES' || note.title === 'BREAKING CHANGES' ) {
 				return 'major';
 			}
 

--- a/packages/ckeditor5-dev-env/tests/release-tools/utils/getnewversiontype.js
+++ b/packages/ckeditor5-dev-env/tests/release-tools/utils/getnewversiontype.js
@@ -25,6 +25,13 @@ describe( 'dev-env/release-tools/utils', () => {
 			expect( getNewVersionType( commits ) ).to.equal( 'major' );
 		} );
 
+		it( 'returns "major" if BREAKING CHANGES was introduced in "type:Other" commit', () => {
+			const commits = [
+				{ isPublicCommit: true, notes: [ { title: 'BREAKING CHANGES' } ], rawType: 'Other' }
+			];
+			expect( getNewVersionType( commits ) ).to.equal( 'major' );
+		} );
+
 		it( 'returns "major" if MAJOR BREAKING CHANGES was introduced in "type:Fix" commit', () => {
 			const commits = [
 				{ isPublicCommit: true, notes: [ { title: 'MAJOR BREAKING CHANGES' } ], rawType: 'Fix' }
@@ -32,9 +39,23 @@ describe( 'dev-env/release-tools/utils', () => {
 			expect( getNewVersionType( commits ) ).to.equal( 'major' );
 		} );
 
+		it( 'returns "major" if BREAKING CHANGES was introduced in "type:Fix" commit', () => {
+			const commits = [
+				{ isPublicCommit: true, notes: [ { title: 'BREAKING CHANGES' } ], rawType: 'Fix' }
+			];
+			expect( getNewVersionType( commits ) ).to.equal( 'major' );
+		} );
+
 		it( 'returns "major" if MAJOR BREAKING CHANGES was introduced in "type:Feature" commit', () => {
 			const commits = [
 				{ isPublicCommit: true, notes: [ { title: 'MAJOR BREAKING CHANGES' } ], rawType: 'Feature' }
+			];
+			expect( getNewVersionType( commits ) ).to.equal( 'major' );
+		} );
+
+		it( 'returns "major" if BREAKING CHANGES was introduced in "type:Feature" commit', () => {
+			const commits = [
+				{ isPublicCommit: true, notes: [ { title: 'BREAKING CHANGES' } ], rawType: 'Feature' }
 			];
 			expect( getNewVersionType( commits ) ).to.equal( 'major' );
 		} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix (env): The `getNewVersionType()` util will return a proper version when generating the changelog for a single package. Closes ckeditor/ckeditor5#8265.

Feature (env): `generateChangelogForSinglePackage()` accepts an optional option: `options.releaseBranch` (which is equal `master` by default). 
