### PR TITLE
Fixed HTTP#404 warnings in image tests.

### DIFF
--- a/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getkarmaconfig.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getkarmaconfig.js
@@ -44,6 +44,8 @@ module.exports = function getKarmaConfig( options ) {
 		// Files saved in directory `ckeditor5/packages/ckeditor5-utils/tests/_assets/` are available under: http://0.0.0.0:{port}/assets/
 		proxies: {
 			'/assets/': '/base/packages/ckeditor5-utils/tests/_assets/',
+
+			// See: https://github.com/ckeditor/ckeditor5/issues/8823.
 			'/example.com/image.png': '/base/packages/ckeditor5-utils/tests/_assets/sample.png',
 			'/www.example.com/image.png': '/base/packages/ckeditor5-utils/tests/_assets/sample.png'
 		},

--- a/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getkarmaconfig.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getkarmaconfig.js
@@ -43,7 +43,9 @@ module.exports = function getKarmaConfig( options ) {
 
 		// Files saved in directory `ckeditor5/packages/ckeditor5-utils/tests/_assets/` are available under: http://0.0.0.0:{port}/assets/
 		proxies: {
-			'/assets/': '/base/packages/ckeditor5-utils/tests/_assets/'
+			'/assets/': '/base/packages/ckeditor5-utils/tests/_assets/',
+			'/example.com/image.png': '/base/packages/ckeditor5-utils/tests/_assets/sample.png',
+			'/www.example.com/image.png': '/base/packages/ckeditor5-utils/tests/_assets/sample.png'
 		},
 
 		// List of files/patterns to load in the browser.

--- a/packages/ckeditor5-dev-tests/tests/utils/automated-tests/getkarmaconfig.js
+++ b/packages/ckeditor5-dev-tests/tests/utils/automated-tests/getkarmaconfig.js
@@ -96,4 +96,26 @@ describe( 'getKarmaConfig()', () => {
 		expect( karmaConfig.files[ 0 ] ).to.equal( 'workspace/entry-file.js' );
 		expect( karmaConfig.files[ 1 ].pattern ).to.equal( 'packages/ckeditor5-utils/tests/_assets/**/*' );
 	} );
+
+	// See: https://github.com/ckeditor/ckeditor5/issues/8823
+	it( 'should define proxies to static assets resources', () => {
+		const karmaConfig = getKarmaConfig( {
+			files: [ '*' ],
+			reporter: 'mocha',
+			sourceMap: false,
+			coverage: false,
+			browsers: [ 'Chrome' ],
+			watch: false,
+			verbose: false,
+			themePath: 'workspace/path/to/theme.css',
+			entryFile: 'workspace/entry-file.js',
+			globPatterns: {
+				'*': 'workspace/packages/ckeditor5-*/tests/**/*.js'
+			}
+		} );
+
+		expect( karmaConfig ).to.have.own.property( 'proxies' );
+		expect( karmaConfig.proxies ).to.have.own.property( '/example.com/image.png' );
+		expect( karmaConfig.proxies ).to.have.own.property( '/www.example.com/image.png' );
+	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal (tests): Added proxies for `/example.com/image.png`, and `/www.example.com/image.png` URLs to serve the static image. Closes ckeditor/ckeditor5#8823.