### PR TITLE
Web crawler - show full error message and detect the `unhandledRejection` error

### DIFF
--- a/packages/ckeditor5-dev-docs/lib/web-crawler/index.js
+++ b/packages/ckeditor5-dev-docs/lib/web-crawler/index.js
@@ -57,7 +57,10 @@ module.exports = async function verify( options ) {
 	console.log( chalk.bold( '\n🔎 Starting the Crawler\n' ) );
 
 	process.on( 'unhandledRejection', reason => {
-		const error = reason instanceof Error ? reason.stack : reason;
+		const error = util.inspect( reason, {
+			breakLength: Infinity,
+			compact: true
+		} );
 
 		console.log( chalk.red.bold( `\n🔥 Caught the \`unhandledRejection\` error: ${ error }\n` ) );
 

--- a/packages/ckeditor5-dev-docs/lib/web-crawler/utils.js
+++ b/packages/ckeditor5-dev-docs/lib/web-crawler/utils.js
@@ -21,16 +21,6 @@ function getBaseUrl( url ) {
 }
 
 /**
- * Extracts first line from error message.
- *
- * @param {String} message Error message.
- * @returns {String}
- */
-function getFirstLineFromErrorMessage( message ) {
-	return message.split( '\n' ).shift();
-}
-
-/**
  * Checks, if provided string is a valid URL utilizing the HTTP or HTTPS protocols.
  *
  * @param {String} url The URL to validate.
@@ -56,7 +46,6 @@ function toArray( data ) {
 
 module.exports = {
 	getBaseUrl,
-	getFirstLineFromErrorMessage,
 	isUrlValid,
 	toArray
 };


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature (docs): Web crawler shows the full console error that has been captured. Closes ckeditor/ckeditor5#11505.

Feature (docs): Web crawler listens to the `unhandledRejection` errors and marks the script execution as failed.

Other (docs): Web crawler can now properly serialize objects and iterables that are passed to the console.

---

### Additional information

We have decided that we will not introduce a new flag for these features, but enable them by default.
