### PR TITLE
Better CC watermarks

### DIFF
--- a/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getkarmaconfig.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getkarmaconfig.js
@@ -151,7 +151,13 @@ module.exports = function getKarmaConfig( options ) {
 					type: 'lcovonly',
 					dir: coverageDir
 				}
-			]
+			],
+			watermarks: {
+				statements: [ 50, 100 ],
+				functions: [ 50, 100 ],
+				branches: [ 50, 100 ],
+				lines: [ 50, 100 ]
+			}
 		};
 	}
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other (tests): Set watermarks for code coverage reports so anything less than 100% is instantly visible. Closes ckeditor/ckeditor5#9956.