### PR TITLE
Fixed yarn clean script for Windows OS

### DIFF
--- a/packages/ckeditor5-dev-utils/lib/tools.js
+++ b/packages/ckeditor5-dev-utils/lib/tools.js
@@ -330,7 +330,10 @@ module.exports = {
 	clean( rootDir, glob, options = { verbosity: 'info' } ) {
 		const del = require( 'del' );
 
-		return del( path.join( rootDir, glob ) )
+		const joinedPath = path.join( rootDir, glob );
+		const normalizedPath = joinedPath.split( path.sep ).join( path.posix.sep );
+
+		return del( normalizedPath )
 			.then( paths => {
 				const log = require( './logger' )( options.verbosity );
 

--- a/packages/ckeditor5-dev-utils/lib/tools.js
+++ b/packages/ckeditor5-dev-utils/lib/tools.js
@@ -331,7 +331,7 @@ module.exports = {
 		const del = require( 'del' );
 
 		const joinedPath = path.join( rootDir, glob );
-		const normalizedPath = joinedPath.split( path.sep ).join( path.posix.sep );
+		const normalizedPath = joinedPath.split( '\u005C' ).join( '/' );
 
 		return del( normalizedPath )
 			.then( paths => {

--- a/packages/ckeditor5-dev-utils/lib/tools.js
+++ b/packages/ckeditor5-dev-utils/lib/tools.js
@@ -331,7 +331,7 @@ module.exports = {
 		const del = require( 'del' );
 
 		const joinedPath = path.join( rootDir, glob );
-		const normalizedPath = joinedPath.split( '\u005C' ).join( '/' );
+		const normalizedPath = joinedPath.split( '\\' ).join( '/' );
 
 		return del( normalizedPath )
 			.then( paths => {

--- a/packages/ckeditor5-dev-utils/tests/tools.js
+++ b/packages/ckeditor5-dev-utils/tests/tools.js
@@ -553,8 +553,8 @@ describe( 'utils', () => {
 
 		describe( 'clean', () => {
 			const files = [
-				path.posix.join( 'test', 'foo', 'bar' ),
-				path.posix.join( 'test', 'bar', 'foo' )
+				path.join( 'test', 'foo', 'bar' ),
+				path.join( 'test', 'bar', 'foo' )
 			];
 
 			let delArg;
@@ -570,7 +570,7 @@ describe( 'utils', () => {
 			it( 'removes files and informs about deletion using a logger', () => {
 				return tools.clean( 'test', '**' )
 					.then( () => {
-						expect( delArg ).to.equal( path.posix.join( 'test', '**' ) );
+						expect( delArg ).to.equal( path.join( 'test', '**' ) );
 						expect( loggerVerbosity ).to.equal( 'info' );
 						expect( infoSpy.calledTwice ).to.equal( true );
 						expect( infoSpy.firstCall.args[ 0 ] ).to.match( new RegExp( files[ 0 ] ) );
@@ -579,9 +579,11 @@ describe( 'utils', () => {
 			} );
 
 			it( 'works with paths that contain backslash', () => {
-				return tools.clean( 'test\\path', '**\\packages' )
+				path.sep = sinon.stub();
+				path.sep.returns( '\u005C' );
+				return tools.clean( 'test\u005Cpath', '**\u005Cpackages' )
 					.then( () => {
-						expect( delArg ).to.equal( path.posix.join( 'test/path', '**/packages' ) );
+						expect( delArg ).to.equal( path.join( 'test/path', '**/packages' ) );
 						expect( loggerVerbosity ).to.equal( 'info' );
 						expect( infoSpy.calledTwice ).to.equal( true );
 						expect( infoSpy.firstCall.args[ 0 ] ).to.match( new RegExp( files[ 0 ] ) );

--- a/packages/ckeditor5-dev-utils/tests/tools.js
+++ b/packages/ckeditor5-dev-utils/tests/tools.js
@@ -579,7 +579,7 @@ describe( 'utils', () => {
 			} );
 
 			it( 'works with paths that contain backslash', () => {
-				return tools.clean( 'test\u005Cpath', '**\u005Cpackages' )
+				return tools.clean( 'test\\path', '**\\packages' )
 					.then( () => {
 						expect( delArg ).to.equal( path.join( 'test/path', '**/packages' ) );
 						expect( loggerVerbosity ).to.equal( 'info' );

--- a/packages/ckeditor5-dev-utils/tests/tools.js
+++ b/packages/ckeditor5-dev-utils/tests/tools.js
@@ -582,10 +582,6 @@ describe( 'utils', () => {
 				return tools.clean( 'test\\path', '**\\packages' )
 					.then( () => {
 						expect( delArg ).to.equal( path.join( 'test/path', '**/packages' ) );
-						expect( loggerVerbosity ).to.equal( 'info' );
-						expect( infoSpy.calledTwice ).to.equal( true );
-						expect( infoSpy.firstCall.args[ 0 ] ).to.match( new RegExp( files[ 0 ] ) );
-						expect( infoSpy.secondCall.args[ 0 ] ).to.match( new RegExp( files[ 1 ] ) );
 					} );
 			} );
 		} );

--- a/packages/ckeditor5-dev-utils/tests/tools.js
+++ b/packages/ckeditor5-dev-utils/tests/tools.js
@@ -581,7 +581,7 @@ describe( 'utils', () => {
 			it( 'works with paths that contain backslash', () => {
 				return tools.clean( 'test\u005Cpath', '**\u005Cpackages' )
 					.then( () => {
-						expect( delArg ).to.equal( 'test/path/**/packages' );
+						expect( delArg ).to.equal( path.join( 'test/path', '**/packages' ) );
 						expect( loggerVerbosity ).to.equal( 'info' );
 						expect( infoSpy.calledTwice ).to.equal( true );
 						expect( infoSpy.firstCall.args[ 0 ] ).to.match( new RegExp( files[ 0 ] ) );

--- a/packages/ckeditor5-dev-utils/tests/tools.js
+++ b/packages/ckeditor5-dev-utils/tests/tools.js
@@ -579,8 +579,6 @@ describe( 'utils', () => {
 			} );
 
 			it( 'works with paths that contain backslash', () => {
-				path.sep = sinon.stub();
-				path.sep.returns( '\u005C' );
 				return tools.clean( 'test\u005Cpath', '**\u005Cpackages' )
 					.then( () => {
 						expect( delArg ).to.equal( 'test/path/**/packages' );

--- a/packages/ckeditor5-dev-utils/tests/tools.js
+++ b/packages/ckeditor5-dev-utils/tests/tools.js
@@ -583,7 +583,7 @@ describe( 'utils', () => {
 				path.sep.returns( '\u005C' );
 				return tools.clean( 'test\u005Cpath', '**\u005Cpackages' )
 					.then( () => {
-						expect( delArg ).to.equal( path.join( 'test/path', '**/packages' ) );
+						expect( delArg ).to.equal( 'test/path/**/packages' );
 						expect( loggerVerbosity ).to.equal( 'info' );
 						expect( infoSpy.calledTwice ).to.equal( true );
 						expect( infoSpy.firstCall.args[ 0 ] ).to.match( new RegExp( files[ 0 ] ) );

--- a/packages/ckeditor5-dev-utils/tests/tools.js
+++ b/packages/ckeditor5-dev-utils/tests/tools.js
@@ -553,8 +553,8 @@ describe( 'utils', () => {
 
 		describe( 'clean', () => {
 			const files = [
-				path.join( 'test', 'foo', 'bar' ),
-				path.join( 'test', 'bar', 'foo' )
+				path.posix.join( 'test', 'foo', 'bar' ),
+				path.posix.join( 'test', 'bar', 'foo' )
 			];
 
 			let delArg;
@@ -570,7 +570,18 @@ describe( 'utils', () => {
 			it( 'removes files and informs about deletion using a logger', () => {
 				return tools.clean( 'test', '**' )
 					.then( () => {
-						expect( delArg ).to.equal( path.join( 'test', '**' ) );
+						expect( delArg ).to.equal( path.posix.join( 'test', '**' ) );
+						expect( loggerVerbosity ).to.equal( 'info' );
+						expect( infoSpy.calledTwice ).to.equal( true );
+						expect( infoSpy.firstCall.args[ 0 ] ).to.match( new RegExp( files[ 0 ] ) );
+						expect( infoSpy.secondCall.args[ 0 ] ).to.match( new RegExp( files[ 1 ] ) );
+					} );
+			} );
+
+			it( 'works with paths that contain backslash', () => {
+				return tools.clean( 'test\\path', '**\\packages' )
+					.then( () => {
+						expect( delArg ).to.equal( path.posix.join( 'test/path', '**/packages' ) );
 						expect( loggerVerbosity ).to.equal( 'info' );
 						expect( infoSpy.calledTwice ).to.equal( true );
 						expect( infoSpy.firstCall.args[ 0 ] ).to.match( new RegExp( files[ 0 ] ) );


### PR DESCRIPTION
Fix (utils): The `tools.clean()` function will resolve paths correctly on Windows environments. Closes ckeditor/ckeditor5#10141.