### PR TITLE
`getPackagesToRelease()` handles pre-release versions

### DIFF
--- a/packages/ckeditor5-dev-env/lib/release-tools/utils/getpackagestorelease.js
+++ b/packages/ckeditor5-dev-env/lib/release-tools/utils/getpackagestorelease.js
@@ -78,14 +78,14 @@ module.exports = function getPackagesToRelease( pathsToPackages, options ) {
 // @param {String} packageName Package to look.
 // @returns {String|null} `null` if the version was not found.
 function findVersionInChangelog( changelog, packageName ) {
-	const existingPackageRegExp = new RegExp( `\\[${ packageName.replace( '/', '\\/' ) }\\].*v[\\d.]+\\ => v([\\d.]+)` );
+	const existingPackageRegExp = new RegExp( `\\[${ packageName.replace( '/', '\\/' ) }\\].*v[\\d.]+\\ => v([\\d.a-z]+)` );
 	let match = changelog.match( existingPackageRegExp );
 
 	if ( match ) {
 		return match[ 1 ];
 	}
 
-	const newPackageRegExp = new RegExp( `\\[${ packageName.replace( '/', '\\/' ) }\\].*v([\\d.]+)` );
+	const newPackageRegExp = new RegExp( `\\[${ packageName.replace( '/', '\\/' ) }\\].*v([\\d.a-z]+)` );
 	match = changelog.match( newPackageRegExp );
 
 	return match ? match[ 1 ] : null;

--- a/packages/ckeditor5-dev-env/lib/release-tools/utils/getpackagestorelease.js
+++ b/packages/ckeditor5-dev-env/lib/release-tools/utils/getpackagestorelease.js
@@ -72,23 +72,59 @@ module.exports = function getPackagesToRelease( pathsToPackages, options ) {
 //      [packageName](https://www.npmjs.com/package/packageName): v0.0.1
 //
 // where:
-//   `v0.0.1` is the current version (not published yet),
+//   `v0.0.1` is the current version (not published yet).
+//
+// The function handles pre-release, so, e.g. `v1.0.0.alpha.0` is also a proper input.
+//
+// Keep in mind that the dash (`-`) is a separator of the pre-release. Other characters are not allowed
+// and npm will not publish a package if its version does not contain the symbol.
 //
 // @param {String} changelog Changes.
 // @param {String} packageName Package to look.
 // @returns {String|null} `null` if the version was not found.
 function findVersionInChangelog( changelog, packageName ) {
-	const existingPackageRegExp = new RegExp( `\\[${ packageName.replace( '/', '\\/' ) }\\].*v[\\d.]+\\ => v([\\d.a-z]+)` );
+	// Pick: `x.y.z` or `x.y.z-prerelease.n`, assumptions: `x, y, z, n = { 0, 1, 2, ... }`.
+	const semVer = '\\d+\\.\\d+\\.\\d+(.[a-z\\d.]+)?';
+
+	const existingPackageRegExp = new RegExp( `\\[${ packageName.replace( '/', '\\/' ) }\\].*v(${ semVer })+\\ (=>) v(${ semVer })` );
+	// Groups:
+	// 1. Previous version.
+	// 2. Previous version - pre-release part.
+	// 3. "=>" character that suggests that the package exists on npm.
+	// 4. New version.
+	// 5. New version - pre-release part.
+
 	let match = changelog.match( existingPackageRegExp );
 
+	// The package exists on npm.
 	if ( match ) {
-		return match[ 1 ];
+		// The version does not match to `x.y.z-prerelease.n`, npm will not allow publish it.
+		if ( match[ 5 ] && !match[ 5 ].startsWith( '-' ) ) {
+			return null;
+		}
+
+		return match[ 4 ];
 	}
 
-	const newPackageRegExp = new RegExp( `\\[${ packageName.replace( '/', '\\/' ) }\\].*v([\\d.a-z]+)` );
+	// At this stage, we know that it will be the first release of `packageName`.
+	// If the specified version is correct, let's use it.
+	const newPackageRegExp = new RegExp( `\\[${ packageName.replace( '/', '\\/' ) }\\].*v(${ semVer })` );
+	// Groups:
+	// 1. New version.
+	// 2. New version - pre-release part.
+
 	match = changelog.match( newPackageRegExp );
 
-	return match ? match[ 1 ] : null;
+	if ( !match ) {
+		return null;
+	}
+
+	// The version does not match to `x.y.z-prerelease.n`, npm will not allow publish it.
+	if ( match[ 2 ] && !match[ 2 ].startsWith( '-' ) ) {
+		return null;
+	}
+
+	return match[ 1 ];
 }
 
 /**

--- a/packages/ckeditor5-dev-env/tests/release-tools/utils/getpackagestorelease.js
+++ b/packages/ckeditor5-dev-env/tests/release-tools/utils/getpackagestorelease.js
@@ -204,11 +204,11 @@ describe( 'dev-env/release-tools/utils', () => {
 				sandbox.stub( process, 'cwd' ).returns( '/cwd' );
 
 				const changes = [
-					'[ckeditor5](npm link): v1.0.0 => v2.0.0.alpha.1',
-					'[@ckeditor/ckeditor5-core](npm link): v1.0.0 => v2.0.0.alpha.1'
+					'[ckeditor5](npm link): v1.0.0 => v2.0.0-alpha.0',
+					'[@ckeditor/ckeditor5-core](npm link): v1.0.0 => v2.0.0-alpha.0'
 				].join( '\n' );
 
-				return getPackagesToRelease( packagesToCheck, { changes, version: '2.0.0.alpha.1' } )
+				return getPackagesToRelease( packagesToCheck, { changes, version: '2.0.0-alpha.0' } )
 					.then( packages => {
 						expect( packages.size ).to.equal( 2 );
 
@@ -218,10 +218,10 @@ describe( 'dev-env/release-tools/utils', () => {
 						expect( stubs.chdir.thirdCall.args[ 0 ] ).to.equal( '/cwd' );
 
 						const corePackage = packages.get( '@ckeditor/ckeditor5-core' );
-						expect( corePackage.version ).to.equal( '2.0.0.alpha.1' );
+						expect( corePackage.version ).to.equal( '2.0.0-alpha.0' );
 
 						const ckeditor5Package = packages.get( 'ckeditor5' );
-						expect( ckeditor5Package.version ).to.equal( '2.0.0.alpha.1' );
+						expect( ckeditor5Package.version ).to.equal( '2.0.0-alpha.0' );
 					} );
 			} );
 
@@ -234,23 +234,23 @@ describe( 'dev-env/release-tools/utils', () => {
 				// ckeditor5
 				stubs.getPackageJson.onFirstCall().returns( {
 					name: 'ckeditor5',
-					version: '1.0.0'
+					version: '2.0.0-alpha.0'
 				} );
 
 				// @ckeditor/ckeditor5-core
 				stubs.getPackageJson.onSecondCall().returns( {
 					name: '@ckeditor/ckeditor5-core',
-					version: '1.0.0'
+					version: '2.0.0-alpha.0'
 				} );
 
 				sandbox.stub( process, 'cwd' ).returns( '/cwd' );
 
 				const changes = [
-					'[ckeditor5](npm link): v2.0.0.alpha.1 => v2.0.0.rc.1',
-					'[@ckeditor/ckeditor5-core](npm link): v2.0.0.alpha.1 => v2.0.0.rc.1'
+					'[ckeditor5](npm link): v2.0.0-alpha.0 => v2.0.0-rc.0',
+					'[@ckeditor/ckeditor5-core](npm link): v2.0.0-alpha.0 => v2.0.0-rc.0'
 				].join( '\n' );
 
-				return getPackagesToRelease( packagesToCheck, { changes, version: '2.0.0.rc.1' } )
+				return getPackagesToRelease( packagesToCheck, { changes, version: '2.0.0-rc.0' } )
 					.then( packages => {
 						expect( packages.size ).to.equal( 2 );
 
@@ -260,10 +260,10 @@ describe( 'dev-env/release-tools/utils', () => {
 						expect( stubs.chdir.thirdCall.args[ 0 ] ).to.equal( '/cwd' );
 
 						const corePackage = packages.get( '@ckeditor/ckeditor5-core' );
-						expect( corePackage.version ).to.equal( '2.0.0.rc.1' );
+						expect( corePackage.version ).to.equal( '2.0.0-rc.0' );
 
 						const ckeditor5Package = packages.get( 'ckeditor5' );
-						expect( ckeditor5Package.version ).to.equal( '2.0.0.rc.1' );
+						expect( ckeditor5Package.version ).to.equal( '2.0.0-rc.0' );
 					} );
 			} );
 
@@ -288,11 +288,11 @@ describe( 'dev-env/release-tools/utils', () => {
 				sandbox.stub( process, 'cwd' ).returns( '/cwd' );
 
 				const changes = [
-					'[ckeditor5](npm link): v1.0.0 => v2.0.0.rc.1',
-					'[@ckeditor/ckeditor5-core](npm link): v1.0.0 => v2.0.0.rc.1'
+					'[ckeditor5](npm link): v1.0.0 => v2.0.0-rc.0',
+					'[@ckeditor/ckeditor5-core](npm link): v1.0.0 => v2.0.0-rc.0'
 				].join( '\n' );
 
-				return getPackagesToRelease( packagesToCheck, { changes, version: '2.0.0.rc.1' } )
+				return getPackagesToRelease( packagesToCheck, { changes, version: '2.0.0-rc.0' } )
 					.then( packages => {
 						expect( packages.size ).to.equal( 2 );
 
@@ -302,10 +302,10 @@ describe( 'dev-env/release-tools/utils', () => {
 						expect( stubs.chdir.thirdCall.args[ 0 ] ).to.equal( '/cwd' );
 
 						const corePackage = packages.get( '@ckeditor/ckeditor5-core' );
-						expect( corePackage.version ).to.equal( '2.0.0.rc.1' );
+						expect( corePackage.version ).to.equal( '2.0.0-rc.0' );
 
 						const ckeditor5Package = packages.get( 'ckeditor5' );
-						expect( ckeditor5Package.version ).to.equal( '2.0.0.rc.1' );
+						expect( ckeditor5Package.version ).to.equal( '2.0.0-rc.0' );
 					} );
 			} );
 
@@ -330,11 +330,11 @@ describe( 'dev-env/release-tools/utils', () => {
 				sandbox.stub( process, 'cwd' ).returns( '/cwd' );
 
 				const changes = [
-					'[ckeditor5](npm link): v1.0.0.alpha.1',
-					'[@ckeditor/ckeditor5-core](npm link): v1.0.0.alpha.1'
+					'[ckeditor5](npm link): v1.0.0-alpha.0',
+					'[@ckeditor/ckeditor5-core](npm link): v1.0.0-alpha.0'
 				].join( '\n' );
 
-				return getPackagesToRelease( packagesToCheck, { changes, version: '1.0.0.alpha.1' } )
+				return getPackagesToRelease( packagesToCheck, { changes, version: '1.0.0-alpha.0' } )
 					.then( packages => {
 						expect( packages.size ).to.equal( 2 );
 
@@ -344,10 +344,91 @@ describe( 'dev-env/release-tools/utils', () => {
 						expect( stubs.chdir.thirdCall.args[ 0 ] ).to.equal( '/cwd' );
 
 						const corePackage = packages.get( '@ckeditor/ckeditor5-core' );
-						expect( corePackage.version ).to.equal( '1.0.0.alpha.1' );
+						expect( corePackage.version ).to.equal( '1.0.0-alpha.0' );
 
 						const ckeditor5Package = packages.get( 'ckeditor5' );
-						expect( ckeditor5Package.version ).to.equal( '1.0.0.alpha.1' );
+						expect( ckeditor5Package.version ).to.equal( '1.0.0-alpha.0' );
+					} );
+			} );
+
+			it( 'does not return a package if a version misses the "dash" symbol (an existing package)', () => {
+				const packagesToCheck = new Set( [
+					'/packages/ckeditor5-core'
+				] );
+
+				// @ckeditor/ckeditor5-core
+				stubs.getPackageJson.onFirstCall().returns( {
+					name: '@ckeditor/ckeditor5-core',
+					version: '1.0.0'
+				} );
+
+				sandbox.stub( process, 'cwd' ).returns( '/cwd' );
+
+				const changes = [
+					'[@ckeditor/ckeditor5-core](npm link): v1.0.0 => v2.0.0.alpha.0'
+				].join( '\n' );
+
+				return getPackagesToRelease( packagesToCheck, { changes, version: '2.0.0-alpha.0' } )
+					.then( packages => {
+						expect( packages.size ).to.equal( 0 );
+
+						expect( stubs.chdir.calledTwice ).to.equal( true );
+						expect( stubs.chdir.firstCall.args[ 0 ] ).to.equal( '/packages/ckeditor5-core' );
+						expect( stubs.chdir.secondCall.args[ 0 ] ).to.equal( '/cwd' );
+					} );
+			} );
+
+			it( 'does not return a package if a version misses the "dash" symbol (an existing package, from alpha to rc)', () => {
+				const packagesToCheck = new Set( [
+					'/packages/ckeditor5-core'
+				] );
+
+				// @ckeditor/ckeditor5-core
+				stubs.getPackageJson.onFirstCall().returns( {
+					name: '@ckeditor/ckeditor5-core',
+					version: '2.0.0-alpha.0'
+				} );
+
+				sandbox.stub( process, 'cwd' ).returns( '/cwd' );
+
+				const changes = [
+					'[@ckeditor/ckeditor5-core](npm link): v2.0.0-alpha.0 => v2.0.0.rc.0'
+				].join( '\n' );
+
+				return getPackagesToRelease( packagesToCheck, { changes, version: '2.0.0-rc.0' } )
+					.then( packages => {
+						expect( packages.size ).to.equal( 0 );
+
+						expect( stubs.chdir.calledTwice ).to.equal( true );
+						expect( stubs.chdir.firstCall.args[ 0 ] ).to.equal( '/packages/ckeditor5-core' );
+						expect( stubs.chdir.secondCall.args[ 0 ] ).to.equal( '/cwd' );
+					} );
+			} );
+
+			it( 'does not return a package if a version misses the "dash" symbol (a new package)', () => {
+				const packagesToCheck = new Set( [
+					'/packages/ckeditor5-core'
+				] );
+
+				// @ckeditor/ckeditor5-core
+				stubs.getPackageJson.onFirstCall().returns( {
+					name: '@ckeditor/ckeditor5-core',
+					version: '1.0.0'
+				} );
+
+				sandbox.stub( process, 'cwd' ).returns( '/cwd' );
+
+				const changes = [
+					'[@ckeditor/ckeditor5-core](npm link): v1.0.0.alpha.0'
+				].join( '\n' );
+
+				return getPackagesToRelease( packagesToCheck, { changes, version: '1.0.0-alpha.0' } )
+					.then( packages => {
+						expect( packages.size ).to.equal( 0 );
+
+						expect( stubs.chdir.calledTwice ).to.equal( true );
+						expect( stubs.chdir.firstCall.args[ 0 ] ).to.equal( '/packages/ckeditor5-core' );
+						expect( stubs.chdir.secondCall.args[ 0 ] ).to.equal( '/cwd' );
 					} );
 			} );
 		} );

--- a/packages/ckeditor5-dev-env/tests/release-tools/utils/getpackagestorelease.js
+++ b/packages/ckeditor5-dev-env/tests/release-tools/utils/getpackagestorelease.js
@@ -180,5 +180,176 @@ describe( 'dev-env/release-tools/utils', () => {
 					expect( corePackage.version ).to.equal( '1.0.0' );
 				} );
 		} );
+
+		// See: https://github.com/ckeditor/ckeditor5/issues/10583.
+		describe( 'pre-release versions', () => {
+			it( 'returns proper versions for existing packages (alpha release)', () => {
+				const packagesToCheck = new Set( [
+					'/cwd',
+					'/packages/ckeditor5-core'
+				] );
+
+				// ckeditor5
+				stubs.getPackageJson.onFirstCall().returns( {
+					name: 'ckeditor5',
+					version: '1.0.0'
+				} );
+
+				// @ckeditor/ckeditor5-core
+				stubs.getPackageJson.onSecondCall().returns( {
+					name: '@ckeditor/ckeditor5-core',
+					version: '1.0.0'
+				} );
+
+				sandbox.stub( process, 'cwd' ).returns( '/cwd' );
+
+				const changes = [
+					'[ckeditor5](npm link): v1.0.0 => v2.0.0.alpha.1',
+					'[@ckeditor/ckeditor5-core](npm link): v1.0.0 => v2.0.0.alpha.1'
+				].join( '\n' );
+
+				return getPackagesToRelease( packagesToCheck, { changes, version: '2.0.0.alpha.1' } )
+					.then( packages => {
+						expect( packages.size ).to.equal( 2 );
+
+						expect( stubs.chdir.calledThrice ).to.equal( true );
+						expect( stubs.chdir.firstCall.args[ 0 ] ).to.equal( '/cwd' );
+						expect( stubs.chdir.secondCall.args[ 0 ] ).to.equal( '/packages/ckeditor5-core' );
+						expect( stubs.chdir.thirdCall.args[ 0 ] ).to.equal( '/cwd' );
+
+						const corePackage = packages.get( '@ckeditor/ckeditor5-core' );
+						expect( corePackage.version ).to.equal( '2.0.0.alpha.1' );
+
+						const ckeditor5Package = packages.get( 'ckeditor5' );
+						expect( ckeditor5Package.version ).to.equal( '2.0.0.alpha.1' );
+					} );
+			} );
+
+			it( 'returns proper versions for existing packages (release candidate)', () => {
+				const packagesToCheck = new Set( [
+					'/cwd',
+					'/packages/ckeditor5-core'
+				] );
+
+				// ckeditor5
+				stubs.getPackageJson.onFirstCall().returns( {
+					name: 'ckeditor5',
+					version: '1.0.0'
+				} );
+
+				// @ckeditor/ckeditor5-core
+				stubs.getPackageJson.onSecondCall().returns( {
+					name: '@ckeditor/ckeditor5-core',
+					version: '1.0.0'
+				} );
+
+				sandbox.stub( process, 'cwd' ).returns( '/cwd' );
+
+				const changes = [
+					'[ckeditor5](npm link): v2.0.0.alpha.1 => v2.0.0.rc.1',
+					'[@ckeditor/ckeditor5-core](npm link): v2.0.0.alpha.1 => v2.0.0.rc.1'
+				].join( '\n' );
+
+				return getPackagesToRelease( packagesToCheck, { changes, version: '2.0.0.rc.1' } )
+					.then( packages => {
+						expect( packages.size ).to.equal( 2 );
+
+						expect( stubs.chdir.calledThrice ).to.equal( true );
+						expect( stubs.chdir.firstCall.args[ 0 ] ).to.equal( '/cwd' );
+						expect( stubs.chdir.secondCall.args[ 0 ] ).to.equal( '/packages/ckeditor5-core' );
+						expect( stubs.chdir.thirdCall.args[ 0 ] ).to.equal( '/cwd' );
+
+						const corePackage = packages.get( '@ckeditor/ckeditor5-core' );
+						expect( corePackage.version ).to.equal( '2.0.0.rc.1' );
+
+						const ckeditor5Package = packages.get( 'ckeditor5' );
+						expect( ckeditor5Package.version ).to.equal( '2.0.0.rc.1' );
+					} );
+			} );
+
+			it( 'returns proper versions for existing packages (from alpha to release candidate)', () => {
+				const packagesToCheck = new Set( [
+					'/cwd',
+					'/packages/ckeditor5-core'
+				] );
+
+				// ckeditor5
+				stubs.getPackageJson.onFirstCall().returns( {
+					name: 'ckeditor5',
+					version: '1.0.0'
+				} );
+
+				// @ckeditor/ckeditor5-core
+				stubs.getPackageJson.onSecondCall().returns( {
+					name: '@ckeditor/ckeditor5-core',
+					version: '1.0.0'
+				} );
+
+				sandbox.stub( process, 'cwd' ).returns( '/cwd' );
+
+				const changes = [
+					'[ckeditor5](npm link): v1.0.0 => v2.0.0.rc.1',
+					'[@ckeditor/ckeditor5-core](npm link): v1.0.0 => v2.0.0.rc.1'
+				].join( '\n' );
+
+				return getPackagesToRelease( packagesToCheck, { changes, version: '2.0.0.rc.1' } )
+					.then( packages => {
+						expect( packages.size ).to.equal( 2 );
+
+						expect( stubs.chdir.calledThrice ).to.equal( true );
+						expect( stubs.chdir.firstCall.args[ 0 ] ).to.equal( '/cwd' );
+						expect( stubs.chdir.secondCall.args[ 0 ] ).to.equal( '/packages/ckeditor5-core' );
+						expect( stubs.chdir.thirdCall.args[ 0 ] ).to.equal( '/cwd' );
+
+						const corePackage = packages.get( '@ckeditor/ckeditor5-core' );
+						expect( corePackage.version ).to.equal( '2.0.0.rc.1' );
+
+						const ckeditor5Package = packages.get( 'ckeditor5' );
+						expect( ckeditor5Package.version ).to.equal( '2.0.0.rc.1' );
+					} );
+			} );
+
+			it( 'returns proper versions for new packages (alpha release)', () => {
+				const packagesToCheck = new Set( [
+					'/cwd',
+					'/packages/ckeditor5-core'
+				] );
+
+				// ckeditor5
+				stubs.getPackageJson.onFirstCall().returns( {
+					name: 'ckeditor5',
+					version: '1.0.0'
+				} );
+
+				// @ckeditor/ckeditor5-core
+				stubs.getPackageJson.onSecondCall().returns( {
+					name: '@ckeditor/ckeditor5-core',
+					version: '1.0.0'
+				} );
+
+				sandbox.stub( process, 'cwd' ).returns( '/cwd' );
+
+				const changes = [
+					'[ckeditor5](npm link): v1.0.0.alpha.1',
+					'[@ckeditor/ckeditor5-core](npm link): v1.0.0.alpha.1'
+				].join( '\n' );
+
+				return getPackagesToRelease( packagesToCheck, { changes, version: '1.0.0.alpha.1' } )
+					.then( packages => {
+						expect( packages.size ).to.equal( 2 );
+
+						expect( stubs.chdir.calledThrice ).to.equal( true );
+						expect( stubs.chdir.firstCall.args[ 0 ] ).to.equal( '/cwd' );
+						expect( stubs.chdir.secondCall.args[ 0 ] ).to.equal( '/packages/ckeditor5-core' );
+						expect( stubs.chdir.thirdCall.args[ 0 ] ).to.equal( '/cwd' );
+
+						const corePackage = packages.get( '@ckeditor/ckeditor5-core' );
+						expect( corePackage.version ).to.equal( '1.0.0.alpha.1' );
+
+						const ckeditor5Package = packages.get( 'ckeditor5' );
+						expect( ckeditor5Package.version ).to.equal( '1.0.0.alpha.1' );
+					} );
+			} );
+		} );
 	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: The `getPackagesToRelease()` function handles pre-release versions properly. Closes ckeditor/ckeditor5#10583.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
