### PR TITLE
Allowed DOMRect as a valid type in API docs

### DIFF
--- a/packages/jsdoc-plugins/lib/validator/types.js
+++ b/packages/jsdoc-plugins/lib/validator/types.js
@@ -36,6 +36,7 @@ const BASIC_TYPES = [
 	'Event',
 	'FocusEvent',
 	'ClientRect',
+	'DOMRect',
 	'Window',
 	'ErrorEvent',
 	'PromiseRejectionEvent',


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature (jsdoc-plugins): Allowed DOMRect as a valid type in API docs. Closes ckeditor5#10216.

---

### Additional information

Needed by https://github.com/ckeditor/ckeditor5/pull/10174/files.