### PR TITLE
Test environment should not throw an error when watching sources

### DIFF
--- a/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getwebpackconfig.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getwebpackconfig.js
@@ -90,7 +90,23 @@ module.exports = function getWebpackConfigForAutomatedTests( options ) {
 								debugFlags: options.debug
 							}
 						},
-						'ts-loader'
+						{
+							loader: 'ts-loader',
+							options: {
+								// Override default settings specified in `tsconfig.json`.
+								compilerOptions: {
+									// Do not emit any JS file as these TypeScript files are just passed through webpack.
+									// Automated tests have a single entry point.
+									// See: https://github.com/ckeditor/ckeditor5/issues/12111.
+									noEmit: false,
+									// Do not emit any file when couldn't compile a TS file.
+									// Otherwise, karma prints an error on the top of the output log and then, execute tests.
+									// It might give a false positive results. Tests are OK while something could not be compiled.
+									// In such a case we would like to throw an error.
+									noEmitOnError: true
+								}
+							}
+						}
 					]
 				}
 			]

--- a/packages/ckeditor5-dev-tests/lib/utils/manual-tests/getwebpackconfig.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/manual-tests/getwebpackconfig.js
@@ -105,7 +105,22 @@ module.exports = function getWebpackConfigForManualTests( options ) {
 								debugFlags: options.debug
 							}
 						},
-						'ts-loader'
+						{
+							loader: 'ts-loader',
+							options: {
+								// Override default settings specified in `tsconfig.json`.
+								compilerOptions: {
+									// Do not emit any JS file as these TypeScript files are just passed through webpack.
+									// Manual tests have their entry point. Only these files should be stored on a file system.
+									// See: https://github.com/ckeditor/ckeditor5/issues/12111.
+									noEmit: false,
+									// When both (JS and TS) files are imported by a manual test while updating the JS files,
+									// the `ts-loader` emits the "TypeScript emitted no output" error.
+									// Disabling the `noEmitOnError` option fixes the problem.
+									noEmitOnError: false
+								}
+							}
+						}
 					]
 				}
 			]

--- a/packages/ckeditor5-dev-tests/tests/utils/automated-tests/getwebpackconfig.js
+++ b/packages/ckeditor5-dev-tests/tests/utils/automated-tests/getwebpackconfig.js
@@ -180,4 +180,26 @@ describe( 'getWebpackConfigForAutomatedTests()', () => {
 		expect( getDefinitionsFromFile.firstCall.args[ 0 ] ).to.equal( 'path/to/secrets.js' );
 		expect( plugin.definitions.LICENSE_KEY ).to.equal( 'secret' );
 	} );
+
+	it( 'should process TypeScript files properly', () => {
+		const webpackConfig = getWebpackConfigForAutomatedTests( {} );
+
+		const tsRule = webpackConfig.module.rules.find( rule => {
+			return rule.test.toString().endsWith( '/\\.ts$/' );
+		} );
+
+		if ( !tsRule ) {
+			throw new Error( 'A loader for ".ts" files was not found.' );
+		}
+
+		expect( tsRule.use[ 0 ].loader.endsWith( 'ck-debug-loader.js' ) ).to.be.true;
+		expect( tsRule.use[ 1 ] ).to.be.an( 'object' );
+		expect( tsRule.use[ 1 ] ).to.have.property( 'loader', 'ts-loader' );
+		expect( tsRule.use[ 1 ] ).to.have.property( 'options' );
+		expect( tsRule.use[ 1 ].options ).to.have.property( 'compilerOptions' );
+		expect( tsRule.use[ 1 ].options.compilerOptions ).to.deep.equal( {
+			noEmit: false,
+			noEmitOnError: true
+		} );
+	} );
 } );

--- a/packages/ckeditor5-dev-tests/tests/utils/manual-tests/getwebpackconfig.js
+++ b/packages/ckeditor5-dev-tests/tests/utils/manual-tests/getwebpackconfig.js
@@ -62,6 +62,13 @@ describe( 'getWebpackConfigForManualTests()', () => {
 		}
 
 		expect( tsRule.use[ 0 ].loader.endsWith( 'ck-debug-loader.js' ) ).to.be.true;
-		expect( tsRule.use[ 1 ] ).to.equal( 'ts-loader' );
+		expect( tsRule.use[ 1 ] ).to.be.an( 'object' );
+		expect( tsRule.use[ 1 ] ).to.have.property( 'loader', 'ts-loader' );
+		expect( tsRule.use[ 1 ] ).to.have.property( 'options' );
+		expect( tsRule.use[ 1 ].options ).to.have.property( 'compilerOptions' );
+		expect( tsRule.use[ 1 ].options.compilerOptions ).to.deep.equal( {
+			noEmit: false,
+			noEmitOnError: false
+		} );
 	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix (tests): Override compiler options when processing test files to avoid errors when modifying source files when the watcher mode is enabled. Both tasks use `noEmit=false`. Additionally, for manual tests use `noEmitOnError=false`. For automated tests, use `noEmitOnError=true` to avoid running tests when the TypeScript compilator ends with an error Closes ckeditor/ckeditor5#12111.