### PR TITLE
Transifex migration to API v3.0 - Upload process

### DIFF
--- a/packages/ckeditor5-dev-env/lib/translations/transifex-service-for-api-v3.0.js
+++ b/packages/ckeditor5-dev-env/lib/translations/transifex-service-for-api-v3.0.js
@@ -111,7 +111,7 @@ async function getResourceUploadDetails( uploadId ) {
 				return setTimeout( checkUploadStatus, 500 );
 			}
 
-			return resolve( statusResponse.attributes );
+			return resolve( statusResponse );
 		}, 250 );
 	} );
 }

--- a/packages/ckeditor5-dev-env/lib/translations/upload.js
+++ b/packages/ckeditor5-dev-env/lib/translations/upload.js
@@ -5,53 +5,121 @@
 
 'use strict';
 
-const fs = require( 'fs' );
+const fs = require( 'fs/promises' );
 const path = require( 'path' );
 const logger = require( '@ckeditor/ckeditor5-dev-utils' ).logger();
 const Table = require( 'cli-table' );
 const chalk = require( 'chalk' );
-const transifexService = require( './transifex-service' );
+// const transifexService = require( './transifex-service' );
+const transifexService = require( './transifex-service-for-api-v3.0' );
 const { verifyProperties } = require( './utils' );
+const { tools } = require( '@ckeditor/ckeditor5-dev-utils' );
 
 /**
  * Uploads translations to the Transifex from collected files that are saved by default in the 'ckeditor5/build/.transifex' directory.
  *
  * @param {Object} config
  * @param {String} config.token Token to the Transifex API.
- * @param {String} config.url Transifex API URL where the request should be send.
- * @param {String} config.translationsDirectory An absolute path where to look for the translation files.
+ * @param {String} config.organizationName Name of the organization to which the project belongs.
+ * @param {String} config.projectName Name of the project for downloading the translations.
+ * @param {String} config.cwd Current work directory.
+ * @param {Map.<String,String>} config.packages A resource name -> package path map for which translations should be uploaded.
  * @returns {Promise}
  */
-module.exports = function upload( config ) {
-	verifyProperties( config, [ 'token', 'url', 'translationsDirectory' ] );
+module.exports = async function upload( config ) {
+	// verifyProperties( config, [ 'token' ] );
 
-	// Make sure to use unix paths.
-	const pathToPoTranslations = config.translationsDirectory.split( /[\\/]/g ).join( '/' );
+	transifexService.init( config.token );
 
-	const potFiles = fs.readdirSync( pathToPoTranslations ).map( packageName => ( {
-		packageName,
-		path: path.posix.join( pathToPoTranslations, packageName, 'en.pot' )
-	} ) );
+	logger.info( 'Fetching project information...' );
+
+	const localizablePackageNames = [ ...config.packages.keys() ];
+
+	const { organizationName, projectName } = config;
+
+	// Find existing resources on Transifex.
+	const { resources } = await transifexService.getProjectData(
+		organizationName,
+		projectName,
+		localizablePackageNames
+	);
+
+	const resourcesToUpload = new Map();
+
+	// Then, prepare a map containing all resources to upload.
+	// The map defines a path to the translation file for each package.
+	// Also, it knows whether the resource exists on Tx. If don't, a new one should be created.
+	for ( const [ resourceName, relativePath ] of config.packages ) {
+		resourcesToUpload.set( resourceName, {
+			potFile: path.join( config.cwd, relativePath, 'en.pot' ),
+			isNew: !resources.find( item => item.attributes.name === resourceName )
+		} );
+	}
 
 	const summaryCollection = {
 		created: [],
 		updated: []
 	};
 
-	return Promise.resolve()
-		.then( () => transifexService.getResources( config ) )
-		.then( resources => resources.map( resource => resource.slug ) )
-		.then( uploadedPackageNames => getUploadedPackages( potFiles, uploadedPackageNames ) )
-		.then( areUploadedResources => createOrUpdateResources( config, areUploadedResources, potFiles, summaryCollection ) )
-		.then( () => {
-			logger.info( 'All resources uploaded.\n' );
+	logger.info( 'Uploading new translations...' );
 
-			printSummary( summaryCollection );
-		} )
-		.catch( err => {
-			logger.error( err );
-			throw err;
-		} );
+	const uploadIds = [];
+
+	for ( const [ resourceName, { potFile, isNew } ] of resourcesToUpload ) {
+		const spinner = tools.createSpinner( `Processing "${ resourceName }"...`, { indentLevel: 1 } );
+		spinner.start();
+
+		// For new packages, before uploading their translations, we need to create a dedicated resource.
+		if ( isNew ) {
+			await transifexService.createResource( { organizationName, projectName, resourceName } );
+		}
+
+		const content = await fs.readFile( potFile, 'utf-8' );
+
+		const jobId = await transifexService.createSourceFile( { organizationName, projectName, resourceName, content } );
+
+		uploadIds.push( jobId );
+		spinner.finish();
+	}
+
+	logger.info( 'Collecting responses...' );
+
+	const uploadDetails = await Promise.all(
+		uploadIds.map( async uuid => transifexService.getResourceUploadDetails( uuid ) )
+	);
+
+	for ( const details of uploadDetails ) {
+		
+	}
+
+	logger.info( 'Done.' );
+
+	printSummary( summaryCollection );
+
+	// // Make sure to use unix paths.
+	// const pathToPoTranslations = config.translationsDirectory.split( /[\\/]/g ).join( '/' );
+	//
+	// const potFiles = fs.readdirSync( pathToPoTranslations ).map( packageName => ( {
+	// 	packageName,
+	// 	path: path.posix.join( pathToPoTranslations, packageName, 'en.pot' )
+	// } ) );
+	//
+
+	//
+	// return Promise.resolve()
+	// 	.then( () => transifexService.getResources( config ) )
+	// 	.then( resources => resources.map( resource => resource.slug ) )
+	// 	.then( uploadedPackageNames => getUploadedPackages( potFiles, uploadedPackageNames ) )
+	// 	.then( areUploadedResources => createOrUpdateResources( config, areUploadedResources, potFiles, summaryCollection ) )
+	// 	.then( () => {
+	// 		logger.info( 'All resources uploaded.\n' );
+	//
+	// 		printSummary( summaryCollection );
+	// 	} )
+	// 	.catch( err => {
+	// 		logger.error( err );
+	// 		throw err;
+	// 	} );
 };
 
 function getUploadedPackages( potFiles, uploadedPackageNames ) {

--- a/packages/ckeditor5-dev-env/package.json
+++ b/packages/ckeditor5-dev-env/package.json
@@ -34,7 +34,7 @@
     "mockery": "^2.1.0",
     "mock-fs": "^5.1.2",
     "proxyquire": "^2.1.3",
-    "sinon": "^9.0.2"
+    "sinon": "^13.0.1"
   },
   "engines": {
     "node": ">=14.0.0",

--- a/packages/ckeditor5-dev-env/tests/translations/transifex-service-for-api-v3.0.js
+++ b/packages/ckeditor5-dev-env/tests/translations/transifex-service-for-api-v3.0.js
@@ -41,6 +41,10 @@ describe( 'dev-env/translations/transifex-service-for-api-v3.0', () => {
 				}
 			} ) ),
 
+			createResource: sinon.stub(),
+			createResourceStringAsyncUpload: sinon.stub(),
+			getResourceStringAsyncUpload: sinon.stub(),
+
 			transifexApi: {
 				setup: sinon.stub().callsFake( ( { auth } ) => {
 					stubs.transifexApi.auth = sinon.stub().returns( { Authorization: `Bearer ${ auth }` } );
@@ -48,6 +52,15 @@ describe( 'dev-env/translations/transifex-service-for-api-v3.0', () => {
 
 				Organization: {
 					get: ( ...args ) => stubs.getOrganizations( ...args )
+				},
+
+				Resource: {
+					create: ( ...args ) => stubs.createResource( ...args )
+				},
+
+				ResourceStringAsyncUpload: {
+					create: ( ...args ) => stubs.createResourceStringAsyncUpload( ...args ),
+					get: ( ...args ) => stubs.getResourceStringAsyncUpload( ...args )
 				},
 
 				...[ 'ResourceStringAsyncDownload', 'ResourceTranslationAsyncDownload' ].reduce( ( result, methodName ) => {
@@ -484,6 +497,311 @@ describe( 'dev-env/translations/transifex-service-for-api-v3.0', () => {
 			const language = { attributes: { code: 'pl' } };
 
 			expect( transifexService.getLanguageCode( language ) ).to.equal( 'pl' );
+		} );
+	} );
+
+	describe( 'createResource', () => {
+		it( 'should create a new resource and return its attributes', () => {
+			const organizationName = 'ckeditor';
+			const projectName = 'ckeditor5';
+			const resourceName = 'ckeditor5-foo';
+
+			const apiResponse = {
+				data: {
+					attributes: {},
+					id: 'o:ckeditor:p:ckeditor5:r:ckeditor5-foo',
+					links: {},
+					relationships: {
+						i18n_format: {
+							data: {
+								id: 'PO',
+								type: 'i18n_formats'
+							}
+						},
+						project: {
+							data: {
+								id: 'o:ckeditor:p:ckeditor5',
+								type: 'projects'
+							}
+						}
+					},
+					type: 'resources'
+				}
+			};
+
+			stubs.createResource.resolves( apiResponse );
+
+			return transifexService.createResource( { organizationName, projectName, resourceName } )
+				.then( response => {
+					expect( stubs.createResource.callCount ).to.equal( 1 );
+					expect( stubs.createResource.firstCall.args[ 0 ] ).to.deep.equal( {
+						name: 'ckeditor5-foo',
+						relationships: {
+							i18n_format: {
+								data: {
+									id: 'PO',
+									type: 'i18n_formats'
+								}
+							},
+							project: {
+								data: {
+									id: 'o:ckeditor:p:ckeditor5',
+									type: 'projects'
+								}
+							}
+						},
+						slug: 'ckeditor5-foo'
+					} );
+
+					expect( response ).to.equal( apiResponse );
+				} );
+		} );
+
+		it( 'should reject a promise if Transifex API rejected', () => {
+			const organizationName = 'ckeditor';
+			const projectName = 'ckeditor5';
+			const resourceName = 'ckeditor5-foo';
+
+			const apiError = new Error( 'JsonApiError: 418, I\'m a teapot' );
+
+			stubs.createResource.rejects( apiError );
+
+			return transifexService.createResource( { organizationName, projectName, resourceName } )
+				.then(
+					() => {
+						throw new Error( 'Expected to be rejected.' );
+					},
+					err => {
+						expect( apiError ).to.equal( err );
+					}
+				);
+		} );
+	} );
+
+	describe( 'createSourceFile', () => {
+		it( 'should create a new resource and return its attributes', () => {
+			const organizationName = 'ckeditor';
+			const projectName = 'ckeditor5';
+			const resourceName = 'ckeditor5-foo';
+			const content = '# ckeditor5-foo';
+
+			const apiResponse = {
+				id: '4abfc726-6a27-4c33-9d99-e5254c8df748',
+				type: 'resource_strings_async_uploads'
+			};
+
+			stubs.createResourceStringAsyncUpload.resolves( apiResponse );
+
+			return transifexService.createSourceFile( { organizationName, projectName, resourceName, content } )
+				.then( response => {
+					expect( stubs.createResourceStringAsyncUpload.callCount ).to.equal( 1 );
+					expect( stubs.createResourceStringAsyncUpload.firstCall.args[ 0 ] ).to.deep.equal( {
+						attributes: {
+							content: '# ckeditor5-foo',
+							content_encoding: 'text'
+						},
+						relationships: {
+							resource: {
+								data: {
+									id: 'o:ckeditor:p:ckeditor5:r:ckeditor5-foo',
+									type: 'resources'
+								}
+							}
+						},
+						type: 'resource_strings_async_uploads'
+					} );
+
+					expect( response ).to.equal( apiResponse.id );
+				} );
+		} );
+
+		it( 'should reject a promise if Transifex API rejected', () => {
+			const organizationName = 'ckeditor';
+			const projectName = 'ckeditor5';
+			const resourceName = 'ckeditor5-foo';
+			const content = '# ckeditor5-foo';
+
+			const apiError = new Error( 'JsonApiError: 418, I\'m a teapot' );
+
+			stubs.createResourceStringAsyncUpload.rejects( apiError );
+
+			return transifexService.createSourceFile( { organizationName, projectName, resourceName, content } )
+				.then(
+					() => {
+						throw new Error( 'Expected to be rejected.' );
+					},
+					err => {
+						expect( apiError ).to.equal( err );
+					}
+				);
+		} );
+	} );
+
+	describe( 'getResourceUploadDetails', () => {
+		let clock;
+
+		beforeEach( () => {
+			clock = sinon.useFakeTimers();
+		} );
+
+		afterEach( () => {
+			clock.restore();
+		} );
+
+		it( 'should return a promise that resolves after 250ms (Transifex processed the upload)', async () => {
+			const apiResponse = {
+				id: '4abfc726-6a27-4c33-9d99-e5254c8df748',
+				attributes: {
+					status: 'succeeded'
+				},
+				type: 'resource_strings_async_uploads'
+			};
+
+			stubs.getResourceStringAsyncUpload.resolves( apiResponse );
+
+			const promise = transifexService.getResourceUploadDetails( '4abfc726-6a27-4c33-9d99-e5254c8df748' );
+
+			expect( promise ).to.be.a( 'promise' );
+			expect( stubs.getResourceStringAsyncUpload.callCount ).to.equal( 0 );
+
+			await clock.tickAsync( 250 );
+			expect( stubs.getResourceStringAsyncUpload.callCount ).to.equal( 1 );
+			expect( stubs.getResourceStringAsyncUpload.firstCall.args[ 0 ] ).to.equal( '4abfc726-6a27-4c33-9d99-e5254c8df748' );
+
+			const result = await promise;
+
+			expect( result ).to.equal( apiResponse );
+		} );
+
+		it( 'should return a promise that resolves after 1250ms (Transifex processed the upload 1s, status=pending)', async () => {
+			const apiResponse = {
+				id: '4abfc726-6a27-4c33-9d99-e5254c8df748',
+				attributes: {
+					status: 'succeeded'
+				},
+				type: 'resource_strings_async_uploads'
+			};
+
+			stubs.getResourceStringAsyncUpload.onFirstCall().resolves( {
+				attributes: { status: 'pending' }
+			} );
+			stubs.getResourceStringAsyncUpload.onSecondCall().resolves( {
+				attributes: { status: 'pending' }
+			} );
+			stubs.getResourceStringAsyncUpload.onThirdCall().resolves( apiResponse );
+
+			const promise = transifexService.getResourceUploadDetails( '4abfc726-6a27-4c33-9d99-e5254c8df748' );
+
+			expect( promise ).to.be.a( 'promise' );
+			expect( stubs.getResourceStringAsyncUpload.callCount ).to.equal( 0 );
+
+			await clock.tickAsync( 250 );
+			expect( stubs.getResourceStringAsyncUpload.callCount ).to.equal( 1 );
+			expect( stubs.getResourceStringAsyncUpload.firstCall.args[ 0 ] ).to.equal( '4abfc726-6a27-4c33-9d99-e5254c8df748' );
+
+			await clock.tickAsync( 500 );
+			expect( stubs.getResourceStringAsyncUpload.callCount ).to.equal( 2 );
+			expect( stubs.getResourceStringAsyncUpload.firstCall.args[ 0 ] ).to.equal( '4abfc726-6a27-4c33-9d99-e5254c8df748' );
+
+			await clock.tickAsync( 500 );
+			expect( stubs.getResourceStringAsyncUpload.callCount ).to.equal( 3 );
+			expect( stubs.getResourceStringAsyncUpload.firstCall.args[ 0 ] ).to.equal( '4abfc726-6a27-4c33-9d99-e5254c8df748' );
+
+			expect( await promise ).to.equal( apiResponse );
+		} );
+
+		it( 'should return a promise that resolves after 1250ms (Transifex processed the upload 1s, status=processing)', async () => {
+			const apiResponse = {
+				id: '4abfc726-6a27-4c33-9d99-e5254c8df748',
+				attributes: {
+					status: 'succeeded'
+				},
+				type: 'resource_strings_async_uploads'
+			};
+
+			stubs.getResourceStringAsyncUpload.onFirstCall().resolves( {
+				attributes: { status: 'processing' }
+			} );
+			stubs.getResourceStringAsyncUpload.onSecondCall().resolves( {
+				attributes: { status: 'processing' }
+			} );
+			stubs.getResourceStringAsyncUpload.onThirdCall().resolves( apiResponse );
+
+			const promise = transifexService.getResourceUploadDetails( '4abfc726-6a27-4c33-9d99-e5254c8df748' );
+
+			expect( promise ).to.be.a( 'promise' );
+			expect( stubs.getResourceStringAsyncUpload.callCount ).to.equal( 0 );
+
+			await clock.tickAsync( 250 );
+			expect( stubs.getResourceStringAsyncUpload.callCount ).to.equal( 1 );
+			expect( stubs.getResourceStringAsyncUpload.firstCall.args[ 0 ] ).to.equal( '4abfc726-6a27-4c33-9d99-e5254c8df748' );
+
+			await clock.tickAsync( 500 );
+			expect( stubs.getResourceStringAsyncUpload.callCount ).to.equal( 2 );
+			expect( stubs.getResourceStringAsyncUpload.firstCall.args[ 0 ] ).to.equal( '4abfc726-6a27-4c33-9d99-e5254c8df748' );
+
+			await clock.tickAsync( 500 );
+			expect( stubs.getResourceStringAsyncUpload.callCount ).to.equal( 3 );
+			expect( stubs.getResourceStringAsyncUpload.firstCall.args[ 0 ] ).to.equal( '4abfc726-6a27-4c33-9d99-e5254c8df748' );
+
+			expect( await promise ).to.equal( apiResponse );
+		} );
+
+		it( 'should return a promise that rejects if Transifex returned an error (no-delay)', async () => {
+			const apiResponse = new Error( 'JsonApiError' );
+
+			stubs.getResourceStringAsyncUpload.rejects( apiResponse );
+
+			const promise = transifexService.getResourceUploadDetails( '4abfc726-6a27-4c33-9d99-e5254c8df748' )
+				.then(
+					() => {
+						throw new Error( 'Expected to be rejected.' );
+					},
+					err => {
+						expect( err ).to.equal( apiResponse );
+					}
+				);
+
+			expect( promise ).to.be.a( 'promise' );
+			expect( stubs.getResourceStringAsyncUpload.callCount ).to.equal( 0 );
+
+			await clock.tickAsync( 250 );
+			expect( stubs.getResourceStringAsyncUpload.callCount ).to.equal( 1 );
+			expect( stubs.getResourceStringAsyncUpload.firstCall.args[ 0 ] ).to.equal( '4abfc726-6a27-4c33-9d99-e5254c8df748' );
+
+			return promise;
+		} );
+
+		it( 'should return a promise that rejects if Transifex returned an error (delay)', async () => {
+			const apiResponse = new Error( 'JsonApiError' );
+
+			stubs.getResourceStringAsyncUpload.onFirstCall().resolves( {
+				attributes: { status: 'processing' }
+			} );
+			stubs.getResourceStringAsyncUpload.onSecondCall().rejects( apiResponse );
+
+			const promise = transifexService.getResourceUploadDetails( '4abfc726-6a27-4c33-9d99-e5254c8df748' )
+				.then(
+					() => {
+						throw new Error( 'Expected to be rejected.' );
+					},
+					err => {
+						expect( err ).to.equal( apiResponse );
+					}
+				);
+
+			expect( promise ).to.be.a( 'promise' );
+			expect( stubs.getResourceStringAsyncUpload.callCount ).to.equal( 0 );
+
+			await clock.tickAsync( 250 );
+			expect( stubs.getResourceStringAsyncUpload.callCount ).to.equal( 1 );
+			expect( stubs.getResourceStringAsyncUpload.firstCall.args[ 0 ] ).to.equal( '4abfc726-6a27-4c33-9d99-e5254c8df748' );
+
+			await clock.tickAsync( 500 );
+			expect( stubs.getResourceStringAsyncUpload.callCount ).to.equal( 2 );
+			expect( stubs.getResourceStringAsyncUpload.firstCall.args[ 0 ] ).to.equal( '4abfc726-6a27-4c33-9d99-e5254c8df748' );
+
+			return promise;
 		} );
 	} );
 } );

--- a/packages/ckeditor5-dev-env/tests/translations/transifex-service-for-api-v3.0.js
+++ b/packages/ckeditor5-dev-env/tests/translations/transifex-service-for-api-v3.0.js
@@ -648,7 +648,7 @@ describe( 'dev-env/translations/transifex-service-for-api-v3.0', () => {
 			clock.restore();
 		} );
 
-		it( 'should return a promise that resolves after 250ms (Transifex processed the upload)', async () => {
+		it( 'should return a promise with resolved upload details (Transifex processed the upload)', async () => {
 			const apiResponse = {
 				id: '4abfc726-6a27-4c33-9d99-e5254c8df748',
 				attributes: {
@@ -662,9 +662,6 @@ describe( 'dev-env/translations/transifex-service-for-api-v3.0', () => {
 			const promise = transifexService.getResourceUploadDetails( '4abfc726-6a27-4c33-9d99-e5254c8df748' );
 
 			expect( promise ).to.be.a( 'promise' );
-			expect( stubs.getResourceStringAsyncUpload.callCount ).to.equal( 0 );
-
-			await clock.tickAsync( 250 );
 			expect( stubs.getResourceStringAsyncUpload.callCount ).to.equal( 1 );
 			expect( stubs.getResourceStringAsyncUpload.firstCall.args[ 0 ] ).to.equal( '4abfc726-6a27-4c33-9d99-e5254c8df748' );
 
@@ -673,7 +670,7 @@ describe( 'dev-env/translations/transifex-service-for-api-v3.0', () => {
 			expect( result ).to.equal( apiResponse );
 		} );
 
-		it( 'should return a promise that resolves after 1250ms (Transifex processed the upload 1s, status=pending)', async () => {
+		it( 'should return a promise that resolves after 3000ms (Transifex processed the upload 1s, status=pending)', async () => {
 			const apiResponse = {
 				id: '4abfc726-6a27-4c33-9d99-e5254c8df748',
 				attributes: {
@@ -685,32 +682,22 @@ describe( 'dev-env/translations/transifex-service-for-api-v3.0', () => {
 			stubs.getResourceStringAsyncUpload.onFirstCall().resolves( {
 				attributes: { status: 'pending' }
 			} );
-			stubs.getResourceStringAsyncUpload.onSecondCall().resolves( {
-				attributes: { status: 'pending' }
-			} );
-			stubs.getResourceStringAsyncUpload.onThirdCall().resolves( apiResponse );
+			stubs.getResourceStringAsyncUpload.onSecondCall().resolves( apiResponse );
 
 			const promise = transifexService.getResourceUploadDetails( '4abfc726-6a27-4c33-9d99-e5254c8df748' );
 
 			expect( promise ).to.be.a( 'promise' );
-			expect( stubs.getResourceStringAsyncUpload.callCount ).to.equal( 0 );
-
-			await clock.tickAsync( 250 );
 			expect( stubs.getResourceStringAsyncUpload.callCount ).to.equal( 1 );
 			expect( stubs.getResourceStringAsyncUpload.firstCall.args[ 0 ] ).to.equal( '4abfc726-6a27-4c33-9d99-e5254c8df748' );
 
-			await clock.tickAsync( 500 );
+			await clock.tickAsync( 3000 );
 			expect( stubs.getResourceStringAsyncUpload.callCount ).to.equal( 2 );
-			expect( stubs.getResourceStringAsyncUpload.firstCall.args[ 0 ] ).to.equal( '4abfc726-6a27-4c33-9d99-e5254c8df748' );
-
-			await clock.tickAsync( 500 );
-			expect( stubs.getResourceStringAsyncUpload.callCount ).to.equal( 3 );
-			expect( stubs.getResourceStringAsyncUpload.firstCall.args[ 0 ] ).to.equal( '4abfc726-6a27-4c33-9d99-e5254c8df748' );
+			expect( stubs.getResourceStringAsyncUpload.secondCall.args[ 0 ] ).to.equal( '4abfc726-6a27-4c33-9d99-e5254c8df748' );
 
 			expect( await promise ).to.equal( apiResponse );
 		} );
 
-		it( 'should return a promise that resolves after 1250ms (Transifex processed the upload 1s, status=processing)', async () => {
+		it( 'should return a promise that resolves after 3000ms (Transifex processed the upload 1s, status=processing)', async () => {
 			const apiResponse = {
 				id: '4abfc726-6a27-4c33-9d99-e5254c8df748',
 				attributes: {
@@ -722,27 +709,17 @@ describe( 'dev-env/translations/transifex-service-for-api-v3.0', () => {
 			stubs.getResourceStringAsyncUpload.onFirstCall().resolves( {
 				attributes: { status: 'processing' }
 			} );
-			stubs.getResourceStringAsyncUpload.onSecondCall().resolves( {
-				attributes: { status: 'processing' }
-			} );
-			stubs.getResourceStringAsyncUpload.onThirdCall().resolves( apiResponse );
+			stubs.getResourceStringAsyncUpload.onSecondCall().resolves( apiResponse );
 
 			const promise = transifexService.getResourceUploadDetails( '4abfc726-6a27-4c33-9d99-e5254c8df748' );
 
 			expect( promise ).to.be.a( 'promise' );
-			expect( stubs.getResourceStringAsyncUpload.callCount ).to.equal( 0 );
-
-			await clock.tickAsync( 250 );
 			expect( stubs.getResourceStringAsyncUpload.callCount ).to.equal( 1 );
 			expect( stubs.getResourceStringAsyncUpload.firstCall.args[ 0 ] ).to.equal( '4abfc726-6a27-4c33-9d99-e5254c8df748' );
 
-			await clock.tickAsync( 500 );
+			await clock.tickAsync( 3000 );
 			expect( stubs.getResourceStringAsyncUpload.callCount ).to.equal( 2 );
-			expect( stubs.getResourceStringAsyncUpload.firstCall.args[ 0 ] ).to.equal( '4abfc726-6a27-4c33-9d99-e5254c8df748' );
-
-			await clock.tickAsync( 500 );
-			expect( stubs.getResourceStringAsyncUpload.callCount ).to.equal( 3 );
-			expect( stubs.getResourceStringAsyncUpload.firstCall.args[ 0 ] ).to.equal( '4abfc726-6a27-4c33-9d99-e5254c8df748' );
+			expect( stubs.getResourceStringAsyncUpload.secondCall.args[ 0 ] ).to.equal( '4abfc726-6a27-4c33-9d99-e5254c8df748' );
 
 			expect( await promise ).to.equal( apiResponse );
 		} );
@@ -752,7 +729,7 @@ describe( 'dev-env/translations/transifex-service-for-api-v3.0', () => {
 
 			stubs.getResourceStringAsyncUpload.rejects( apiResponse );
 
-			const promise = transifexService.getResourceUploadDetails( '4abfc726-6a27-4c33-9d99-e5254c8df748' )
+			return transifexService.getResourceUploadDetails( '4abfc726-6a27-4c33-9d99-e5254c8df748' )
 				.then(
 					() => {
 						throw new Error( 'Expected to be rejected.' );
@@ -761,15 +738,6 @@ describe( 'dev-env/translations/transifex-service-for-api-v3.0', () => {
 						expect( err ).to.equal( apiResponse );
 					}
 				);
-
-			expect( promise ).to.be.a( 'promise' );
-			expect( stubs.getResourceStringAsyncUpload.callCount ).to.equal( 0 );
-
-			await clock.tickAsync( 250 );
-			expect( stubs.getResourceStringAsyncUpload.callCount ).to.equal( 1 );
-			expect( stubs.getResourceStringAsyncUpload.firstCall.args[ 0 ] ).to.equal( '4abfc726-6a27-4c33-9d99-e5254c8df748' );
-
-			return promise;
 		} );
 
 		it( 'should return a promise that rejects if Transifex returned an error (delay)', async () => {
@@ -791,15 +759,42 @@ describe( 'dev-env/translations/transifex-service-for-api-v3.0', () => {
 				);
 
 			expect( promise ).to.be.a( 'promise' );
-			expect( stubs.getResourceStringAsyncUpload.callCount ).to.equal( 0 );
 
-			await clock.tickAsync( 250 );
-			expect( stubs.getResourceStringAsyncUpload.callCount ).to.equal( 1 );
-			expect( stubs.getResourceStringAsyncUpload.firstCall.args[ 0 ] ).to.equal( '4abfc726-6a27-4c33-9d99-e5254c8df748' );
+			await clock.tickAsync( 3000 );
 
-			await clock.tickAsync( 500 );
-			expect( stubs.getResourceStringAsyncUpload.callCount ).to.equal( 2 );
-			expect( stubs.getResourceStringAsyncUpload.firstCall.args[ 0 ] ).to.equal( '4abfc726-6a27-4c33-9d99-e5254c8df748' );
+			return promise;
+		} );
+
+		it( 'should return a promise that rejects if reached the maximum number of requests to Transifex', async () => {
+			// 10 is equal to the `MAX_REQUEST_ATTEMPTS` constant.
+			for ( let i = 0; i < 10; ++i ) {
+				stubs.getResourceStringAsyncUpload.onCall( i ).resolves( {
+					attributes: { status: 'processing' }
+				} );
+			}
+
+			const promise = transifexService.getResourceUploadDetails( '4abfc726-6a27-4c33-9d99-e5254c8df748' )
+				.then(
+					() => {
+						throw new Error( 'Expected to be rejected.' );
+					},
+					err => {
+						expect( err ).to.deep.equal( {
+							errors: [
+								{
+									detail: 'Failed to retrieve the upload details.'
+								}
+							]
+						} );
+					}
+				);
+
+			expect( promise ).to.be.a( 'promise' );
+
+			for ( let i = 0; i < 9; ++i ) {
+				expect( stubs.getResourceStringAsyncUpload.callCount, `getResourceStringAsyncUpload, call: ${ i + 1 }` ).to.equal( i + 1 );
+				await clock.tickAsync( 3000 );
+			}
 
 			return promise;
 		} );

--- a/packages/ckeditor5-dev-env/tests/translations/upload.js
+++ b/packages/ckeditor5-dev-env/tests/translations/upload.js
@@ -5,40 +5,35 @@
 
 'use strict';
 
-const path = require( 'path' );
 const sinon = require( 'sinon' );
-const mockery = require( 'mockery' );
 const { expect } = require( 'chai' );
 const proxyquire = require( 'proxyquire' );
 
 describe( 'dev-env/translations/upload()', () => {
-	let sandbox, stubs, upload, packageNames, serverResources, fileContents;
+	let stubs, upload;
 
 	beforeEach( () => {
-		sandbox = sinon.createSandbox();
-
-		mockery.enable( {
-			useCleanCache: true,
-			warnOnReplace: false,
-			warnOnUnregistered: false
-		} );
-
 		stubs = {
+			fs: {
+				readFile: sinon.stub()
+			},
+
+			path: {
+				join: sinon.stub().callsFake( ( ...chunks ) => chunks.join( '/' ) )
+			},
+
 			logger: {
-				info: sandbox.stub(),
-				warning: sandbox.stub(),
-				error: sandbox.stub()
+				info: sinon.stub(),
+				warning: sinon.stub(),
+				error: sinon.stub()
 			},
 
 			transifexService: {
-				getResources: sandbox.spy( () => Promise.resolve( serverResources ) ),
-				postResource: sandbox.stub().resolves( [] ),
-				putResourceContent: sandbox.stub().resolves( {} )
-			},
-
-			fs: {
-				readdirSync: sandbox.spy( () => packageNames ),
-				createReadStream: sandbox.spy( fileName => fileContents[ fileName ] )
+				init: sinon.stub(),
+				getProjectData: sinon.stub(),
+				createResource: sinon.stub(),
+				createSourceFile: sinon.stub(),
+				getResourceUploadDetails: sinon.stub()
 			},
 
 			table: {
@@ -47,424 +42,406 @@ describe( 'dev-env/translations/upload()', () => {
 				toString: sinon.stub()
 			},
 
+			tools: {
+				createSpinner: sinon.stub()
+			},
+
 			chalk: {
-				gray: sinon.stub(),
-				underline: sinon.stub()
+				gray: sinon.stub().callsFake( msg => msg ),
+				cyan: sinon.stub().callsFake( msg => msg ),
+				italic: sinon.stub().callsFake( msg => msg )
+			},
+
+			utils: {
+				verifyProperties: sinon.stub()
 			}
 		};
 
-		mockery.registerMock( './transifex-service', stubs.transifexService );
-
-		mockery.registerMock( 'cli-table', class Table {
-			constructor( ...args ) {
-				stubs.table.constructor( ...args );
-			}
-
-			push( ...args ) {
-				return stubs.table.push( ...args );
-			}
-
-			toString( ...args ) {
-				return stubs.table.toString( ...args );
-			}
-		} );
-
-		sandbox.stub( process, 'cwd' ).returns( path.join( 'workspace', 'ckeditor5' ) );
-
 		upload = proxyquire( '../../lib/translations/upload', {
 			'@ckeditor/ckeditor5-dev-utils': {
-				logger: () => stubs.logger
+				logger: () => stubs.logger,
+				tools: stubs.tools
 			},
-			'fs': stubs.fs,
-			'chalk': {
-				gray: stubs.chalk.gray.callsFake( msg => msg ),
-				underline: stubs.chalk.underline.callsFake( msg => msg )
-			}
+			'path': stubs.path,
+			'fs/promises': stubs.fs,
+			'chalk': stubs.chalk,
+			'cli-table': class Table {
+				constructor( ...args ) {
+					stubs.table.constructor( ...args );
+				}
+
+				push( ...args ) {
+					return stubs.table.push( ...args );
+				}
+
+				toString( ...args ) {
+					return stubs.table.toString( ...args );
+				}
+			},
+			'./transifex-service-for-api-v3.0': stubs.transifexService,
+			'./utils': stubs.utils
 		} );
 	} );
 
 	afterEach( () => {
-		mockery.disable();
-		sandbox.restore();
+		sinon.restore();
 	} );
 
-	it( 'should create and update resources on the Transifex', () => {
-		packageNames = [
-			'ckeditor5-core',
-			'ckeditor5-ui'
-		];
-
-		serverResources = [ {
-			slug: 'ckeditor5-core'
-		} ];
-
-		fileContents = {
-			'/workspace/ckeditor5/build/.transifex/ckeditor5-ui/en.pot': '# ckeditor-ui en.pot content',
-			'/workspace/ckeditor5/build/.transifex/ckeditor5-core/en.pot': '# ckeditor-core en.pot content'
+	it( 'should reject a promise if required properties are not specified', () => {
+		const error = new Error( 'The specified object misses the following properties: packages.' );
+		const config = {
+			cwd: '/home/ckeditor5',
+			token: 'token',
+			organizationName: 'ckeditor',
+			projectName: 'ckeditor5'
 		};
 
-		stubs.transifexService.postResource.onCall( 0 ).resolves( [ 4 ] );
-		stubs.transifexService.putResourceContent.onCall( 0 ).resolves( { strings_added: 1, strings_updated: 0, strings_delete: 3 } );
+		stubs.utils.verifyProperties.throws( error );
 
-		const uploadOptions = {
-			token: 'secretToken',
-			url: 'https://api.example.com',
-			translationsDirectory: '/workspace/ckeditor5/build/.transifex'
+		return upload( config )
+			.then(
+				() => {
+					throw new Error( 'Expected to be rejected.' );
+				},
+				err => {
+					expect( err ).to.equal( error );
+
+					expect( stubs.utils.verifyProperties.callCount ).to.equal( 1 );
+					expect( stubs.utils.verifyProperties.firstCall.args[ 0 ] ).to.deep.equal( config );
+					expect( stubs.utils.verifyProperties.firstCall.args[ 1 ] ).to.deep.equal( [
+						'token',
+						'organizationName',
+						'projectName',
+						'cwd',
+						'packages'
+					] );
+				}
+			);
+	} );
+
+	it( 'should create a new resource if the package is processed for the first time', () => {
+		const packages = new Map( [
+			[ 'ckeditor5-non-existing-01', 'build/.transifex/ckeditor5-non-existing-01' ]
+		] );
+
+		const config = {
+			packages,
+			cwd: '/home/ckeditor5',
+			token: 'token',
+			organizationName: 'ckeditor',
+			projectName: 'ckeditor5'
 		};
 
-		return upload( uploadOptions )
+		stubs.transifexService.getProjectData.resolves( {
+			resources: []
+		} );
+
+		stubs.transifexService.createResource.resolves();
+		stubs.transifexService.createSourceFile.resolves( 'uuid-01' );
+		stubs.transifexService.getResourceUploadDetails.resolves(
+			createResourceUploadDetailsResponse( 'ckeditor5-non-existing-01', 0, 0, 0 )
+		);
+
+		stubs.tools.createSpinner.returns( {
+			start: sinon.stub(),
+			finish: sinon.stub()
+		} );
+
+		return upload( config )
 			.then( () => {
-				sinon.assert.calledOnce( stubs.transifexService.getResources );
-				sinon.assert.calledWithExactly( stubs.fs.readdirSync, '/workspace/ckeditor5/build/.transifex' );
-
-				sinon.assert.calledOnce( stubs.transifexService.postResource );
-				sinon.assert.calledWithExactly( stubs.transifexService.postResource, {
-					token: 'secretToken',
-					url: 'https://api.example.com',
-					name: 'ckeditor5-ui',
-					slug: 'ckeditor5-ui',
-					content: '# ckeditor-ui en.pot content'
-				} );
-
-				sinon.assert.calledOnce( stubs.transifexService.putResourceContent );
-
-				sinon.assert.calledWithExactly( stubs.transifexService.putResourceContent, {
-					token: 'secretToken',
-					url: 'https://api.example.com',
-					slug: 'ckeditor5-core',
-					name: 'ckeditor5-core',
-					content: '# ckeditor-core en.pot content'
-				} );
-			} );
-	} );
-
-	it( 'should report an error and throw it when something goes wrong', () => {
-		const error = new Error();
-		stubs.transifexService.getResources = sandbox.spy( () => Promise.reject( error ) );
-
-		const uploadOptions = {
-			token: 'secretToken',
-			url: 'https://api.example.com',
-			translationsDirectory: '/workspace/ckeditor5/build/.transifex'
-		};
-
-		return upload( uploadOptions )
-			.then( () => {
-				throw new Error( 'It should throws an error' );
-			}, err => {
-				expect( err ).to.equal( error );
-				sinon.assert.calledOnce( stubs.logger.error );
-				sinon.assert.calledWithExactly( stubs.logger.error, error );
-			} );
-	} );
-
-	it( 'should print a table with summary (created and updated items)', () => {
-		stubs.table.toString.onFirstCall().returns( '┻━┻' );
-		stubs.table.toString.onSecondCall().returns( '┳━┳' );
-
-		// Random order by design.
-		packageNames = [
-			'ckeditor5-widget',
-			'ckeditor5-ui',
-			'ckeditor5-utils',
-			'ckeditor5-engine',
-			'ckeditor5-basic-styles',
-			'ckeditor5-link',
-			'ckeditor5-core',
-			'ckeditor5-autoformat'
-		];
-
-		// Existing resources.
-		serverResources = [
-			{ slug: 'ckeditor5-core' },
-			{ slug: 'ckeditor5-basic-styles' },
-			{ slug: 'ckeditor5-engine' },
-			{ slug: 'ckeditor5-autoformat' }
-		];
-
-		stubs.transifexService.postResource.reset();
-
-		stubs.transifexService.postResource.onCall( 0 ).resolves( [ 4 ] );
-		stubs.transifexService.postResource.onCall( 1 ).resolves( [ 2 ] );
-		stubs.transifexService.postResource.onCall( 2 ).resolves( [ 1 ] );
-		stubs.transifexService.postResource.onCall( 3 ).resolves( [ 5 ] );
-
-		stubs.transifexService.putResourceContent.reset();
-
-		stubs.transifexService.putResourceContent.onCall( 0 ).resolves( { strings_added: 1, strings_updated: 0, strings_delete: 3 } );
-		stubs.transifexService.putResourceContent.onCall( 1 ).resolves( { strings_added: 1, strings_updated: 2, strings_delete: 0 } );
-		stubs.transifexService.putResourceContent.onCall( 2 ).resolves( { strings_added: 0, strings_updated: 0, strings_delete: 0 } );
-		stubs.transifexService.putResourceContent.onCall( 3 ).resolves( { strings_added: 0, strings_updated: 0, strings_delete: 0 } );
-
-		fileContents = {};
-
-		for ( const item of packageNames ) {
-			fileContents[ `/workspace/ckeditor5/build/.transifex/${ item }/en.pot` ] = `# ${ item } en.pot content`;
-		}
-
-		const uploadOptions = {
-			token: 'secretToken',
-			url: 'https://api.example.com',
-			translationsDirectory: '/workspace/ckeditor5/build/.transifex'
-		};
-
-		return upload( uploadOptions )
-			.then( () => {
-				expect( stubs.logger.info.callCount ).to.equal( 13 );
-
-				// Parsed packages. Info log about processing.
-				expect( stubs.logger.info.getCall( 0 ).args[ 0 ] ).to.equal( 'Processing "ckeditor5-widget"...' );
-				expect( stubs.logger.info.getCall( 1 ).args[ 0 ] ).to.equal( 'Processing "ckeditor5-ui"...' );
-				expect( stubs.logger.info.getCall( 2 ).args[ 0 ] ).to.equal( 'Processing "ckeditor5-utils"...' );
-				expect( stubs.logger.info.getCall( 3 ).args[ 0 ] ).to.equal( 'Processing "ckeditor5-engine"...' );
-				expect( stubs.logger.info.getCall( 4 ).args[ 0 ] ).to.equal( 'Processing "ckeditor5-basic-styles"...' );
-				expect( stubs.logger.info.getCall( 5 ).args[ 0 ] ).to.equal( 'Processing "ckeditor5-link"...' );
-				expect( stubs.logger.info.getCall( 6 ).args[ 0 ] ).to.equal( 'Processing "ckeditor5-core"...' );
-				expect( stubs.logger.info.getCall( 7 ).args[ 0 ] ).to.equal( 'Processing "ckeditor5-autoformat"...' );
-
-				// Finished parsing packages.
-				expect( stubs.logger.info.getCall( 8 ).args[ 0 ] ).to.equal( 'All resources uploaded.\n' );
-
-				// Drawing the tables.
-				expect( stubs.logger.info.getCall( 9 ).args[ 0 ] ).to.equal( 'Created resources:\n' );
-				expect( stubs.logger.info.getCall( 10 ).args[ 0 ] ).to.equal( '┻━┻\n' );
-				expect( stubs.logger.info.getCall( 11 ).args[ 0 ] ).to.equal( 'Updated resources:\n' );
-				expect( stubs.logger.info.getCall( 12 ).args[ 0 ] ).to.equal( '┳━┳' );
-
-				// Each package should be added into a table.
-				expect( stubs.table.push.callCount ).to.equal( 8 );
-
-				// Packages should be sorted by their names.
-				// Calls 1-4 are for new (created) resources.
-				expect( stubs.table.push.getCall( 0 ).args[ 0 ] ).to.deep.equal( [ 'ckeditor5-link', '5' ] );
-				expect( stubs.table.push.getCall( 1 ).args[ 0 ] ).to.deep.equal( [ 'ckeditor5-ui', '2' ] );
-				expect( stubs.table.push.getCall( 2 ).args[ 0 ] ).to.deep.equal( [ 'ckeditor5-utils', '1' ] );
-				expect( stubs.table.push.getCall( 3 ).args[ 0 ] ).to.deep.equal( [ 'ckeditor5-widget', '4' ] );
-
-				// Calls 5-8 are for updated resources.
-				// First should be displayed packages with changes, then no changes items.
-				expect( stubs.table.push.getCall( 4 ).args[ 0 ] ).to.deep.equal( [ 'ckeditor5-basic-styles', '1', '2', '0' ] );
-				expect( stubs.table.push.getCall( 5 ).args[ 0 ] ).to.deep.equal( [ 'ckeditor5-engine', '1', '0', '3' ] );
-				expect( stubs.table.push.getCall( 6 ).args[ 0 ] ).to.deep.equal( [ 'ckeditor5-autoformat', '0', '0', '0' ] );
-				expect( stubs.table.push.getCall( 7 ).args[ 0 ] ).to.deep.equal( [ 'ckeditor5-core', '0', '0', '0' ] );
-
-				// Both table headers should be underlined.
-				expect( stubs.chalk.underline.callCount ).to.equal( 2 );
-				expect( stubs.chalk.underline.getCall( 0 ).args[ 0 ] ).to.equal( 'Created resources:' );
-				expect( stubs.chalk.underline.getCall( 1 ).args[ 0 ] ).to.equal( 'Updated resources:' );
-
-				// Updated packages with no changes should be grayed out.
-				// Each package calls the function 4 times.
-				expect( stubs.chalk.gray.callCount ).to.equal( 8 );
-				expect( stubs.chalk.gray.getCall( 0 ).args[ 0 ] ).to.equal( 'ckeditor5-autoformat' );
-				expect( stubs.chalk.gray.getCall( 1 ).args[ 0 ] ).to.equal( '0' );
-				expect( stubs.chalk.gray.getCall( 2 ).args[ 0 ] ).to.equal( '0' );
-				expect( stubs.chalk.gray.getCall( 3 ).args[ 0 ] ).to.equal( '0' );
-				expect( stubs.chalk.gray.getCall( 4 ).args[ 0 ] ).to.equal( 'ckeditor5-core' );
-				expect( stubs.chalk.gray.getCall( 5 ).args[ 0 ] ).to.equal( '0' );
-				expect( stubs.chalk.gray.getCall( 6 ).args[ 0 ] ).to.equal( '0' );
-				expect( stubs.chalk.gray.getCall( 7 ).args[ 0 ] ).to.equal( '0' );
-			} );
-	} );
-
-	it( 'should print a table with summary (created items only)', () => {
-		stubs.table.toString.onFirstCall().returns( '┻━┻' );
-
-		// Random order by design.
-		packageNames = [
-			'ckeditor5-widget',
-			'ckeditor5-ui',
-			'ckeditor5-utils',
-			'ckeditor5-link'
-		];
-
-		// Existing resources.
-		serverResources = [];
-
-		stubs.transifexService.postResource.reset();
-
-		stubs.transifexService.postResource.onCall( 0 ).resolves( [ 4 ] );
-		stubs.transifexService.postResource.onCall( 1 ).resolves( [ 2 ] );
-		stubs.transifexService.postResource.onCall( 2 ).resolves( [ 1 ] );
-		stubs.transifexService.postResource.onCall( 3 ).resolves( [ 5 ] );
-
-		fileContents = {};
-
-		for ( const item of packageNames ) {
-			fileContents[ `workspace/ckeditor5/build/.transifex/${ item }/en.pot` ] = `# ${ item } en.pot content`;
-		}
-
-		const uploadOptions = {
-			token: 'secretToken',
-			url: 'https://api.example.com',
-			translationsDirectory: '/workspace/ckeditor5/build/.transifex'
-		};
-
-		return upload( uploadOptions )
-			.then( () => {
-				expect( stubs.logger.info.callCount ).to.equal( 7 );
-
-				// Parsed packages. Info log about processing.
-				expect( stubs.logger.info.getCall( 0 ).args[ 0 ] ).to.equal( 'Processing "ckeditor5-widget"...' );
-				expect( stubs.logger.info.getCall( 1 ).args[ 0 ] ).to.equal( 'Processing "ckeditor5-ui"...' );
-				expect( stubs.logger.info.getCall( 2 ).args[ 0 ] ).to.equal( 'Processing "ckeditor5-utils"...' );
-				expect( stubs.logger.info.getCall( 3 ).args[ 0 ] ).to.equal( 'Processing "ckeditor5-link"...' );
-
-				// Finished parsing packages.
-				expect( stubs.logger.info.getCall( 4 ).args[ 0 ] ).to.equal( 'All resources uploaded.\n' );
-
-				// Drawing the tables.
-				expect( stubs.logger.info.getCall( 5 ).args[ 0 ] ).to.equal( 'Created resources:\n' );
-				expect( stubs.logger.info.getCall( 6 ).args[ 0 ] ).to.equal( '┻━┻\n' );
-
-				// Each package should be added into a table.
-				expect( stubs.table.push.callCount ).to.equal( 4 );
-
-				expect( stubs.table.push.getCall( 0 ).args[ 0 ] ).to.deep.equal( [ 'ckeditor5-link', '5' ] );
-				expect( stubs.table.push.getCall( 1 ).args[ 0 ] ).to.deep.equal( [ 'ckeditor5-ui', '2' ] );
-				expect( stubs.table.push.getCall( 2 ).args[ 0 ] ).to.deep.equal( [ 'ckeditor5-utils', '1' ] );
-				expect( stubs.table.push.getCall( 3 ).args[ 0 ] ).to.deep.equal( [ 'ckeditor5-widget', '4' ] );
-
-				// A table header should be underlined.
-				expect( stubs.chalk.underline.callCount ).to.equal( 1 );
-				expect( stubs.chalk.underline.getCall( 0 ).args[ 0 ] ).to.equal( 'Created resources:' );
-			} );
-	} );
-
-	it( 'should print a table with summary (updated items only)', () => {
-		stubs.table.toString.onFirstCall().returns( '┳━┳' );
-
-		// Random order by design.
-		packageNames = [
-			'ckeditor5-engine',
-			'ckeditor5-basic-styles',
-			'ckeditor5-core',
-			'ckeditor5-autoformat'
-		];
-
-		// Existing resources.
-		serverResources = [
-			{ slug: 'ckeditor5-core' },
-			{ slug: 'ckeditor5-basic-styles' },
-			{ slug: 'ckeditor5-engine' },
-			{ slug: 'ckeditor5-autoformat' }
-		];
-
-		stubs.transifexService.putResourceContent.reset();
-
-		stubs.transifexService.putResourceContent.onCall( 0 ).resolves( { strings_added: 1, strings_updated: 0, strings_delete: 3 } );
-		stubs.transifexService.putResourceContent.onCall( 1 ).resolves( { strings_added: 1, strings_updated: 2, strings_delete: 0 } );
-		stubs.transifexService.putResourceContent.onCall( 2 ).resolves( { strings_added: 0, strings_updated: 0, strings_delete: 0 } );
-		stubs.transifexService.putResourceContent.onCall( 3 ).resolves( { strings_added: 0, strings_updated: 0, strings_delete: 0 } );
-
-		fileContents = {};
-
-		for ( const item of packageNames ) {
-			fileContents[ `workspace/ckeditor5/build/.transifex/${ item }/en.pot` ] = `# ${ item } en.pot content`;
-		}
-
-		const uploadOptions = {
-			token: 'secretToken',
-			url: 'https://api.example.com',
-			translationsDirectory: '/workspace/ckeditor5/build/.transifex'
-		};
-
-		return upload( uploadOptions )
-			.then( () => {
-				expect( stubs.logger.info.callCount ).to.equal( 7 );
-
-				// Parsed packages. Info log about processing.
-				expect( stubs.logger.info.getCall( 0 ).args[ 0 ] ).to.equal( 'Processing "ckeditor5-engine"...' );
-				expect( stubs.logger.info.getCall( 1 ).args[ 0 ] ).to.equal( 'Processing "ckeditor5-basic-styles"...' );
-				expect( stubs.logger.info.getCall( 2 ).args[ 0 ] ).to.equal( 'Processing "ckeditor5-core"...' );
-				expect( stubs.logger.info.getCall( 3 ).args[ 0 ] ).to.equal( 'Processing "ckeditor5-autoformat"...' );
-
-				// Finished parsing packages.
-				expect( stubs.logger.info.getCall( 4 ).args[ 0 ] ).to.equal( 'All resources uploaded.\n' );
-
-				// Drawing the tables.
-				expect( stubs.logger.info.getCall( 5 ).args[ 0 ] ).to.equal( 'Updated resources:\n' );
-				expect( stubs.logger.info.getCall( 6 ).args[ 0 ] ).to.equal( '┳━┳' );
-
-				// Each package should be added into a table.
-				expect( stubs.table.push.callCount ).to.equal( 4 );
-
-				expect( stubs.table.push.getCall( 0 ).args[ 0 ] ).to.deep.equal( [ 'ckeditor5-basic-styles', '1', '2', '0' ] );
-				expect( stubs.table.push.getCall( 1 ).args[ 0 ] ).to.deep.equal( [ 'ckeditor5-engine', '1', '0', '3' ] );
-				expect( stubs.table.push.getCall( 2 ).args[ 0 ] ).to.deep.equal( [ 'ckeditor5-autoformat', '0', '0', '0' ] );
-				expect( stubs.table.push.getCall( 3 ).args[ 0 ] ).to.deep.equal( [ 'ckeditor5-core', '0', '0', '0' ] );
-
-				// A table header should be underlined.
-				expect( stubs.chalk.underline.callCount ).to.equal( 1 );
-				expect( stubs.chalk.underline.getCall( 0 ).args[ 0 ] ).to.equal( 'Updated resources:' );
-
-				expect( stubs.chalk.gray.callCount ).to.equal( 8 );
-				expect( stubs.chalk.gray.getCall( 0 ).args[ 0 ] ).to.equal( 'ckeditor5-autoformat' );
-				expect( stubs.chalk.gray.getCall( 1 ).args[ 0 ] ).to.equal( '0' );
-				expect( stubs.chalk.gray.getCall( 2 ).args[ 0 ] ).to.equal( '0' );
-				expect( stubs.chalk.gray.getCall( 3 ).args[ 0 ] ).to.equal( '0' );
-				expect( stubs.chalk.gray.getCall( 4 ).args[ 0 ] ).to.equal( 'ckeditor5-core' );
-				expect( stubs.chalk.gray.getCall( 5 ).args[ 0 ] ).to.equal( '0' );
-				expect( stubs.chalk.gray.getCall( 6 ).args[ 0 ] ).to.equal( '0' );
-				expect( stubs.chalk.gray.getCall( 7 ).args[ 0 ] ).to.equal( '0' );
-			} );
-	} );
-
-	it( 'should fail with an error describing missing properties if the required were not passed to the function', async () => {
-		try {
-			await upload( {} );
-		} catch ( err ) {
-			expect( err.message ).to.equal( 'The specified object misses the following properties: token, url, translationsDirectory.' );
-		}
-	} );
-
-	it( 'should create and update resources on the Transifex (Windows paths on input)', () => {
-		packageNames = [
-			'ckeditor5-core',
-			'ckeditor5-ui'
-		];
-
-		serverResources = [ {
-			slug: 'ckeditor5-core'
-		} ];
-
-		fileContents = {
-			'C:/workspace/ckeditor5/build/.transifex/ckeditor5-ui/en.pot': '# ckeditor-ui en.pot content',
-			'C:/workspace/ckeditor5/build/.transifex/ckeditor5-core/en.pot': '# ckeditor-core en.pot content'
-		};
-
-		stubs.transifexService.postResource.onCall( 0 ).resolves( [ 4 ] );
-		stubs.transifexService.putResourceContent.onCall( 0 ).resolves( { strings_added: 1, strings_updated: 0, strings_delete: 3 } );
-
-		const uploadOptions = {
-			token: 'secretToken',
-			url: 'https://api.example.com',
-			translationsDirectory: 'C:\\workspace\\ckeditor5\\build\\.transifex'
-		};
-
-		return upload( uploadOptions )
-			.then( () => {
-				sinon.assert.calledOnce( stubs.transifexService.getResources );
-				sinon.assert.calledWithExactly( stubs.fs.readdirSync, 'C:/workspace/ckeditor5/build/.transifex' );
-
-				sinon.assert.calledOnce( stubs.transifexService.postResource );
-				sinon.assert.calledWithExactly( stubs.transifexService.postResource, {
-					token: 'secretToken',
-					url: 'https://api.example.com',
-					name: 'ckeditor5-ui',
-					slug: 'ckeditor5-ui',
-					content: '# ckeditor-ui en.pot content'
-				} );
-
-				sinon.assert.calledOnce( stubs.transifexService.putResourceContent );
-
-				sinon.assert.calledWithExactly( stubs.transifexService.putResourceContent, {
-					token: 'secretToken',
-					url: 'https://api.example.com',
-					slug: 'ckeditor5-core',
-					name: 'ckeditor5-core',
-					content: '# ckeditor-core en.pot content'
+				expect( stubs.transifexService.createResource.callCount ).to.equal( 1 );
+				expect( stubs.transifexService.createResource.firstCall.args[ 0 ] ).to.deep.equal( {
+					organizationName: 'ckeditor',
+					projectName: 'ckeditor5',
+					resourceName: 'ckeditor5-non-existing-01'
 				} );
 			} );
+	} );
+
+	it( 'should not create a new resource if the package exists on Transifex', () => {
+		const packages = new Map( [
+			[ 'ckeditor5-existing-11', 'build/.transifex/ckeditor5-existing-11' ]
+		] );
+
+		const config = {
+			packages,
+			cwd: '/home/ckeditor5',
+			token: 'token',
+			organizationName: 'ckeditor',
+			projectName: 'ckeditor5'
+		};
+
+		stubs.transifexService.getProjectData.resolves( {
+			resources: [
+				{ attributes: { name: 'ckeditor5-existing-11' } }
+			]
+		} );
+
+		stubs.transifexService.createSourceFile.resolves( 'uuid-11' );
+
+		stubs.transifexService.getResourceUploadDetails.resolves(
+			createResourceUploadDetailsResponse( 'ckeditor5-existing-11', 0, 0, 0 )
+		);
+
+		stubs.tools.createSpinner.returns( {
+			start: sinon.stub(),
+			finish: sinon.stub()
+		} );
+
+		return upload( config )
+			.then( () => {
+				expect( stubs.transifexService.createResource.callCount ).to.equal( 0 );
+			} );
+	} );
+
+	it( 'should send a new translation source to Transifex', () => {
+		const packages = new Map( [
+			[ 'ckeditor5-existing-11', 'build/.transifex/ckeditor5-existing-11' ]
+		] );
+
+		const config = {
+			packages,
+			cwd: '/home/ckeditor5',
+			token: 'token',
+			organizationName: 'ckeditor',
+			projectName: 'ckeditor5'
+		};
+
+		stubs.transifexService.getProjectData.resolves( {
+			resources: [
+				{ attributes: { name: 'ckeditor5-existing-11' } }
+			]
+		} );
+
+		stubs.transifexService.createSourceFile.resolves( 'uuid-11' );
+
+		stubs.transifexService.getResourceUploadDetails.resolves(
+			createResourceUploadDetailsResponse( 'ckeditor5-existing-11', 0, 0, 0 )
+		);
+
+		stubs.fs.readFile.resolves( '# Example file.' );
+
+		stubs.tools.createSpinner.returns( {
+			start: sinon.stub(),
+			finish: sinon.stub()
+		} );
+
+		return upload( config )
+			.then( () => {
+				expect( stubs.fs.readFile.callCount ).to.equal( 1 );
+				expect( stubs.fs.readFile.firstCall.args[ 0 ] ).to.equal( '/home/ckeditor5/build/.transifex/ckeditor5-existing-11/en.pot' );
+				expect( stubs.fs.readFile.firstCall.args[ 1 ] ).to.equal( 'utf-8' );
+				expect( stubs.transifexService.createSourceFile.callCount ).to.equal( 1 );
+				expect( stubs.transifexService.createSourceFile.firstCall.args[ 0 ] ).to.deep.equal( {
+					organizationName: 'ckeditor',
+					projectName: 'ckeditor5',
+					resourceName: 'ckeditor5-existing-11',
+					content: '# Example file.'
+				} );
+				expect( stubs.transifexService.getResourceUploadDetails.callCount ).to.equal( 1 );
+				expect( stubs.transifexService.getResourceUploadDetails.firstCall.args[ 0 ] ).to.equal( 'uuid-11' );
+			} );
+	} );
+
+	it( 'should keep informed a developer what the script does', () => {
+		const packages = new Map( [
+			[ 'ckeditor5-non-existing-01', 'build/.transifex/ckeditor5-non-existing-01' ]
+		] );
+
+		const config = {
+			packages,
+			cwd: '/home/ckeditor5',
+			token: 'token',
+			organizationName: 'ckeditor',
+			projectName: 'ckeditor5'
+		};
+
+		stubs.transifexService.getProjectData.resolves( {
+			resources: []
+		} );
+
+		stubs.transifexService.createResource.resolves();
+		stubs.transifexService.createSourceFile.resolves( 'uuid-01' );
+		stubs.transifexService.getResourceUploadDetails.resolves(
+			createResourceUploadDetailsResponse( 'ckeditor5-non-existing-01', 0, 0, 0 )
+		);
+
+		const packageSpinner = {
+			start: sinon.stub(),
+			finish: sinon.stub()
+		};
+		const processSpinner = {
+			start: sinon.stub(),
+			finish: sinon.stub()
+		};
+
+		stubs.tools.createSpinner.onFirstCall().returns( packageSpinner );
+		stubs.tools.createSpinner.onSecondCall().returns( processSpinner );
+
+		stubs.table.toString.returns( '┻━┻' );
+
+		return upload( config )
+			.then( () => {
+				expect( stubs.logger.info.callCount ).to.equal( 5 );
+				expect( stubs.logger.info.getCall( 0 ).args[ 0 ] ).to.equal( '\n📍 Fetching project information...' );
+				expect( stubs.logger.info.getCall( 1 ).args[ 0 ] ).to.equal( '' );
+				expect( stubs.logger.info.getCall( 2 ).args[ 0 ] ).to.equal( '\n📍 Uploading new translations...' );
+				expect( stubs.logger.info.getCall( 3 ).args[ 0 ] ).to.equal( '\n📍 Done.' );
+				expect( stubs.logger.info.getCall( 4 ).args[ 0 ] ).to.equal( '┻━┻' );
+
+				expect( stubs.tools.createSpinner.callCount ).to.equal( 2 );
+
+				expect( stubs.tools.createSpinner.firstCall.args[ 0 ] ).to.equal( 'Processing "ckeditor5-non-existing-01"' );
+				expect( stubs.tools.createSpinner.firstCall.args[ 1 ] ).to.deep.equal( {
+					emoji: '👉',
+					indentLevel: 1
+				} );
+				expect( stubs.tools.createSpinner.secondCall.args[ 0 ] ).to.equal( 'Collecting responses... It takes a while.' );
+
+				expect( packageSpinner.start.called ).to.equal( true );
+				expect( packageSpinner.finish.called ).to.equal( true );
+				expect( processSpinner.start.called ).to.equal( true );
+				expect( processSpinner.finish.called ).to.equal( true );
+				expect( stubs.chalk.gray.callCount ).to.equal( 1 );
+				expect( stubs.chalk.italic.callCount ).to.equal( 1 );
+			} );
+	} );
+
+	describe( 'processing multiple packages', () => {
+		let packages, config;
+
+		beforeEach( () => {
+			packages = new Map( [
+				[ 'ckeditor5-existing-11', 'build/.transifex/ckeditor5-existing-11' ],
+				[ 'ckeditor5-existing-14', 'build/.transifex/ckeditor5-existing-14' ],
+				[ 'ckeditor5-non-existing-03', 'build/.transifex/ckeditor5-non-existing-03' ],
+				[ 'ckeditor5-non-existing-01', 'build/.transifex/ckeditor5-non-existing-01' ],
+				[ 'ckeditor5-existing-13', 'build/.transifex/ckeditor5-existing-13' ],
+				[ 'ckeditor5-non-existing-02', 'build/.transifex/ckeditor5-non-existing-02' ],
+				[ 'ckeditor5-existing-12', 'build/.transifex/ckeditor5-existing-12' ]
+			] );
+
+			config = {
+				packages,
+				cwd: '/home/ckeditor5',
+				token: 'token',
+				organizationName: 'ckeditor',
+				projectName: 'ckeditor5'
+			};
+
+			for ( const [ packageName, packagePath ] of packages ) {
+				// Mock translation files.
+				stubs.fs.readFile.withArgs( config.cwd + '/' + packagePath + '/en.pot' ).resolves( '# ' + packageName );
+
+				// Mock Tx response when uploading a new translation content.
+				const uuid = 'uuid-' + packageName.match( /(\d+)$/ )[ 1 ];
+				const withArgs = {
+					organizationName: 'ckeditor',
+					projectName: 'ckeditor5',
+					resourceName: packageName,
+					content: '# ' + packageName
+				};
+				stubs.transifexService.createSourceFile.withArgs( withArgs ).resolves( uuid );
+			}
+
+			// Mock resources on Transifex.
+			stubs.transifexService.getProjectData.resolves( {
+				resources: [
+					{ attributes: { name: 'ckeditor5-existing-11' } },
+					{ attributes: { name: 'ckeditor5-existing-12' } },
+					{ attributes: { name: 'ckeditor5-existing-13' } },
+					{ attributes: { name: 'ckeditor5-existing-14' } }
+				]
+			} );
+
+			stubs.transifexService.createResource.resolves();
+
+			stubs.transifexService.getResourceUploadDetails.withArgs( 'uuid-01' ).resolves(
+				createResourceUploadDetailsResponse( 'ckeditor5-non-existing-01', 3, 0, 0 )
+			);
+			stubs.transifexService.getResourceUploadDetails.withArgs( 'uuid-02' ).resolves(
+				createResourceUploadDetailsResponse( 'ckeditor5-non-existing-02', 0, 0, 0 )
+			);
+			stubs.transifexService.getResourceUploadDetails.withArgs( 'uuid-03' ).resolves(
+				createResourceUploadDetailsResponse( 'ckeditor5-non-existing-03', 1, 0, 0 )
+			);
+			stubs.transifexService.getResourceUploadDetails.withArgs( 'uuid-11' ).resolves(
+				createResourceUploadDetailsResponse( 'ckeditor5-existing-11', 0, 0, 0 )
+			);
+			stubs.transifexService.getResourceUploadDetails.withArgs( 'uuid-12' ).resolves(
+				createResourceUploadDetailsResponse( 'ckeditor5-existing-12', 0, 1, 1 )
+			);
+			stubs.transifexService.getResourceUploadDetails.withArgs( 'uuid-13' ).resolves(
+				createResourceUploadDetailsResponse( 'ckeditor5-existing-13', 2, 0, 0 )
+			);
+			stubs.transifexService.getResourceUploadDetails.withArgs( 'uuid-14' ).resolves(
+				createResourceUploadDetailsResponse( 'ckeditor5-existing-14', 0, 0, 0 )
+			);
+
+			stubs.tools.createSpinner.returns( {
+				start: sinon.stub(),
+				finish: sinon.stub()
+			} );
+		} );
+
+		it( 'should handle all packages', () => {
+			return upload( config )
+				.then( () => {
+					expect( stubs.transifexService.getProjectData.callCount ).to.equal( 1 );
+					expect( stubs.transifexService.createResource.callCount ).to.equal( 3 );
+					expect( stubs.transifexService.createSourceFile.callCount ).to.equal( 7 );
+					expect( stubs.transifexService.getResourceUploadDetails.callCount ).to.equal( 7 );
+					expect( stubs.tools.createSpinner.callCount ).to.equal( 8 );
+				} );
+		} );
+
+		it( 'should display a summary table with sorted packages (new, has changes, A-Z)', () => {
+			return upload( config )
+				.then( () => {
+					expect( stubs.table.push.callCount ).to.equal( 1 );
+					expect( stubs.table.push.firstCall.args ).to.be.an( 'array' );
+					expect( stubs.table.push.firstCall.args ).to.lengthOf( 7 );
+
+					// 1x for printing "It takes a while",
+					// 5x for each column, x2 for each resource.
+					expect( stubs.chalk.gray.callCount ).to.equal( 11 );
+
+					expect( stubs.table.push.firstCall.args ).to.deep.equal( [
+						[ 'ckeditor5-non-existing-01', '🆕', '3', '0', '0' ],
+						[ 'ckeditor5-non-existing-03', '🆕', '1', '0', '0' ],
+						[ 'ckeditor5-non-existing-02', '🆕', '0', '0', '0' ],
+						[ 'ckeditor5-existing-12', '', '0', '1', '1' ],
+						[ 'ckeditor5-existing-13', '', '2', '0', '0' ],
+						[ 'ckeditor5-existing-11', '', '0', '0', '0' ],
+						[ 'ckeditor5-existing-14', '', '0', '0', '0' ]
+					] );
+				} );
+		} );
 	} );
 } );
+
+/**
+ * Returns an object that looks like a response from Transifex API.
+ *
+ * @param {String} packageName
+ * @param {Number} created
+ * @param {Number} updated
+ * @param {Number} deleted
+ * @returns {Object}
+ */
+function createResourceUploadDetailsResponse( packageName, created, updated, deleted ) {
+	return {
+		related: {
+			resource: {
+				id: `o:ckeditor:p:ckeditor5:r:${ packageName }`
+			}
+		},
+		attributes: {
+			details: {
+				strings_created: created,
+				strings_updated: updated,
+				strings_deleted: deleted
+			}
+		}
+	};
+}

--- a/packages/ckeditor5-dev-tests/package.json
+++ b/packages/ckeditor5-dev-tests/package.json
@@ -46,7 +46,7 @@
     "postcss-loader": "^4.3.0",
     "process": "^0.11.10",
     "raw-loader": "^4.0.1",
-    "sinon": "^9.0.2",
+    "sinon": "^13.0.1",
     "sinon-chai": "^3.5.0",
     "slack-notify": "^0.1.7",
     "style-loader": "^2.0.0",

--- a/packages/ckeditor5-dev-utils/lib/tools/create-spinner.js
+++ b/packages/ckeditor5-dev-utils/lib/tools/create-spinner.js
@@ -22,6 +22,7 @@ const INDENT_SIZE = 3;
  * @param {String} title Description of the current processed task.
  * @param {Object} [options={}]
  * @param {Boolean} [options.isDisabled] Whether the spinner should be disabled.
+ * @param {String} [options.emoji='📍'] An emoji that will replace the spinner when it finishes.
  * @param {Number} [options.indentLevel=1] The indent level.
  * @return {CKEditor5Spinner}
  */
@@ -29,6 +30,7 @@ module.exports = function createSpinner( title, options = {} ) {
 	const isEnabled = !options.isDisabled && isInteractive();
 	const indentLevel = options.indentLevel || 0;
 	const indent = ' '.repeat( indentLevel * INDENT_SIZE );
+	const emoji = options.emoji || '📍';
 
 	let timerId;
 
@@ -69,7 +71,7 @@ module.exports = function createSpinner( title, options = {} ) {
 			clearLastLine();
 
 			cliCursor.show();
-			console.log( `${ indent }📍 ${ title }` );
+			console.log( `${ indent }${ emoji } ${ title }` );
 		}
 	};
 

--- a/packages/ckeditor5-dev-utils/lib/tools/create-spinner.js
+++ b/packages/ckeditor5-dev-utils/lib/tools/create-spinner.js
@@ -37,7 +37,7 @@ module.exports = function createSpinner( title, options = {} ) {
 	return {
 		start() {
 			if ( !isEnabled ) {
-				console.log( `📍 ${ title }` );
+				console.log( `${ emoji } ${ title }` );
 				return;
 			}
 
@@ -62,7 +62,9 @@ module.exports = function createSpinner( title, options = {} ) {
 			}, cliSpinners.dots12.interval );
 		},
 
-		finish() {
+		finish( options = {} ) {
+			const finishEmoji = options.emoji || emoji;
+
 			if ( !isEnabled ) {
 				return;
 			}
@@ -71,7 +73,7 @@ module.exports = function createSpinner( title, options = {} ) {
 			clearLastLine();
 
 			cliCursor.show();
-			console.log( `${ indent }${ emoji } ${ title }` );
+			console.log( `${ indent }${ finishEmoji } ${ title }` );
 		}
 	};
 

--- a/packages/ckeditor5-dev-utils/package.json
+++ b/packages/ckeditor5-dev-utils/package.json
@@ -34,7 +34,7 @@
     "lodash": "^4.17.15",
     "mockery": "^2.1.0",
     "proxyquire": "^2.1.0",
-    "sinon": "^7.3.2",
+    "sinon": "^13.0.1",
     "vinyl": "^2.1.0"
   },
   "peerDependencies": {

--- a/packages/ckeditor5-dev-utils/tests/tools/create-spinner.js
+++ b/packages/ckeditor5-dev-utils/tests/tools/create-spinner.js
@@ -274,5 +274,18 @@ describe( 'lib/utils/create-spinner', () => {
 			expect( consoleStub.calledOnce ).to.equal( true );
 			expect( consoleStub.firstCall.args[ 0 ] ).to.equal( '   📍 Foo.' );
 		} );
+
+		it( 'prints the specified emoji when finished', () => {
+			const spinner = createSpinner( 'Foo.', { emoji: '👉' } );
+			const consoleStub = sinon.stub( console, 'log' );
+
+			spinner.start();
+			spinner.finish();
+
+			consoleStub.restore();
+
+			expect( consoleStub.calledOnce ).to.equal( true );
+			expect( consoleStub.firstCall.args[ 0 ] ).to.equal( '👉 Foo.' );
+		} );
 	} );
 } );

--- a/packages/ckeditor5-dev-utils/tests/tools/create-spinner.js
+++ b/packages/ckeditor5-dev-utils/tests/tools/create-spinner.js
@@ -275,7 +275,7 @@ describe( 'lib/utils/create-spinner', () => {
 			expect( consoleStub.firstCall.args[ 0 ] ).to.equal( '   📍 Foo.' );
 		} );
 
-		it( 'prints the specified emoji when finished', () => {
+		it( 'prints the specified emoji when created a spinner if it finished', () => {
 			const spinner = createSpinner( 'Foo.', { emoji: '👉' } );
 			const consoleStub = sinon.stub( console, 'log' );
 
@@ -286,6 +286,46 @@ describe( 'lib/utils/create-spinner', () => {
 
 			expect( consoleStub.calledOnce ).to.equal( true );
 			expect( consoleStub.firstCall.args[ 0 ] ).to.equal( '👉 Foo.' );
+		} );
+
+		it( 'prints the specified title if spinner cannot be created if CLI is not interactive', () => {
+			stubs.isInteractive.returns( false );
+
+			const spinner = createSpinner( 'Foo.', { emoji: '👉' } );
+			const consoleStub = sinon.stub( console, 'log' );
+
+			spinner.start();
+
+			consoleStub.restore();
+
+			expect( consoleStub.calledOnce ).to.equal( true );
+			expect( consoleStub.firstCall.args[ 0 ] ).to.equal( '👉 Foo.' );
+		} );
+
+		it( 'allows overriding the emoji (use default emoji when creating a spinner)', () => {
+			const spinner = createSpinner( 'Foo.' );
+			const consoleStub = sinon.stub( console, 'log' );
+
+			spinner.start();
+			spinner.finish( { emoji: '❌' } );
+
+			consoleStub.restore();
+
+			expect( consoleStub.calledOnce ).to.equal( true );
+			expect( consoleStub.firstCall.args[ 0 ] ).to.equal( '❌ Foo.' );
+		} );
+
+		it( 'allows overriding the emoji (passed an emoji when creating a spinner)', () => {
+			const spinner = createSpinner( 'Foo.', { emoji: '👉' } );
+			const consoleStub = sinon.stub( console, 'log' );
+
+			spinner.start();
+			spinner.finish( { emoji: '❌' } );
+
+			consoleStub.restore();
+
+			expect( consoleStub.calledOnce ).to.equal( true );
+			expect( consoleStub.firstCall.args[ 0 ] ).to.equal( '❌ Foo.' );
 		} );
 	} );
 } );

--- a/packages/ckeditor5-dev-webpack-plugin/package.json
+++ b/packages/ckeditor5-dev-webpack-plugin/package.json
@@ -14,7 +14,7 @@
   "devDependencies": {
     "chai": "^4.2.0",
     "proxyquire": "^2.1.3",
-    "sinon": "^9.0.2"
+    "sinon": "^13.0.1"
   },
   "peerDependencies": {
     "webpack": "^4.43.0 || ^5.24.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -441,41 +441,24 @@
   dependencies:
     "@octokit/openapi-types" "^11.2.0"
 
-"@sinonjs/commons@^1", "@sinonjs/commons@^1.3.0", "@sinonjs/commons@^1.4.0", "@sinonjs/commons@^1.6.0", "@sinonjs/commons@^1.7.0", "@sinonjs/commons@^1.8.1":
+"@sinonjs/commons@^1.6.0", "@sinonjs/commons@^1.7.0", "@sinonjs/commons@^1.8.3":
   version "1.8.3"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.3.tgz#3802ddd21a50a949b6721ddd72da36e67e7f1b2d"
   integrity sha512-xkNcLAn/wZaX14RPlwizcKicDk9G3F8m2nU3L7Ukm5zBgTwiT0wsoFAHx9Jq56fJA1z/7uKGtCRu16sOUCLIHQ==
   dependencies:
     type-detect "4.0.8"
 
-"@sinonjs/fake-timers@^6.0.0", "@sinonjs/fake-timers@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz#293674fccb3262ac782c7aadfdeca86b10c75c40"
-  integrity sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==
+"@sinonjs/fake-timers@>=5", "@sinonjs/fake-timers@^9.0.0":
+  version "9.1.1"
+  resolved "https://registry.yarnpkg.com/@sinonjs/fake-timers/-/fake-timers-9.1.1.tgz#7b698e0b9d12d93611f06ee143c30ced848e2840"
+  integrity sha512-Wp5vwlZ0lOqpSYGKqr53INws9HLkt6JDc/pDZcPf7bchQnrXJMXPns8CXx0hFikMSGSWfvtvvpb2gtMVfkWagA==
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
-"@sinonjs/formatio@^3.2.1":
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/@sinonjs/formatio/-/formatio-3.2.2.tgz#771c60dfa75ea7f2d68e3b94c7e888a78781372c"
-  integrity sha512-B8SEsgd8gArBLMD6zpRw3juQ2FVSsmdd7qlevyDqzS9WTCtvF55/gAL+h6gue8ZvPYcdiPdvueM/qm//9XzyTQ==
-  dependencies:
-    "@sinonjs/commons" "^1"
-    "@sinonjs/samsam" "^3.1.0"
-
-"@sinonjs/samsam@^3.1.0", "@sinonjs/samsam@^3.3.3":
-  version "3.3.3"
-  resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-3.3.3.tgz#46682efd9967b259b81136b9f120fd54585feb4a"
-  integrity sha512-bKCMKZvWIjYD0BLGnNrxVuw4dkWCYsLqFOUWw8VgKF/+5Y+mE7LfHWPIYoDXowH+3a9LsWDMo0uAP8YDosPvHQ==
-  dependencies:
-    "@sinonjs/commons" "^1.3.0"
-    array-from "^2.1.1"
-    lodash "^4.17.15"
-
-"@sinonjs/samsam@^5.3.1":
-  version "5.3.1"
-  resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-5.3.1.tgz#375a45fe6ed4e92fca2fb920e007c48232a6507f"
-  integrity sha512-1Hc0b1TtyfBu8ixF/tpfSHTVWKwCBLY4QJbkgnE7HcwyvT2xArDxb4K7dMgqRm3szI+LJbzmW/s4xxEhv6hwDg==
+"@sinonjs/samsam@^6.1.1":
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-6.1.1.tgz#627f7f4cbdb56e6419fa2c1a3e4751ce4f6a00b1"
+  integrity sha512-cZ7rKJTLiE7u7Wi/v9Hc2fs3Ucc3jrWeMgPHbbTCeVAB2S0wOBbYlkJVeNSL04i7fdhT8wIbDq1zhC/PXTD2SA==
   dependencies:
     "@sinonjs/commons" "^1.6.0"
     lodash.get "^4.4.2"
@@ -487,9 +470,9 @@
   integrity sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==
 
 "@transifex/api@^2.1.2":
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/@transifex/api/-/api-2.1.2.tgz#0df1ec3aa5161fb1175147f986d74ab7074c245d"
-  integrity sha512-OenxtYilXJacm6qTJW208GjzN02StFKs9V4xenkReLdN+5j6DquLWYD19mp0tu9Msyiz7zoHugmRW3wz4r3Rlg==
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/@transifex/api/-/api-2.4.1.tgz#1654de2e3106c43dc49d7a3edea330b9362668be"
+  integrity sha512-4PeeZ19UT6HkHvA5RShG7QhIHLQLV7js4T2g/T9XoERB1eTPj9BFmVGGXT3L/3J+oRupsxgjteVkxHd6FqUmHA==
   dependencies:
     core-js "^3.17.2"
 
@@ -977,11 +960,6 @@ array-differ@^3.0.0:
   resolved "https://registry.yarnpkg.com/array-differ/-/array-differ-3.0.0.tgz#3cbb3d0f316810eafcc47624734237d6aee4ae6b"
   integrity sha512-THtfYS6KtME/yIAhKjZ2ul7XI96lQGHRputJQHO80LAWQnuGP4iCIN8vdMRboGbIEYBwU33q8Tch1os2+X0kMg==
 
-array-from@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/array-from/-/array-from-2.1.1.tgz#cfe9d8c26628b9dc5aecc62a9f5d8f1f352c1195"
-  integrity sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=
-
 array-ify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/array-ify/-/array-ify-1.0.0.tgz#9e528762b4a9066ad163a6962a364418e9626ece"
@@ -1366,12 +1344,12 @@ browser-stdout@1.3.1:
   integrity sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==
 
 browserslist@^4.0.0, browserslist@^4.14.5, browserslist@^4.16.6, browserslist@^4.17.5:
-  version "4.19.3"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.19.3.tgz#29b7caad327ecf2859485f696f9604214bedd383"
-  integrity sha512-XK3X4xtKJ+Txj8G5c30B4gsm71s69lqXlkYui4s6EkKxuv49qjYlY6oVd+IFJ73d4YymtM3+djvvt/R/iJwwDg==
+  version "4.20.0"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.20.0.tgz#35951e3541078c125d36df76056e94738a52ebe9"
+  integrity sha512-bnpOoa+DownbciXj0jVGENf8VYQnE2LNWomhYuCsMmmx9Jd9lwq0WXODuwpSsp8AVdKM2/HorrzxAfbKvWTByQ==
   dependencies:
-    caniuse-lite "^1.0.30001312"
-    electron-to-chromium "^1.4.71"
+    caniuse-lite "^1.0.30001313"
+    electron-to-chromium "^1.4.76"
     escalade "^3.1.1"
     node-releases "^2.0.2"
     picocolors "^1.0.0"
@@ -1519,10 +1497,10 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001312:
-  version "1.0.30001312"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001312.tgz#e11eba4b87e24d22697dae05455d5aea28550d5f"
-  integrity sha512-Wiz1Psk2MEK0pX3rUzWaunLTZzqS2JYZFzNKqAiJGiuxIjRPLgV6+VDPOg6lQOUxmDwhTlh198JsTTi8Hzw6aQ==
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001313:
+  version "1.0.30001314"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001314.tgz#65c7f9fb7e4594fca0a333bec1d8939662377596"
+  integrity sha512-0zaSO+TnCHtHJIbpLroX7nsD+vYuOVjl3uzFbJO1wMVbuveJA0RK2WcQA9ZUIOiO0/ArMiMgHJLxfEZhQiC0kw==
 
 caseless@~0.12.0:
   version "0.12.0"
@@ -1997,9 +1975,9 @@ core-js@^2.4.0, core-js@^2.5.0:
   integrity sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==
 
 core-js@^3.17.2:
-  version "3.19.3"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.19.3.tgz#6df8142a996337503019ff3235a7022d7cdf4559"
-  integrity sha512-LeLBMgEGSsG7giquSzvgBrTS7V5UL6ks3eQlUSbN8dJStlLFiRzUm5iqsRyzUB8carhfKjkJ2vzKqE6z1Vga9g==
+  version "3.21.1"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.21.1.tgz#f2e0ddc1fc43da6f904706e8e955bc19d06a0d94"
+  integrity sha512-FRq5b/VMrWlrmCzwRrpDYNxyHP9BcAZC+xHJaqTgIE5091ZV1NTmyh0sGOg5XqpnHvR0svdy0sv1gWA1zmhxig==
 
 core-util-is@1.0.2:
   version "1.0.2"
@@ -2188,17 +2166,17 @@ cssnano-preset-default@^4.0.8:
     postcss-svgo "^4.0.3"
     postcss-unique-selectors "^4.0.1"
 
-cssnano-preset-default@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/cssnano-preset-default/-/cssnano-preset-default-5.2.0.tgz#2579d38b9217746f2cf9f938954a91e00418ded6"
-  integrity sha512-3N5Vcptj2pqVKpHVqH6ezOJvqikR2PdLTbTrsrhF61FbLRQuujAqZ2sKN5rvcMsb7hFjrNnjZT8CGEkxoN/Pwg==
+cssnano-preset-default@^5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/cssnano-preset-default/-/cssnano-preset-default-5.2.1.tgz#a83b15d3294c69bd1cedd14b0066c2f2357d108e"
+  integrity sha512-Y+CUCS5iZ1uzHn5KtmKIlysQVXrTtLCnYsYTOJcbdd5rghOwtw1gobvEXefBncjGO4fWwGZr9/n9hwZfo6W1Fw==
   dependencies:
     css-declaration-sorter "^6.0.3"
     cssnano-utils "^3.1.0"
     postcss-calc "^8.2.3"
     postcss-colormin "^5.3.0"
     postcss-convert-values "^5.1.0"
-    postcss-discard-comments "^5.1.0"
+    postcss-discard-comments "^5.1.1"
     postcss-discard-duplicates "^5.1.0"
     postcss-discard-empty "^5.1.0"
     postcss-discard-overridden "^5.1.0"
@@ -2221,7 +2199,7 @@ cssnano-preset-default@^5.2.0:
     postcss-reduce-initial "^5.1.0"
     postcss-reduce-transforms "^5.1.0"
     postcss-svgo "^5.1.0"
-    postcss-unique-selectors "^5.1.0"
+    postcss-unique-selectors "^5.1.1"
 
 cssnano-util-get-arguments@^4.0.0:
   version "4.0.0"
@@ -2261,11 +2239,11 @@ cssnano@^4.0.0:
     postcss "^7.0.0"
 
 cssnano@^5.0.8:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/cssnano/-/cssnano-5.1.0.tgz#cf977d660a5824d0d5542639ed1d4045afd84cbe"
-  integrity sha512-wWxave1wMlThGg4ueK98jFKaNqXnQd1nVZpSkQ9XvR+YymlzP1ofWqES1JkHtI250LksP9z5JH+oDcrKDJezAg==
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/cssnano/-/cssnano-5.1.1.tgz#2df44d26461b95f699096b6830df5107b1a758f4"
+  integrity sha512-WWfN7jBK/3Uk3oX/jsFbQApDf9DkXj6dOYull5ZaSGskcDggzg3RyDZI4GKKO+00LdfLMEZtY1cwTQUL+YMg2Q==
   dependencies:
-    cssnano-preset-default "^5.2.0"
+    cssnano-preset-default "^5.2.1"
     lilconfig "^2.0.3"
     yaml "^1.10.2"
 
@@ -2293,10 +2271,10 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
-date-format@^4.0.3:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/date-format/-/date-format-4.0.3.tgz#f63de5dc08dc02efd8ef32bf2a6918e486f35873"
-  integrity sha512-7P3FyqDcfeznLZp2b+OMitV9Sz2lUnsT87WaTat9nVwqsBkTzPG3lPLNwW3en6F4pHUiWzr6vb8CLhjdK9bcxQ==
+date-format@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/date-format/-/date-format-4.0.4.tgz#b58036e29e74121fca3e1b3e0dc4a62c65faa233"
+  integrity sha512-/jyf4rhB17ge328HJuJjAcmRtCsGd+NDeAtahRBTaK6vSPR6MO5HlrAit3Nn7dVjaa6sowW0WXt8yQtLyZQFRg==
 
 dateformat@^3.0.0:
   version "3.0.3"
@@ -2486,25 +2464,20 @@ detect-indent@^4.0.0:
   dependencies:
     repeating "^2.0.0"
 
-devtools-protocol@0.0.960912:
-  version "0.0.960912"
-  resolved "https://registry.yarnpkg.com/devtools-protocol/-/devtools-protocol-0.0.960912.tgz#411c1fa355eddb72f06c4a8743f2808766db6245"
-  integrity sha512-I3hWmV9rWHbdnUdmMKHF2NuYutIM2kXz2mdXW8ha7TbRlGTVs+PF+PsB5QWvpCek4Fy9B+msiispCfwlhG5Sqg==
+devtools-protocol@0.0.969999:
+  version "0.0.969999"
+  resolved "https://registry.yarnpkg.com/devtools-protocol/-/devtools-protocol-0.0.969999.tgz#3d6be0a126b3607bb399ae2719b471dda71f3478"
+  integrity sha512-6GfzuDWU0OFAuOvBokXpXPLxjOJ5DZ157Ue3sGQQM3LgAamb8m0R0ruSfN0DDu+XG5XJgT50i6zZ/0o8RglreQ==
 
 di@^0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/di/-/di-0.0.1.tgz#806649326ceaa7caa3306d75d985ea2748ba913c"
   integrity sha1-gGZJMmzqp8qjMG112YXqJ0i6kTw=
 
-diff@3.5.0, diff@^3.5.0:
+diff@3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
   integrity sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==
-
-diff@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
-  integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
 
 diff@^5.0.0:
   version "5.0.0"
@@ -2633,10 +2606,10 @@ ee-first@1.1.1:
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
 
-electron-to-chromium@^1.4.71:
-  version "1.4.75"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.75.tgz#d1ad9bb46f2f1bf432118c2be21d27ffeae82fdd"
-  integrity sha512-LxgUNeu3BVU7sXaKjUDD9xivocQLxFtq6wgERrutdY/yIOps3ODOZExK1jg8DTEg4U8TUCb5MLGeWFOYuxjF3Q==
+electron-to-chromium@^1.4.76:
+  version "1.4.80"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.80.tgz#299a1ea3e32810934b4e3c2e4d4cb53136fdab3f"
+  integrity sha512-COsbJCGVYCc/aAY4cd94x1Js3q0r406YKGbdL8LXHg0O9dEjuFEFU/vZneRxBxKo/f1lLHi0YyAR7sbFM+i8Bg==
 
 emoji-regex@^7.0.1:
   version "7.0.3"
@@ -2705,10 +2678,10 @@ engine.io@~3.5.0:
     engine.io-parser "~2.2.0"
     ws "~7.4.2"
 
-enhanced-resolve@^5.8.3:
-  version "5.9.1"
-  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.9.1.tgz#e898cea44d9199fd92137496cff5691b910fb43e"
-  integrity sha512-jdyZMwCQ5Oj4c5+BTnkxPgDZO/BJzh/ADDmKebayyzNwjVX1AFCeGkOfxNx0mHi2+8BKC5VxUYiw3TIvoT7vhw==
+enhanced-resolve@^5.9.2:
+  version "5.9.2"
+  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.9.2.tgz#0224dcd6a43389ebfb2d55efee517e5466772dd9"
+  integrity sha512-GIm3fQfwLJ8YZx2smuHpBKkXC1yOk+OBEmKckVyL0i/ea8mqDEykK3ld5dgH1QYPNyT/lIllxV2LULnxCHaHkA==
   dependencies:
     graceful-fs "^4.2.4"
     tapable "^2.2.0"
@@ -3242,7 +3215,7 @@ flat@^4.1.0:
   dependencies:
     is-buffer "~2.0.3"
 
-flatted@^3.1.0, flatted@^3.2.4:
+flatted@^3.1.0, flatted@^3.2.5:
   version "3.2.5"
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.5.tgz#76c8584f4fc843db64702a6bd04ab7a8bd666da3"
   integrity sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==
@@ -3296,7 +3269,7 @@ fs-constants@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs-constants/-/fs-constants-1.0.0.tgz#6be0de9be998ce16af8afc24497b9ee9b7ccd9ad"
   integrity sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==
 
-fs-extra@^10.0.0:
+fs-extra@^10.0.1:
   version "10.0.1"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-10.0.1.tgz#27de43b4320e833f6867cc044bfce29fdf0ef3b8"
   integrity sha512-NbdoVMZso2Lsrn/QwLXOy6rm0ufY2zEOKCDzJR/0kBsb0E6qed0P3iYK+Ath3BfvXEeu4JhEtXLgILx5psUfag==
@@ -4590,9 +4563,9 @@ karma-chai@^0.1.0:
   integrity sha1-vuWtQEAFF4Ea40u5RfdikJEIt5o=
 
 karma-chrome-launcher@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/karma-chrome-launcher/-/karma-chrome-launcher-3.1.0.tgz#805a586799a4d05f4e54f72a204979f3f3066738"
-  integrity sha512-3dPs/n7vgz1rxxtynpzZTvb9y/GIaW8xjAwcIGttLbycqoFtI7yo1NGnQi6oFTherRE+GIhCAHZC4vEqWGhNvg==
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/karma-chrome-launcher/-/karma-chrome-launcher-3.1.1.tgz#baca9cc071b1562a1db241827257bfe5cab597ea"
+  integrity sha512-hsIglcq1vtboGPAN+DGCISCFOxW+ZVnIqhDQcCMqqCp+4dmJ0Qpq5QAjkbA0X2L9Mi6OBkHi2Srrbmm7pUKkzQ==
   dependencies:
     which "^1.2.1"
 
@@ -4908,27 +4881,15 @@ log-update@^4.0.0:
     wrap-ansi "^6.2.0"
 
 log4js@^6.2.1:
-  version "6.4.1"
-  resolved "https://registry.yarnpkg.com/log4js/-/log4js-6.4.1.tgz#9d3a8bf2c31c1e213fe3fc398a6053f7a2bc53e8"
-  integrity sha512-iUiYnXqAmNKiIZ1XSAitQ4TmNs8CdZYTAWINARF3LjnsLN8tY5m0vRwd6uuWj/yNY0YHxeZodnbmxKFUOM2rMg==
+  version "6.4.2"
+  resolved "https://registry.yarnpkg.com/log4js/-/log4js-6.4.2.tgz#45ec783835acc525b397f52cf086e26994fe3b70"
+  integrity sha512-k80cggS2sZQLBwllpT1p06GtfvzMmSdUCkW96f0Hj83rKGJDAu2vZjt9B9ag2vx8Zz1IXzxoLgqvRJCdMKybGg==
   dependencies:
-    date-format "^4.0.3"
+    date-format "^4.0.4"
     debug "^4.3.3"
-    flatted "^3.2.4"
+    flatted "^3.2.5"
     rfdc "^1.3.0"
-    streamroller "^3.0.2"
-
-lolex@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/lolex/-/lolex-4.2.0.tgz#ddbd7f6213ca1ea5826901ab1222b65d714b3cd7"
-  integrity sha512-gKO5uExCXvSm6zbF562EvM+rd1kQDnB9AZBbiQVzf1ZmdDpxUSvpnAaVOP83N/31mRK8Ml8/VE8DMvsAZQ+7wg==
-
-lolex@^5.0.1:
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/lolex/-/lolex-5.1.2.tgz#953694d098ce7c07bc5ed6d0e42bc6c0c6d5a367"
-  integrity sha512-h4hmjAvHTmd+25JSwrtTIuwbKdwg5NzZVRMLn9saij4SZaepCrTCxPr35H/3bjwfMJtN+t3CX8672UIkglz28A==
-  dependencies:
-    "@sinonjs/commons" "^1.7.0"
+    streamroller "^3.0.4"
 
 loose-envify@^1.0.0:
   version "1.4.0"
@@ -4965,11 +4926,11 @@ macos-release@^2.2.0:
   integrity sha512-EIgv+QZ9r+814gjJj0Bt5vSLJLzswGmSUbUpbi9AIr/fsN2IWFBl2NucV9PAiek+U1STK468tEkxmVYUtuAN3g==
 
 magic-string@^0.25.7:
-  version "0.25.7"
-  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.7.tgz#3f497d6fd34c669c6798dcb821f2ef31f5445051"
-  integrity sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==
+  version "0.25.9"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.9.tgz#de7f9faf91ef8a1c91d02c2e5314c8277dbcdd1c"
+  integrity sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==
   dependencies:
-    sourcemap-codec "^1.4.4"
+    sourcemap-codec "^1.4.8"
 
 make-dir@^3.0.0, make-dir@^3.0.2, make-dir@^3.1.0:
   version "3.1.0"
@@ -5344,24 +5305,13 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
-nise@^1.5.2:
-  version "1.5.3"
-  resolved "https://registry.yarnpkg.com/nise/-/nise-1.5.3.tgz#9d2cfe37d44f57317766c6e9408a359c5d3ac1f7"
-  integrity sha512-Ymbac/94xeIrMf59REBPOv0thr+CJVFMhrlAkW/gjCIE58BGQdCj0x7KRCb3yz+Ga2Rz3E9XXSvUyyxqqhjQAQ==
+nise@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/nise/-/nise-5.1.1.tgz#ac4237e0d785ecfcb83e20f389185975da5c31f3"
+  integrity sha512-yr5kW2THW1AkxVmCnKEh4nbYkJdB3I7LUkiUgOvEkOp414mc2UMaHMA7pjq1nYowhdoJZGwEKGaQVbxfpWj10A==
   dependencies:
-    "@sinonjs/formatio" "^3.2.1"
-    "@sinonjs/text-encoding" "^0.7.1"
-    just-extend "^4.0.2"
-    lolex "^5.0.1"
-    path-to-regexp "^1.7.0"
-
-nise@^4.0.4:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/nise/-/nise-4.1.0.tgz#8fb75a26e90b99202fa1e63f448f58efbcdedaf6"
-  integrity sha512-eQMEmGN/8arp0xsvGoQ+B1qvSkR73B1nWSCh7nOt5neMCtwcQVYQGdzQMhcNscktTsWB54xnlSQFzOAPJD8nXA==
-  dependencies:
-    "@sinonjs/commons" "^1.7.0"
-    "@sinonjs/fake-timers" "^6.0.0"
+    "@sinonjs/commons" "^1.8.3"
+    "@sinonjs/fake-timers" ">=5"
     "@sinonjs/text-encoding" "^0.7.1"
     just-extend "^4.0.2"
     path-to-regexp "^1.7.0"
@@ -5964,10 +5914,10 @@ postcss-discard-comments@^4.0.2:
   dependencies:
     postcss "^7.0.0"
 
-postcss-discard-comments@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/postcss-discard-comments/-/postcss-discard-comments-5.1.0.tgz#87be4e0953bf599935837b940c701f8d4eca7d0b"
-  integrity sha512-L0IKF4jAshRyn03SkEO6ar/Ipz2oLywVbg2THf2EqqdNkBwmVMxuTR/RoAltOw4piiaLt3gCAdrbAqmTBInmhg==
+postcss-discard-comments@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/postcss-discard-comments/-/postcss-discard-comments-5.1.1.tgz#e90019e1a0e5b99de05f63516ce640bd0df3d369"
+  integrity sha512-5JscyFmvkUxz/5/+TB3QTTT9Gi9jHkcn8dcmmuN68JQcv3aQg4y88yEHHhwFB52l/NkaJ43O0dbksGMAo49nfQ==
 
 postcss-discard-duplicates@^4.0.2:
   version "4.0.2"
@@ -6456,10 +6406,10 @@ postcss-unique-selectors@^4.0.1:
     postcss "^7.0.0"
     uniqs "^2.0.0"
 
-postcss-unique-selectors@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/postcss-unique-selectors/-/postcss-unique-selectors-5.1.0.tgz#70a945da1b0599d00f617222a44ba1d82a676694"
-  integrity sha512-LmUhgGobtpeVJJHuogzjLRwJlN7VH+BL5c9GKMVJSS/ejoyePZkXvNsYUtk//F6vKOGK86gfRS0xH7fXQSDtvA==
+postcss-unique-selectors@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/postcss-unique-selectors/-/postcss-unique-selectors-5.1.1.tgz#a9f273d1eacd09e9aa6088f4b0507b18b1b541b6"
+  integrity sha512-5JiODlELrz8L2HwxfPnhOWZYWDxVHWL83ufOv84NrcgipI7TaeRsatAhK4Tr2/ZiYldpK/wBvw5BD3qfaK96GA==
   dependencies:
     postcss-selector-parser "^6.0.5"
 
@@ -6482,9 +6432,9 @@ postcss@^7.0.0, postcss@^7.0.1, postcss@^7.0.14, postcss@^7.0.18, postcss@^7.0.2
     source-map "^0.6.1"
 
 postcss@^8.1.10, postcss@^8.2.15:
-  version "8.4.7"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.7.tgz#f99862069ec4541de386bf57f5660a6c7a0875a8"
-  integrity sha512-L9Ye3r6hkkCeOETQX6iOaWZgjp3LL6Lpqm6EtgbKrgqGGteRMNb9vzBfRL96YOSu8o7x3MfIH9Mo5cPJFGrW6A==
+  version "8.4.8"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.8.tgz#dad963a76e82c081a0657d3a2f3602ce10c2e032"
+  integrity sha512-2tXEqGxrjvAO6U+CJzDL2Fk2kPHTv1jQsYkSoMeOis2SsYaXRO2COxTdQp99cYvif9JTXaAk9lYGc3VhJt7JPQ==
   dependencies:
     nanoid "^3.3.1"
     picocolors "^1.0.0"
@@ -6575,13 +6525,13 @@ punycode@^2.1.0, punycode@^2.1.1:
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
 puppeteer@^13.1.3:
-  version "13.4.1"
-  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-13.4.1.tgz#495b91d2fae3e9761a31bab1820ad179caac0fd9"
-  integrity sha512-2arcYPEGvLV9HvOw01Zv1b1IAXrMWHqsFJn0Hn00qe9HtCmaF0b8FlrbdLjCIbkaFc6icH5+GqcG8R5KxlJSRg==
+  version "13.5.1"
+  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-13.5.1.tgz#d0f751bf36120efc2ebf74c7562a204a84e500e9"
+  integrity sha512-wWxO//vMiqxlvuzHMAJ0pRJeDHvDtM7DQpW1GKdStz2nZo2G42kOXBDgkmQ+zqjwMCFofKGesBeeKxIkX9BO+w==
   dependencies:
     cross-fetch "3.1.5"
     debug "4.3.3"
-    devtools-protocol "0.0.960912"
+    devtools-protocol "0.0.969999"
     extract-zip "2.0.1"
     https-proxy-agent "5.0.0"
     pkg-dir "4.2.0"
@@ -6940,9 +6890,9 @@ rxjs@^6.6.0:
     tslib "^1.9.0"
 
 rxjs@^7.5.1:
-  version "7.5.4"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.5.4.tgz#3d6bd407e6b7ce9a123e76b1e770dc5761aa368d"
-  integrity sha512-h5M3Hk78r6wAheJF0a5YahB1yRQKCsZ4MsGdZ5O9ETbVtjPcScGfrMmoOq7EBsCRzd4BDkvDJ7ogP8Sz5tTFiQ==
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.5.5.tgz#2ebad89af0f560f460ad5cc4213219e1f7dd4e9f"
+  integrity sha512-sy+H0pQofO95VDmFLzyaw9xNJU4KTRSwQIGM6+iG3SypAtCiLDzpeG8sJrNCWn2Up9km+KhkvTdbkrdy+yzZdw==
   dependencies:
     tslib "^2.1.0"
 
@@ -7148,30 +7098,17 @@ sinon-chai@^3.5.0:
   resolved "https://registry.yarnpkg.com/sinon-chai/-/sinon-chai-3.7.0.tgz#cfb7dec1c50990ed18c153f1840721cf13139783"
   integrity sha512-mf5NURdUaSdnatJx3uhoBOrY9dtL19fiOtAdT1Azxg3+lNJFiuN0uzaU3xX1LeAfL17kHQhTAJgpsfhbMJMY2g==
 
-sinon@^7.3.2:
-  version "7.5.0"
-  resolved "https://registry.yarnpkg.com/sinon/-/sinon-7.5.0.tgz#e9488ea466070ea908fd44a3d6478fd4923c67ec"
-  integrity sha512-AoD0oJWerp0/rY9czP/D6hDTTUYGpObhZjMpd7Cl/A6+j0xBE+ayL/ldfggkBXUs0IkvIiM1ljM8+WkOc5k78Q==
+sinon@^13.0.1:
+  version "13.0.1"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-13.0.1.tgz#2a568beca2084c48985dd98e276e065c81738e3c"
+  integrity sha512-8yx2wIvkBjIq/MGY1D9h1LMraYW+z1X0mb648KZnKSdvLasvDu7maa0dFaNYdTDczFgbjNw2tOmWdTk9saVfwQ==
   dependencies:
-    "@sinonjs/commons" "^1.4.0"
-    "@sinonjs/formatio" "^3.2.1"
-    "@sinonjs/samsam" "^3.3.3"
-    diff "^3.5.0"
-    lolex "^4.2.0"
-    nise "^1.5.2"
-    supports-color "^5.5.0"
-
-sinon@^9.0.2:
-  version "9.2.4"
-  resolved "https://registry.yarnpkg.com/sinon/-/sinon-9.2.4.tgz#e55af4d3b174a4443a8762fa8421c2976683752b"
-  integrity sha512-zljcULZQsJxVra28qIAL6ow1Z9tpattkCTEJR4RBP3TGc00FcttsP5pK284Nas5WjMZU5Yzy3kAIp3B3KRf5Yg==
-  dependencies:
-    "@sinonjs/commons" "^1.8.1"
-    "@sinonjs/fake-timers" "^6.0.1"
-    "@sinonjs/samsam" "^5.3.1"
-    diff "^4.0.2"
-    nise "^4.0.4"
-    supports-color "^7.1.0"
+    "@sinonjs/commons" "^1.8.3"
+    "@sinonjs/fake-timers" "^9.0.0"
+    "@sinonjs/samsam" "^6.1.1"
+    diff "^5.0.0"
+    nise "^5.1.1"
+    supports-color "^7.2.0"
 
 slack-notify@^0.1.7:
   version "0.1.7"
@@ -7347,7 +7284,7 @@ source-map@~0.7.2:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
   integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
 
-sourcemap-codec@^1.4.4:
+sourcemap-codec@^1.4.8:
   version "1.4.8"
   resolved "https://registry.yarnpkg.com/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz#ea804bd94857402e6992d05a38ef1ae35a9ab4c4"
   integrity sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==
@@ -7456,14 +7393,14 @@ static-extend@^0.1.1:
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
   integrity sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=
 
-streamroller@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/streamroller/-/streamroller-3.0.2.tgz#30418d0eee3d6c93ec897f892ed098e3a81e68b7"
-  integrity sha512-ur6y5S5dopOaRXBuRIZ1u6GC5bcEXHRZKgfBjfCglMhmIf+roVCECjvkEYzNQOXIN2/JPnkMPW/8B3CZoKaEPA==
+streamroller@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/streamroller/-/streamroller-3.0.4.tgz#27ad87339d829483f89c5f33fd60ea6731e4183c"
+  integrity sha512-GI9NzeD+D88UFuIlJkKNDH/IsuR+qIN7Qh8EsmhoRZr9bQoehTraRgwtLUkZbpcAw+hLPfHOypmppz8YyGK68w==
   dependencies:
-    date-format "^4.0.3"
-    debug "^4.1.1"
-    fs-extra "^10.0.0"
+    date-format "^4.0.4"
+    debug "^4.3.3"
+    fs-extra "^10.0.1"
 
 string-argv@0.3.1:
   version "0.3.1"
@@ -7644,14 +7581,14 @@ supports-color@^2.0.0:
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
   integrity sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=
 
-supports-color@^5.3.0, supports-color@^5.5.0:
+supports-color@^5.3.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
   integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
   dependencies:
     has-flag "^3.0.0"
 
-supports-color@^7.0.0, supports-color@^7.1.0:
+supports-color@^7.0.0, supports-color@^7.1.0, supports-color@^7.2.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz#1b7dcdcb32b8138801b3e478ba6a51caa89648da"
   integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
@@ -8022,9 +7959,9 @@ uc.micro@^1.0.1, uc.micro@^1.0.5:
   integrity sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==
 
 uglify-js@^3.1.4:
-  version "3.15.2"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.15.2.tgz#1ed2c976f448063b1f87adb68c741be79959f951"
-  integrity sha512-peeoTk3hSwYdoc9nrdiEJk+gx1ALCtTjdYuKSXMTDqq7n1W7dHPqWDdSi+BPL0ni2YMeHD7hKUSdbj3TZauY2A==
+  version "3.15.3"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.15.3.tgz#9aa82ca22419ba4c0137642ba0df800cb06e0471"
+  integrity sha512-6iCVm2omGJbsu3JWac+p6kUiOpg3wFO2f8lIXjfEb8RrmLjzog1wTPMmwKB7swfzzqxj9YM+sGUM++u1qN4qJg==
 
 unbox-primitive@^1.0.1:
   version "1.0.1"
@@ -8258,9 +8195,9 @@ webpack-sources@^3.2.3:
   integrity sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==
 
 webpack@^5.58.1:
-  version "5.69.1"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.69.1.tgz#8cfd92c192c6a52c99ab00529b5a0d33aa848dc5"
-  integrity sha512-+VyvOSJXZMT2V5vLzOnDuMz5GxEqLk7hKWQ56YxPW/PQRUuKimPqmEIJOx8jHYeyo65pKbapbW464mvsKbaj4A==
+  version "5.70.0"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.70.0.tgz#3461e6287a72b5e6e2f4872700bc8de0d7500e6d"
+  integrity sha512-ZMWWy8CeuTTjCxbeaQI21xSswseF2oNOwc70QSKNePvmxE7XW36i7vpBMYZFAUHPwQiEbNGCEYIOOlyRbdGmxw==
   dependencies:
     "@types/eslint-scope" "^3.7.3"
     "@types/estree" "^0.0.51"
@@ -8271,7 +8208,7 @@ webpack@^5.58.1:
     acorn-import-assertions "^1.7.6"
     browserslist "^4.14.5"
     chrome-trace-event "^1.0.2"
-    enhanced-resolve "^5.8.3"
+    enhanced-resolve "^5.9.2"
     es-module-lexer "^0.9.0"
     eslint-scope "5.1.1"
     events "^3.2.0"


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature (env): Redesigned the upload translations process. If a response from Transifex suggests that something went wrong, the script stores resources that couldn't be processed. When rerunning the script, packages listed in the file will be processed only.

Feature (tools): The `createSpinner()` function accepts a new option: `emoji`. It allows replacing the default one. Also, the `#finish()` method accepts the same option.

---

Transifex cannot process any of the packages, they will be stored in a file.

![image](https://user-images.githubusercontent.com/2270764/157891821-a4d41563-9cb3-45a3-93d6-bf755e73695e.png)

Rerun the script.

![image](https://user-images.githubusercontent.com/2270764/157892199-d7e82895-eb25-4c8d-a6b9-d5bd5246e548.png)

Finished with no errors.

![image](https://user-images.githubusercontent.com/2270764/157892291-2d416972-18cf-4fe0-9260-1f8914b550e4.png)


