### PR TITLE
Added handling for the "©" character when updating licenses

### DIFF
--- a/packages/ckeditor5-dev-env/lib/tasks/bump-year.js
+++ b/packages/ckeditor5-dev-env/lib/tasks/bump-year.js
@@ -55,7 +55,7 @@ module.exports = function bumpYear( params ) {
 
 	filesToUpdate.forEach( fileName => {
 		const fileContent = fs.readFileSync( fileName, 'utf-8' );
-		const yearRegexp = new RegExp( `(?<=Copyright \\(c\\) ${ params.initialYear }-)\\d{4}`, 'g' );
+		const yearRegexp = new RegExp( `(?<=Copyright (?:\\(c\\)|\u00A9) ${ params.initialYear }-)\\d{4}`, 'g' );
 
 		const updatedFileContent = fileContent.replace( yearRegexp, currentYear );
 

--- a/packages/ckeditor5-dev-env/lib/tasks/bump-year.js
+++ b/packages/ckeditor5-dev-env/lib/tasks/bump-year.js
@@ -55,7 +55,7 @@ module.exports = function bumpYear( params ) {
 
 	filesToUpdate.forEach( fileName => {
 		const fileContent = fs.readFileSync( fileName, 'utf-8' );
-		const yearRegexp = new RegExp( `(?<=Copyright (?:\\(c\\)|\u00A9) ${ params.initialYear }-)\\d{4}`, 'g' );
+		const yearRegexp = new RegExp( `(?<=Copyright (?:\\(c\\)|©) ${ params.initialYear }-)\\d{4}`, 'g' );
 
 		const updatedFileContent = fileContent.replace( yearRegexp, currentYear );
 


### PR DESCRIPTION
Other (env): Added handling for the `©` character when updating licenses. Closes ckeditor/ckeditor5#11119.