### PR TITLE
Release tools can handle mono-repo that is a part of other mono-repo

### DIFF
--- a/packages/ckeditor5-dev-env/lib/release-tools/tasks/releasesubrepositories.js
+++ b/packages/ckeditor5-dev-env/lib/release-tools/tasks/releasesubrepositories.js
@@ -286,8 +286,7 @@ module.exports = function releaseSubRepositories( options ) {
 				// Prepare the main repository release details.
 				const packageJson = getPackageJson( options.cwd );
 				const releaseDetails = {
-					version: packageJson.version,
-					changes: getChangesForVersion( packageJson.version, options.cwd )
+					version: packageJson.version
 				};
 
 				if ( releaseOptions.github ) {
@@ -295,6 +294,7 @@ module.exports = function releaseSubRepositories( options ) {
 						exec( 'git remote get-url origin --push' ).trim()
 					);
 
+					releaseDetails.changes = getChangesForVersion( packageJson.version, options.cwd );
 					releaseDetails.repositoryOwner = repositoryInfo.owner;
 					releaseDetails.repositoryName = repositoryInfo.name;
 				}
@@ -372,12 +372,7 @@ module.exports = function releaseSubRepositories( options ) {
 			try {
 				return exec( `npm show ${ packageName } version` ).trim();
 			} catch ( err ) {
-				const errorAsArray = err.message.split( '\n' ).slice( 0, 2 );
-
-				if (
-					errorAsArray[ 0 ].endsWith( 'npm ERR! code E404' ) &&
-					errorAsArray[ 1 ] === `npm ERR! 404 '${ packageName }' is not in the npm registry.`
-				) {
+				if ( err.message.match( /npm ERR! 404/ ) ) {
 					return null;
 				}
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature (env): The `bumpVersions()` function can read the changelog file from an external directory (using `options.changelogDirectory`). Thanks to that, the private packages from the mono-repository can be released using a public changelog.

Feature (env): The `bumpVersions()` function allows skipping upgrading versions of dependencies between updated packages (using `options.skipUpdatingDependencies` which is `false` by default).

Fix (env): Simplified a check whether a package was published on NPM in the `releaseSubRepositories()` function. 

Other (env): The `bumpVersions()` function returns a promise with a collection that contains all updated packages. Previously the promise didn't resolve anything.

---

### Additional information

I'd like to do a live review because those scripts require much work that I don't want to share here. 
