### PR TITLE
Fixed incorrect path interpretation for theme-lark package

### DIFF
--- a/packages/ckeditor5-dev-tests/bin/check-dependencies.js
+++ b/packages/ckeditor5-dev-tests/bin/check-dependencies.js
@@ -428,7 +428,7 @@ function findMisplacedDependencies( dependencies, devDependencies, dependenciesT
  * @returns {Boolean}
  */
 function isDevDependency( absolutePaths ) {
-	return !absolutePaths.some( absolutePath => absolutePath.match( /[/\\](src|theme)/ ) );
+	return !absolutePaths.some( absolutePath => absolutePath.match( /[/\\](src|theme)[/\\]/ ) );
 }
 
 /**

--- a/packages/ckeditor5-dev-tests/bin/check-dependencies.js
+++ b/packages/ckeditor5-dev-tests/bin/check-dependencies.js
@@ -428,7 +428,7 @@ function findMisplacedDependencies( dependencies, devDependencies, dependenciesT
  * @returns {Boolean}
  */
 function isDevDependency( absolutePaths ) {
-	return !absolutePaths.some( absolutePath => absolutePath.match( /src|theme/ ) );
+	return !absolutePaths.some( absolutePath => absolutePath.match( /[/\\](src|theme)/ ) );
 }
 
 /**


### PR DESCRIPTION
Fix (tests): Prevented `isDevDependency()` function from reading "theme" word from the `ckeditor5-theme-lark` package name. See ckeditor/ckeditor5#9998.