### PR TITLE
Removed `jsdoc` from `peerDependencies`

### DIFF
--- a/packages/jsdoc-plugins/package.json
+++ b/packages/jsdoc-plugins/package.json
@@ -22,9 +22,6 @@
     "glob": "^7.1.3",
     "tmp": "^0.2.1"
   },
-  "peerDependencies": {
-    "jsdoc": "^3.6.0"
-  },
   "engines": {
     "node": ">=12.0.0",
     "npm": ">=5.7.1"


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal (jsdoc-plugins): Removed `jsdoc` from `peerDependencies`. Closes https://github.com/ckeditor/ckeditor5/issues/7870.

---

### Additional information

How to verify that locally:
1. In the `package.json` from `ckeditor5` repo provide a path to your local `ckeditor5-dev-docs` package: e.g. `"@ckeditor/ckeditor5-dev-docs": "file:../ckeditor5-dev/packages/ckeditor5-dev-docs"`.
2. In the `package.json` from `packages/jsdoc-plugins` from `ckeditor5-dev` repo provide a path to your local `jsdoc-plugins` package: e.g. `"@ckeditor/jsdoc-plugins": "file:../jsdoc-plugins"`.
3. From `ckeditor5` repo call `yarn --force` and confirm that `jsdoc@^3.6.0` unmet peer dependency is no longer displayed.