### PR TITLE
Ping an author of a commit that caused to fail the CI

### DIFF
--- a/packages/ckeditor5-dev-tests/bin/members.json
+++ b/packages/ckeditor5-dev-tests/bin/members.json
@@ -1,0 +1,21 @@
+{
+  "AnnaTomanek": "U044RC5NQ",
+  "Comandeer": "U0BK6HSJJ",
+  "FilipTokarski": "URSK5KV9V",
+  "godai78": "U017DJLU7NX",
+  "jacekbogdanski": "U8LAY97DE",
+  "kwach2000": "U01BRKQL8P4",
+  "LukaszGudel": "U01FRHAT8T1",
+  "ma2ciek": "U2JGX5TC7",
+  "magda-chrzescian": "U01FL082L22",
+  "maxbarnas": "U1EN0S6NT",
+  "mlewand": "U03UQQ1N3",
+  "Mgsy": "U5A38S2PN",
+  "niegowski": "U01017YC7C7",
+  "oleq": "U03UU2MNN",
+  "pomek": "U1D6HMH5M",
+  "psmyrek": "U01BJRWJCSJ",
+  "Reinmar": "U03UQRP0C",
+  "scofalik": "U05611ZMM",
+  "wwalc": "U03UQQ8PY"
+}

--- a/packages/ckeditor5-dev-tests/bin/notify-travis-status.js
+++ b/packages/ckeditor5-dev-tests/bin/notify-travis-status.js
@@ -200,7 +200,6 @@ function getCommitAuthor() {
 	const curlOutput = childProcess.spawnSync( 'curl', curlArguments, {
 		encoding: 'utf8',
 		shell: true,
-		stdout: 'inherit',
 		stderr: 'inherit'
 	} );
 

--- a/packages/ckeditor5-dev-tests/bin/notify-travis-status.js
+++ b/packages/ckeditor5-dev-tests/bin/notify-travis-status.js
@@ -11,6 +11,8 @@
 // - SLACK_WEBHOOK_URL - a URL where the notification should be sent
 // - START_TIME - POSIX time (when the script has begun the job)
 // - END_TIME - POSIX time (when the script has finished the job)
+// - GITHUB_TOKEN - token to a Github account with the scope: "repos". It is requires for obtaining an author of
+//   the commit if the build failed. The repository can be private and we can't use the public API.
 //
 // If the `SLACK_NOTIFY_COMMIT_URL` environment variable is defined, the script use the URL as the commit URL.
 // Otherwise, a marge of variables `TRAVIS_REPO_SLUG` and `TRAVIS_COMMIT` will be used.

--- a/packages/ckeditor5-dev-tests/bin/notify-travis-status.js
+++ b/packages/ckeditor5-dev-tests/bin/notify-travis-status.js
@@ -7,7 +7,7 @@
 
 /* eslint-env node */
 
-// This script assumes that is being executed on Travis CI. It requires three environment variables:
+// This script assumes that is being executed on Travis CI. It requires following environment variables:
 // - SLACK_WEBHOOK_URL - a URL where the notification should be sent
 // - START_TIME - POSIX time (when the script has begun the job)
 // - END_TIME - POSIX time (when the script has finished the job)
@@ -125,7 +125,7 @@ if ( commitAuthor ) {
 	if ( slackAccount ) {
 		data.text = `<@${ slackAccount }>, could you take a look?`;
 	} else {
-		data.text = '_An author of the commit could not be obtained._';
+		data.text = '_The author of the commit could not be obtained._';
 	}
 }
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature (tests): The `notify-travis-status` script will mention an author of a commit that caused to fail the CI.

---

### Additional information

More details about the implementation in the internal repo.
