### PR TITLE
Prepare a build that will be attached to the `window` object

### DIFF
--- a/packages/ckeditor5-dev-utils/lib/builds/getdllpluginwebpackconfig.js
+++ b/packages/ckeditor5-dev-utils/lib/builds/getdllpluginwebpackconfig.js
@@ -38,7 +38,7 @@ module.exports = function getDllPluginWebpackConfig( options ) {
 
 			path: path.join( options.packagePath, 'build' ),
 			filename: getIndexFileName( packageName ),
-			libraryTarget: 'umd',
+			libraryTarget: 'window',
 			libraryExport: 'default'
 		},
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix (utils): A DLL-consumer package produced by webpack should be assigned to the `window` object. See ckeditor/ckeditor5#9039.
