### PR TITLE
Added new method for fetching all current translations from Transifex for specified resource and language

### DIFF
--- a/packages/ckeditor5-dev-env/lib/translations/transifex-service.js
+++ b/packages/ckeditor5-dev-env/lib/translations/transifex-service.js
@@ -24,9 +24,11 @@ module.exports = {
 	getTranslations,
 	getResourceName,
 	getLanguageCode,
+	isSourceLanguage,
 	createResource,
 	createSourceFile,
-	getResourceUploadDetails
+	getResourceUploadDetails,
+	getResourceTranslations
 };
 
 /**
@@ -234,6 +236,24 @@ async function getTranslations( resource, languages ) {
 			...translationRequests.failed
 		]
 	};
+}
+
+/**
+ * Fetches all the translations for the specified resource and language. The returned array contains translation items (objects) with
+ * attributes and relationships to other Transifex entities.
+ *
+ * @param {String} resourceId The resource id for which translation should be downloaded.
+ * @param {String} languageId The language id for which translation should be downloaded.
+ * @returns {Promise.<Array.<Object>>}
+ */
+async function getResourceTranslations( resourceId, languageId ) {
+	const translations = transifexApi.ResourceTranslation
+		.filter( { resource: resourceId, language: languageId } )
+		.include( 'resource_string' );
+
+	await translations.fetch();
+
+	return translations.data;
 }
 
 /**

--- a/packages/ckeditor5-dev-env/lib/translations/transifex-service.js
+++ b/packages/ckeditor5-dev-env/lib/translations/transifex-service.js
@@ -103,7 +103,7 @@ async function createSourceFile( options ) {
 		type: 'resource_strings_async_uploads'
 	};
 
-	return transifexApi.ResourceStringAsyncUpload.create( requestData )
+	return transifexApi.ResourceStringsAsyncUpload.create( requestData )
 		.then( response => response.id );
 }
 
@@ -116,7 +116,7 @@ async function createSourceFile( options ) {
  * @returns {Promise}
  */
 async function getResourceUploadDetails( uploadId, numberOfAttempts = 1 ) {
-	return transifexApi.ResourceStringAsyncUpload.get( uploadId )
+	return transifexApi.ResourceStringsAsyncUpload.get( uploadId )
 		.then( statusResponse => {
 			const status = statusResponse.attributes.status;
 			const isPending = status === 'pending' || status === 'processing';
@@ -247,7 +247,7 @@ async function getTranslations( resource, languages ) {
  * @returns {Promise.<Array.<Object>>}
  */
 async function getResourceTranslations( resourceId, languageId ) {
-	const translations = transifexApi.ResourceTranslation
+	const translations = transifexApi.ResourceTranslations
 		.filter( { resource: resourceId, language: languageId } )
 		.include( 'resource_string' );
 
@@ -273,7 +273,7 @@ function createDownloadRequest( resource, language, numberOfAttempts = 1 ) {
 	};
 
 	const relationships = isSourceLanguage( language ) ? { resource } : { resource, language };
-	const requestName = isSourceLanguage( language ) ? 'ResourceStringAsyncDownload' : 'ResourceTranslationAsyncDownload';
+	const requestName = isSourceLanguage( language ) ? 'ResourceStringsAsyncDownload' : 'ResourceTranslationsAsyncDownload';
 	const requestType = isSourceLanguage( language ) ? 'resource_strings_async_downloads' : 'resource_translations_async_downloads';
 
 	return transifexApi[ requestName ]

--- a/packages/ckeditor5-dev-env/lib/translations/transifex-service.js
+++ b/packages/ckeditor5-dev-env/lib/translations/transifex-service.js
@@ -247,13 +247,12 @@ async function getTranslations( resource, languages ) {
  * @returns {Promise.<Array.<Object>>}
  */
 async function getResourceTranslations( resourceId, languageId ) {
-	const translations = transifexApi.ResourceTranslations
+	const translations = transifexApi.ResourceTranslation
 		.filter( { resource: resourceId, language: languageId } )
 		.include( 'resource_string' );
 
-	await translations.fetch();
-
-	return translations.data;
+	return translations.fetch()
+		.then( () => translations.data );
 }
 
 /**

--- a/packages/ckeditor5-dev-env/package.json
+++ b/packages/ckeditor5-dev-env/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "@ckeditor/ckeditor5-dev-utils": "^30.3.1",
     "@octokit/rest": "^17.9.2",
-    "@transifex/api": "^2.1.2",
+    "@transifex/api": "^4.2.1",
     "chalk": "^4.0.0",
     "cli-table": "^0.3.1",
     "compare-func": "^2.0.0",


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other (env): Added new method `getResourceTranslations()` in `lib/translations/transifex-service.js` for fetching all current translations from Transifex for specified resource and language.

Other (env): Exposed new method `isSourceLanguage()` in `lib/translations/transifex-service.js` that checks if the specified language is the source language (English).

Internal (env): Bumped the `@transifex/api` package to v4.2.1.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
