### PR TITLE
Changed a way how the packages are grouped in the mono-repository changelog

### DIFF
--- a/packages/ckeditor5-dev-env/lib/release-tools/tasks/generatechangelogformonorepository.js
+++ b/packages/ckeditor5-dev-env/lib/release-tools/tasks/generatechangelogformonorepository.js
@@ -10,7 +10,6 @@ const path = require( 'path' );
 const { tools, logger } = require( '@ckeditor/ckeditor5-dev-utils' );
 const compareFunc = require( 'compare-func' );
 const chalk = require( 'chalk' );
-const minimatch = require( 'minimatch' );
 const semver = require( 'semver' );
 const changelogUtils = require( '../utils/changelog' );
 const cli = require( '../utils/cli' );
@@ -490,10 +489,10 @@ module.exports = function generateChangelogForMonoRepository( options ) {
 		}
 
 		for ( const [ packageName, version ] of dependencies ) {
-			const packageWithoutScope = packageName.replace( /^@ckeditor\//, '' );
+			const packageScope = packageName.replace( /^@ckeditor\/ckeditor5?-/, '' );
 
 			for ( const singleScope of scopes ) {
-				if ( minimatch( packageWithoutScope, '*' + singleScope ) ) {
+				if ( packageScope === singleScope ) {
 					packages.set( packageName, version );
 					dependencies.delete( packageName );
 				}


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix (env): Changed packages in the generated changelog will be grouped to proper sections by exact comparing their scopes instead of matching values. Closes ckeditor/ckeditor5#8596.

---

### Additional information

The case mentioned in the issue was resolved:

![image](https://user-images.githubusercontent.com/2270764/104183355-21507e80-5412-11eb-81de-9a2e5f3919bd.png)

