### PR TITLE
Support for TypeScript when collecting translation entries

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,9 @@
     "release:bump-version": "node ./scripts/bump-versions.js",
     "release:publish": "node ./scripts/publish.js",
     "lint": "eslint --quiet \"**/*.js\"",
-    "precommit": "lint-staged"
+    "precommit": "lint-staged",
+    "clean": "npx rimraf package-lock.json yarn.lock ./**/node_modules",
+    "reinstall": "yarn run clean && yarn install"
   },
   "lint-staged": {
     "**/*.js": [

--- a/packages/ckeditor5-dev-utils/package.json
+++ b/packages/ckeditor5-dev-utils/package.json
@@ -5,12 +5,12 @@
   "keywords": [],
   "main": "lib/index.js",
   "dependencies": {
+    "@babel/parser": "^7.18.9",
+    "@babel/traverse": "^7.18.9",
     "@ckeditor/ckeditor5-dev-webpack-plugin": "^30.3.3",
-    "acorn": "^6.2.1",
-    "acorn-walk": "^6.2.0",
     "chalk": "^3.0.0",
-    "cli-spinners": "^2.6.1",
     "cli-cursor": "^3.1.0",
+    "cli-spinners": "^2.6.1",
     "cssnano": "^5.0.0",
     "del": "^5.0.0",
     "escodegen": "^1.9.0",
@@ -27,8 +27,8 @@
     "shelljs": "^0.8.1",
     "style-loader": "^2.0.0",
     "terser-webpack-plugin": "^4.2.3",
-    "ts-loader": "^9.3.0",
-    "through2": "^3.0.1"
+    "through2": "^3.0.1",
+    "ts-loader": "^9.3.0"
   },
   "devDependencies": {
     "chai": "^4.1.2",

--- a/packages/ckeditor5-dev-utils/tests/translations/findmessages.js
+++ b/packages/ckeditor5-dev-utils/tests/translations/findmessages.js
@@ -57,6 +57,29 @@ describe( 'findMessages', () => {
 		] );
 	} );
 
+	it( 'should not throw an error when defining a type after an instantiation expression', () => {
+		const errors = [];
+		const messages = [];
+
+		findMessages(
+			`function addEventListener<TEvent extends BaseEvent>(
+				listener: Emitter,
+				emitter: Emitter,
+				event: TEvent[ 'name' ],
+				callback: GetCallback<TEvent>,
+				options: CallbackOptions
+			) {
+				( listener._addEventListener<TEvent> ) .call( emitter, event, callback, options );
+			}`,
+			'emitter.ts',
+			message => messages.push( message ),
+			error => errors.push( error )
+		);
+
+		expect( messages.length ).to.equal( 0 );
+		expect( errors.length ).to.equal( 0 );
+	} );
+
 	it( 'should parse provided code and find messages inside the `t()` function calls on object literals', () => {
 		const messages = [];
 

--- a/packages/ckeditor5-dev-utils/tests/translations/findmessages.js
+++ b/packages/ckeditor5-dev-utils/tests/translations/findmessages.js
@@ -40,14 +40,21 @@ describe( 'findMessages', () => {
 			`function x( param: string ): void {
                 const t = this.t;
                 t( 'Image' );
-                t( 'CKEditor' );
+                t( { string: 'CKEditor', ID: 'CKEDITOR' } );
+                t( { string: 'Image', plural: 'Images' } );
+                t( { string: 'Image', plural: 'Images', id: 'AN_IMAGE' } );
                 g( 'Some other function' );
 			}`,
 			'foo.ts',
 			message => messages.push( message )
 		);
 
-		expect( messages ).to.deep.equal( [ { id: 'Image', string: 'Image' }, { id: 'CKEditor', string: 'CKEditor' } ] );
+		expect( messages ).to.deep.equal( [
+			{ id: 'Image', string: 'Image' },
+			{ id: 'CKEditor', string: 'CKEditor' },
+			{ id: 'Image', plural: 'Images', string: 'Image' },
+			{ id: 'AN_IMAGE', plural: 'Images', string: 'Image' }
+		] );
 	} );
 
 	it( 'should parse provided code and find messages inside the `t()` function calls on object literals', () => {

--- a/packages/ckeditor5-dev-utils/tests/translations/findmessages.js
+++ b/packages/ckeditor5-dev-utils/tests/translations/findmessages.js
@@ -33,6 +33,23 @@ describe( 'findMessages', () => {
 		expect( messages ).to.deep.equal( [ { id: 'Image', string: 'Image' }, { id: 'CKEditor', string: 'CKEditor' } ] );
 	} );
 
+	it( 'should parse provided TypeScript code and find messages from `t()` function calls on string literals', () => {
+		const messages = [];
+
+		findMessages(
+			`function x( param: string ): void {
+                const t = this.t;
+                t( 'Image' );
+                t( 'CKEditor' );
+                g( 'Some other function' );
+			}`,
+			'foo.ts',
+			message => messages.push( message )
+		);
+
+		expect( messages ).to.deep.equal( [ { id: 'Image', string: 'Image' }, { id: 'CKEditor', string: 'CKEditor' } ] );
+	} );
+
 	it( 'should parse provided code and find messages inside the `t()` function calls on object literals', () => {
 		const messages = [];
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Support for TypeScript when collecting translation entries. Closes ckeditor/ckeditor5#12029.

---

### Additional information

It looks like `acorn`, even in the newest version, doesn't understand TypeScript sources.

TypeScript support is provided in another package - `@babel/parser`, and the `@babel` ecosystem has also a separate package for walking in the generated tree - `@babel/traverse`.

Initially, I thought it would be possible to prepare an `acorn`-compatible AST from the `@babel/parser` to re-use the existing `acorn-walk` package that currently finds all `t()` calls. According to the documentation from `@babel/parser` it should be possible, because it is shipped with the `estree` plugin, which produces the AST that is `acorn`-compatible. Unfortunately, it didn't quite work, because some deeply nested `t()` calls were not detected, so the script reported multiple unused contexts for texts that in fact are used in our sources.

Luckily, the default AST format produced by the `@babel/parser` is very close to the `acorn` format (see [the list of all differences](https://babeljs.io/docs/en/babel-parser#output)). Also the `@babel/traverse` interface is almost identical to `acorn-walk`, so replacing both was fairly easy.

There is also a related PR - https://github.com/ckeditor/ckeditor5/pull/12128 - that restores the `ckeditor5-utils` package in the `translations:collect` script.