### PR TITLE
Added `--identity-file` (`-i`) option for automated tests

### DIFF
--- a/packages/ckeditor5-dev-tests/lib/tasks/runmanualtests.js
+++ b/packages/ckeditor5-dev-tests/lib/tasks/runmanualtests.js
@@ -40,7 +40,6 @@ module.exports = function runManualTests( options ) {
 	const themePath = options.themePath || null;
 	const language = options.language;
 	const additionalLanguages = options.additionalLanguages;
-	const identityFile = normalizeIdentityFile( options.identityFile );
 	const silent = options.silent || false;
 	const disableWatch = options.disableWatch || false;
 
@@ -54,7 +53,7 @@ module.exports = function runManualTests( options ) {
 				language,
 				additionalLanguages,
 				debug: options.debug,
-				identityFile,
+				identityFile: options.identityFile,
 				disableWatch
 			} ),
 			compileManualTestHtmlFiles( {
@@ -69,21 +68,3 @@ module.exports = function runManualTests( options ) {
 		] ) )
 		.then( () => createManualTestServer( buildDir, options.port ) );
 };
-
-/**
- * @param {String|null} identityFile
- * @returns {String|null}
- */
-function normalizeIdentityFile( identityFile ) {
-	if ( !identityFile ) {
-		return null;
-	}
-
-	// Passed an absolute path.
-	if ( path.isAbsolute( identityFile ) ) {
-		return identityFile;
-	}
-
-	// Passed a relative path. Merge it with the current working directory.
-	return path.join( process.cwd(), identityFile );
-}

--- a/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getkarmaconfig.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getkarmaconfig.js
@@ -76,6 +76,7 @@ module.exports = function getKarmaConfig( options ) {
 		webpack: getWebpackConfigForAutomatedTests( {
 			files: Object.keys( options.globPatterns ).map( key => options.globPatterns[ key ] ),
 			sourceMap: options.sourceMap,
+			identityFile: options.identityFile,
 			coverage: options.coverage,
 			themePath: options.themePath,
 			debug: options.debug

--- a/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getwebpackconfig.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getwebpackconfig.js
@@ -9,16 +9,20 @@ const path = require( 'path' );
 const escapedPathSep = path.sep == '/' ? '/' : '\\\\';
 const webpack = require( 'webpack' );
 const { getPostCssConfig } = require( '@ckeditor/ckeditor5-dev-utils' ).styles;
+const getDefinitionsFromFile = require( '../getdefinitionsfromfile' );
 
 /**
  * @param {Object} options
  * @returns {Object}
  */
 module.exports = function getWebpackConfigForAutomatedTests( options ) {
+	const definitions = Object.assign( {}, getDefinitionsFromFile( options.identityFile ) );
+
 	const config = {
 		mode: 'development',
 
 		plugins: [
+			new webpack.DefinePlugin( definitions ),
 			new webpack.ProvidePlugin( {
 				process: 'process/browser'
 			} )

--- a/packages/ckeditor5-dev-tests/lib/utils/automated-tests/parsearguments.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/automated-tests/parsearguments.js
@@ -26,7 +26,8 @@ module.exports = function parseArguments( args ) {
 			'repositories',
 			'language',
 			'theme-path',
-			'additional-languages'
+			'additional-languages',
+			'identity-file'
 		],
 
 		boolean: [

--- a/packages/ckeditor5-dev-tests/lib/utils/getdefinitionsfromfile.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/getdefinitionsfromfile.js
@@ -1,0 +1,48 @@
+/**
+ * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+'use strict';
+
+const path = require( 'path' );
+
+/**
+ * @param {String|null} definitionSource
+ * @returns {Object}
+ */
+module.exports = function getDefinitionsFromFile( definitionSource ) {
+	if ( !definitionSource ) {
+		return {};
+	}
+
+	try {
+		const definitions = require( normalizeDefinitionSource( definitionSource ) );
+
+		const stringifiedDefinitions = {};
+
+		for ( const definitionName in definitions ) {
+			stringifiedDefinitions[ definitionName ] = JSON.stringify( definitions[ definitionName ] );
+		}
+
+		return stringifiedDefinitions;
+	} catch ( err ) {
+		console.error( err.message );
+
+		return {};
+	}
+};
+
+/**
+ * @param {String|null} definitionSource
+ * @returns {String|null}
+ */
+function normalizeDefinitionSource( definitionSource ) {
+	// Passed an absolute path.
+	if ( path.isAbsolute( definitionSource ) ) {
+		return definitionSource;
+	}
+
+	// Passed a relative path. Merge it with the current working directory.
+	return path.join( process.cwd(), definitionSource );
+}

--- a/packages/ckeditor5-dev-tests/lib/utils/manual-tests/getwebpackconfig.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/manual-tests/getwebpackconfig.js
@@ -10,6 +10,7 @@ const WebpackNotifierPlugin = require( './webpacknotifierplugin' );
 const { getPostCssConfig } = require( '@ckeditor/ckeditor5-dev-utils' ).styles;
 const CKEditorWebpackPlugin = require( '@ckeditor/ckeditor5-dev-webpack-plugin' );
 const webpack = require( 'webpack' );
+const getDefinitionsFromFile = require( '../getdefinitionsfromfile' );
 
 /**
  * @param {Object} options
@@ -135,28 +136,3 @@ module.exports = function getWebpackConfigForManualTests( options ) {
 	return webpackConfig;
 };
 
-/**
- * @param {String|null} definitionSource
- * @returns {Object}
- */
-function getDefinitionsFromFile( definitionSource ) {
-	if ( !definitionSource ) {
-		return {};
-	}
-
-	try {
-		const definitions = require( definitionSource );
-
-		const stringifiedDefinitions = {};
-
-		for ( const definitionName in definitions ) {
-			stringifiedDefinitions[ definitionName ] = JSON.stringify( definitions[ definitionName ] );
-		}
-
-		return stringifiedDefinitions;
-	} catch ( err ) {
-		console.error( err.message );
-
-		return {};
-	}
-}

--- a/packages/ckeditor5-dev-tests/tests/tasks/runmanualtests.js
+++ b/packages/ckeditor5-dev-tests/tests/tasks/runmanualtests.js
@@ -89,7 +89,7 @@ describe( 'runManualTests', () => {
 					additionalLanguages: undefined,
 					debug: undefined,
 					disableWatch: false,
-					identityFile: null
+					identityFile: undefined
 				} );
 
 				expect( spies.server.calledOnce ).to.equal( true );
@@ -158,7 +158,7 @@ describe( 'runManualTests', () => {
 					additionalLanguages: undefined,
 					debug: [ 'CK_DEBUG' ],
 					disableWatch: false,
-					identityFile: null
+					identityFile: undefined
 				} );
 
 				expect( spies.server.calledOnce ).to.equal( true );
@@ -231,7 +231,7 @@ describe( 'runManualTests', () => {
 					additionalLanguages: [ 'ar', 'en' ],
 					debug: [ 'CK_DEBUG' ],
 					disableWatch: false,
-					identityFile: null
+					identityFile: undefined
 				} );
 
 				expect( spies.server.calledOnce ).to.equal( true );
@@ -342,7 +342,7 @@ describe( 'runManualTests', () => {
 					debug: undefined,
 					additionalLanguages: undefined,
 					disableWatch: false,
-					identityFile: 'workspace/path/to/secrets.js'
+					identityFile: 'path/to/secrets.js'
 				} );
 			} );
 	} );
@@ -388,7 +388,7 @@ describe( 'runManualTests', () => {
 					additionalLanguages: undefined,
 					debug: undefined,
 					disableWatch: false,
-					identityFile: null
+					identityFile: undefined
 				} );
 
 				expect( spies.server.calledOnce ).to.equal( true );
@@ -433,7 +433,7 @@ describe( 'runManualTests', () => {
 					additionalLanguages: undefined,
 					debug: undefined,
 					disableWatch: true,
-					identityFile: null
+					identityFile: undefined
 				} );
 
 				expect( spies.server.calledOnce ).to.equal( true );

--- a/packages/ckeditor5-dev-tests/tests/utils/automated-tests/assertions/equal-markup.js
+++ b/packages/ckeditor5-dev-tests/tests/utils/automated-tests/assertions/equal-markup.js
@@ -26,7 +26,7 @@ describe( 'equalMarkup chai assertion', () => {
 			).to.equalMarkup(
 				'<paragraph>foo bXXX[]r baz</paragraph>'
 			);
-		} ).to.not.throw;
+		} ).to.not.throw();
 	} );
 
 	it( 'should throw AssertionError for unequal markups', () => {

--- a/packages/ckeditor5-dev-tests/tests/utils/automated-tests/getkarmaconfig.js
+++ b/packages/ckeditor5-dev-tests/tests/utils/automated-tests/getkarmaconfig.js
@@ -24,6 +24,7 @@ describe( 'getKarmaConfig()', () => {
 		process.env = Object.assign( {}, originalEnv, { TRAVIS: false } );
 
 		mockery.enable( {
+			useCleanCache: true,
 			warnOnReplace: false,
 			warnOnUnregistered: false
 		} );
@@ -72,31 +73,6 @@ describe( 'getKarmaConfig()', () => {
 		expect( karmaConfig ).to.have.own.property( 'singleRun', true );
 	} );
 
-	it( 'should define proxies to static assets resources', () => {
-		const karmaConfig = getKarmaConfig( {
-			files: [ '*' ],
-			reporter: 'mocha',
-			sourceMap: false,
-			coverage: false,
-			browsers: [ 'Chrome' ],
-			watch: false,
-			verbose: false,
-			themePath: 'workspace/path/to/theme.css',
-			entryFile: 'workspace/entry-file.js',
-			globPatterns: {
-				'*': 'workspace/packages/ckeditor5-*/tests/**/*.js'
-			}
-		} );
-
-		expect( karmaConfig ).to.have.own.property( 'proxies' );
-		expect( karmaConfig.proxies ).to.have.own.property( '/assets/' );
-
-		expect( karmaConfig.files ).to.be.an( 'array' );
-		expect( karmaConfig.files.length ).to.equal( 2 );
-		expect( karmaConfig.files[ 0 ] ).to.equal( 'workspace/entry-file.js' );
-		expect( karmaConfig.files[ 1 ].pattern ).to.equal( 'packages/ckeditor5-utils/tests/_assets/**/*' );
-	} );
-
 	// See: https://github.com/ckeditor/ckeditor5/issues/8823
 	it( 'should define proxies to static assets resources', () => {
 		const karmaConfig = getKarmaConfig( {
@@ -115,8 +91,14 @@ describe( 'getKarmaConfig()', () => {
 		} );
 
 		expect( karmaConfig ).to.have.own.property( 'proxies' );
+		expect( karmaConfig.proxies ).to.have.own.property( '/assets/' );
 		expect( karmaConfig.proxies ).to.have.own.property( '/example.com/image.png' );
 		expect( karmaConfig.proxies ).to.have.own.property( '/www.example.com/image.png' );
+
+		expect( karmaConfig.files ).to.be.an( 'array' );
+		expect( karmaConfig.files.length ).to.equal( 2 );
+		expect( karmaConfig.files[ 0 ] ).to.equal( 'workspace/entry-file.js' );
+		expect( karmaConfig.files[ 1 ].pattern ).to.equal( 'packages/ckeditor5-utils/tests/_assets/**/*' );
 	} );
 
 	it( 'should contain a list of available plugins', () => {

--- a/packages/ckeditor5-dev-tests/tests/utils/getdefinitionsfromfile.js
+++ b/packages/ckeditor5-dev-tests/tests/utils/getdefinitionsfromfile.js
@@ -70,28 +70,29 @@ describe( 'getDefinitionsFromFile()', () => {
 		expect( definitions ).to.deep.equal( {} );
 	} );
 
-	it( 'should not throw an error if stringifying the identity file has failed', () => {
-		sinon.stub( JSON, 'stringify' ).throws( new Error( 'Example error.' ) );
+	it( 'should not throw an error and return empty object if path to identity file is not valid', () => {
+		let definitions;
 
 		expect( () => {
-			getDefinitionsFromFile( '/workspace/path/to/secret.js' );
+			definitions = getDefinitionsFromFile( 'foo.js' );
+		} ).to.not.throw();
+
+		expect( consoleStub.callCount ).to.equal( 1 );
+		expect( consoleStub.firstCall.args[ 0 ] ).to.satisfy( msg => msg.startsWith( 'Cannot find module \'/workspace/foo.js\'' ) );
+		expect( definitions ).to.deep.equal( {} );
+	} );
+
+	it( 'should not throw an error and return empty object if stringifying the identity file has failed', () => {
+		sinon.stub( JSON, 'stringify' ).throws( new Error( 'Example error.' ) );
+
+		let definitions;
+
+		expect( () => {
+			definitions = getDefinitionsFromFile( '/workspace/path/to/secret.js' );
 		} ).to.not.throw();
 
 		expect( consoleStub.callCount ).to.equal( 1 );
 		expect( consoleStub.firstCall.args[ 0 ] ).to.equal( 'Example error.' );
-	} );
-
-	it( 'should return empty object if stringifying the identity file has failed', () => {
-		sinon.stub( JSON, 'stringify' ).throws( new Error( 'Example error.' ) );
-
-		const definitions = getDefinitionsFromFile( '/workspace/path/to/secret.js' );
-
-		expect( definitions ).to.deep.equal( {} );
-	} );
-
-	it( 'should return empty object if path to identity file is not valid', () => {
-		const definitions = getDefinitionsFromFile( 'foo' );
-
 		expect( definitions ).to.deep.equal( {} );
 	} );
 } );

--- a/packages/ckeditor5-dev-tests/tests/utils/getdefinitionsfromfile.js
+++ b/packages/ckeditor5-dev-tests/tests/utils/getdefinitionsfromfile.js
@@ -1,0 +1,97 @@
+/**
+ * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+'use strict';
+
+const mockery = require( 'mockery' );
+const sinon = require( 'sinon' );
+const { expect } = require( 'chai' );
+
+describe( 'getDefinitionsFromFile()', () => {
+	let getDefinitionsFromFile, consoleStub;
+
+	beforeEach( () => {
+		consoleStub = sinon.stub( console, 'error' );
+		sinon.stub( process, 'cwd' ).returns( '/workspace' );
+
+		mockery.enable( {
+			useCleanCache: true,
+			warnOnReplace: false,
+			warnOnUnregistered: false
+		} );
+
+		mockery.registerMock( 'path', {
+			join: sinon.stub().callsFake( ( ...chunks ) => chunks.join( '/' ).replace( '/./', '/' ) ),
+			isAbsolute: sinon.stub().callsFake( path => path.startsWith( '/' ) )
+		} );
+
+		mockery.registerMock( '/workspace/path/to/secret.js', {
+			SECRET: 'secret',
+			ANOTHER_SECRET: 'another-secret',
+			NON_PRIMITIVE_SECRET: {
+				foo: [ 'bar', 'baz' ]
+			}
+		} );
+
+		getDefinitionsFromFile = require( '../../lib/utils/getdefinitionsfromfile' );
+	} );
+
+	afterEach( () => {
+		sinon.restore();
+		mockery.disable();
+		mockery.deregisterAll();
+	} );
+
+	it( 'should return definition object if path to identity file is relative', () => {
+		const definitions = getDefinitionsFromFile( './path/to/secret.js' );
+
+		expect( definitions ).to.deep.equal( {
+			SECRET: '"secret"',
+			ANOTHER_SECRET: '"another-secret"',
+			NON_PRIMITIVE_SECRET: '{"foo":["bar","baz"]}'
+		} );
+	} );
+
+	it( 'should return definition object if path to identity file is absolute', () => {
+		const definitions = getDefinitionsFromFile( '/workspace/path/to/secret.js' );
+
+		expect( definitions ).to.deep.equal( {
+			SECRET: '"secret"',
+			ANOTHER_SECRET: '"another-secret"',
+			NON_PRIMITIVE_SECRET: '{"foo":["bar","baz"]}'
+		} );
+	} );
+
+	it( 'should return empty object if path to identity file is not provided', () => {
+		const definitions = getDefinitionsFromFile();
+
+		expect( definitions ).to.deep.equal( {} );
+	} );
+
+	it( 'should not throw an error if stringifying the identity file has failed', () => {
+		sinon.stub( JSON, 'stringify' ).throws( new Error( 'Example error.' ) );
+
+		expect( () => {
+			getDefinitionsFromFile( '/workspace/path/to/secret.js' );
+		} ).to.not.throw();
+
+		expect( consoleStub.callCount ).to.equal( 1 );
+		expect( consoleStub.firstCall.args[ 0 ] ).to.equal( 'Example error.' );
+	} );
+
+	it( 'should return empty object if stringifying the identity file has failed', () => {
+		sinon.stub( JSON, 'stringify' ).throws( new Error( 'Example error.' ) );
+
+		const definitions = getDefinitionsFromFile( '/workspace/path/to/secret.js' );
+
+		expect( definitions ).to.deep.equal( {} );
+	} );
+
+	it( 'should return empty object if path to identity file is not valid', () => {
+		const definitions = getDefinitionsFromFile( 'foo' );
+
+		expect( definitions ).to.deep.equal( {} );
+	} );
+} );

--- a/packages/ckeditor5-dev-tests/tests/utils/manual-tests/removedir.js
+++ b/packages/ckeditor5-dev-tests/tests/utils/manual-tests/removedir.js
@@ -16,6 +16,7 @@ describe( 'removeDir', () => {
 
 	before( () => {
 		mockery.enable( {
+			useCleanCache: true,
 			warnOnReplace: false,
 			warnOnUnregistered: false
 		} );

--- a/packages/ckeditor5-dev-utils/tests/tools.js
+++ b/packages/ckeditor5-dev-utils/tests/tools.js
@@ -20,6 +20,7 @@ describe( 'utils', () => {
 		sandbox = sinon.createSandbox();
 
 		mockery.enable( {
+			useCleanCache: true,
 			warnOnReplace: false,
 			warnOnUnregistered: false
 		} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature (tests): Added `--identity-file` (`-i`) option for automated tests.