### PR TITLE
Translations for DLL (dev)

### DIFF
--- a/packages/ckeditor5-dev-utils/lib/builds/getdllpluginwebpackconfig.js
+++ b/packages/ckeditor5-dev-utils/lib/builds/getdllpluginwebpackconfig.js
@@ -11,6 +11,7 @@ const TerserPlugin = require( 'terser-webpack-plugin' );
 const bundler = require( '../bundler' );
 const styles = require( '../styles' );
 const tools = require( '../tools' );
+const CKEditorWebpackPlugin = require( '@ckeditor/ckeditor5-dev-webpack-plugin' );
 
 /**
  * Returns a webpack configuration that creates a bundle file for the specified package. Thanks to that, plugins exported
@@ -46,6 +47,12 @@ module.exports = function getDllPluginWebpackConfig( options ) {
 		},
 
 		plugins: [
+			new CKEditorWebpackPlugin( {
+				// UI language. Language codes follow the https://en.wikipedia.org/wiki/ISO_639-1 format.
+				language: 'en',
+				additionalLanguages: 'all',
+				sourceFilesPattern: /^src[/\\].+\.js$/
+			} ),
 			new webpack.BannerPlugin( {
 				banner: bundler.getLicenseBanner(),
 				raw: true

--- a/packages/ckeditor5-dev-utils/lib/builds/getdllpluginwebpackconfig.js
+++ b/packages/ckeditor5-dev-utils/lib/builds/getdllpluginwebpackconfig.js
@@ -51,7 +51,8 @@ module.exports = function getDllPluginWebpackConfig( options ) {
 				// UI language. Language codes follow the https://en.wikipedia.org/wiki/ISO_639-1 format.
 				language: 'en',
 				additionalLanguages: 'all',
-				sourceFilesPattern: /^src[/\\].+\.js$/
+				sourceFilesPattern: /^src[/\\].+\.js$/,
+				skipPluralFormFunction: true
 			} ),
 			new webpack.BannerPlugin( {
 				banner: bundler.getLicenseBanner(),

--- a/packages/ckeditor5-dev-utils/lib/builds/getdllpluginwebpackconfig.js
+++ b/packages/ckeditor5-dev-utils/lib/builds/getdllpluginwebpackconfig.js
@@ -15,13 +15,13 @@ const CKEditorWebpackPlugin = require( '@ckeditor/ckeditor5-dev-webpack-plugin' 
 
 /**
  * Returns a webpack configuration that creates a bundle file for the specified package. Thanks to that, plugins exported
- * by the package can be added to ready-to-use builds.
+ * by the package can be added to DLL builds.
  *
  * @param {Object} options
  * @param {String} options.themePath An absolute path to the theme package.
  * @param {String} options.packagePath An absolute path to the root directory of the package.
- * @param {String} options.manifestPath An absolute path to the DLL manifest file.
- * @param {Boolean} options.isDevelopmentMode Whether to build a dev mode of the package.
+ * @param {String} options.manifestPath An absolute path to the CKEditor 5 DLL manifest file.
+ * @param {Boolean} [options.isDevelopmentMode=false] Whether to build a dev mode of the package.
  * @returns {Object}
  */
 module.exports = function getDllPluginWebpackConfig( options ) {

--- a/packages/ckeditor5-dev-utils/lib/translations/multiplelanguagetranslationservice.js
+++ b/packages/ckeditor5-dev-utils/lib/translations/multiplelanguagetranslationservice.js
@@ -130,7 +130,7 @@ module.exports = class MultipleLanguageTranslationService extends EventEmitter {
 		findMessages(
 			source,
 			fileName,
-			message => this._foundMessageIds.add( message.id ),
+			message => this.addIdMessage( message.id ),
 			error => this.emit( 'warning', error )
 		);
 
@@ -237,6 +237,15 @@ module.exports = class MultipleLanguageTranslationService extends EventEmitter {
 			// Translation assets outputted to separate translation files.
 			...this._getTranslationAssets( outputDirectory, assetLanguages )
 		];
+	}
+
+	/**
+	 * Adds the specified `id` to the collection which will be translated to the specified language.
+	 *
+	 * @param {String} id
+	 */
+	addIdMessage( id ) {
+		this._foundMessageIds.add( id );
 	}
 
 	/**

--- a/packages/ckeditor5-dev-utils/lib/translations/multiplelanguagetranslationservice.js
+++ b/packages/ckeditor5-dev-utils/lib/translations/multiplelanguagetranslationservice.js
@@ -386,11 +386,16 @@ module.exports = class MultipleLanguageTranslationService extends EventEmitter {
 	 * Returns a path to the translation directory depending on the path to the package.
 	 *
 	 * @protected
-	 * @param {String} pathToPackage
+	 * @param {String|null} relativePathToPackage
 	 * @returns {String}
 	 */
-	_getPathToTranslationDirectory( pathToPackage ) {
-		return path.join( pathToPackage, 'lang', 'translations' );
+	_getPathToTranslationDirectory( relativePathToPackage ) {
+		// If the `relativePathToPackage` is not specified, translations for a single package are processed.
+		if ( relativePathToPackage ) {
+			return path.join( relativePathToPackage, 'lang', 'translations' );
+		}
+
+		return path.join( 'lang', 'translations' );
 	}
 };
 

--- a/packages/ckeditor5-dev-utils/package.json
+++ b/packages/ckeditor5-dev-utils/package.json
@@ -5,6 +5,7 @@
   "keywords": [],
   "main": "lib/index.js",
   "dependencies": {
+    "@ckeditor/ckeditor5-dev-webpack-plugin": "^25.3.0",
     "acorn": "^6.2.1",
     "acorn-walk": "^6.2.0",
     "chalk": "^3.0.0",

--- a/packages/ckeditor5-dev-webpack-plugin/README.md
+++ b/packages/ckeditor5-dev-webpack-plugin/README.md
@@ -65,6 +65,14 @@ A pattern which is used for determining if a file may contain messages to transl
 
 An option that allows specifying the target file to which all translations will be outputted. This option supports a string, regular expression and a function. If no asset exists with the name, it will be created automatically and filled with translations.
 
+### `includeCorePackageTranslations`
+
+When set to `true`, all translations from the `ckeditor5-core` package will be added into the bundle files. Defaults to `false`.
+
+### `skipPluralFormFunction`
+
+When set to `true`, the `getPluralForm()` function (if exists for the specified language) will not be added into the bundle file. Defaults to `false`.
+
 ### `corePackagePattern`
 
 (internal)
@@ -74,6 +82,11 @@ A pattern which is used to get a path to the core translation package from `core
 
 (internal)
 A sample path to the `ckeditor5-core` package. A test import to this file shows if the `ckeditor5-core` package is available and allows to load the core package translations first.
+
+### `corePackageContextsResourcePath`
+
+(internal)
+A path the `context.json` file in the `ckeditor5-core` package. It is used if the `includeCorePackageTranslations` option is set to `true`.
 
 You can read more about localizing the editor in the [Setting the UI language](https://docs.ckeditor.com/ckeditor5/latest/features/ui-language.html) guide.
 

--- a/packages/ckeditor5-dev-webpack-plugin/lib/index.js
+++ b/packages/ckeditor5-dev-webpack-plugin/lib/index.js
@@ -52,7 +52,8 @@ module.exports = class CKEditorWebpackPlugin {
 			corePackageSampleResourcePath: options.corePackageSampleResourcePath || '@ckeditor/ckeditor5-core/src/editor/editor.js',
 			corePackageContextsResourcePath: options.corePackageContextsResourcePath || '@ckeditor/ckeditor5-core/lang/contexts.json',
 			translationsOutputFile: options.translationsOutputFile,
-			includeCorePackageTranslations: !!options.includeCorePackageTranslations
+			includeCorePackageTranslations: !!options.includeCorePackageTranslations,
+			skipPluralFormFunction: !!options.skipPluralFormFunction
 		};
 	}
 
@@ -94,7 +95,8 @@ module.exports = class CKEditorWebpackPlugin {
 			additionalLanguages,
 			addMainLanguageTranslationsToAllAssets,
 			buildAllTranslationsToSeparateFiles,
-			translationsOutputFile: this.options.translationsOutputFile
+			translationsOutputFile: this.options.translationsOutputFile,
+			skipPluralFormFunction: this.options.skipPluralFormFunction
 		} );
 
 		serveTranslations( compiler, this.options, translationService );
@@ -128,4 +130,5 @@ module.exports = class CKEditorWebpackPlugin {
  * @property {Boolean} [includeCorePackageTranslations=false] A flag that determines whether all translations found in the core package
  * should be added to the output bundle file. If set to true, translations from the core package will be saved even if are not
  * used in the source code (*.js files).
+ * @property {Boolean} [skipPluralFormFunction=false] Whether the `getPluralForm()` function should be added in the output bundle file.
  */

--- a/packages/ckeditor5-dev-webpack-plugin/lib/index.js
+++ b/packages/ckeditor5-dev-webpack-plugin/lib/index.js
@@ -50,7 +50,9 @@ module.exports = class CKEditorWebpackPlugin {
 			packageNamesPattern: options.packageNamesPattern || /[/\\]ckeditor5-[^/\\]+[/\\]/,
 			corePackagePattern: options.corePackagePattern || /[/\\]ckeditor5-core/,
 			corePackageSampleResourcePath: options.corePackageSampleResourcePath || '@ckeditor/ckeditor5-core/src/editor/editor.js',
-			translationsOutputFile: options.translationsOutputFile
+			corePackageContextsResourcePath: options.corePackageContextsResourcePath || '@ckeditor/ckeditor5-core/lang/contexts.json',
+			translationsOutputFile: options.translationsOutputFile,
+			includeCorePackageTranslations: !!options.includeCorePackageTranslations
 		};
 	}
 
@@ -113,11 +115,17 @@ module.exports = class CKEditorWebpackPlugin {
  * @property {Boolean} [verbose] An option that make this plugin log all warnings into the console.
  * @property {Boolean} [addMainLanguageTranslationsToAllAssets] An option that allows outputting translations to more than one
  * JS asset.
- * @property {String} [corePackageSampleResourcePath] TODO
+ * @property {String} [corePackageSampleResourcePath] A path (ES6 import) to the file that determines whether the `ckeditor5-core` package
+ * exists. The package contains common translations used by many packages. To avoid duplications, they are shared by the core package.
+ * @property {String} [corePackageContextsResourcePath] A path (ES6 import) to the file where all contexts are specified
+ * for the `ckeditor5-core` package.
  * @property {Boolean} [buildAllTranslationsToSeparateFiles] An option that makes all translations output to separate files.
  * @property {String} [sourceFilesPattern] An option that allows override the default pattern for CKEditor 5 source files.
  * @property {String} [packageNamesPattern] An option that allows override the default pattern for CKEditor 5 package names.
  * @property {String} [corePackagePattern] An option that allows override the default CKEditor 5 core package pattern.
  * @property {String|Function|RegExp} [translationsOutputFile] An option allowing outputting all translation file to the given file.
  * If a file specified by a path (string) does not exist, then it will be created. Otherwise, translations will be outputted to the file.
+ * @property {Boolean} [includeCorePackageTranslations=false] A flag that determines whether all translations found in the core package
+ * should be added to the output bundle file. If set to true, translations from the core package will be saved even if are not
+ * used in the source code (*.js files).
  */

--- a/packages/ckeditor5-dev-webpack-plugin/lib/servetranslations.js
+++ b/packages/ckeditor5-dev-webpack-plugin/lib/servetranslations.js
@@ -70,6 +70,26 @@ module.exports = function serveTranslations( compiler, options, translationServi
 
 			translationService.loadPackage( corePackage );
 		} );
+
+		// Translations from the core package may not be used in the source code (in *.js files).
+		// However, in the case of the DLL integration, core translations should be inserted in the bundle file,
+		// because features that use common identifiers do not provide translation ids by themselves.
+		if ( options.includeCorePackageTranslations ) {
+			resolver.resolve( { cwd }, cwd, options.corePackageContextsResourcePath, {}, ( err, pathToResource ) => {
+				if ( err ) {
+					console.warn( 'Cannot find the CKEditor 5 core translation context (which defaults to `@ckeditor/ckeditor5-core`).' );
+
+					return;
+				}
+
+				// Add all context messages found in the core package.
+				const contexts = require( pathToResource );
+
+				for ( const item of Object.keys( contexts ) ) {
+					translationService.addIdMessage( item );
+				}
+			} );
+		}
 	} );
 
 	// Load translation files and add a loader if the package match requirements.

--- a/packages/ckeditor5-dev-webpack-plugin/tests/index.js
+++ b/packages/ckeditor5-dev-webpack-plugin/tests/index.js
@@ -57,6 +57,60 @@ describe( 'webpack-plugin/CKEditorWebpackPlugin', () => {
 
 			expect( ckeditorWebpackPlugin.options.outputDirectory ).to.equal( 'custom' );
 		} );
+
+		describe( 'options', () => {
+			describe( '#corePackageContextsResourcePath', () => {
+				it( 'should use the default value if not set', () => {
+					const ckeditorWebpackPlugin = new CKEditorWebpackPlugin( {} );
+
+					expect( ckeditorWebpackPlugin.options.corePackageContextsResourcePath ).to.equal(
+						'@ckeditor/ckeditor5-core/lang/contexts.json'
+					);
+				} );
+
+				it( 'should overwrite the default value if specified in the configuration', () => {
+					const ckeditorWebpackPlugin = new CKEditorWebpackPlugin( {
+						corePackageContextsResourcePath: '@ckeditor/ckeditor5-utils/lang/contexts.json'
+					} );
+
+					expect( ckeditorWebpackPlugin.options.corePackageContextsResourcePath ).to.equal(
+						'@ckeditor/ckeditor5-utils/lang/contexts.json'
+					);
+				} );
+			} );
+
+			describe( '#includeCorePackageTranslations', () => {
+				it( 'should use the default value if not set', () => {
+					const ckeditorWebpackPlugin = new CKEditorWebpackPlugin( {} );
+
+					expect( ckeditorWebpackPlugin.options.includeCorePackageTranslations ).to.equal( false );
+				} );
+
+				it( 'should overwrite the default value if specified in the configuration', () => {
+					const ckeditorWebpackPlugin = new CKEditorWebpackPlugin( {
+						includeCorePackageTranslations: true
+					} );
+
+					expect( ckeditorWebpackPlugin.options.includeCorePackageTranslations ).to.equal( true );
+				} );
+			} );
+
+			describe( '#skipPluralFormFunction', () => {
+				it( 'should use the default value if not set', () => {
+					const ckeditorWebpackPlugin = new CKEditorWebpackPlugin( {} );
+
+					expect( ckeditorWebpackPlugin.options.skipPluralFormFunction ).to.equal( false );
+				} );
+
+				it( 'should overwrite the default value if specified in the configuration', () => {
+					const ckeditorWebpackPlugin = new CKEditorWebpackPlugin( {
+						skipPluralFormFunction: true
+					} );
+
+					expect( ckeditorWebpackPlugin.options.skipPluralFormFunction ).to.equal( true );
+				} );
+			} );
+		} );
 	} );
 
 	describe( 'apply()', () => {
@@ -93,7 +147,8 @@ describe( 'webpack-plugin/CKEditorWebpackPlugin', () => {
 						additionalLanguages: [],
 						buildAllTranslationsToSeparateFiles: false,
 						addMainLanguageTranslationsToAllAssets: false,
-						translationsOutputFile: undefined
+						translationsOutputFile: undefined,
+						skipPluralFormFunction: false
 					}
 				);
 			} );
@@ -118,7 +173,8 @@ describe( 'webpack-plugin/CKEditorWebpackPlugin', () => {
 						additionalLanguages: [ 'en' ],
 						buildAllTranslationsToSeparateFiles: false,
 						addMainLanguageTranslationsToAllAssets: false,
-						translationsOutputFile: undefined
+						translationsOutputFile: undefined,
+						skipPluralFormFunction: false
 					}
 				);
 			} );
@@ -143,11 +199,38 @@ describe( 'webpack-plugin/CKEditorWebpackPlugin', () => {
 						additionalLanguages: [],
 						buildAllTranslationsToSeparateFiles: false,
 						addMainLanguageTranslationsToAllAssets: false,
-						translationsOutputFile: undefined
+						translationsOutputFile: undefined,
+						skipPluralFormFunction: false
 					}
 				);
 
 				sinon.assert.notCalled( console.warn );
+			} );
+
+			it( 'passes the skipPluralFormFunction option to the translation service', () => {
+				const options = {
+					language: 'pl',
+					skipPluralFormFunction: true
+				};
+
+				const ckeditorWebpackPlugin = new CKEditorWebpackPlugin( options );
+				ckeditorWebpackPlugin.apply( {} );
+
+				sinon.assert.calledOnce( stubs.serveTranslations );
+
+				sinon.assert.calledOnce( stubs.MultipleLanguageTranslationService );
+				sinon.assert.calledWithExactly(
+					stubs.MultipleLanguageTranslationService,
+					{
+						mainLanguage: 'pl',
+						compileAllLanguages: false,
+						additionalLanguages: [],
+						buildAllTranslationsToSeparateFiles: false,
+						addMainLanguageTranslationsToAllAssets: false,
+						translationsOutputFile: undefined,
+						skipPluralFormFunction: true
+					}
+				);
 			} );
 		} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other (utils): The webpack configuration for DLL builds now produces the translation files.

Feature (webpack-plugin): Introduced several new options that improve the output files produced by the plugin.

New options:
  * `corePackageContextsResourcePath` - (optional) a path to the file where all translation contexts are specified for the `ckeditor5-core` package. Defaults to `'@ckeditor/ckeditor5-core/lang/contexts.json'`.
  * `includeCorePackageTranslations` - (optional) a flag that determines whether all translations found in the core package should be added to the output bundle file. If set to `true`, translations from the core package will be saved even if are not used in the source code (*.js files). Defaults to `false`.
  * `skipPluralFormFunction`- (optional) a flag that determines whether the `getPluralForm()` function should not be added in the output bundle file. Defaults to `false`.

---

### Additional information

Required for: ckeditor/ckeditor5#10330.
