### PR TITLE
Improve self import linter error mesage

### DIFF
--- a/packages/ckeditor5-dev-tests/bin/check-dependencies.js
+++ b/packages/ckeditor5-dev-tests/bin/check-dependencies.js
@@ -98,8 +98,9 @@ depCheck( packageDirectory, depCheckOptions )
 		console.log( chalk.red( 'Found some issue with dependencies.\n' ) );
 
 		if ( data[ 0 ] ) {
-			console.log( chalk.yellow( 'Invalid itself imports:' ) );
+			console.log( chalk.yellow( 'Invalid itself imports found in:' ) );
 			console.log( data[ 0 ] + '\n' );
+			console.log( '🧾 Imports from local package must always use relative path.\n' );
 		}
 
 		if ( data[ 1 ] ) {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other (tests): Improved linter error message for self-imports. Closes https://github.com/ckeditor/ckeditor5/issues/8245.

---

### Additional information

Example error message:

<img src="https://user-images.githubusercontent.com/56868128/96707608-67102480-1398-11eb-8597-237ff9223812.png" width="700">

