### PR TITLE
Added the `esbuild-loader` for JavaScript files to speed up rebuilding the manual and automated tests

### DIFF
--- a/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getwebpackconfig.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getwebpackconfig.js
@@ -72,10 +72,17 @@ module.exports = function getWebpackConfigForAutomatedTests( options ) {
 				},
 				{
 					test: /\.js$/,
-					loader: require.resolve( '../ck-debug-loader' ),
-					options: {
-						debugFlags: options.debug
-					}
+					use: [
+						{
+							loader: 'esbuild-loader'
+						},
+						{
+							loader: require.resolve( '../ck-debug-loader' ),
+							options: {
+								debugFlags: options.debug
+							}
+						}
+					]
 				}
 			]
 		},

--- a/packages/ckeditor5-dev-tests/lib/utils/manual-tests/getwebpackconfig.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/manual-tests/getwebpackconfig.js
@@ -87,10 +87,17 @@ module.exports = function getWebpackConfigForManualTests( options ) {
 				},
 				{
 					test: /\.js$/,
-					loader: require.resolve( '../ck-debug-loader' ),
-					options: {
-						debugFlags: options.debug
-					}
+					use: [
+						{
+							loader: 'esbuild-loader'
+						},
+						{
+							loader: require.resolve( '../ck-debug-loader' ),
+							options: {
+								debugFlags: options.debug
+							}
+						}
+					]
 				}
 			]
 		},

--- a/packages/ckeditor5-dev-tests/package.json
+++ b/packages/ckeditor5-dev-tests/package.json
@@ -21,6 +21,7 @@
     "del": "^5.1.0",
     "depcheck": "^1.3.1",
     "dom-combiner": "^0.1.3",
+    "esbuild-loader": "^2.19.0",
     "fs-extra": "^9.0.0",
     "glob": "^7.1.6",
     "istanbul-instrumenter-loader": "^3.0.1",


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other (tests): Added the `esbuild-loader` for JavaScript files to speed up rebuilding the manual and automated tests.

---

### ❗Please read the description below before trying to merge this PR.

TL;DR: In my opinion it is not worth it, as the profit is no or negligible. Probably moving fully to the `esbuild` from `webpack` would accelerate all things, but this is another story (for another issue).

Let's start with the raw results. The table below shows the average time needed to compile the tests. Each result is the average value calculated of 5 runs.

<table><tbody><tr><td rowspan="3">&nbsp;</td><td colspan="4" align="center">Average compilation time</td></tr><tr><td colspan="2" align="center">Manual tests</td><td colspan="2" align="center">Automated tests</td></tr><tr><td align="center">before</td><td align="center">after</td><td align="center">before</td><td align="center">after</td></tr><tr><td align="right">all packages</td><td align="right">crashed<sup>1</sup></td><td align="right">1 min 23 sec</td><td align="right">12.5 sec</td><td align="right">12.4 sec</td></tr><tr><td align="right"><code>ckeditor5-engine</code></td><td align="right">11.8 sec</td><td align="right">8.5 sec</td><td align="right">4.9 sec</td><td align="right">4.9 sec</td></tr><tr><td align="right"><code>ckeditor5-image</code></td><td align="right">9.7 sec</td><td align="right">8.1 sec</td><td align="right">4.8 sec</td><td align="right">4.9 sec</td></tr><tr><td align="right"><code>ckeditor5-list</code></td><td align="right">7.1 sec</td><td align="right">6.9 sec</td><td align="right">4.9 sec</td><td align="right">4.8 sec</td></tr><tr><td align="right"><code>ckeditor5-alignment</code></td><td align="right">5.0 sec</td><td align="right">5.3 sec</td><td align="right">3.8 sec</td><td align="right">3.7 sec</td></tr></tbody></table>

<sup>1</sup> There is a workaround to prevent it from crashing by running `yarn run manual --disable-watch`.

#### Manual tests

In manual tests, there is a benefit in using `esbuild-loader` only for packages that contain a lot of tests. For the `ckeditor5-engine` package it is about 30% and for the `ckeditor5-image` - around 15%. For other packages where the are less tests, no measurable difference can be noticed. Before and after the change, the compilation time can be assumed as the same.

One unexpected advantage of the `esbuild-loader` in manual tests is that we can suddenly build all of your manual tests at once. Previously, without the new loader, it is not possible and the `yarn run manual` script crashes and burns in an epic manner. On the other hand, we are still also able to build all manual tests in the old way with `yarn run manual --disable-watch`, which means that files are not watched and the source maps are not generated, but who would like the active watcher and source maps when running all manual tests?

The big downside of using this `esbuild-loader` is that [it removes all comments from source maps and it can't be turned off](https://github.com/evanw/esbuild/issues/516#issuecomment-725093126). This is not acceptable.

In conclusion, despite some (but not significant) acceleration in large packages, I don't see any point in integrating the `esbuild-loader` into manual test tooling.

#### Automated tests

In automated tests, the results before and after the changes are practically the same so I also don't see any point in integrating the `esbuild-loader` into the tooling.