### PR TITLE
Remove instance/static symbols when comparing doclets

### DIFF
--- a/packages/jsdoc-plugins/lib/relation-fixer/getmissingdocletsdata.js
+++ b/packages/jsdoc-plugins/lib/relation-fixer/getmissingdocletsdata.js
@@ -40,7 +40,16 @@ function getMissingDocletsData( docletMap, docletCollection, interfaceClassOrMix
 		}
 
 		const docletsOfSameMember = docletCollection.get( `memberof:${ clonedDoclet.memberof }` ).filter( d => {
-			return d.name === clonedDoclet.name && d.kind === clonedDoclet.kind;
+			// Different types, so avoid comparing their names.
+			if ( d.kind !== clonedDoclet.kind ) {
+				return false;
+			}
+
+			// Static members are separated using the dot character.
+			const docletName = d.name.replace( /^[#.]/, '' );
+			const clonedDocletName = clonedDoclet.name.replace( /^[#.]/, '' );
+
+			return docletName === clonedDocletName;
 		} );
 
 		if ( docletsOfSameMember.length === 0 ) {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix (jsdoc-plugins): When detecting doclets of the same member, remove a prefix for instance/static symbols. Closes ckeditor/ckeditor5#8691.

---

### Additional information

The goal is to generate proper docs for the `DataController#set` method.

![image](https://user-images.githubusercontent.com/2270764/142830736-cdc84c90-e783-423e-a39a-17e7abb53d9b.png)

But the PR fixes all cases when a mixed method is overridden by a class. However, it's hard to say do we have more cases.
