### PR TITLE
Added support for paginated resource translations results from Transifex

### DIFF
--- a/packages/ckeditor5-dev-env/lib/translations/transifex-service.js
+++ b/packages/ckeditor5-dev-env/lib/translations/transifex-service.js
@@ -251,8 +251,25 @@ async function getResourceTranslations( resourceId, languageId ) {
 		.filter( { resource: resourceId, language: languageId } )
 		.include( 'resource_string' );
 
-	return translations.fetch()
-		.then( () => translations.data );
+	// Returned translations might be paginated, so return the whole collection.
+	let page = translations;
+	const results = [];
+
+	await page.fetch();
+
+	while ( true ) {
+		for ( const item of page.data ) {
+			results.push( item );
+		}
+
+		if ( !page.next ) {
+			break;
+		}
+
+		page = await page.getNext();
+	}
+
+	return results;
 }
 
 /**


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix (env): Added support for paginated resource translations results from Transifex. Closes ckeditor/ckeditor5#12098.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
