### PR TITLE
Allowed the "license-header" ESLint rule. Fixed broken license headers across the project

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,6 +11,14 @@ module.exports = {
 		node: true
 	},
 	rules: {
-		'no-console': 'off'
+		'no-console': 'off',
+		'ckeditor5-rules/license-header': [ 'error', {
+			headerLines: [
+				'/**',
+				' * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.',
+				' * For licensing, see LICENSE.md.',
+				' */'
+			]
+		} ]
 	}
 };

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "eslint": "^7.0.0",
-    "eslint-config-ckeditor5": "^3.1.0",
+    "eslint-config-ckeditor5": "^4.0.0",
     "husky": "^4.2.5",
     "lint-staged": "^10.2.4",
     "mocha": "^7.1.2",
@@ -32,7 +32,7 @@
     "changelog": "node ./scripts/changelog.js",
     "release:bump-version": "node ./scripts/bump-versions.js",
     "release:publish": "node ./scripts/publish.js",
-    "lint": "eslint --quiet '**/*.js'",
+    "lint": "eslint --quiet \"**/*.js\"",
     "precommit": "lint-staged"
   },
   "lint-staged": {

--- a/packages/ckeditor5-dev-docs/lib/web-crawler/constants.js
+++ b/packages/ckeditor5-dev-docs/lib/web-crawler/constants.js
@@ -2,7 +2,7 @@
 
 /**
  * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
- * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ * For licensing, see LICENSE.md.
  */
 
 /* eslint-env node */

--- a/packages/ckeditor5-dev-docs/lib/web-crawler/index.js
+++ b/packages/ckeditor5-dev-docs/lib/web-crawler/index.js
@@ -2,7 +2,7 @@
 
 /**
  * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
- * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ * For licensing, see LICENSE.md.
  */
 
 /* eslint-env node */

--- a/packages/ckeditor5-dev-docs/lib/web-crawler/spinner.js
+++ b/packages/ckeditor5-dev-docs/lib/web-crawler/spinner.js
@@ -2,7 +2,7 @@
 
 /**
  * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
- * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ * For licensing, see LICENSE.md.
  */
 
 /* eslint-env node */

--- a/packages/ckeditor5-dev-docs/lib/web-crawler/utils.js
+++ b/packages/ckeditor5-dev-docs/lib/web-crawler/utils.js
@@ -2,7 +2,7 @@
 
 /**
  * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
- * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ * For licensing, see LICENSE.md.
  */
 
 /* eslint-env node */

--- a/packages/ckeditor5-dev-tests/lib/utils/automated-tests/assertions/attribute.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/automated-tests/assertions/attribute.js
@@ -1,6 +1,6 @@
 /**
  * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
- * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ * For licensing, see LICENSE.md.
  */
 
 /**

--- a/packages/ckeditor5-dev-tests/lib/utils/automated-tests/assertions/equal-markup.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/automated-tests/assertions/equal-markup.js
@@ -1,6 +1,6 @@
 /**
  * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
- * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ * For licensing, see LICENSE.md.
  */
 
 const AssertionError = require( 'assertion-error' );

--- a/packages/ckeditor5-dev-tests/tests/utils/automated-tests/assertions/attribute.js
+++ b/packages/ckeditor5-dev-tests/tests/utils/automated-tests/assertions/attribute.js
@@ -1,6 +1,6 @@
 /**
  * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
- * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ * For licensing, see LICENSE.md.
  */
 
 const chai = require( 'chai' );

--- a/packages/ckeditor5-dev-tests/tests/utils/automated-tests/assertions/equal-markup.js
+++ b/packages/ckeditor5-dev-tests/tests/utils/automated-tests/assertions/equal-markup.js
@@ -1,6 +1,6 @@
 /**
  * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
- * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ * For licensing, see LICENSE.md.
  */
 
 const chai = require( 'chai' );

--- a/packages/ckeditor5-dev-utils/lib/translations/retryasyncfunction.js
+++ b/packages/ckeditor5-dev-utils/lib/translations/retryasyncfunction.js
@@ -1,7 +1,7 @@
 /**
-* @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
-* For licensing, see LICENSE.md.
-*/
+ * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
 
 'use strict';
 

--- a/packages/ckeditor5-dev-utils/tests/translations/multiplelanguagetranslationservice.js
+++ b/packages/ckeditor5-dev-utils/tests/translations/multiplelanguagetranslationservice.js
@@ -1,9 +1,9 @@
-/* eslint-disable no-eval */
-
 /**
  * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md.
  */
+
+/* eslint-disable no-eval */
 
 'use strict';
 

--- a/packages/jsdoc-plugins/lib/custom-tags/error.js
+++ b/packages/jsdoc-plugins/lib/custom-tags/error.js
@@ -1,6 +1,6 @@
 /**
  * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
- * Licensed under the terms of the MIT License (see LICENSE.md).
+ * For licensing, see LICENSE.md.
  */
 
 'use strict';

--- a/packages/jsdoc-plugins/lib/custom-tags/observable.js
+++ b/packages/jsdoc-plugins/lib/custom-tags/observable.js
@@ -1,6 +1,6 @@
 /**
  * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
- * Licensed under the terms of the MIT License (see LICENSE.md).
+ * For licensing, see LICENSE.md.
  */
 
 'use strict';

--- a/packages/jsdoc-plugins/lib/event-extender/event-extender.js
+++ b/packages/jsdoc-plugins/lib/event-extender/event-extender.js
@@ -1,6 +1,6 @@
 /**
  * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
- * Licensed under the terms of the MIT License (see LICENSE.md).
+ * For licensing, see LICENSE.md.
  */
 
 'use strict';

--- a/packages/jsdoc-plugins/lib/export-fixer/export-fixer.js
+++ b/packages/jsdoc-plugins/lib/export-fixer/export-fixer.js
@@ -1,6 +1,6 @@
 /**
  * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
- * Licensed under the terms of the MIT License (see LICENSE.md).
+ * For licensing, see LICENSE.md.
  */
 
 'use strict';

--- a/packages/jsdoc-plugins/lib/fix-code-snippets.js
+++ b/packages/jsdoc-plugins/lib/fix-code-snippets.js
@@ -1,6 +1,6 @@
 /**
  * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
- * Licensed under the terms of the MIT License (see LICENSE.md).
+ * For licensing, see LICENSE.md.
  */
 
 /**

--- a/packages/jsdoc-plugins/lib/longname-fixer/fixers/convert-short-refs-to-full-refs.js
+++ b/packages/jsdoc-plugins/lib/longname-fixer/fixers/convert-short-refs-to-full-refs.js
@@ -1,6 +1,6 @@
 /**
  * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
- * Licensed under the terms of the MIT License (see LICENSE.md).
+ * For licensing, see LICENSE.md.
  */
 
 'use strict';

--- a/packages/jsdoc-plugins/lib/longname-fixer/fixers/fix-incorrect-class-constructor.js
+++ b/packages/jsdoc-plugins/lib/longname-fixer/fixers/fix-incorrect-class-constructor.js
@@ -1,6 +1,6 @@
 /**
  * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
- * Licensed under the terms of the MIT License (see LICENSE.md).
+ * For licensing, see LICENSE.md.
  */
 
 'use strict';

--- a/packages/jsdoc-plugins/lib/longname-fixer/longname-fixer.js
+++ b/packages/jsdoc-plugins/lib/longname-fixer/longname-fixer.js
@@ -1,6 +1,6 @@
 /**
  * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
- * Licensed under the terms of the MIT License (see LICENSE.md).
+ * For licensing, see LICENSE.md.
  */
 
 /**

--- a/packages/jsdoc-plugins/lib/observable-event-provider/addmissingeventdocletsforobservables.js
+++ b/packages/jsdoc-plugins/lib/observable-event-provider/addmissingeventdocletsforobservables.js
@@ -1,6 +1,6 @@
 /**
  * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
- * Licensed under the terms of the MIT License (see LICENSE.md).
+ * For licensing, see LICENSE.md.
  */
 
 'use strict';

--- a/packages/jsdoc-plugins/lib/observable-event-provider/index.js
+++ b/packages/jsdoc-plugins/lib/observable-event-provider/index.js
@@ -1,6 +1,6 @@
 /**
  * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
- * Licensed under the terms of the MIT License (see LICENSE.md).
+ * For licensing, see LICENSE.md.
  */
 
 'use strict';

--- a/packages/jsdoc-plugins/lib/relation-fixer/addmissingdoclets.js
+++ b/packages/jsdoc-plugins/lib/relation-fixer/addmissingdoclets.js
@@ -1,6 +1,6 @@
 /**
  * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
- * Licensed under the terms of the MIT License (see LICENSE.md).
+ * For licensing, see LICENSE.md.
  */
 
 'use strict';

--- a/packages/jsdoc-plugins/lib/relation-fixer/addtypedefproperties.js
+++ b/packages/jsdoc-plugins/lib/relation-fixer/addtypedefproperties.js
@@ -1,6 +1,6 @@
 /**
  * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
- * Licensed under the terms of the MIT License (see LICENSE.md).
+ * For licensing, see LICENSE.md.
  */
 
 'use strict';

--- a/packages/jsdoc-plugins/lib/relation-fixer/buildrelations.js
+++ b/packages/jsdoc-plugins/lib/relation-fixer/buildrelations.js
@@ -1,6 +1,6 @@
 /**
  * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
- * Licensed under the terms of the MIT License (see LICENSE.md).
+ * For licensing, see LICENSE.md.
  */
 
 'use strict';

--- a/packages/jsdoc-plugins/lib/relation-fixer/filteroutintenraldoclets.js
+++ b/packages/jsdoc-plugins/lib/relation-fixer/filteroutintenraldoclets.js
@@ -1,6 +1,6 @@
 /**
  * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
- * Licensed under the terms of the MIT License (see LICENSE.md).
+ * For licensing, see LICENSE.md.
  */
 
 'use strict';

--- a/packages/jsdoc-plugins/lib/relation-fixer/getmissingdocletsdata.js
+++ b/packages/jsdoc-plugins/lib/relation-fixer/getmissingdocletsdata.js
@@ -1,6 +1,6 @@
 /**
  * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
- * Licensed under the terms of the MIT License (see LICENSE.md).
+ * For licensing, see LICENSE.md.
  */
 
 'use strict';

--- a/packages/jsdoc-plugins/lib/relation-fixer/index.js
+++ b/packages/jsdoc-plugins/lib/relation-fixer/index.js
@@ -1,6 +1,6 @@
 /**
  * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
- * Licensed under the terms of the MIT License (see LICENSE.md).
+ * For licensing, see LICENSE.md.
  */
 
 'use strict';

--- a/packages/jsdoc-plugins/lib/utils/doclet-collection.js
+++ b/packages/jsdoc-plugins/lib/utils/doclet-collection.js
@@ -1,6 +1,6 @@
 /**
  * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
- * Licensed under the terms of the MIT License (see LICENSE.md).
+ * For licensing, see LICENSE.md.
  */
 
 'use strict';

--- a/packages/jsdoc-plugins/lib/utils/doclet-logger.js
+++ b/packages/jsdoc-plugins/lib/utils/doclet-logger.js
@@ -1,6 +1,6 @@
 /**
  * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
- * Licensed under the terms of the MIT License (see LICENSE.md).
+ * For licensing, see LICENSE.md.
  */
 
 'use strict';

--- a/packages/jsdoc-plugins/lib/validator/doclet-validator.js
+++ b/packages/jsdoc-plugins/lib/validator/doclet-validator.js
@@ -1,6 +1,6 @@
 /**
  * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
- * Licensed under the terms of the MIT License (see LICENSE.md).
+ * For licensing, see LICENSE.md.
  */
 
 'use strict';

--- a/packages/jsdoc-plugins/lib/validator/types.js
+++ b/packages/jsdoc-plugins/lib/validator/types.js
@@ -1,6 +1,6 @@
 /**
  * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
- * Licensed under the terms of the MIT License (see LICENSE.md).
+ * For licensing, see LICENSE.md.
  */
 
 'use strict';

--- a/packages/jsdoc-plugins/lib/validator/validator.js
+++ b/packages/jsdoc-plugins/lib/validator/validator.js
@@ -1,6 +1,6 @@
 /**
  * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
- * Licensed under the terms of the MIT License (see LICENSE.md).
+ * For licensing, see LICENSE.md.
  */
 
 'use strict';

--- a/packages/jsdoc-plugins/tests/comment-fixer.js
+++ b/packages/jsdoc-plugins/tests/comment-fixer.js
@@ -1,6 +1,6 @@
 /**
  * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
- * Licensed under the terms of the MIT License (see LICENSE.md).
+ * For licensing, see LICENSE.md.
  */
 
 'use strict';

--- a/packages/jsdoc-plugins/tests/convert-short-refs-to-full-refs.js
+++ b/packages/jsdoc-plugins/tests/convert-short-refs-to-full-refs.js
@@ -1,6 +1,6 @@
 /**
  * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
- * Licensed under the terms of the MIT License (see LICENSE.md).
+ * For licensing, see LICENSE.md.
  */
 
 'use strict';

--- a/packages/jsdoc-plugins/tests/doclet-collection.js
+++ b/packages/jsdoc-plugins/tests/doclet-collection.js
@@ -1,6 +1,6 @@
 /**
  * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
- * Licensed under the terms of the MIT License (see LICENSE.md).
+ * For licensing, see LICENSE.md.
  */
 
 'use strict';

--- a/packages/jsdoc-plugins/tests/doclet-validator.js
+++ b/packages/jsdoc-plugins/tests/doclet-validator.js
@@ -1,6 +1,6 @@
 /**
  * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
- * Licensed under the terms of the MIT License (see LICENSE.md).
+ * For licensing, see LICENSE.md.
  */
 
 'use strict';

--- a/packages/jsdoc-plugins/tests/fix-code-snippets.js
+++ b/packages/jsdoc-plugins/tests/fix-code-snippets.js
@@ -1,6 +1,6 @@
 /**
  * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
- * Licensed under the terms of the MIT License (see LICENSE.md).
+ * For licensing, see LICENSE.md.
  */
 
 'use strict';

--- a/packages/jsdoc-plugins/tests/integration-tests/_utils/logger.js
+++ b/packages/jsdoc-plugins/tests/integration-tests/_utils/logger.js
@@ -1,6 +1,6 @@
 /**
  * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
- * Licensed under the terms of the MIT License (see LICENSE.md).
+ * For licensing, see LICENSE.md.
  */
 
 'use strict';

--- a/packages/jsdoc-plugins/tests/observable-event-provider/addmissingeventdocletsforobservables.js
+++ b/packages/jsdoc-plugins/tests/observable-event-provider/addmissingeventdocletsforobservables.js
@@ -1,6 +1,6 @@
 /**
  * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
- * Licensed under the terms of the MIT License (see LICENSE.md).
+ * For licensing, see LICENSE.md.
  */
 
 'use strict';

--- a/packages/jsdoc-plugins/tests/relation-fixer/addmissingdoclets.js
+++ b/packages/jsdoc-plugins/tests/relation-fixer/addmissingdoclets.js
@@ -1,6 +1,6 @@
 /**
  * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
- * Licensed under the terms of the MIT License (see LICENSE.md).
+ * For licensing, see LICENSE.md.
  */
 
 'use strict';

--- a/packages/jsdoc-plugins/tests/relation-fixer/buildrelations.js
+++ b/packages/jsdoc-plugins/tests/relation-fixer/buildrelations.js
@@ -1,6 +1,6 @@
 /**
  * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
- * Licensed under the terms of the MIT License (see LICENSE.md).
+ * For licensing, see LICENSE.md.
  */
 
 'use strict';

--- a/packages/jsdoc-plugins/tests/relation-fixer/relationfixerintegration.js
+++ b/packages/jsdoc-plugins/tests/relation-fixer/relationfixerintegration.js
@@ -1,6 +1,6 @@
 /**
  * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
- * Licensed under the terms of the MIT License (see LICENSE.md).
+ * For licensing, see LICENSE.md.
  */
 
 'use strict';

--- a/packages/jsdoc-plugins/tests/relation-fixer/test-data/inheritance-implicit.js
+++ b/packages/jsdoc-plugins/tests/relation-fixer/test-data/inheritance-implicit.js
@@ -1,6 +1,6 @@
 /**
  * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
- * Licensed under the terms of the MIT License (see LICENSE.md).
+ * For licensing, see LICENSE.md.
  */
 
 'use strict';

--- a/packages/jsdoc-plugins/tests/relation-fixer/test-data/inheritance-inheritdoc.js
+++ b/packages/jsdoc-plugins/tests/relation-fixer/test-data/inheritance-inheritdoc.js
@@ -1,6 +1,6 @@
 /**
  * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
- * Licensed under the terms of the MIT License (see LICENSE.md).
+ * For licensing, see LICENSE.md.
  */
 
 'use strict';

--- a/packages/jsdoc-plugins/tests/relation-fixer/test-data/interface.js
+++ b/packages/jsdoc-plugins/tests/relation-fixer/test-data/interface.js
@@ -1,6 +1,6 @@
 /**
  * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
- * Licensed under the terms of the MIT License (see LICENSE.md).
+ * For licensing, see LICENSE.md.
  */
 
 'use strict';

--- a/packages/jsdoc-plugins/tests/relation-fixer/test-data/mixins.js
+++ b/packages/jsdoc-plugins/tests/relation-fixer/test-data/mixins.js
@@ -1,6 +1,6 @@
 /**
  * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
- * Licensed under the terms of the MIT License (see LICENSE.md).
+ * For licensing, see LICENSE.md.
  */
 
 'use strict';

--- a/packages/jsdoc-plugins/tests/relation-fixer/test-data/unwanted-doclets.js
+++ b/packages/jsdoc-plugins/tests/relation-fixer/test-data/unwanted-doclets.js
@@ -1,6 +1,6 @@
 /**
  * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
- * Licensed under the terms of the MIT License (see LICENSE.md).
+ * For licensing, see LICENSE.md.
  */
 
 'use strict';

--- a/scripts/bump-versions.js
+++ b/scripts/bump-versions.js
@@ -2,7 +2,7 @@
 
 /**
  * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
- * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ * For licensing, see LICENSE.md.
  */
 
 /* eslint-env node */

--- a/scripts/publish.js
+++ b/scripts/publish.js
@@ -2,7 +2,7 @@
 
 /**
  * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
- * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ * For licensing, see LICENSE.md.
  */
 
 /* eslint-env node */

--- a/yarn.lock
+++ b/yarn.lock
@@ -2812,18 +2812,18 @@ escodegen@^1.9.0:
   optionalDependencies:
     source-map "~0.6.1"
 
-eslint-config-ckeditor5@^3.1.0:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/eslint-config-ckeditor5/-/eslint-config-ckeditor5-3.1.1.tgz#aeb289e858c7103aac09c9bd9347a60db62eedbc"
-  integrity sha512-fiV+pokuTd8wi9primorw06/XpXfhj7+LopRvuEdzqDumXpP0FUznllrnodogXE4+Mg9qX7tAs6YJeyArqyqQQ==
+eslint-config-ckeditor5@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-ckeditor5/-/eslint-config-ckeditor5-4.0.0.tgz#6a4fc760525a0405532c4d6b095d8a17af3cba58"
+  integrity sha512-PDjWbo/PQ/gEvTGmNnEbLl63H+h0weQQkWV23jVCjvrr2Y5FyrVvQhizF5OqCDb5alSk1+RREUURZGhzMzy8LA==
   dependencies:
-    eslint-plugin-ckeditor5-rules "^1.0.0"
+    eslint-plugin-ckeditor5-rules "^4.0.0"
     eslint-plugin-mocha "^7.0.0"
 
-eslint-plugin-ckeditor5-rules@^1.0.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-ckeditor5-rules/-/eslint-plugin-ckeditor5-rules-1.3.0.tgz#faf1fde859cf79e989f248e8a08e6955c317fdcd"
-  integrity sha512-7TjodWU2BRxbsCrhagRCn+V2Qh1UGmBnldG/jWL6HJgTPrsDYhqiS86aJUYsLR2FLEW6X39czXfI556qeMkCKQ==
+eslint-plugin-ckeditor5-rules@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-ckeditor5-rules/-/eslint-plugin-ckeditor5-rules-4.0.0.tgz#79d1fd8235212fe5b534b404ecba9a0f35aa1f92"
+  integrity sha512-zjePsfFahvkytgyWZtWOwaWyhXMUalTTQwXQ4XbX0x000R/4YmZh64ikCSJuW8v6acfvQcbFtCdXn/8+dipYKg==
 
 eslint-plugin-mocha@^7.0.0:
   version "7.0.1"


### PR DESCRIPTION
Internal: Allowed the "license-header" ESLint rule. Fixed broken license headers across the project. See ckeditor/ckeditor5#11468.