### PR TITLE
Fixed `changelog.getChangesForVersion()` util leaking to other releases

### DIFF
--- a/packages/ckeditor5-dev-env/lib/release-tools/utils/changelog.js
+++ b/packages/ckeditor5-dev-env/lib/release-tools/utils/changelog.js
@@ -30,7 +30,7 @@ const utils = {
 		version = version.replace( /^v/, '' );
 
 		const changelog = utils.getChangelog( cwd ).replace( utils.changelogHeader, '\n' );
-		const match = changelog.match( new RegExp( `\\n(## \\[?${ version }\\]?[\\s\\S]+?)(?:\\n## \\[|$)` ) );
+		const match = changelog.match( new RegExp( `\\n(## \\[?${ version }\\]?[\\s\\S]+?)(?:\\n## \\[?|$)` ) );
 
 		if ( !match || !match[ 1 ] ) {
 			return null;

--- a/packages/ckeditor5-dev-env/tests/release-tools/utils/changelog.js
+++ b/packages/ckeditor5-dev-env/tests/release-tools/utils/changelog.js
@@ -37,10 +37,11 @@ describe( 'dev-env/release-tools/utils', () => {
 					'* Cloned the main module. ([abcd123](https://github.com))'
 				].join( '\n' );
 
-				const changelog =
-					`## [0.1.0](https://github.com) (2017-01-13)
-
-${ expectedChangelog }`;
+				const changelog = [
+					'## [0.1.0](https://github.com) (2017-01-13)',
+					'',
+					expectedChangelog
+				].join( '\n' );
 
 				const currentChangelogStub = sandbox.stub( utils, 'getChangelog' )
 					.returns( utils.changelogHeader + changelog );
@@ -58,10 +59,11 @@ ${ expectedChangelog }`;
 					'* Cloned the main module. ([abcd123](https://github.com))'
 				].join( '\n' );
 
-				const changelog =
-					`## 0.1.0 (2017-01-13)
-
-${ expectedChangelog }`;
+				const changelog = [
+					'## 0.1.0 (2017-01-13)',
+					'',
+					expectedChangelog
+				].join( '\n' );
 
 				const currentChangelogStub = sandbox.stub( utils, 'getChangelog' )
 					.returns( utils.changelogHeader + changelog );
@@ -73,25 +75,27 @@ ${ expectedChangelog }`;
 			} );
 
 			it( 'returns changes between tags', () => {
-				const expectedChangelog =
-`### Features
+				const expectedChangelog = [
+					'### Features',
+					'',
+					'* Cloned the main module. ([abcd123](https://github.com))',
+					'',
+					'### BREAKING CHANGE',
+					'',
+					'* Bump the major!'
+				].join( '\n' );
 
-* Cloned the main module. ([abcd123](https://github.com))
-
-### BREAKING CHANGE
-
-* Bump the major!`;
-
-				const changelog =
-`## [1.0.0](https://github.com/) (2017-01-13)
-
-${ expectedChangelog }
-
-## [0.1.0](https://github.com) (2017-01-13)
-
-### Features
-
-* Cloned the main module. ([abcd123](https://github.com))`;
+				const changelog = [
+					'## [1.0.0](https://github.com/) (2017-01-13)',
+					'',
+					expectedChangelog,
+					'',
+					'## [0.1.0](https://github.com) (2017-01-13)',
+					'',
+					'### Features',
+					'',
+					'* Cloned the main module. ([abcd123](https://github.com))'
+				].join( '\n' );
 
 				const currentChangelogStub = sandbox.stub( utils, 'getChangelog' )
 					.returns( utils.changelogHeader + changelog );
@@ -103,12 +107,13 @@ ${ expectedChangelog }
 			} );
 
 			it( 'returns null if cannot find changes for the specified version', () => {
-				const changelog =
-`## [0.1.0](https://github.com) (2017-01-13)
-
-### Features
-
-* Cloned the main module. ([abcd123](https://github.com))`;
+				const changelog = [
+					'## [0.1.0](https://github.com) (2017-01-13)',
+					'',
+					'### Features',
+					'',
+					'* Cloned the main module. ([abcd123](https://github.com))'
+				].join( '\n' );
 
 				sandbox.stub( utils, 'getChangelog' )
 					.returns( utils.changelogHeader + changelog );
@@ -117,20 +122,21 @@ ${ expectedChangelog }
 			} );
 
 			it( 'does not leak or stop too early', () => {
-				const changelog =
-`## [0.3.0](https://github.com) (2017-01-13)
-
-3
-
-Some text ## [like a release header]
-
-## [0.2.0](https://github.com) (2017-01-13)
-
-2
-
-## [0.1.0](https://github.com) (2017-01-13)
-
-1`;
+				const changelog = [
+					'## [0.3.0](https://github.com) (2017-01-13)',
+					'',
+					'3',
+					'',
+					'Some text ## [like a release header]',
+					'',
+					'## [0.2.0](https://github.com) (2017-01-13)',
+					'',
+					'2',
+					'',
+					'## [0.1.0](https://github.com) (2017-01-13)',
+					'',
+					'1'
+				].join( '\n' );
 
 				sandbox.stub( utils, 'getChangelog' )
 					.returns( utils.changelogHeader + changelog );
@@ -143,10 +149,11 @@ Some text ## [like a release header]
 			} );
 
 			it( 'works when date is not specified', () => {
-				const changelog =
-`## 0.3.0
-
-Foo`;
+				const changelog = [
+					'## 0.3.0',
+					'',
+					'Foo'
+				].join( '\n' );
 
 				sandbox.stub( utils, 'getChangelog' )
 					.returns( utils.changelogHeader + changelog );

--- a/packages/ckeditor5-dev-env/tests/release-tools/utils/changelog.js
+++ b/packages/ckeditor5-dev-env/tests/release-tools/utils/changelog.js
@@ -121,7 +121,21 @@ describe( 'dev-env/release-tools/utils', () => {
 				expect( utils.getChangesForVersion( 'v1.0.0' ) ).to.equal( null );
 			} );
 
-			it( 'does not leak or stop too early', () => {
+			it( 'works when date is not specified', () => {
+				const changelog = [
+					'## 0.3.0',
+					'',
+					'Foo'
+				].join( '\n' );
+
+				sandbox.stub( utils, 'getChangelog' )
+					.returns( utils.changelogHeader + changelog );
+
+				expect( utils.getChangesForVersion( 'v0.3.0' ) )
+					.to.equal( 'Foo' );
+			} );
+
+			it( 'captures correct range of changes (case 1)', () => {
 				const changelog = [
 					'## [0.3.0](https://github.com) (2017-01-13)',
 					'',
@@ -148,21 +162,7 @@ describe( 'dev-env/release-tools/utils', () => {
 					.to.equal( '2' );
 			} );
 
-			it( 'works when date is not specified', () => {
-				const changelog = [
-					'## 0.3.0',
-					'',
-					'Foo'
-				].join( '\n' );
-
-				sandbox.stub( utils, 'getChangelog' )
-					.returns( utils.changelogHeader + changelog );
-
-				expect( utils.getChangesForVersion( 'v0.3.0' ) )
-					.to.equal( 'Foo' );
-			} );
-
-			it( 'does not leak to other releases (case 1)', () => {
+			it( 'captures correct range of changes (case 2)', () => {
 				const changelog = [
 					'Changelog',
 					'=========',
@@ -191,7 +191,7 @@ describe( 'dev-env/release-tools/utils', () => {
 				expect( utils.getChangesForVersion( '1.0.0' ) ).to.equal( 'This is the initial release.' );
 			} );
 
-			it( 'does not leak to other releases (case 2)', () => {
+			it( 'captures correct range of changes (case 3)', () => {
 				const changelog = [
 					'Changelog',
 					'=========',
@@ -224,7 +224,7 @@ describe( 'dev-env/release-tools/utils', () => {
 				].join( '\n' ) );
 			} );
 
-			it( 'does not leak to other releases (case 3)', () => {
+			it( 'captures correct range of changes (case 4)', () => {
 				const changelog = [
 					'Changelog',
 					'=========',

--- a/packages/ckeditor5-dev-env/tests/release-tools/utils/changelog.js
+++ b/packages/ckeditor5-dev-env/tests/release-tools/utils/changelog.js
@@ -135,7 +135,7 @@ describe( 'dev-env/release-tools/utils', () => {
 					.to.equal( 'Foo' );
 			} );
 
-			it( 'captures correct range of changes (case 1)', () => {
+			it( 'captures correct range of changes (headers are URLs)', () => {
 				const changelog = [
 					'## [0.3.0](https://github.com) (2017-01-13)',
 					'',
@@ -162,7 +162,7 @@ describe( 'dev-env/release-tools/utils', () => {
 					.to.equal( '2' );
 			} );
 
-			it( 'captures correct range of changes (case 2)', () => {
+			it( 'captures correct range of changes (headers are plain text, "the initial" release check)', () => {
 				const changelog = [
 					'Changelog',
 					'=========',
@@ -191,7 +191,7 @@ describe( 'dev-env/release-tools/utils', () => {
 				expect( utils.getChangesForVersion( '1.0.0' ) ).to.equal( 'This is the initial release.' );
 			} );
 
-			it( 'captures correct range of changes (case 3)', () => {
+			it( 'captures correct range of changes (headers are plain text, "middle" version check)', () => {
 				const changelog = [
 					'Changelog',
 					'=========',
@@ -224,7 +224,7 @@ describe( 'dev-env/release-tools/utils', () => {
 				].join( '\n' ) );
 			} );
 
-			it( 'captures correct range of changes (case 4)', () => {
+			it( 'captures correct range of changes (headers are plain text, "the latest" check)', () => {
 				const changelog = [
 					'Changelog',
 					'=========',

--- a/packages/ckeditor5-dev-env/tests/release-tools/utils/changelog.js
+++ b/packages/ckeditor5-dev-env/tests/release-tools/utils/changelog.js
@@ -154,6 +154,101 @@ Foo`;
 				expect( utils.getChangesForVersion( 'v0.3.0' ) )
 					.to.equal( 'Foo' );
 			} );
+
+			it( 'does not leak to other releases (case 1)', () => {
+				const changelog = [
+					'Changelog',
+					'=========',
+					'',
+					'## 1.0.2 (2022-02-22)',
+					'',
+					'### Other changes',
+					'',
+					'* Other change for `1.0.2`.',
+					'',
+					'',
+					'## 1.0.1 (2022-02-22)',
+					'',
+					'### Other changes',
+					'',
+					'* Other change for `1.0.1`.',
+					'',
+					'',
+					'## 1.0.0 (2022-02-22)',
+					'',
+					'This is the initial release.'
+				].join( '\n' );
+
+				sandbox.stub( utils, 'getChangelog' ).returns( utils.changelogHeader + changelog );
+
+				expect( utils.getChangesForVersion( '1.0.0' ) ).to.equal( 'This is the initial release.' );
+			} );
+
+			it( 'does not leak to other releases (case 2)', () => {
+				const changelog = [
+					'Changelog',
+					'=========',
+					'',
+					'## 1.0.2 (2022-02-22)',
+					'',
+					'### Other changes',
+					'',
+					'* Other change for `1.0.2`.',
+					'',
+					'',
+					'## 1.0.1 (2022-02-22)',
+					'',
+					'### Other changes',
+					'',
+					'* Other change for `1.0.1`.',
+					'',
+					'',
+					'## 1.0.0 (2022-02-22)',
+					'',
+					'This is the initial release.'
+				].join( '\n' );
+
+				sandbox.stub( utils, 'getChangelog' ).returns( utils.changelogHeader + changelog );
+
+				expect( utils.getChangesForVersion( '1.0.1' ) ).to.equal( [
+					'### Other changes',
+					'',
+					'* Other change for `1.0.1`.'
+				].join( '\n' ) );
+			} );
+
+			it( 'does not leak to other releases (case 3)', () => {
+				const changelog = [
+					'Changelog',
+					'=========',
+					'',
+					'## 1.0.2 (2022-02-22)',
+					'',
+					'### Other changes',
+					'',
+					'* Other change for `1.0.2`.',
+					'',
+					'',
+					'## 1.0.1 (2022-02-22)',
+					'',
+					'### Other changes',
+					'',
+					'* Other change for `1.0.1`.',
+					'',
+					'',
+					'## 1.0.0 (2022-02-22)',
+					'',
+					'This is the initial release.'
+				].join( '\n' );
+
+				sandbox.stub( utils, 'getChangelog' ).returns( utils.changelogHeader + changelog );
+
+				expect( utils.getChangesForVersion( '1.0.2' ) ).to.equal( [
+					'### Other changes',
+					'',
+					'* Other change for `1.0.2`.'
+				].join( '\n' ) );
+			} );
 		} );
 
 		describe( 'getChangelog()', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix (env): Fixed `changelog.getChangesForVersion()` util leaking to other releases. Closes ckeditor/ckeditor5#11322.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
