### PR TITLE
Passed the `noIsPseudoSelector` option to `postcss-nesting`

### DIFF
--- a/packages/ckeditor5-dev-utils/lib/styles/getpostcssconfig.js
+++ b/packages/ckeditor5-dev-utils/lib/styles/getpostcssconfig.js
@@ -23,7 +23,10 @@ module.exports = function getPostCssConfig( options = {} ) {
 			require( 'postcss-import' )(),
 			require( './themeimporter' )( options.themeImporter ),
 			require( 'postcss-mixins' )(),
-			require( 'postcss-nesting' )(),
+			require( 'postcss-nesting' )( {
+				// https://github.com/ckeditor/ckeditor5/issues/11730
+				noIsPseudoSelector: true
+			} ),
 			require( './themelogger' )()
 		]
 	};

--- a/packages/ckeditor5-dev-utils/tests/styles/getpostcssconfig.js
+++ b/packages/ckeditor5-dev-utils/tests/styles/getpostcssconfig.js
@@ -66,6 +66,15 @@ describe( 'styles', () => {
 			} );
 		} );
 
+		// https://github.com/ckeditor/ckeditor5/issues/11730
+		it( 'passes options to postcss-nesting', () => {
+			getPostCssConfig();
+
+			sinon.assert.calledWithExactly( stubs[ 'postcss-nesting' ], {
+				noIsPseudoSelector: true
+			} );
+		} );
+
 		it( 'supports #sourceMap option', () => {
 			expect( getPostCssConfig( { sourceMap: true } ).sourceMap )
 				.to.equal( 'inline' );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other (utils): Passed the `noIsPseudoSelector` option to `postcss-nesting` for backward compatibility in browsers that do not support CSS `:is()`. Closes #ckeditor/ckeditor5#11730.
