### PR TITLE
DLL: Removed `libraryExport` from the configuration

### DIFF
--- a/packages/ckeditor5-dev-utils/lib/builds/getdllpluginwebpackconfig.js
+++ b/packages/ckeditor5-dev-utils/lib/builds/getdllpluginwebpackconfig.js
@@ -38,8 +38,7 @@ module.exports = function getDllPluginWebpackConfig( options ) {
 
 			path: path.join( options.packagePath, 'build' ),
 			filename: getIndexFileName( packageName ),
-			libraryTarget: 'window',
-			libraryExport: 'default'
+			libraryTarget: 'window'
 		},
 
 		optimization: {

--- a/packages/ckeditor5-dev-utils/tests/builds/getdllpluginwebpackconfig.js
+++ b/packages/ckeditor5-dev-utils/tests/builds/getdllpluginwebpackconfig.js
@@ -120,4 +120,16 @@ describe( 'builds/getDllPluginWebpackConfig()', () => {
 		expect( webpackConfig.optimization.minimize ).to.equal( false );
 		expect( webpackConfig.optimization.minimizer ).to.be.undefined;
 	} );
+
+	it( 'should not export any library by default', () => {
+		stubs.tools.readPackageName.returns( '@ckeditor/ckeditor5-dev' );
+
+		const webpackConfig = getDllPluginWebpackConfig( {
+			packagePath: '/package/path',
+			themePath: '/theme/path',
+			manifestPath: '/manifest/path'
+		} );
+
+		expect( webpackConfig.output.libraryTarget ).to.be.undefined;
+	} );
 } );

--- a/packages/ckeditor5-dev-utils/tests/builds/getdllpluginwebpackconfig.js
+++ b/packages/ckeditor5-dev-utils/tests/builds/getdllpluginwebpackconfig.js
@@ -130,6 +130,6 @@ describe( 'builds/getDllPluginWebpackConfig()', () => {
 			manifestPath: '/manifest/path'
 		} );
 
-		expect( webpackConfig.output.libraryTarget ).to.be.undefined;
+		expect( webpackConfig.output.libraryExport ).to.be.undefined;
 	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix (utils): The webpack configuration returned by the `getDllPluginWebpackConfig()` function will not export the default library (`libraryExport`) anymore. See ckeditor/ckeditor5#9134.

MAJOR BREAKING CHANGE (utils): The `getDllPluginWebpackConfig()` function will not export the default library anymore. 

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
