### PR TITLE
Cast all numbers to strings when playing with the cli-table package

### DIFF
--- a/packages/ckeditor5-dev-env/lib/translations/upload.js
+++ b/packages/ckeditor5-dev-env/lib/translations/upload.js
@@ -103,7 +103,7 @@ function printSummary( summaryCollection ) {
 		const items = summaryCollection.created.sort( sortByPackageName() );
 
 		for ( const [ packageName, response ] of items ) {
-			table.push( [ packageName, response[ 0 ] ] );
+			table.push( [ packageName, response[ 0 ].toString() ] );
 		}
 
 		logger.info( table.toString() + '\n' );
@@ -126,11 +126,21 @@ function printSummary( summaryCollection ) {
 			.sort( sortByPackageName() );
 
 		for ( const [ packageName, response ] of changedItems ) {
-			table.push( [ packageName, response.strings_added, response.strings_updated, response.strings_delete ] );
+			table.push( [
+				packageName,
+				response.strings_added.toString(),
+				response.strings_updated.toString(),
+				response.strings_delete.toString()
+			] );
 		}
 
 		for ( const [ packageName, response ] of nonChangedItems ) {
-			const rowData = [ packageName, response.strings_added, response.strings_updated, response.strings_delete ];
+			const rowData = [
+				packageName,
+				response.strings_added.toString(),
+				response.strings_updated.toString(),
+				response.strings_delete.toString()
+			];
 
 			table.push( rowData.map( item => chalk.gray( item ) ) );
 		}

--- a/packages/ckeditor5-dev-env/tests/translations/upload.js
+++ b/packages/ckeditor5-dev-env/tests/translations/upload.js
@@ -103,6 +103,9 @@ describe( 'dev-env/translations/upload()', () => {
 			'/workspace/ckeditor5/build/.transifex/ckeditor5-core/en.pot': '# ckeditor-core en.pot content'
 		};
 
+		stubs.transifexService.postResource.onCall( 0 ).resolves( [ 4 ] );
+		stubs.transifexService.putResourceContent.onCall( 0 ).resolves( { strings_added: 1, strings_updated: 0, strings_delete: 3 } );
+
 		const uploadOptions = {
 			token: 'secretToken',
 			url: 'https://api.example.com',
@@ -233,17 +236,17 @@ describe( 'dev-env/translations/upload()', () => {
 
 				// Packages should be sorted by their names.
 				// Calls 1-4 are for new (created) resources.
-				expect( stubs.table.push.getCall( 0 ).args[ 0 ] ).to.deep.equal( [ 'ckeditor5-link', 5 ] );
-				expect( stubs.table.push.getCall( 1 ).args[ 0 ] ).to.deep.equal( [ 'ckeditor5-ui', 2 ] );
-				expect( stubs.table.push.getCall( 2 ).args[ 0 ] ).to.deep.equal( [ 'ckeditor5-utils', 1 ] );
-				expect( stubs.table.push.getCall( 3 ).args[ 0 ] ).to.deep.equal( [ 'ckeditor5-widget', 4 ] );
+				expect( stubs.table.push.getCall( 0 ).args[ 0 ] ).to.deep.equal( [ 'ckeditor5-link', '5' ] );
+				expect( stubs.table.push.getCall( 1 ).args[ 0 ] ).to.deep.equal( [ 'ckeditor5-ui', '2' ] );
+				expect( stubs.table.push.getCall( 2 ).args[ 0 ] ).to.deep.equal( [ 'ckeditor5-utils', '1' ] );
+				expect( stubs.table.push.getCall( 3 ).args[ 0 ] ).to.deep.equal( [ 'ckeditor5-widget', '4' ] );
 
 				// Calls 5-8 are for updated resources.
 				// First should be displayed packages with changes, then no changes items.
-				expect( stubs.table.push.getCall( 4 ).args[ 0 ] ).to.deep.equal( [ 'ckeditor5-basic-styles', 1, 2, 0 ] );
-				expect( stubs.table.push.getCall( 5 ).args[ 0 ] ).to.deep.equal( [ 'ckeditor5-engine', 1, 0, 3 ] );
-				expect( stubs.table.push.getCall( 6 ).args[ 0 ] ).to.deep.equal( [ 'ckeditor5-autoformat', 0, 0, 0 ] );
-				expect( stubs.table.push.getCall( 7 ).args[ 0 ] ).to.deep.equal( [ 'ckeditor5-core', 0, 0, 0 ] );
+				expect( stubs.table.push.getCall( 4 ).args[ 0 ] ).to.deep.equal( [ 'ckeditor5-basic-styles', '1', '2', '0' ] );
+				expect( stubs.table.push.getCall( 5 ).args[ 0 ] ).to.deep.equal( [ 'ckeditor5-engine', '1', '0', '3' ] );
+				expect( stubs.table.push.getCall( 6 ).args[ 0 ] ).to.deep.equal( [ 'ckeditor5-autoformat', '0', '0', '0' ] );
+				expect( stubs.table.push.getCall( 7 ).args[ 0 ] ).to.deep.equal( [ 'ckeditor5-core', '0', '0', '0' ] );
 
 				// Both table headers should be underlined.
 				expect( stubs.chalk.underline.callCount ).to.equal( 2 );
@@ -254,13 +257,13 @@ describe( 'dev-env/translations/upload()', () => {
 				// Each package calls the function 4 times.
 				expect( stubs.chalk.gray.callCount ).to.equal( 8 );
 				expect( stubs.chalk.gray.getCall( 0 ).args[ 0 ] ).to.equal( 'ckeditor5-autoformat' );
-				expect( stubs.chalk.gray.getCall( 1 ).args[ 0 ] ).to.equal( 0 );
-				expect( stubs.chalk.gray.getCall( 2 ).args[ 0 ] ).to.equal( 0 );
-				expect( stubs.chalk.gray.getCall( 3 ).args[ 0 ] ).to.equal( 0 );
+				expect( stubs.chalk.gray.getCall( 1 ).args[ 0 ] ).to.equal( '0' );
+				expect( stubs.chalk.gray.getCall( 2 ).args[ 0 ] ).to.equal( '0' );
+				expect( stubs.chalk.gray.getCall( 3 ).args[ 0 ] ).to.equal( '0' );
 				expect( stubs.chalk.gray.getCall( 4 ).args[ 0 ] ).to.equal( 'ckeditor5-core' );
-				expect( stubs.chalk.gray.getCall( 5 ).args[ 0 ] ).to.equal( 0 );
-				expect( stubs.chalk.gray.getCall( 6 ).args[ 0 ] ).to.equal( 0 );
-				expect( stubs.chalk.gray.getCall( 7 ).args[ 0 ] ).to.equal( 0 );
+				expect( stubs.chalk.gray.getCall( 5 ).args[ 0 ] ).to.equal( '0' );
+				expect( stubs.chalk.gray.getCall( 6 ).args[ 0 ] ).to.equal( '0' );
+				expect( stubs.chalk.gray.getCall( 7 ).args[ 0 ] ).to.equal( '0' );
 			} );
 	} );
 
@@ -317,10 +320,10 @@ describe( 'dev-env/translations/upload()', () => {
 				// Each package should be added into a table.
 				expect( stubs.table.push.callCount ).to.equal( 4 );
 
-				expect( stubs.table.push.getCall( 0 ).args[ 0 ] ).to.deep.equal( [ 'ckeditor5-link', 5 ] );
-				expect( stubs.table.push.getCall( 1 ).args[ 0 ] ).to.deep.equal( [ 'ckeditor5-ui', 2 ] );
-				expect( stubs.table.push.getCall( 2 ).args[ 0 ] ).to.deep.equal( [ 'ckeditor5-utils', 1 ] );
-				expect( stubs.table.push.getCall( 3 ).args[ 0 ] ).to.deep.equal( [ 'ckeditor5-widget', 4 ] );
+				expect( stubs.table.push.getCall( 0 ).args[ 0 ] ).to.deep.equal( [ 'ckeditor5-link', '5' ] );
+				expect( stubs.table.push.getCall( 1 ).args[ 0 ] ).to.deep.equal( [ 'ckeditor5-ui', '2' ] );
+				expect( stubs.table.push.getCall( 2 ).args[ 0 ] ).to.deep.equal( [ 'ckeditor5-utils', '1' ] );
+				expect( stubs.table.push.getCall( 3 ).args[ 0 ] ).to.deep.equal( [ 'ckeditor5-widget', '4' ] );
 
 				// A table header should be underlined.
 				expect( stubs.chalk.underline.callCount ).to.equal( 1 );
@@ -386,10 +389,10 @@ describe( 'dev-env/translations/upload()', () => {
 				// Each package should be added into a table.
 				expect( stubs.table.push.callCount ).to.equal( 4 );
 
-				expect( stubs.table.push.getCall( 0 ).args[ 0 ] ).to.deep.equal( [ 'ckeditor5-basic-styles', 1, 2, 0 ] );
-				expect( stubs.table.push.getCall( 1 ).args[ 0 ] ).to.deep.equal( [ 'ckeditor5-engine', 1, 0, 3 ] );
-				expect( stubs.table.push.getCall( 2 ).args[ 0 ] ).to.deep.equal( [ 'ckeditor5-autoformat', 0, 0, 0 ] );
-				expect( stubs.table.push.getCall( 3 ).args[ 0 ] ).to.deep.equal( [ 'ckeditor5-core', 0, 0, 0 ] );
+				expect( stubs.table.push.getCall( 0 ).args[ 0 ] ).to.deep.equal( [ 'ckeditor5-basic-styles', '1', '2', '0' ] );
+				expect( stubs.table.push.getCall( 1 ).args[ 0 ] ).to.deep.equal( [ 'ckeditor5-engine', '1', '0', '3' ] );
+				expect( stubs.table.push.getCall( 2 ).args[ 0 ] ).to.deep.equal( [ 'ckeditor5-autoformat', '0', '0', '0' ] );
+				expect( stubs.table.push.getCall( 3 ).args[ 0 ] ).to.deep.equal( [ 'ckeditor5-core', '0', '0', '0' ] );
 
 				// A table header should be underlined.
 				expect( stubs.chalk.underline.callCount ).to.equal( 1 );
@@ -397,13 +400,13 @@ describe( 'dev-env/translations/upload()', () => {
 
 				expect( stubs.chalk.gray.callCount ).to.equal( 8 );
 				expect( stubs.chalk.gray.getCall( 0 ).args[ 0 ] ).to.equal( 'ckeditor5-autoformat' );
-				expect( stubs.chalk.gray.getCall( 1 ).args[ 0 ] ).to.equal( 0 );
-				expect( stubs.chalk.gray.getCall( 2 ).args[ 0 ] ).to.equal( 0 );
-				expect( stubs.chalk.gray.getCall( 3 ).args[ 0 ] ).to.equal( 0 );
+				expect( stubs.chalk.gray.getCall( 1 ).args[ 0 ] ).to.equal( '0' );
+				expect( stubs.chalk.gray.getCall( 2 ).args[ 0 ] ).to.equal( '0' );
+				expect( stubs.chalk.gray.getCall( 3 ).args[ 0 ] ).to.equal( '0' );
 				expect( stubs.chalk.gray.getCall( 4 ).args[ 0 ] ).to.equal( 'ckeditor5-core' );
-				expect( stubs.chalk.gray.getCall( 5 ).args[ 0 ] ).to.equal( 0 );
-				expect( stubs.chalk.gray.getCall( 6 ).args[ 0 ] ).to.equal( 0 );
-				expect( stubs.chalk.gray.getCall( 7 ).args[ 0 ] ).to.equal( 0 );
+				expect( stubs.chalk.gray.getCall( 5 ).args[ 0 ] ).to.equal( '0' );
+				expect( stubs.chalk.gray.getCall( 6 ).args[ 0 ] ).to.equal( '0' );
+				expect( stubs.chalk.gray.getCall( 7 ).args[ 0 ] ).to.equal( '0' );
 			} );
 	} );
 
@@ -429,6 +432,9 @@ describe( 'dev-env/translations/upload()', () => {
 			'C:/workspace/ckeditor5/build/.transifex/ckeditor5-ui/en.pot': '# ckeditor-ui en.pot content',
 			'C:/workspace/ckeditor5/build/.transifex/ckeditor5-core/en.pot': '# ckeditor-core en.pot content'
 		};
+
+		stubs.transifexService.postResource.onCall( 0 ).resolves( [ 4 ] );
+		stubs.transifexService.putResourceContent.onCall( 0 ).resolves( { strings_added: 1, strings_updated: 0, strings_delete: 3 } );
 
 		const uploadOptions = {
 			token: 'secretToken',


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix (env): All numbers returned by the Transifex service will be cast to strings due to an error in the `cli-package`. See: Automattic/cli-table#152. Closes ckeditor/ckeditor5#10861.
