### PR TITLE
Fixed dependency checker in detecting missing, unused or misplaced ones from JS, CSS and `package.json` files

### DIFF
--- a/packages/ckeditor5-dev-tests/bin/check-dependencies.js
+++ b/packages/ckeditor5-dev-tests/bin/check-dependencies.js
@@ -37,12 +37,15 @@ async function checkDependencies( packagePaths ) {
  * Checks dependencies in provided package. If the folder does not contain a package.json file the function quits with success.
  *
  * @param {String} packagePath Relative path to package.
+ * @returns {Boolean} The result of checking the dependencies in the package: true = no errors found.
  */
 async function checkDependenciesInPackage( packagePath ) {
 	const packageAbsolutePath = path.resolve( packagePath );
 	const packageJsonPath = path.join( packageAbsolutePath, 'package.json' );
 
 	if ( !fs.existsSync( packageJsonPath ) ) {
+		console.log( `⚠️  Missing package.json file in ${ chalk.bold( packagePath ) }, skipping...` );
+
 		return true;
 	}
 

--- a/packages/ckeditor5-dev-tests/bin/check-dependencies.js
+++ b/packages/ckeditor5-dev-tests/bin/check-dependencies.js
@@ -13,134 +13,164 @@ const glob = require( 'glob' );
 const depCheck = require( 'depcheck' );
 const chalk = require( 'chalk' );
 
-const packageDirectory = process.argv[ 2 ] ? path.resolve( process.argv[ 2 ] ) : process.cwd();
-const packageJson = require( path.join( packageDirectory, 'package.json' ) );
-const nonExistingCSSFiles = [];
+const packagePaths = getPackagePaths( process.argv.slice( 2 ) );
 
-const depCheckOptions = {
-	// We need to add all values manually because if we modify it, the rest is being lost.
-	parsers: {
-		'*.css': parsePostCSS,
-		'*.js': depCheck.parser.es6,
-		'*.jsx': depCheck.parser.jsx,
-		'*.ts': depCheck.parser.typescript,
-		'*.vue': depCheck.parser.vue
-	},
-	ignoreDirs: [ 'docs', 'build' ],
-	ignoreMatches: [ 'eslint', 'eslint-plugin-ckeditor5-rules', 'eslint-plugin-mocha', 'husky', 'lint-staged', 'webpack-cli' ]
-};
-
-if ( Array.isArray( packageJson.depcheckIgnore ) ) {
-	depCheckOptions.ignoreMatches.push( ...packageJson.depcheckIgnore );
-}
-
-console.log( 'Checking dependencies...' );
-
-depCheck( packageDirectory, depCheckOptions )
-	.then( unused => {
-		const missingPackages = groupMissingPackages( unused.missing, packageJson.name );
-
-		const data = [
-			// Invalid itself imports.
-			[ ...getInvalidItselfImports( packageDirectory ) ]
-				.map( entry => '- ' + entry )
-				.join( '\n' ),
-
-			// Missing dependencies.
-			missingPackages.dependencies
-				.map( entry => '- ' + entry )
-				.join( '\n' ),
-
-			// Missing devDependencies.
-			missingPackages.devDependencies
-				.map( entry => '- ' + entry )
-				.join( '\n' ),
-
-			// Unused dependencies.
-			// We need to remove packages which are already defined as `missing`.
-			// `unused.dependencies` lists packages used by JS files. It does not touch CSS files where
-			// a package can be used.
-			unused.dependencies
-				.filter( entry => missingPackages.dependencies.includes( entry ) )
-				.map( entry => '- ' + entry )
-				.join( '\n' ),
-
-			// Unused devDependencies.
-			// We need to remove packages listed as `unused.dependencies` in order to avoid duplicating them.
-			// Also, we need to filter `unused.devDependencies`. See `unused.dependencies` in order to know why.
-			unused.devDependencies
-				.filter( entry => missingPackages.dependencies.includes( entry ) )
-				.filter( packageName => !unused.dependencies.includes( packageName ) )
-				.map( entry => '- ' + entry )
-				.join( '\n' ),
-
-			// Relative CSS imports (files do not exist).
-			nonExistingCSSFiles
-				.map( entry => {
-					return `- "${ chalk.italic( entry.file ) }" imports "${ chalk.italic( entry.import ) }"`;
-				} )
-				.join( '\n' ),
-
-			// Duplicated `dependencies` and `devDependencies`.
-			findDuplicatedDependencies( packageJson.dependencies, packageJson.devDependencies )
-				.map( entry => '- ' + entry )
-				.join( '\n' )
-		];
-
-		const hasErrors = data.some( entry => !!entry );
-
-		if ( !hasErrors ) {
-			console.log( chalk.green( 'All dependencies are defined correctly.' ) );
-
-			return;
-		}
-
-		console.log( chalk.red( 'Found some issue with dependencies.\n' ) );
-
-		if ( data[ 0 ] ) {
-			console.log( chalk.yellow( 'Invalid itself imports found in:' ) );
-			console.log( data[ 0 ] + '\n' );
-			console.log( '🧾 Imports from local package must always use relative path.\n' );
-		}
-
-		if ( data[ 1 ] ) {
-			console.log( chalk.red( 'Missing dependencies:' ) );
-			console.log( data[ 1 ] + '\n' );
-		}
-
-		if ( data[ 2 ] ) {
-			console.log( chalk.red( 'Missing devDependencies:' ) );
-			console.log( data[ 2 ] + '\n' );
-		}
-
-		if ( data[ 3 ] ) {
-			console.log( chalk.cyan( 'Unused dependencies:' ) );
-			console.log( data[ 3 ] + '\n' );
-		}
-
-		if ( data[ 4 ] ) {
-			console.log( chalk.cyan( 'Unused devDependencies:' ) );
-			console.log( data[ 4 ] + '\n' );
-		}
-
-		if ( data[ 5 ] ) {
-			console.log( chalk.yellow( 'Importing CSS files that do not exist:' ) );
-			console.log( data[ 5 ] + '\n' );
-		}
-
-		if ( data[ 6 ] ) {
-			console.log( chalk.yellow( 'Duplicated `dependencies` and `devDependencies`:' ) );
-			console.log( data[ 6 ] + '\n' );
-		}
-
-		process.exit( -1 );
-	} );
+checkDependencies( packagePaths );
 
 /**
- * Returns a Set that contains list of files that import modules using full package name instead of relative path.
+ * Checks dependencies sequentially in all provided packages.
+ *
+ * @param {Set.<String>} packagePaths Relative paths to packages.
+ */
+async function checkDependencies( packagePaths ) {
+	for ( const packagePath of packagePaths ) {
+		const isSuccess = await checkDependenciesInPackage( packagePath );
+
+		// Mark result of this script execution as invalid.
+		if ( !isSuccess ) {
+			process.exitCode = 1;
+		}
+	}
+}
+
+/**
+ * Checks dependencies in provided package. If the folder does not contain a package.json file the function quits with success.
+ *
+ * @param {String} packagePath Relative path to package.
+ */
+async function checkDependenciesInPackage( packagePath ) {
+	const packageAbsolutePath = path.resolve( packagePath );
+	const packageJsonPath = path.join( packageAbsolutePath, 'package.json' );
+
+	if ( !fs.existsSync( packageJsonPath ) ) {
+		return true;
+	}
+
+	const packageJson = require( packageJsonPath );
+
+	const missingCSSFiles = [];
+	const onMissingCSSFile = file => missingCSSFiles.push( file );
+
+	const depCheckOptions = {
+		// We need to add all values manually because if we modify it, the rest is being lost.
+		parsers: {
+			'**/*.css': filePath => parsePostCSS( filePath, onMissingCSSFile ),
+			'**/*.js': depCheck.parser.es6,
+			'**/*.jsx': depCheck.parser.jsx,
+			'**/*.ts': depCheck.parser.typescript,
+			'**/*.vue': depCheck.parser.vue
+		},
+		ignorePatterns: [ 'docs', 'build' ],
+		ignoreMatches: [ 'eslint*', 'webpack*', 'husky', 'lint-staged' ]
+	};
+
+	if ( Array.isArray( packageJson.depcheckIgnore ) ) {
+		depCheckOptions.ignoreMatches.push( ...packageJson.depcheckIgnore );
+	}
+
+	console.log( `🔎 Checking dependencies in ${ chalk.bold( packageJson.name ) }...` );
+
+	const result = await depCheck( packageAbsolutePath, depCheckOptions );
+
+	const missingPackages = groupMissingPackages( result.missing, packageJson.name );
+
+	const errors = [
+		// Invalid itself imports.
+		getInvalidItselfImports( packageAbsolutePath )
+			.map( entry => '- ' + entry )
+			.join( '\n' ),
+
+		// Missing dependencies.
+		missingPackages.dependencies
+			.map( entry => '- ' + entry )
+			.join( '\n' ),
+
+		// Missing devDependencies.
+		missingPackages.devDependencies
+			.map( entry => '- ' + entry )
+			.join( '\n' ),
+
+		// Unused dependencies.
+		result.dependencies
+			.map( entry => '- ' + entry )
+			.join( '\n' ),
+
+		// Unused devDependencies.
+		result.devDependencies
+			.map( entry => '- ' + entry )
+			.join( '\n' ),
+
+		// Relative CSS imports (files do not exist).
+		missingCSSFiles
+			.map( entry => {
+				return `- "${ entry.file }" imports "${ entry.import }"`;
+			} )
+			.join( '\n' ),
+
+		// Duplicated `dependencies` and `devDependencies`.
+		findDuplicatedDependencies( packageJson.dependencies, packageJson.devDependencies )
+			.map( entry => '- ' + entry )
+			.join( '\n' ),
+
+		// Misplaced `dependencies` or `devDependencies`.
+		// Checks whether any package, which is already listed in the `dependencies` or `devDependencies`,
+		// should belong to that list.
+		findMisplacedDependencies( packageJson.dependencies, packageJson.devDependencies, result.using )
+			.reduce( ( result, group ) => {
+				return result + '\n' +
+					group.description + '\n' +
+					group.packageNames.map( entry => '- ' + entry ).join( '\n' ) + '\n';
+			}, '' )
+	];
+
+	const hasErrors = errors.some( error => !!error );
+
+	if ( !hasErrors ) {
+		console.log( chalk.green.bold( '✨ All dependencies are defined correctly.\n' ) );
+
+		return true;
+	}
+
+	console.log( chalk.red.bold( '🔥 Found some issue with dependencies.\n' ) );
+
+	showErrors( errors );
+
+	return false;
+}
+
+/**
+ * Extracts relative paths to packages.
+ *
+ * @param {Array.<String>} args CLI arguments with relative or absolute package paths.
+ * @returns {Set.<String>} Relative package paths.
+ */
+function getPackagePaths( args ) {
+	const PACKAGE_RELATIVE_PATH_REGEXP = /packages\/ckeditor5?-[^/]+/;
+
+	const getPackageRelativePathFromAbsolutePath = path => {
+		const found = path.match( PACKAGE_RELATIVE_PATH_REGEXP );
+
+		return found ? found[ 0 ] : '';
+	};
+
+	const isPackageRelativePath = path => !!path && PACKAGE_RELATIVE_PATH_REGEXP.test( path );
+
+	return args.reduce( ( paths, arg ) => {
+		const relativePath = path.isAbsolute( arg ) ? getPackageRelativePathFromAbsolutePath( arg ) : arg;
+
+		if ( isPackageRelativePath( relativePath ) ) {
+			paths.add( relativePath );
+		}
+
+		return paths;
+	}, new Set() );
+}
+
+/**
+ * Returns an array that contains list of files that import modules using full package name instead of relative path.
  *
  * @param repositoryPath An absolute path to the directory which should be checked.
- * @returns {Set<String>}
+ * @returns {Array.<String>}
  */
 function getInvalidItselfImports( repositoryPath ) {
 	const packageJson = require( path.join( repositoryPath, 'package.json' ) );
@@ -166,7 +196,7 @@ function getInvalidItselfImports( repositoryPath ) {
 			} );
 	}
 
-	return invalidImportsItself;
+	return [ ...invalidImportsItself ].sort();
 }
 
 /**
@@ -183,9 +213,9 @@ function groupMissingPackages( missingPackages, currentPackage ) {
 	const devDependencies = [];
 
 	for ( const packageName of Object.keys( missingPackages ) ) {
-		const isDevDependency = missingPackages[ packageName ].every( absolutePath => absolutePath.match( /tests/ ) );
+		const absolutePaths = missingPackages[ packageName ];
 
-		if ( isDevDependency ) {
+		if ( isDevDependency( absolutePaths ) ) {
 			devDependencies.push( packageName );
 		} else {
 			dependencies.push( packageName );
@@ -197,21 +227,21 @@ function groupMissingPackages( missingPackages, currentPackage ) {
 
 /**
  * Checks whether all packages that have been imported by the CSS file are defined in `package.json` as `dependencies`.
- * Returned array contains list of missing packages.
+ * Returned array contains list of used packages.
  *
- * @param {String} fileContent Content of the checking file.
  * @param {String} filePath An absolute path to the checking file.
- * @param {Array.<String>} dependencies Merged list of dependencies and devDependencies.
+ * @param {Function} onMissingCSSFile Error handler called when a CSS file is not found.
  * @returns {Array.<String>|undefined}
  */
-function parsePostCSS( fileContent, filePath, dependencies ) {
+function parsePostCSS( filePath, onMissingCSSFile ) {
+	const fileContent = fs.readFileSync( filePath, 'utf-8' );
 	const matchedImports = fileContent.match( /^@import "[^"]+";/mg );
 
 	if ( !matchedImports ) {
 		return;
 	}
 
-	const missingPackages = new Set();
+	const usedPackages = new Set();
 
 	matchedImports
 		.map( importLine => {
@@ -248,7 +278,7 @@ function parsePostCSS( fileContent, filePath, dependencies ) {
 				const fileToImport = path.resolve( filePath, '..', importDetails.path );
 
 				if ( !fs.existsSync( fileToImport ) ) {
-					nonExistingCSSFiles.push( {
+					onMissingCSSFile( {
 						file: filePath,
 						import: importDetails.path
 					} );
@@ -257,12 +287,10 @@ function parsePostCSS( fileContent, filePath, dependencies ) {
 				return;
 			}
 
-			if ( !dependencies.includes( importDetails.name ) ) {
-				missingPackages.add( importDetails.name );
-			}
+			usedPackages.add( importDetails.name );
 		} );
 
-	return [ ...missingPackages ];
+	return [ ...usedPackages ].sort();
 }
 
 /**
@@ -289,5 +317,114 @@ function findDuplicatedDependencies( dependencies, devDependencies ) {
 		}
 	}
 
-	return Array.from( duplicatedPackages );
+	return [ ...duplicatedPackages ].sort();
+}
+
+/**
+ * Checks whether all packages, which are already listed in the `dependencies` or `devDependencies`, should belong to that list.
+ * The `devDependencies` list should contain packages, which are not used in the source. Otherwise, a given package should be
+ * added to the `dependencies` list. This function does not check missing dependencies, which is covered elsewhere, but it only
+ * verifies wrongly placed ones.
+ *
+ * @see https://github.com/ckeditor/ckeditor5/issues/8817#issuecomment-759353134
+ * @param {Object|undefined} dependencies Defined dependencies from package.json.
+ * @param {Object|undefined} devDependencies Defined development dependencies from package.json.
+ * @param {Object} dependenciesToCheck All dependencies that have been found and files where they are used.
+ * @returns {Array.<Object>} Misplaced packages. Each array item is an object containing
+ * the `description` string and `packageNames` array of strings.
+ */
+function findMisplacedDependencies( dependencies, devDependencies, dependenciesToCheck ) {
+	const deps = Object.keys( dependencies || {} );
+	const devDeps = Object.keys( devDependencies || {} );
+
+	const misplacedPackages = {
+		missingInDependencies: {
+			description: '🧾 The following packages are used in the source and should be moved to `dependencies`',
+			packageNames: new Set()
+		},
+		missingInDevDependencies: {
+			description: '🧾 The following packages are not used in the source and should be moved to `devDependencies`',
+			packageNames: new Set()
+		}
+	};
+
+	for ( const [ packageName, absolutePaths ] of Object.entries( dependenciesToCheck ) ) {
+		const isDevDep = isDevDependency( absolutePaths );
+		const isMissingInDependencies = !isDevDep && !deps.includes( packageName ) && devDeps.includes( packageName );
+		const isMissingInDevDependencies = isDevDep && deps.includes( packageName ) && !devDeps.includes( packageName );
+
+		if ( isMissingInDependencies ) {
+			misplacedPackages.missingInDependencies.packageNames.add( packageName );
+		}
+
+		if ( isMissingInDevDependencies ) {
+			misplacedPackages.missingInDevDependencies.packageNames.add( packageName );
+		}
+	}
+
+	return Object
+		.values( misplacedPackages )
+		.filter( item => item.packageNames.size > 0 )
+		.map( item => ( {
+			description: item.description,
+			packageNames: [ ...item.packageNames ].sort()
+		} ) );
+}
+
+/**
+ * Checks if a package is a development dependency: a package not used in the source and theme.
+ *
+ * @param {Array.<String>} absolutePaths Files where a given package has been imported.
+ * @returns {Boolean}
+ */
+function isDevDependency( absolutePaths ) {
+	return !absolutePaths.some( absolutePath => absolutePath.match( /src|theme/ ) );
+}
+
+/**
+ * Displays all found errors.
+ *
+ * @param {Array.<String>} data Collection of errors.
+ */
+function showErrors( data ) {
+	if ( data[ 0 ] ) {
+		console.log( chalk.red( '❌ Invalid itself imports found in:' ) );
+		console.log( data[ 0 ] + '\n' );
+		console.log( '🧾 Imports from local package must always use relative path.\n' );
+	}
+
+	if ( data[ 1 ] ) {
+		console.log( chalk.red( '❌ Missing dependencies:' ) );
+		console.log( data[ 1 ] + '\n' );
+	}
+
+	if ( data[ 2 ] ) {
+		console.log( chalk.red( '❌ Missing devDependencies:' ) );
+		console.log( data[ 2 ] + '\n' );
+	}
+
+	if ( data[ 3 ] ) {
+		console.log( chalk.red( '❌ Unused dependencies:' ) );
+		console.log( data[ 3 ] + '\n' );
+	}
+
+	if ( data[ 4 ] ) {
+		console.log( chalk.red( '❌ Unused devDependencies:' ) );
+		console.log( data[ 4 ] + '\n' );
+	}
+
+	if ( data[ 5 ] ) {
+		console.log( chalk.red( '❌ Importing CSS files that do not exist:' ) );
+		console.log( data[ 5 ] + '\n' );
+	}
+
+	if ( data[ 6 ] ) {
+		console.log( chalk.red( '❌ Duplicated `dependencies` and `devDependencies`:' ) );
+		console.log( data[ 6 ] + '\n' );
+	}
+
+	if ( data[ 7 ] ) {
+		console.log( chalk.red( '❌ Misplaced dependencies (`dependencies` ⮀ `devDependencies`):' ) );
+		console.log( data[ 7 ] + '\n' );
+	}
 }

--- a/packages/ckeditor5-dev-tests/package.json
+++ b/packages/ckeditor5-dev-tests/package.json
@@ -18,7 +18,7 @@
     "commonmark": "^0.29.1",
     "cssnano": "^4.1.10",
     "del": "^5.1.0",
-    "depcheck": "^0.9.2",
+    "depcheck": "^1.3.1",
     "dom-combiner": "^0.1.3",
     "fs-extra": "^9.0.0",
     "glob": "^7.1.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -139,7 +139,7 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.10.3", "@babel/parser@^7.10.4", "@babel/parser@^7.12.3", "@babel/parser@^7.12.5", "@babel/parser@^7.7.7":
+"@babel/parser@^7.10.3", "@babel/parser@^7.10.4", "@babel/parser@^7.12.3", "@babel/parser@^7.12.5":
   version "7.12.5"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.12.5.tgz#b4af32ddd473c0bfa643bd7ff0728b8e71b81ea0"
   integrity sha512-FVM6RZQ0mn2KCf1VUED7KepYeUWoVShczewOCfm3nzoBybaih51h+sYVVGthW9M6lPByEPTQf+xm27PBdlpwmQ==
@@ -153,7 +153,7 @@
     "@babel/parser" "^7.10.4"
     "@babel/types" "^7.10.4"
 
-"@babel/traverse@^7.12.1", "@babel/traverse@^7.12.5", "@babel/traverse@^7.7.4":
+"@babel/traverse@^7.12.1", "@babel/traverse@^7.12.5":
   version "7.12.5"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.12.5.tgz#78a0c68c8e8a35e4cacfd31db8bb303d5606f095"
   integrity sha512-xa15FbQnias7z9a62LwYAA5SZZPkHIXpd42C6uW68o8uTuua96FHZy1y61Va5P/i83FAAcMpW8+A/QayntzuqA==
@@ -418,7 +418,7 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.6.tgz#f4c7ec43e81b319a9815115031709f26987891f0"
   integrity sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==
 
-"@types/minimatch@*":
+"@types/minimatch@*", "@types/minimatch@^3.0.3":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
   integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
@@ -803,6 +803,11 @@ arr-union@^3.1.0:
   resolved "https://registry.yarnpkg.com/arr-union/-/arr-union-3.1.0.tgz#e39b09aea9def866a8f206e288af63919bae39c4"
   integrity sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=
 
+array-differ@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/array-differ/-/array-differ-3.0.0.tgz#3cbb3d0f316810eafcc47624734237d6aee4ae6b"
+  integrity sha512-THtfYS6KtME/yIAhKjZ2ul7XI96lQGHRputJQHO80LAWQnuGP4iCIN8vdMRboGbIEYBwU33q8Tch1os2+X0kMg==
+
 array-from@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/array-from/-/array-from-2.1.1.tgz#cfe9d8c26628b9dc5aecc62a9f5d8f1f352c1195"
@@ -844,6 +849,11 @@ arrify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
   integrity sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=
+
+arrify@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/arrify/-/arrify-2.0.1.tgz#c9655e9331e0abcd588d2a7cad7e9956f66701fa"
+  integrity sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==
 
 asn1.js@^5.2.0:
   version "5.4.1"
@@ -1340,10 +1350,10 @@ buffer@^4.3.0:
     ieee754 "^1.1.4"
     isarray "^1.0.0"
 
-builtin-modules@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-3.1.0.tgz#aad97c15131eb76b65b50ef208e7584cd76a7484"
-  integrity sha512-k0KL0aWZuBt2lrxrcASWDfwOLMnodeQjodT/1SxEQAXsHANgo6ZC/VEaSEHCXt7aSTZ4/4H5LKa+tBXmW7Vtvw==
+builtin-modules@^3.1.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-3.2.0.tgz#45d5db99e7ee5e6bc4f362e008bf917ab5049887"
+  integrity sha512-lGzLKcioL90C7wMczpkY0n/oART3MbBa8R9OFGE1rJxoVI86u4WAGfEk8Wjv10eKSyTHVGkSo3bvBylCEtk7LA==
 
 builtin-status-codes@^3.0.0:
   version "3.0.0"
@@ -1462,6 +1472,11 @@ camelcase@^5.0.0, camelcase@^5.3.1:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
 
+camelcase@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.2.0.tgz#924af881c9d525ac9d87f40d964e5cea982a1809"
+  integrity sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==
+
 caniuse-api@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/caniuse-api/-/caniuse-api-3.0.0.tgz#5e4d90e2274961d46291997df599e3ed008ee4c0"
@@ -1561,6 +1576,21 @@ chokidar@3.3.0:
     readdirp "~3.2.0"
   optionalDependencies:
     fsevents "~2.1.1"
+
+"chokidar@>=2.0.0 <4.0.0":
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.0.tgz#458a4816a415e9d3b3caa4faec2b96a6935a9e65"
+  integrity sha512-JgQM9JS92ZbFR4P90EvmzNpSGhpPBGBSj10PILeDyYFwp4h2/D9OM03wsJ4zW1fEp4ka2DGrnUeD7FuvQ2aZ2Q==
+  dependencies:
+    anymatch "~3.1.1"
+    braces "~3.0.2"
+    glob-parent "~5.1.0"
+    is-binary-path "~2.1.0"
+    is-glob "~4.0.1"
+    normalize-path "~3.0.0"
+    readdirp "~3.5.0"
+  optionalDependencies:
+    fsevents "~2.3.1"
 
 chokidar@^2.1.8:
   version "2.1.8"
@@ -1680,6 +1710,15 @@ cliui@^6.0.0:
     string-width "^4.2.0"
     strip-ansi "^6.0.0"
     wrap-ansi "^6.2.0"
+
+cliui@^7.0.2:
+  version "7.0.4"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-7.0.4.tgz#a0265ee655476fc807aea9df3df8df7783808b4f"
+  integrity sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==
+  dependencies:
+    string-width "^4.2.0"
+    strip-ansi "^6.0.0"
+    wrap-ansi "^7.0.0"
 
 clone-buffer@^1.0.0:
   version "1.0.0"
@@ -1977,7 +2016,7 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
 
-cosmiconfig@^5.0.0, cosmiconfig@^5.2.1:
+cosmiconfig@^5.0.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-5.2.1.tgz#040f726809c591e77a17c0a3626ca45b4f168b1a"
   integrity sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==
@@ -2362,28 +2401,34 @@ delayed-stream@~1.0.0:
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
   integrity sha1-3zrhmayt+31ECqrgsp4icrJOxhk=
 
-depcheck@^0.9.2:
-  version "0.9.2"
-  resolved "https://registry.yarnpkg.com/depcheck/-/depcheck-0.9.2.tgz#9e3198b44a527836914c61ba5395479c62ecbaf4"
-  integrity sha512-w5f+lSZqLJJkk58s44eOd0Vor7hLZot4PlFL0y2JsIX5LuHQ2eAjHlDVeGBD4Mj6ZQSKakvKWRRCcPlvrdU2Sg==
+depcheck@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/depcheck/-/depcheck-1.3.1.tgz#b4765503da3e6ba1f3810dad0c34c0a649e7e91d"
+  integrity sha512-lLMfqX2J+ZF3xUEqHpgCNk+dA8erAfW6XURGNAIyUS4KL2i3lezXGYDevYk3G0rWCwy/3CpxE8ek10NrURFOtQ==
   dependencies:
-    "@babel/parser" "^7.7.7"
-    "@babel/traverse" "^7.7.4"
-    builtin-modules "^3.0.0"
-    camelcase "^5.3.1"
-    cosmiconfig "^5.2.1"
-    debug "^4.1.1"
+    "@babel/parser" "^7.12.5"
+    "@babel/traverse" "^7.12.5"
+    builtin-modules "^3.1.0"
+    camelcase "^6.2.0"
+    cosmiconfig "^7.0.0"
+    debug "^4.2.0"
     deps-regex "^0.1.4"
-    js-yaml "^3.4.2"
-    lodash "^4.17.15"
-    minimatch "^3.0.2"
-    node-sass-tilde-importer "^1.0.2"
+    ignore "^5.1.8"
+    js-yaml "^3.14.0"
+    json5 "^2.1.3"
+    lodash "^4.17.20"
+    minimatch "^3.0.4"
+    multimatch "^5.0.0"
     please-upgrade-node "^3.2.0"
+    query-ast "^1.0.3"
+    readdirp "^3.5.0"
     require-package-name "^2.0.1"
-    resolve "^1.14.1"
-    vue-template-compiler "^2.6.11"
-    walkdir "^0.4.1"
-    yargs "^15.0.2"
+    resolve "^1.18.1"
+    sass "^1.29.0"
+    scss-parser "^1.0.4"
+    semver "^7.3.2"
+    vue-template-compiler "^2.6.12"
+    yargs "^16.1.0"
 
 depd@~1.1.2:
   version "1.1.2"
@@ -3135,11 +3180,6 @@ find-cache-dir@^3.2.0:
     make-dir "^3.0.2"
     pkg-dir "^4.1.0"
 
-find-parent-dir@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/find-parent-dir/-/find-parent-dir-0.3.0.tgz#33c44b429ab2b2f0646299c5f9f718f376ff8d54"
-  integrity sha1-M8RLQpqysvBkYpnF+fcY83b/jVQ=
-
 find-up@3.0.0, find-up@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-3.0.0.tgz#49169f1d7993430646da61ecc5ae355c21c97b73"
@@ -3290,6 +3330,11 @@ fsevents@~2.1.1, fsevents@~2.1.2:
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.1.3.tgz#fb738703ae8d2f9fe900c33836ddebee8b97f23e"
   integrity sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==
 
+fsevents@~2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.1.tgz#b209ab14c61012636c8863507edf7fb68cc54e9f"
+  integrity sha512-YR47Eg4hChJGAB1O3yEAOkGO+rlzutoICGqGo9EZ4lKWokzZRSyIW1QmTzqjtw8MJdj9srP869CuWw/hyzSiBw==
+
 function-bind@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
@@ -3305,7 +3350,7 @@ gensync@^1.0.0-beta.1:
   resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.2.tgz#32a6ee76c3d7f52d46b2b1ae5d93fea8580a25e0"
   integrity sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==
 
-get-caller-file@^2.0.1:
+get-caller-file@^2.0.1, get-caller-file@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
@@ -3730,7 +3775,7 @@ ignore@^4.0.6:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
 
-ignore@^5.1.1:
+ignore@^5.1.1, ignore@^5.1.8:
   version "5.1.8"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.8.tgz#f150a8b50a34289b33e22f5889abd4d8016f0e57"
   integrity sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==
@@ -3837,7 +3882,14 @@ interpret@^1.0.0:
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.4.0.tgz#665ab8bc4da27a774a40584e812e3e0fa45b1a1e"
   integrity sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==
 
-invariant@^2.2.2:
+invariant@2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.2.tgz#9e1f56ac0acdb6bf303306f338be3b204ae60360"
+  integrity sha1-nh9WrArNtr8wMwbzOL47IErmA2A=
+  dependencies:
+    loose-envify "^1.0.0"
+
+invariant@2.2.4, invariant@^2.2.2:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
   integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
@@ -3918,6 +3970,13 @@ is-core-module@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.0.0.tgz#58531b70aed1db7c0e8d4eb1a0a2d1ddd64bd12d"
   integrity sha512-jq1AH6C8MuteOoBPwkxHafmByhL9j5q4OaPGdbuD+ZtQJVzH+i6E3BJDQcBA09k57i2Hh2yQbEG8yObZ0jdlWw==
+  dependencies:
+    has "^1.0.3"
+
+is-core-module@^2.1.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.2.0.tgz#97037ef3d52224d85163f5597b2b63d9afed981a"
+  integrity sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==
   dependencies:
     has "^1.0.3"
 
@@ -4297,10 +4356,18 @@ js-yaml@3.13.1:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
-js-yaml@^3.13.1, js-yaml@^3.4.2:
+js-yaml@^3.13.1:
   version "3.14.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.0.tgz#a7a34170f26a21bb162424d8adacb4113a69e482"
   integrity sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^4.0.0"
+
+js-yaml@^3.14.0:
+  version "3.14.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.1.tgz#dae812fdb3825fa306609a8717383c50c36a0537"
+  integrity sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
@@ -4393,7 +4460,7 @@ json5@^1.0.1:
   dependencies:
     minimist "^1.2.0"
 
-json5@^2.1.2:
+json5@^2.1.2, json5@^2.1.3:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.1.3.tgz#c9b0f7fa9233bfe5807fe66fcf3a5617ed597d43"
   integrity sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==
@@ -4718,7 +4785,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@^4.17.10, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.4, lodash@~4.17.14:
+lodash@^4.17.10, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.4, lodash@~4.17.14:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
@@ -5003,7 +5070,7 @@ minimalistic-crypto-utils@^1.0.0, minimalistic-crypto-utils@^1.0.1:
   resolved "https://registry.yarnpkg.com/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
   integrity sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=
 
-minimatch@3.0.4, minimatch@^3.0.2, minimatch@^3.0.4:
+minimatch@3.0.4, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
@@ -5132,6 +5199,17 @@ ms@2.1.2, ms@^2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
+multimatch@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/multimatch/-/multimatch-5.0.0.tgz#932b800963cea7a31a033328fa1e0c3a1874dbe6"
+  integrity sha512-ypMKuglUrZUD99Tk2bUQ+xNQj43lPEfAeX2o9cTteAmShXy2VHDJpuwu1o0xqoKCt9jLVAvwyFKdLTPXKAfJyA==
+  dependencies:
+    "@types/minimatch" "^3.0.3"
+    array-differ "^3.0.0"
+    array-union "^2.1.0"
+    arrify "^2.0.1"
+    minimatch "^3.0.4"
+
 mute-stream@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
@@ -5254,13 +5332,6 @@ node-releases@^1.1.65:
   version "1.1.65"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.65.tgz#52d9579176bd60f23eba05c4438583f341944b81"
   integrity sha512-YpzJOe2WFIW0V4ZkJQd/DGR/zdVwc/pI4Nl1CZrBO19FdRcSTmsuhdttw9rsTzzJLrNcSloLiBbEYx1C4f6gpA==
-
-node-sass-tilde-importer@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/node-sass-tilde-importer/-/node-sass-tilde-importer-1.0.2.tgz#1a15105c153f648323b4347693fdb0f331bad1ce"
-  integrity sha512-Swcmr38Y7uB78itQeBm3mThjxBy9/Ah/ykPIaURY/L6Nec9AyRoL/jJ7ECfMR+oZeCTVQNxVMu/aHU+TLRVbdg==
-  dependencies:
-    find-parent-dir "^0.3.0"
 
 normalize-package-data@^2.5.0:
   version "2.5.0"
@@ -6261,6 +6332,14 @@ qs@~6.5.2:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
 
+query-ast@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/query-ast/-/query-ast-1.0.3.tgz#4a18374950fa80cbf9b03d7b945bbac8bb4250bf"
+  integrity sha512-k7z4jilpZCujhiJ+QeKSwYXHc9HxqiVKlVE7/em0zBfPpcqnXKUP8F7ld7XaAkO6oXeAD7yonqcNJWqOF2pSGA==
+  dependencies:
+    invariant "2.2.2"
+    lodash "^4.17.15"
+
 querystring-es3@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/querystring-es3/-/querystring-es3-0.2.1.tgz#9ec61f79049875707d69414596fd907a4d711e73"
@@ -6376,19 +6455,19 @@ readdirp@^2.2.1:
     micromatch "^3.1.10"
     readable-stream "^2.0.2"
 
+readdirp@^3.5.0, readdirp@~3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.5.0.tgz#9ba74c019b15d365278d2e91bb8c48d7b4d42c9e"
+  integrity sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==
+  dependencies:
+    picomatch "^2.2.1"
+
 readdirp@~3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.2.0.tgz#c30c33352b12c96dfb4b895421a49fd5a9593839"
   integrity sha512-crk4Qu3pmXwgxdSgGhgA/eXiJAPQiX4GMOZZMXnqKxHX7TaoL+3gQVo/WeuAiogr07DpnfjIMpXXa+PAIvwPGQ==
   dependencies:
     picomatch "^2.0.4"
-
-readdirp@~3.5.0:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.5.0.tgz#9ba74c019b15d365278d2e91bb8c48d7b4d42c9e"
-  integrity sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==
-  dependencies:
-    picomatch "^2.2.1"
 
 rechoir@^0.6.2:
   version "0.6.2"
@@ -6530,12 +6609,20 @@ resolve-url@^0.2.1:
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
   integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
 
-resolve@^1.1.6, resolve@^1.1.7, resolve@^1.10.0, resolve@^1.11.1, resolve@^1.14.1, resolve@^1.3.2:
+resolve@^1.1.6, resolve@^1.1.7, resolve@^1.10.0, resolve@^1.11.1, resolve@^1.3.2:
   version "1.18.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.18.1.tgz#018fcb2c5b207d2a6424aee361c5a266da8f4130"
   integrity sha512-lDfCPaMKfOJXjy0dPayzPdF1phampNWr3qFCjAu+rw/qbQmr5jWH5xN2hwh9QKfw9E5v4hwV7A+jrCmL8yjjqA==
   dependencies:
     is-core-module "^2.0.0"
+    path-parse "^1.0.6"
+
+resolve@^1.18.1:
+  version "1.19.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.19.0.tgz#1af5bf630409734a067cae29318aac7fa29a267c"
+  integrity sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==
+  dependencies:
+    is-core-module "^2.1.0"
     path-parse "^1.0.6"
 
 restore-cursor@^3.1.0:
@@ -6646,6 +6733,13 @@ safe-regex@^1.1.0:
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
+sass@^1.29.0:
+  version "1.32.4"
+  resolved "https://registry.yarnpkg.com/sass/-/sass-1.32.4.tgz#308bf29dd7f53d44ae4f06580e9a910ad9aa411e"
+  integrity sha512-N0BT0PI/t3+gD8jKa83zJJUb7ssfQnRRfqN+GIErokW6U4guBpfYl8qYB+OFLEho+QvnV5ZH1R9qhUC/Z2Ch9w==
+  dependencies:
+    chokidar ">=2.0.0 <4.0.0"
+
 sax@~1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
@@ -6684,6 +6778,14 @@ schema-utils@^3.0.0:
     "@types/json-schema" "^7.0.6"
     ajv "^6.12.5"
     ajv-keywords "^3.5.2"
+
+scss-parser@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/scss-parser/-/scss-parser-1.0.4.tgz#61cdeb28701ffcb497954b9b05729c6d38eb8b9f"
+  integrity sha512-oDZwDfY2JhnDrHNZPcdcPNVTpAXsJBY2/uhFfN0IzMy1xExAfJDcI1Yl/VXhfRsdQL3wLeg6/Oxt3cafBOuMzQ==
+  dependencies:
+    invariant "2.2.4"
+    lodash "^4.17.4"
 
 semver-compare@^1.0.0:
   version "1.0.0"
@@ -7858,18 +7960,13 @@ void-elements@^2.0.0:
   resolved "https://registry.yarnpkg.com/void-elements/-/void-elements-2.0.1.tgz#c066afb582bb1cb4128d60ea92392e94d5e9dbec"
   integrity sha1-wGavtYK7HLQSjWDqkjkulNXp2+w=
 
-vue-template-compiler@^2.6.11:
+vue-template-compiler@^2.6.12:
   version "2.6.12"
   resolved "https://registry.yarnpkg.com/vue-template-compiler/-/vue-template-compiler-2.6.12.tgz#947ed7196744c8a5285ebe1233fe960437fcc57e"
   integrity sha512-OzzZ52zS41YUbkCBfdXShQTe69j1gQDZ9HIX8miuC9C3rBCk9wIRjLiZZLrmX9V+Ftq/YEyv1JaVr5Y/hNtByg==
   dependencies:
     de-indent "^1.0.2"
     he "^1.1.0"
-
-walkdir@^0.4.1:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/walkdir/-/walkdir-0.4.1.tgz#dc119f83f4421df52e3061e514228a2db20afa39"
-  integrity sha512-3eBwRyEln6E1MSzcxcVpQIhRG8Q1jLvEqRmCZqS3dsfXEDR/AhOF4d+jHg1qvDCpYaVRZjENPQyrVxAkQqxPgQ==
 
 watchpack-chokidar2@^2.0.0:
   version "2.0.0"
@@ -8018,6 +8115,15 @@ wrap-ansi@^6.2.0:
     string-width "^4.1.0"
     strip-ansi "^6.0.0"
 
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
@@ -8072,6 +8178,11 @@ y18n@^4.0.0:
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz#95ef94f85ecc81d007c264e190a120f0a3c8566b"
   integrity sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==
 
+y18n@^5.0.5:
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.5.tgz#8769ec08d03b1ea2df2500acef561743bbb9ab18"
+  integrity sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg==
+
 yallist@^3.0.2:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
@@ -8097,6 +8208,11 @@ yargs-parser@^18.1.2, yargs-parser@^18.1.3:
   dependencies:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
+
+yargs-parser@^20.2.2:
+  version "20.2.4"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.4.tgz#b42890f14566796f85ae8e3a25290d205f154a54"
+  integrity sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==
 
 yargs-unparser@1.6.0:
   version "1.6.0"
@@ -8139,6 +8255,19 @@ yargs@^15.0.2, yargs@^15.3.1:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^18.1.2"
+
+yargs@^16.1.0:
+  version "16.2.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-16.2.0.tgz#1c82bf0f6b6a66eafce7ef30e376f49a12477f66"
+  integrity sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==
+  dependencies:
+    cliui "^7.0.2"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.0"
+    y18n "^5.0.5"
+    yargs-parser "^20.2.2"
 
 yeast@0.1.2:
   version "0.1.2"


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix (tests): Improved the dependency checker in detecting missing, unused, or misplaced packages from JS, CSS, and `package.json` files. Closes ckeditor/ckeditor5#8817.

---

### Additional information

Related PR is https://github.com/ckeditor/ckeditor5/pull/8854, which fixes errors found by this improved dependency checker.

The dependency checker is able to detect the new DLL-style imports, like `import { Plugin } from 'ckeditor5/src/core';`.
The `depcheck` version has been bumped to latest v1.3.1.

Fixes:
* Unused dependencies are now properly detected in JS or `package.json` files.
* Dependencies from CSS files are now properly detected and counted in the results.

Improvements:
* Misplaced dependencies `dependencies`  ⮀  `devDependencies` are now detected and reported.