### PR TITLE
Added an option for disabling watchers in the manual test server

### DIFF
--- a/packages/ckeditor5-dev-tests/bin/test-manual.js
+++ b/packages/ckeditor5-dev-tests/bin/test-manual.js
@@ -14,6 +14,11 @@ const tests = require( '../lib/index' );
 const cwd = process.cwd();
 const options = tests.parseArguments( process.argv.slice( 2 ) );
 
+// By default, the watch mechanism should be enabled in manual tests.
+// However, it makes sense to disable it when a developer wants to compile these files once,
+// without rebuilding it. See: https://github.com/ckeditor/ckeditor5/issues/10982.
+options.disableWatch = process.argv.includes( '--disable-watch' );
+
 if ( options.files.length === 0 ) {
 	options.files = [ '*', 'ckeditor5' ];
 }

--- a/packages/ckeditor5-dev-tests/lib/tasks/runautomatedtests.js
+++ b/packages/ckeditor5-dev-tests/lib/tasks/runautomatedtests.js
@@ -3,8 +3,6 @@
  * For licensing, see LICENSE.md.
  */
 
-/* jshint node: true, strict: true */
-
 'use strict';
 
 const fs = require( 'fs' );

--- a/packages/ckeditor5-dev-tests/lib/tasks/runmanualtests.js
+++ b/packages/ckeditor5-dev-tests/lib/tasks/runmanualtests.js
@@ -21,6 +21,8 @@ const transformFileOptionToTestGlob = require( '../utils/transformfileoptiontote
  * @param {Object} options
  * @param {Array.<String>} options.files Glob patterns specifying which tests to run.
  * @param {String} options.themePath A path to the theme the PostCSS theme-importer plugin is supposed to load.
+ * @param {Boolean} options.disableWatch Whether to disable the watch mechanism. If set to true, changes in source files
+ * will not trigger webpack.
  * @param {String} [options.language] A language passed to `CKEditorWebpackPlugin`.
  * @param {Array.<String>} [options.additionalLanguages] Additional languages passed to `CKEditorWebpackPlugin`.
  * @param {Number} [options.port] A port number used by the `createManualTestServer`.
@@ -53,14 +55,16 @@ module.exports = function runManualTests( options ) {
 				language,
 				additionalLanguages,
 				debug: options.debug,
-				identityFile
+				identityFile,
+				disableWatch: options.disableWatch
 			} ),
 			compileManualTestHtmlFiles( {
 				buildDir,
 				patterns,
 				language,
 				additionalLanguages,
-				silent
+				silent,
+				disableWatch: options.disableWatch
 			} ),
 			copyAssets( buildDir )
 		] ) )

--- a/packages/ckeditor5-dev-tests/lib/tasks/runmanualtests.js
+++ b/packages/ckeditor5-dev-tests/lib/tasks/runmanualtests.js
@@ -21,7 +21,7 @@ const transformFileOptionToTestGlob = require( '../utils/transformfileoptiontote
  * @param {Object} options
  * @param {Array.<String>} options.files Glob patterns specifying which tests to run.
  * @param {String} options.themePath A path to the theme the PostCSS theme-importer plugin is supposed to load.
- * @param {Boolean} options.disableWatch Whether to disable the watch mechanism. If set to true, changes in source files
+ * @param {Boolean} [options.disableWatch=false] Whether to disable the watch mechanism. If set to true, changes in source files
  * will not trigger webpack.
  * @param {String} [options.language] A language passed to `CKEditorWebpackPlugin`.
  * @param {Array.<String>} [options.additionalLanguages] Additional languages passed to `CKEditorWebpackPlugin`.
@@ -44,6 +44,7 @@ module.exports = function runManualTests( options ) {
 	const additionalLanguages = options.additionalLanguages;
 	const identityFile = normalizeIdentityFile( options.identityFile );
 	const silent = options.silent || false;
+	const disableWatch = options.disableWatch || false;
 
 	return Promise.resolve()
 		.then( () => removeDir( buildDir, { silent } ) )
@@ -56,7 +57,7 @@ module.exports = function runManualTests( options ) {
 				additionalLanguages,
 				debug: options.debug,
 				identityFile,
-				disableWatch: options.disableWatch
+				disableWatch
 			} ),
 			compileManualTestHtmlFiles( {
 				buildDir,
@@ -64,7 +65,7 @@ module.exports = function runManualTests( options ) {
 				language,
 				additionalLanguages,
 				silent,
-				disableWatch: options.disableWatch
+				disableWatch
 			} ),
 			copyAssets( buildDir )
 		] ) )

--- a/packages/ckeditor5-dev-tests/lib/tasks/runmanualtests.js
+++ b/packages/ckeditor5-dev-tests/lib/tasks/runmanualtests.js
@@ -3,8 +3,6 @@
  * For licensing, see LICENSE.md.
  */
 
-/* jshint node: true, strict: true */
-
 'use strict';
 
 const path = require( 'path' );

--- a/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getkarmaconfig.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getkarmaconfig.js
@@ -3,7 +3,6 @@
  * For licensing, see LICENSE.md.
  */
 
-/* jshint browser: false, node: true, strict: true */
 'use strict';
 
 const path = require( 'path' );

--- a/packages/ckeditor5-dev-tests/lib/utils/manual-tests/compilehtmlfiles.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/manual-tests/compilehtmlfiles.js
@@ -24,6 +24,8 @@ const writer = new commonmark.HtmlRenderer();
  * @param {String} options.buildDir A path where compiled files will be saved.
  * @param {Array.<String>} options.patterns An array of patterns that resolve manual test scripts.
  * @param {String} options.language A language passed to `CKEditorWebpackPlugin`.
+ * @param {Boolean} options.disableWatch Whether to disable the watch mechanism. If set to true, changes in source files
+ * will not trigger webpack.
  * @param {Array.<String>} [options.additionalLanguages] Additional languages passed to `CKEditorWebpackPlugin`.
  * @param {Boolean} [options.silent=false] Whether to hide files that will be processed by the script.
  * @returns {Promise}
@@ -73,14 +75,16 @@ module.exports = function compileHtmlFiles( options ) {
 	} ) );
 
 	// Watch files and compile on change.
-	watchFiles( [ ...sourceMDFiles, ...sourceHtmlFiles ], file => {
-		compileHtmlFile( buildDir, {
-			filePath: getFilePathWithoutExtension( file ),
-			template: viewTemplate,
-			languages: languagesToLoad,
-			silent
+	if ( !options.disableWatch ) {
+		watchFiles( [ ...sourceMDFiles, ...sourceHtmlFiles ], file => {
+			compileHtmlFile( buildDir, {
+				filePath: getFilePathWithoutExtension( file ),
+				template: viewTemplate,
+				languages: languagesToLoad,
+				silent
+			} );
 		} );
-	} );
+	}
 };
 
 /**

--- a/packages/ckeditor5-dev-tests/lib/utils/manual-tests/compilescripts.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/manual-tests/compilescripts.js
@@ -49,8 +49,6 @@ module.exports = function compileManualTestScripts( options ) {
 		disableWatch: options.disableWatch
 	} );
 
-	console.log( webpackConfig );
-
 	return runWebpack( webpackConfig );
 };
 

--- a/packages/ckeditor5-dev-tests/lib/utils/manual-tests/compilescripts.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/manual-tests/compilescripts.js
@@ -19,6 +19,8 @@ const getRelativeFilePath = require( '../getrelativefilepath' );
  * @param {Array.<String>} options.patterns An array of patterns that resolve manual test scripts.
  * @param {String} options.themePath A path to the theme the PostCSS theme-importer plugin is supposed to load.
  * @param {String} options.language A language passed to `CKEditorWebpackPlugin`.
+ * @param {Boolean} options.disableWatch Whether to disable the watch mechanism. If set to true, changes in source files
+ * will not trigger webpack.
  * @param {Array.<String>} [options.additionalLanguages] Additional languages passed to `CKEditorWebpackPlugin`.
  * @param {String} [options.identityFile] A file that provides secret keys used in the test scripts.
  * @returns {Promise}
@@ -43,7 +45,8 @@ module.exports = function compileManualTestScripts( options ) {
 		language: options.language,
 		additionalLanguages: options.additionalLanguages,
 		debug: options.debug,
-		identityFile: options.identityFile
+		identityFile: options.identityFile,
+		disableWatch: options.disableWatch
 	} );
 
 	return runWebpack( webpackConfig );

--- a/packages/ckeditor5-dev-tests/lib/utils/manual-tests/compilescripts.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/manual-tests/compilescripts.js
@@ -3,8 +3,6 @@
  * For licensing, see LICENSE.md.
  */
 
-/* jshint node: true, strict: true */
-
 'use strict';
 
 const path = require( 'path' );

--- a/packages/ckeditor5-dev-tests/lib/utils/manual-tests/compilescripts.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/manual-tests/compilescripts.js
@@ -49,6 +49,8 @@ module.exports = function compileManualTestScripts( options ) {
 		disableWatch: options.disableWatch
 	} );
 
+	console.log( webpackConfig );
+
 	return runWebpack( webpackConfig );
 };
 

--- a/packages/ckeditor5-dev-tests/lib/utils/manual-tests/copyassets.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/manual-tests/copyassets.js
@@ -3,8 +3,6 @@
  * For licensing, see LICENSE.md.
  */
 
-/* jshint node: true, strict: true */
-
 const path = require( 'path' );
 const fs = require( 'fs-extra' );
 

--- a/packages/ckeditor5-dev-tests/lib/utils/manual-tests/getwebpackconfig.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/manual-tests/getwebpackconfig.js
@@ -30,10 +30,6 @@ module.exports = function getWebpackConfigForManualTests( options ) {
 
 		entry: options.entries,
 
-		devtool: false,
-
-		watch: false,
-
 		output: {
 			path: options.buildDir
 		},

--- a/packages/ckeditor5-dev-tests/lib/utils/manual-tests/getwebpackconfig.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/manual-tests/getwebpackconfig.js
@@ -26,7 +26,7 @@ module.exports = function getWebpackConfigForManualTests( options ) {
 	const definitions = Object.assign( {}, getDefinitionsFromFile( options.identityFile ) );
 
 	const webpackConfig = {
-		mode: 'development',
+		mode: 'none',
 
 		entry: options.entries,
 

--- a/packages/ckeditor5-dev-tests/lib/utils/manual-tests/getwebpackconfig.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/manual-tests/getwebpackconfig.js
@@ -30,6 +30,10 @@ module.exports = function getWebpackConfigForManualTests( options ) {
 
 		entry: options.entries,
 
+		devtool: false,
+
+		watch: false,
+
 		output: {
 			path: options.buildDir
 		},

--- a/packages/ckeditor5-dev-tests/lib/utils/manual-tests/getwebpackconfig.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/manual-tests/getwebpackconfig.js
@@ -16,6 +16,7 @@ const webpack = require( 'webpack' );
  * @param {Object} options.entries
  * @param {String} options.buildDir
  * @param {String} options.themePath
+ * @param {Boolean} options.disableWatch
  * @param {String} [options.language]
  * @param {Array.<String>} [options.additionalLanguages]
  * @param {String|null} [options.identityFile]
@@ -24,15 +25,8 @@ const webpack = require( 'webpack' );
 module.exports = function getWebpackConfigForManualTests( options ) {
 	const definitions = Object.assign( {}, getDefinitionsFromFile( options.identityFile ) );
 
-	return {
+	const webpackConfig = {
 		mode: 'development',
-
-		// Use cheap source maps because Safari had problem with ES6 + inline source maps.
-		// We could use cheap source maps every where but karma-webpack doesn't support it:
-		// https://github.com/webpack/karma-webpack/pull/76
-		devtool: 'cheap-source-map',
-
-		watch: true,
 
 		entry: options.entries,
 
@@ -107,6 +101,16 @@ module.exports = function getWebpackConfigForManualTests( options ) {
 			]
 		}
 	};
+
+	if ( !options.disableWatch ) {
+		// Use cheap source maps because Safari had problem with ES6 + inline source maps.
+		// We could use cheap source maps every where but karma-webpack doesn't support it:
+		// https://github.com/webpack/karma-webpack/pull/76
+		webpackConfig.devtool = 'cheap-source-map';
+		webpackConfig.watch = true;
+	}
+
+	return webpackConfig;
 };
 
 /**

--- a/packages/ckeditor5-dev-tests/tests/tasks/runmanualtests.js
+++ b/packages/ckeditor5-dev-tests/tests/tasks/runmanualtests.js
@@ -73,6 +73,7 @@ describe( 'runManualTests', () => {
 					],
 					language: undefined,
 					additionalLanguages: undefined,
+					disableWatch: false,
 					silent: false
 				} );
 
@@ -87,6 +88,7 @@ describe( 'runManualTests', () => {
 					language: undefined,
 					additionalLanguages: undefined,
 					debug: undefined,
+					disableWatch: false,
 					identityFile: null
 				} );
 
@@ -138,6 +140,7 @@ describe( 'runManualTests', () => {
 					],
 					language: undefined,
 					additionalLanguages: undefined,
+					disableWatch: false,
 					silent: false
 				} );
 
@@ -154,6 +157,7 @@ describe( 'runManualTests', () => {
 					language: undefined,
 					additionalLanguages: undefined,
 					debug: [ 'CK_DEBUG' ],
+					disableWatch: false,
 					identityFile: null
 				} );
 
@@ -209,6 +213,7 @@ describe( 'runManualTests', () => {
 					],
 					language: 'pl',
 					additionalLanguages: [ 'ar', 'en' ],
+					disableWatch: false,
 					silent: false
 				} );
 
@@ -225,6 +230,7 @@ describe( 'runManualTests', () => {
 					language: 'pl',
 					additionalLanguages: [ 'ar', 'en' ],
 					debug: [ 'CK_DEBUG' ],
+					disableWatch: false,
 					identityFile: null
 				} );
 
@@ -294,6 +300,7 @@ describe( 'runManualTests', () => {
 					language: undefined,
 					debug: undefined,
 					additionalLanguages: undefined,
+					disableWatch: false,
 					identityFile: '/absolute/path/to/secrets.js'
 				} );
 			} );
@@ -334,6 +341,7 @@ describe( 'runManualTests', () => {
 					language: undefined,
 					debug: undefined,
 					additionalLanguages: undefined,
+					disableWatch: false,
 					identityFile: 'workspace/path/to/secrets.js'
 				} );
 			} );
@@ -364,6 +372,7 @@ describe( 'runManualTests', () => {
 					],
 					language: undefined,
 					additionalLanguages: undefined,
+					disableWatch: false,
 					silent: true
 				} );
 
@@ -378,6 +387,52 @@ describe( 'runManualTests', () => {
 					language: undefined,
 					additionalLanguages: undefined,
 					debug: undefined,
+					disableWatch: false,
+					identityFile: null
+				} );
+
+				expect( spies.server.calledOnce ).to.equal( true );
+				expect( spies.server.firstCall.args[ 0 ] ).to.equal( 'workspace/build/.manual-tests' );
+			} );
+	} );
+
+	it( 'should allow disabling listening for changes in source files', () => {
+		spies.transformFileOptionToTestGlob.returns( [
+			'workspace/packages/ckeditor5-*/tests/**/manual/**/*.js',
+			'workspace/packages/ckeditor-*/tests/**/manual/**/*.js'
+		] );
+
+		return runManualTests( { disableWatch: true } )
+			.then( () => {
+				expect( spies.transformFileOptionToTestGlob.calledOnce ).to.equal( true );
+				expect( spies.transformFileOptionToTestGlob.firstCall.args[ 0 ] ).to.equal( '*' );
+				expect( spies.transformFileOptionToTestGlob.firstCall.args[ 1 ] ).to.equal( true );
+
+				expect( spies.htmlFileCompiler.calledOnce ).to.equal( true );
+				expect( spies.htmlFileCompiler.firstCall.args[ 0 ] ).to.deep.equal( {
+					buildDir: 'workspace/build/.manual-tests',
+					patterns: [
+						'workspace/packages/ckeditor5-*/tests/**/manual/**/*.js',
+						'workspace/packages/ckeditor-*/tests/**/manual/**/*.js'
+					],
+					language: undefined,
+					additionalLanguages: undefined,
+					disableWatch: true,
+					silent: false
+				} );
+
+				expect( spies.scriptCompiler.calledOnce ).to.equal( true );
+				expect( spies.scriptCompiler.firstCall.args[ 0 ] ).to.deep.equal( {
+					buildDir: 'workspace/build/.manual-tests',
+					patterns: [
+						'workspace/packages/ckeditor5-*/tests/**/manual/**/*.js',
+						'workspace/packages/ckeditor-*/tests/**/manual/**/*.js'
+					],
+					themePath: null,
+					language: undefined,
+					additionalLanguages: undefined,
+					debug: undefined,
+					disableWatch: true,
 					identityFile: null
 				} );
 

--- a/packages/ckeditor5-dev-tests/tests/utils/manual-tests/compilescripts.js
+++ b/packages/ckeditor5-dev-tests/tests/utils/manual-tests/compilescripts.js
@@ -60,7 +60,8 @@ describe( 'compileManualTestScripts', () => {
 			themePath: 'path/to/theme',
 			language: 'en',
 			additionalLanguages: [ 'pl', 'ar' ],
-			debug: [ 'CK_DEBUG' ]
+			debug: [ 'CK_DEBUG' ],
+			disableWatch: false
 		} ).then( () => {
 			expect( stubs.getWebpackConfig.calledOnce ).to.equal( true );
 
@@ -74,6 +75,7 @@ describe( 'compileManualTestScripts', () => {
 					'ckeditor5-foo/manual/file2': 'ckeditor5-foo/manual/file2'
 				},
 				debug: [ 'CK_DEBUG' ],
+				disableWatch: false,
 				identityFile: undefined
 			} );
 
@@ -203,7 +205,7 @@ describe( 'compileManualTestScripts', () => {
 		} );
 	} );
 
-	it( 'should pass identity file to Webpack configuration factory', () => {
+	it( 'should pass identity file to webpack configuration factory', () => {
 		stubs.glob.returns( [ 'ckeditor5-foo/manual/file1', 'ckeditor5-foo/manual/file2' ] );
 		const identityFile = '/foo/bar.js';
 
@@ -214,7 +216,8 @@ describe( 'compileManualTestScripts', () => {
 			language: 'en',
 			additionalLanguages: [ 'pl', 'ar' ],
 			debug: [ 'CK_DEBUG' ],
-			identityFile
+			identityFile,
+			disableWatch: false
 		} ).then( () => {
 			expect( stubs.getWebpackConfig.calledOnce ).to.equal( true );
 
@@ -228,7 +231,8 @@ describe( 'compileManualTestScripts', () => {
 					'ckeditor5-foo/manual/file2': 'ckeditor5-foo/manual/file2'
 				},
 				debug: [ 'CK_DEBUG' ],
-				identityFile
+				identityFile,
+				disableWatch: false
 			} );
 
 			expect( stubs.webpack.calledOnce ).to.equal( true );
@@ -237,6 +241,46 @@ describe( 'compileManualTestScripts', () => {
 				entries: {
 					'ckeditor5-foo/manual/file1': 'ckeditor5-foo/manual/file1',
 					'ckeditor5-foo/manual/file2': 'ckeditor5-foo/manual/file2'
+				}
+			} );
+
+			expect( stubs.glob.calledOnce ).to.equal( true );
+			expect( stubs.glob.firstCall.args[ 0 ] ).to.equal( 'manualTestPattern' );
+		} );
+	} );
+
+	it( 'should pass the "disableWatch" option to webpack configuration factory', () => {
+		stubs.glob.returns( [ 'ckeditor5-foo/manual/file1' ] );
+
+		return compileManualTestScripts( {
+			buildDir: 'buildDir',
+			patterns: [ 'manualTestPattern' ],
+			themePath: 'path/to/theme',
+			language: 'en',
+			additionalLanguages: [ 'pl', 'ar' ],
+			debug: [ 'CK_DEBUG' ],
+			disableWatch: true
+		} ).then( () => {
+			expect( stubs.getWebpackConfig.calledOnce ).to.equal( true );
+
+			expect( stubs.getWebpackConfig.firstCall.args[ 0 ] ).to.deep.equal( {
+				buildDir: 'buildDir',
+				themePath: 'path/to/theme',
+				language: 'en',
+				additionalLanguages: [ 'pl', 'ar' ],
+				entries: {
+					'ckeditor5-foo/manual/file1': 'ckeditor5-foo/manual/file1'
+				},
+				debug: [ 'CK_DEBUG' ],
+				identityFile: undefined,
+				disableWatch: true
+			} );
+
+			expect( stubs.webpack.calledOnce ).to.equal( true );
+			expect( stubs.webpack.firstCall.args[ 0 ] ).to.deep.equal( {
+				buildDir: 'buildDir',
+				entries: {
+					'ckeditor5-foo/manual/file1': 'ckeditor5-foo/manual/file1'
 				}
 			} );
 

--- a/packages/ckeditor5-dev-tests/tests/utils/manual-tests/getwebpackconfig.js
+++ b/packages/ckeditor5-dev-tests/tests/utils/manual-tests/getwebpackconfig.js
@@ -1,0 +1,47 @@
+/**
+ * @license Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+'use strict';
+
+const { expect } = require( 'chai' );
+
+describe( 'getWebpackConfigForManualTests()', () => {
+	let getWebpackConfigForManualTests;
+
+	beforeEach( () => {
+		getWebpackConfigForManualTests = require( '../../../lib/utils/manual-tests/getwebpackconfig' );
+	} );
+
+	it( 'should return webpack configuration object', () => {
+		const entries = {
+			'ckeditor5/tests/manual/all-features': '/home/ckeditor/ckeditor5/tests/manual/all-features.js'
+		};
+
+		const buildDir = '/home/ckeditor/ckeditor5/build/.manual-tests';
+
+		const webpackConfig = getWebpackConfigForManualTests( {
+			entries, buildDir
+		} );
+
+		expect( webpackConfig ).to.be.an( 'object' );
+
+		// To avoid "eval()" in files.
+		expect( webpackConfig ).to.have.property( 'mode', 'none' );
+		expect( webpackConfig ).to.have.property( 'entry', entries );
+		expect( webpackConfig ).to.have.property( 'output' );
+		expect( webpackConfig.output ).to.deep.equal( { path: buildDir } );
+		expect( webpackConfig ).to.have.property( 'plugins' );
+		expect( webpackConfig ).to.have.property( 'devtool', 'cheap-source-map' );
+		expect( webpackConfig ).to.have.property( 'watch', true );
+	} );
+
+	it( 'should disable watcher mechanism when passing the "disableWatch" option', () => {
+		const webpackConfig = getWebpackConfigForManualTests( { disableWatch: true } );
+
+		expect( webpackConfig ).to.be.an( 'object' );
+		expect( webpackConfig ).to.not.have.property( 'devtool' );
+		expect( webpackConfig ).to.not.have.property( 'watch' );
+	} );
+} );

--- a/packages/ckeditor5-dev-utils/tests/bundler/geteditorconfig.js
+++ b/packages/ckeditor5-dev-utils/tests/bundler/geteditorconfig.js
@@ -3,8 +3,6 @@
  * For licensing, see LICENSE.md.
  */
 
-/* jshint mocha:true */
-
 'use strict';
 
 const chai = require( 'chai' );

--- a/packages/jsdoc-plugins/tests/relation-fixer/buildrelations.js
+++ b/packages/jsdoc-plugins/tests/relation-fixer/buildrelations.js
@@ -3,8 +3,6 @@
  * Licensed under the terms of the MIT License (see LICENSE.md).
  */
 
-/* jshint mocha:true */
-
 'use strict';
 
 const chai = require( 'chai' );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature (tests): Added an option for disabling watchers in the manual test server. See: ckeditor/ckeditor5#10982.
