### PR TITLE
Added the "--silent" flag to the manual test server

### DIFF
--- a/packages/ckeditor5-dev-tests/lib/tasks/runmanualtests.js
+++ b/packages/ckeditor5-dev-tests/lib/tasks/runmanualtests.js
@@ -25,6 +25,7 @@ const transformFileOptionToTestGlob = require( '../utils/transformfileoptiontote
  * @param {Array.<String>} [options.additionalLanguages] Additional languages passed to `CKEditorWebpackPlugin`.
  * @param {Number} [options.port] A port number used by the `createManualTestServer`.
  * @param {String} [options.identityFile] A file that provides secret keys used in the test scripts.
+ * @param {Boolean} [options.silent=false] Whether to hide files that will be processed by the script.
  * @returns {Promise}
  */
 module.exports = function runManualTests( options ) {
@@ -40,9 +41,10 @@ module.exports = function runManualTests( options ) {
 	const language = options.language;
 	const additionalLanguages = options.additionalLanguages;
 	const identityFile = normalizeIdentityFile( options.identityFile );
+	const silent = options.silent || false;
 
 	return Promise.resolve()
-		.then( () => removeDir( buildDir ) )
+		.then( () => removeDir( buildDir, { silent } ) )
 		.then( () => Promise.all( [
 			compileManualTestScripts( {
 				buildDir,
@@ -57,7 +59,8 @@ module.exports = function runManualTests( options ) {
 				buildDir,
 				patterns,
 				language,
-				additionalLanguages
+				additionalLanguages,
+				silent
 			} ),
 			copyAssets( buildDir )
 		] ) )

--- a/packages/ckeditor5-dev-tests/lib/utils/automated-tests/parsearguments.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/automated-tests/parsearguments.js
@@ -35,7 +35,8 @@ module.exports = function parseArguments( args ) {
 			'server',
 			'source-map',
 			'verbose',
-			'watch'
+			'watch',
+			'silent'
 		],
 
 		alias: {
@@ -64,7 +65,8 @@ module.exports = function parseArguments( args ) {
 			'identity-file': null,
 			repositories: [],
 			'theme-path': null,
-			'additional-languages': null
+			'additional-languages': null,
+			silent: false
 		}
 	};
 

--- a/packages/ckeditor5-dev-tests/lib/utils/manual-tests/removedir.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/manual-tests/removedir.js
@@ -10,14 +10,21 @@ const { logger } = require( '@ckeditor/ckeditor5-dev-utils' );
 const chalk = require( 'chalk' );
 
 /**
- * Removes directory
- * dir package protects you against deleting the current working directory and above.
+ * Removes the specified directory.
+ *
+ * The `del` package protects you against deleting the current working directory and above.
  *
  * @param {String} dir Directory to remove.
+ * @param {Object} [options={}] options
+ * @param {Boolean} [options.silent=false] Whether to hide the path to the directory on the console.
  * @returns {Promise}
  */
-module.exports = function removeDir( dir ) {
+module.exports = function removeDir( dir, options = {} ) {
 	return del( dir ).then( () => {
-		logger().info( `Removed directory '${ chalk.cyan( dir ) }'` );
+		if ( !options.silent ) {
+			logger().info( `Removed directory '${ chalk.cyan( dir ) }'` );
+		}
+
+		return Promise.resolve();
 	} );
 };

--- a/packages/ckeditor5-dev-tests/tests/tasks/runmanualtests.js
+++ b/packages/ckeditor5-dev-tests/tests/tasks/runmanualtests.js
@@ -72,7 +72,8 @@ describe( 'runManualTests', () => {
 						'workspace/packages/ckeditor-*/tests/**/manual/**/*.js'
 					],
 					language: undefined,
-					additionalLanguages: undefined
+					additionalLanguages: undefined,
+					silent: false
 				} );
 
 				expect( spies.scriptCompiler.calledOnce ).to.equal( true );
@@ -136,7 +137,8 @@ describe( 'runManualTests', () => {
 						'workspace/packages/ckeditor-editor-classic/tests/manual/**/*.js'
 					],
 					language: undefined,
-					additionalLanguages: undefined
+					additionalLanguages: undefined,
+					silent: false
 				} );
 
 				expect( spies.scriptCompiler.calledOnce ).to.equal( true );
@@ -206,7 +208,8 @@ describe( 'runManualTests', () => {
 						'workspace/packages/ckeditor-editor-classic/tests/manual/**/*.js'
 					],
 					language: 'pl',
-					additionalLanguages: [ 'ar', 'en' ]
+					additionalLanguages: [ 'ar', 'en' ],
+					silent: false
 				} );
 
 				expect( spies.scriptCompiler.calledOnce ).to.equal( true );
@@ -333,6 +336,53 @@ describe( 'runManualTests', () => {
 					additionalLanguages: undefined,
 					identityFile: 'workspace/path/to/secrets.js'
 				} );
+			} );
+	} );
+
+	it( 'should allow hiding processed files in the console', () => {
+		spies.transformFileOptionToTestGlob.returns( [
+			'workspace/packages/ckeditor5-*/tests/**/manual/**/*.js',
+			'workspace/packages/ckeditor-*/tests/**/manual/**/*.js'
+		] );
+
+		return runManualTests( { silent: true } )
+			.then( () => {
+				expect( spies.removeDir.calledOnce ).to.equal( true );
+				expect( spies.removeDir.firstCall.args[ 0 ] ).to.equal( 'workspace/build/.manual-tests' );
+				expect( spies.removeDir.firstCall.args[ 1 ] ).to.deep.equal( { silent: true } );
+
+				expect( spies.transformFileOptionToTestGlob.calledOnce ).to.equal( true );
+				expect( spies.transformFileOptionToTestGlob.firstCall.args[ 0 ] ).to.equal( '*' );
+				expect( spies.transformFileOptionToTestGlob.firstCall.args[ 1 ] ).to.equal( true );
+
+				expect( spies.htmlFileCompiler.calledOnce ).to.equal( true );
+				expect( spies.htmlFileCompiler.firstCall.args[ 0 ] ).to.deep.equal( {
+					buildDir: 'workspace/build/.manual-tests',
+					patterns: [
+						'workspace/packages/ckeditor5-*/tests/**/manual/**/*.js',
+						'workspace/packages/ckeditor-*/tests/**/manual/**/*.js'
+					],
+					language: undefined,
+					additionalLanguages: undefined,
+					silent: true
+				} );
+
+				expect( spies.scriptCompiler.calledOnce ).to.equal( true );
+				expect( spies.scriptCompiler.firstCall.args[ 0 ] ).to.deep.equal( {
+					buildDir: 'workspace/build/.manual-tests',
+					patterns: [
+						'workspace/packages/ckeditor5-*/tests/**/manual/**/*.js',
+						'workspace/packages/ckeditor-*/tests/**/manual/**/*.js'
+					],
+					themePath: null,
+					language: undefined,
+					additionalLanguages: undefined,
+					debug: undefined,
+					identityFile: null
+				} );
+
+				expect( spies.server.calledOnce ).to.equal( true );
+				expect( spies.server.firstCall.args[ 0 ] ).to.equal( 'workspace/build/.manual-tests' );
 			} );
 	} );
 } );

--- a/packages/ckeditor5-dev-tests/tests/utils/manual-tests/compilehtmlfiles.js
+++ b/packages/ckeditor5-dev-tests/tests/utils/manual-tests/compilehtmlfiles.js
@@ -160,6 +160,10 @@ describe( 'compileHtmlFiles', () => {
 		expect( stubs.fs.copySync ).to.be.calledWithExactly(
 			'static-file.png', path.join( 'buildDir', 'static-file.png' )
 		);
+
+		expect( stubs.logger.info.callCount ).to.equal( 2 );
+		expect( stubs.logger.info.firstCall.args[ 0 ] ).to.match( /^Processing/ );
+		expect( stubs.logger.info.secondCall.args[ 0 ] ).to.match( /^Finished writing/ );
 	} );
 
 	it( 'should compile files with options#language specified', () => {
@@ -416,5 +420,30 @@ describe( 'compileHtmlFiles', () => {
 		);
 
 		separator = '/';
+	} );
+
+	it( 'should compile the manual test and do not inform about the processed file', () => {
+		files = {
+			[ path.join( fakeDirname, 'template.html' ) ]: '<div>template html content</div>',
+			[ path.join( 'path', 'to', 'manual', 'file.md' ) ]: '## Markdown header',
+			[ path.join( 'path', 'to', 'manual', 'file.html' ) ]: '<div>html file content</div>'
+		};
+
+		patternFiles = {
+			[ path.join( 'manualTestPattern', '*.js' ) ]: [ path.join( 'path', 'to', 'manual', 'file.js' ) ],
+			[ path.join( 'path', 'to', 'manual', '**', '*.!(js|html|md)' ) ]: [ 'static-file.png' ]
+		};
+
+		compileHtmlFiles( {
+			buildDir: 'buildDir',
+			language: 'en',
+			patterns: [ path.join( 'manualTestPattern', '*.js' ) ],
+			silent: true
+		} );
+
+		expect( stubs.commonmark.parse ).to.be.calledWithExactly( '## Markdown header' );
+		expect( stubs.fs.ensureDirSync ).to.be.calledWithExactly( 'buildDir' );
+
+		expect( stubs.logger.info.callCount ).to.equal( 0 );
 	} );
 } );

--- a/packages/ckeditor5-dev-tests/tests/utils/manual-tests/removedir.js
+++ b/packages/ckeditor5-dev-tests/tests/utils/manual-tests/removedir.js
@@ -64,4 +64,14 @@ describe( 'removeDir', () => {
 			] );
 		} );
 	} );
+
+	it( 'should remove directory and does not inform about it', () => {
+		return removeDir( 'workspace/directory', { silent: true } ).then( () => {
+			expect( logMessages ).to.deep.equal( [] );
+
+			expect( deletedPaths ).to.deep.equal( [
+				'workspace/directory'
+			] );
+		} );
+	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other (tests): Added the `--silent` flag to the manual test server that allows hiding names of the processed files. Closes ckeditor/ckeditor5#9220.
