### PR TITLE
Make translation output to be ES5 compatible.

### DIFF
--- a/packages/ckeditor5-dev-utils/lib/translations/multiplelanguagetranslationservice.js
+++ b/packages/ckeditor5-dev-utils/lib/translations/multiplelanguagetranslationservice.js
@@ -311,7 +311,7 @@ module.exports = class MultipleLanguageTranslationService extends EventEmitter {
 
 			const outputBody = (
 				'(function(d){' +
-				`	const l = d['${ language }'] = d['${ language }'] || {};` +
+				`	var l = d['${ language }'] = d['${ language }'] || {};` +
 				'	l.dictionary=Object.assign(' +
 				'		l.dictionary||{},' +
 				`		${ stringifiedTranslations }` +


### PR DESCRIPTION
The translation webpack plugin should output ES5 JS (avoid using `const`) to make the output compatible to more use cases. This is necessary since webpack rules does not apply to webpack plugin output.