### PR TITLE
Fixed generating source maps for manual and automated tests

### DIFF
--- a/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getwebpackconfig.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getwebpackconfig.js
@@ -81,9 +81,11 @@ module.exports = function getWebpackConfigForAutomatedTests( options ) {
 	};
 
 	if ( options.sourceMap ) {
-		// Available list: https://webpack.js.org/configuration/devtool/.
-		// In Safari, none of them seems to work.
-		config.devtool = 'cheap-source-map';
+		// After bumping the webpack to v5 and other related tools/libs/whatever, the source maps stopped working for unknown reasons.
+		// The only way to make them work again was to use the inline source maps.
+		//
+		// See https://github.com/ckeditor/ckeditor5/issues/11006.
+		config.devtool = 'inline-source-map';
 	}
 
 	if ( options.coverage ) {

--- a/packages/ckeditor5-dev-tests/tests/utils/automated-tests/getwebpackconfig.js
+++ b/packages/ckeditor5-dev-tests/tests/utils/automated-tests/getwebpackconfig.js
@@ -106,7 +106,7 @@ describe( 'getWebpackConfigForAutomatedTests()', () => {
 			sourceMap: true
 		} );
 
-		expect( webpackConfig.devtool ).to.equal( 'cheap-source-map' );
+		expect( webpackConfig.devtool ).to.equal( 'inline-source-map' );
 	} );
 
 	it( 'should contain a correct paths in resolveLoader', () => {

--- a/packages/ckeditor5-dev-tests/tests/utils/manual-tests/getwebpackconfig.js
+++ b/packages/ckeditor5-dev-tests/tests/utils/manual-tests/getwebpackconfig.js
@@ -33,8 +33,10 @@ describe( 'getWebpackConfigForManualTests()', () => {
 		expect( webpackConfig ).to.have.property( 'output' );
 		expect( webpackConfig.output ).to.deep.equal( { path: buildDir } );
 		expect( webpackConfig ).to.have.property( 'plugins' );
-		expect( webpackConfig ).to.have.property( 'devtool', 'cheap-source-map' );
 		expect( webpackConfig ).to.have.property( 'watch', true );
+
+		// The `devtool` property has been replaced by the `SourceMapDevToolPlugin()`.
+		expect( webpackConfig ).to.not.have.property( 'devtool' );
 	} );
 
 	it( 'should disable watcher mechanism when passing the "disableWatch" option', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix (tests): Fixed generating source maps for manual and automated tests. Closes https://github.com/ckeditor/ckeditor5/issues/11006.

---

### Additional information

#### Manual tests

It looks like the webpack config for manual tests needs more fine grained configuration than the default one. So, instead of the `devtool` option, I manually added the [`SourceMapDevToolPlugin`](https://webpack.js.org/plugins/source-map-dev-tool-plugin) with some custom rules, where source map files are generated.

#### Automated tests

In automated tests, the only source map that works for me is `inline-source-map`.
