### PR TITLE
Do not render protected API docs

### DIFF
--- a/packages/jsdoc-plugins/lib/purge-private-api-docs.js
+++ b/packages/jsdoc-plugins/lib/purge-private-api-docs.js
@@ -55,7 +55,15 @@ module.exports = {
 					return true;
 				}
 
-				return doclet.access !== 'private';
+				if ( doclet.access === 'private' ) {
+					return false;
+				}
+
+				if ( doclet.access === 'protected' ) {
+					return false;
+				}
+
+				return true;
 			} );
 		}
 	},


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix (jsdoc-plugins): Protected members should not be rendered in API docs. Closes ckeditor/ckeditor5#11143.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
