### PR TITLE
Initial version of the webpack config.

### DIFF
--- a/packages/ckeditor5-dev-utils/lib/builds/getdllpluginwebpackconfig.js
+++ b/packages/ckeditor5-dev-utils/lib/builds/getdllpluginwebpackconfig.js
@@ -21,7 +21,7 @@ const tools = require( '../tools' );
  * @param {String} options.manifestPath An absolute path to the DLL manifest file.
  * @returns {Object}
  */
-module.exports = function getPluginWebpackConfig( options ) {
+module.exports = function getDLLPluginWebpackConfig( options ) {
 	const packageName = tools.readPackageName( options.packagePath );
 	const fileName = getIndexFileName( packageName );
 

--- a/packages/ckeditor5-dev-utils/lib/builds/getpluginwebpackconfig.js
+++ b/packages/ckeditor5-dev-utils/lib/builds/getpluginwebpackconfig.js
@@ -1,0 +1,107 @@
+/**
+ * @license Copyright (c) 2003-2020, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+'use strict';
+
+const path = require( 'path' );
+const webpack = require( 'webpack' );
+const TerserPlugin = require( 'terser-webpack-plugin' );
+const bundler = require( '../bundler' );
+const styles = require( '../styles' );
+const tools = require( '../tools' );
+
+/**
+ * @param {Object} options
+ * @param {String} options.themePath Configuration of the theme-importer PostCSS plugin.
+ * @param {String} options.packagePath An absolute path to the root directory of the package.
+ * @param {'production'|'development'} [options.mode='production'] Type of the bundle.
+ * @returns {Object}
+ */
+module.exports = function getPluginWebpackConfig( options ) {
+	const packageName = tools.readPackageName( options.packagePath );
+
+	return {
+		mode: options.mode || 'production',
+
+		devtool: 'source-map',
+
+		performance: { hints: false },
+
+		entry: path.join( options.packagePath, 'src', 'index.js' ),
+
+		output: {
+			library: [ 'CKEditor5', getShortPackageName( packageName ) ],
+
+			path: path.join( options.packagePath, 'dist' ),
+			filename: 'ckeditor.js',
+			libraryTarget: 'umd',
+			libraryExport: 'default'
+		},
+
+		optimization: {
+			minimizer: [
+				new TerserPlugin( {
+					sourceMap: true,
+					terserOptions: {
+						output: {
+							// Preserve CKEditor 5 license comments.
+							comments: /^!/
+						}
+					},
+					extractComments: false
+				} )
+			]
+		},
+
+		plugins: [
+			new webpack.BannerPlugin( {
+				banner: bundler.getLicenseBanner(),
+				raw: true
+			} )
+		],
+
+		module: {
+			rules: [
+				{
+					test: /\.svg$/,
+					use: [ 'raw-loader' ]
+				},
+				{
+					test: /\.css$/,
+					use: [
+						{
+							loader: 'style-loader',
+							options: {
+								injectType: 'singletonStyleTag',
+								attributes: {
+									'data-cke': true
+								}
+							}
+						},
+						{
+							loader: 'postcss-loader',
+							options: styles.getPostCssConfig( {
+								themeImporter: {
+									themePath: options.themePath
+								},
+								minify: true
+							} )
+						}
+					]
+				}
+			]
+		}
+	};
+};
+
+/**
+ * @param {String} packageName
+ * @returns {String}
+ */
+function getShortPackageName( packageName ) {
+	return packageName
+		.replace( /^@ckeditor\/ckeditor5?-/, '' )
+		.replace( /-([a-z])/g, ( match, p1 ) => p1.toUpperCase() );
+}

--- a/packages/ckeditor5-dev-utils/lib/builds/getpluginwebpackconfig.js
+++ b/packages/ckeditor5-dev-utils/lib/builds/getpluginwebpackconfig.js
@@ -18,11 +18,11 @@ const tools = require( '../tools' );
  * @param {Object} options
  * @param {String} options.themePath An absolute path to the theme package.
  * @param {String} options.packagePath An absolute path to the root directory of the package.
+ * @param {String} options.manifestPath An absolute path to the DLL manifest file.
  * @returns {Object}
  */
 module.exports = function getPluginWebpackConfig( options ) {
 	const packageName = tools.readPackageName( options.packagePath );
-	const dllManifestPath = path.join( options.packagePath, '..', '..', 'build', 'ckeditor5-dll.manifest.json' );
 	const fileName = getIndexFileName( packageName );
 
 	return {
@@ -54,7 +54,7 @@ module.exports = function getPluginWebpackConfig( options ) {
 				raw: true
 			} ),
 			new webpack.DllReferencePlugin( {
-				manifest: require( dllManifestPath ),
+				manifest: require( options.manifestPath ),
 				scope: 'ckeditor5/src'
 			} )
 		],

--- a/packages/ckeditor5-dev-utils/lib/builds/index.js
+++ b/packages/ckeditor5-dev-utils/lib/builds/index.js
@@ -6,5 +6,5 @@
 'use strict';
 
 module.exports = {
-	getPluginWebpackConfig: require( './getpluginwebpackconfig' )
+	getDLLPluginWebpackConfig: require( './getdllpluginwebpackconfig' )
 };

--- a/packages/ckeditor5-dev-utils/lib/builds/index.js
+++ b/packages/ckeditor5-dev-utils/lib/builds/index.js
@@ -1,0 +1,10 @@
+/**
+ * @license Copyright (c) 2003-2020, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+'use strict';
+
+module.exports = {
+	getPluginWebpackConfig: require( './getpluginwebpackconfig' )
+};

--- a/packages/ckeditor5-dev-utils/lib/index.js
+++ b/packages/ckeditor5-dev-utils/lib/index.js
@@ -13,5 +13,6 @@ module.exports = {
 	workspace: require( './workspace' ),
 	translations: require( './translations/index' ),
 	bundler: require( './bundler/index' ),
+	builds: require( './builds/index' ),
 	styles: require( './styles/index' )
 };

--- a/packages/ckeditor5-dev-utils/package.json
+++ b/packages/ckeditor5-dev-utils/package.json
@@ -19,6 +19,10 @@
     "postcss-mixins": "^6.2.0",
     "postcss-nesting": "^7.0.0",
     "shelljs": "^0.8.1",
+    "postcss-loader": "^3.0.0",
+    "raw-loader": "^4.0.1",
+    "style-loader": "^1.2.1",
+    "terser-webpack-plugin": "^3.0.2",
     "through2": "^3.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
### Suggested merge commit message (convention)

Internal (utils): Introduced a new object (`builds`) that contains a function (`getDLLPluginWebpackConfig()`) that returns a webpack configuration that uses DLL. See ckeditor/ckeditor5#8586.

---

### Additional information

Required for: https://github.com/ckeditor/ckeditor5/pull/8607
