### PR TITLE
Added new CLI options for webpack config

### DIFF
--- a/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getkarmaconfig.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getkarmaconfig.js
@@ -74,12 +74,8 @@ module.exports = function getKarmaConfig( options ) {
 		preprocessors: preprocessorMap,
 
 		webpack: getWebpackConfigForAutomatedTests( {
-			files: Object.keys( options.globPatterns ).map( key => options.globPatterns[ key ] ),
-			sourceMap: options.sourceMap,
-			identityFile: options.identityFile,
-			coverage: options.coverage,
-			themePath: options.themePath,
-			debug: options.debug
+			...options,
+			files: Object.keys( options.globPatterns ).map( key => options.globPatterns[ key ] )
 		} ),
 
 		webpackMiddleware: {

--- a/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getwebpackconfig.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getwebpackconfig.js
@@ -33,7 +33,9 @@ module.exports = function getWebpackConfigForAutomatedTests( options ) {
 		],
 
 		resolve: {
-			extensions: [ '.ts', '.js', '.json' ]
+			extensions: options.jsFirst ?
+				[ '.js', '.ts', '.json' ] :
+				[ '.ts', '.js', '.json' ]
 		},
 
 		module: {
@@ -153,6 +155,12 @@ module.exports = function getWebpackConfigForAutomatedTests( options ) {
 				}
 			}
 		);
+	}
+
+	if ( options.cache ) {
+		config.cache = {
+			type: 'filesystem'
+		};
 	}
 
 	return config;

--- a/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getwebpackconfig.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getwebpackconfig.js
@@ -33,7 +33,7 @@ module.exports = function getWebpackConfigForAutomatedTests( options ) {
 		],
 
 		resolve: {
-			extensions: options.jsFirst ?
+			extensions: options.resolveJsFirst ?
 				[ '.js', '.ts', '.json' ] :
 				[ '.ts', '.js', '.json' ]
 		},

--- a/packages/ckeditor5-dev-tests/lib/utils/automated-tests/parsearguments.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/automated-tests/parsearguments.js
@@ -38,7 +38,7 @@ module.exports = function parseArguments( args ) {
 			'verbose',
 			'watch',
 			'silent',
-			'js-first',
+			'resolve-js-first',
 			'cache'
 		],
 
@@ -70,7 +70,7 @@ module.exports = function parseArguments( args ) {
 			'theme-path': null,
 			'additional-languages': null,
 			silent: false,
-			'js-first': false,
+			'resolve-js-first': false,
 			cache: false
 		}
 	};
@@ -89,7 +89,7 @@ module.exports = function parseArguments( args ) {
 		'theme-path',
 		'karma-config-overrides',
 		'additional-languages',
-		'js-first'
+		'resolve-js-first'
 	] );
 	splitOptionsToArray( options, [
 		'browsers',

--- a/packages/ckeditor5-dev-tests/lib/utils/automated-tests/parsearguments.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/automated-tests/parsearguments.js
@@ -37,7 +37,9 @@ module.exports = function parseArguments( args ) {
 			'source-map',
 			'verbose',
 			'watch',
-			'silent'
+			'silent',
+			'js-first',
+			'cache'
 		],
 
 		alias: {
@@ -67,7 +69,9 @@ module.exports = function parseArguments( args ) {
 			repositories: [],
 			'theme-path': null,
 			'additional-languages': null,
-			silent: false
+			silent: false,
+			'js-first': false,
+			cache: false
 		}
 	};
 
@@ -84,7 +88,8 @@ module.exports = function parseArguments( args ) {
 		'identity-file',
 		'theme-path',
 		'karma-config-overrides',
-		'additional-languages'
+		'additional-languages',
+		'js-first'
 	] );
 	splitOptionsToArray( options, [
 		'browsers',

--- a/packages/ckeditor5-dev-tests/tests/utils/automated-tests/getkarmaconfig.js
+++ b/packages/ckeditor5-dev-tests/tests/utils/automated-tests/getkarmaconfig.js
@@ -46,7 +46,7 @@ describe( 'getKarmaConfig()', () => {
 	} );
 
 	it( 'should return basic karma config for all tested files', () => {
-		const karmaConfig = getKarmaConfig( {
+		const options = {
 			files: [ '*' ],
 			reporter: 'mocha',
 			sourceMap: false,
@@ -59,17 +59,16 @@ describe( 'getKarmaConfig()', () => {
 			globPatterns: {
 				'*': 'workspace/packages/ckeditor5-*/tests/**/*.js'
 			}
-		} );
+		};
+
+		const karmaConfig = getKarmaConfig( options );
 
 		expect( karmaConfig ).to.have.own.property( 'basePath', 'workspace' );
 		expect( karmaConfig ).to.have.own.property( 'frameworks' );
 		expect( karmaConfig ).to.have.own.property( 'files' );
 		expect( karmaConfig ).to.have.own.property( 'preprocessors' );
 		expect( karmaConfig ).to.have.own.property( 'webpack' );
-		expect( karmaConfig.webpack.files ).to.deep.equal( [ 'workspace/packages/ckeditor5-*/tests/**/*.js' ] );
-		expect( karmaConfig.webpack.sourceMap ).to.equal( false );
-		expect( karmaConfig.webpack.coverage ).to.equal( false );
-		expect( karmaConfig.webpack.themePath ).to.equal( 'workspace/path/to/theme.css' );
+		expect( karmaConfig.webpack ).to.deep.equal( { ...options, files: [ 'workspace/packages/ckeditor5-*/tests/**/*.js' ] } );
 		expect( karmaConfig ).to.have.own.property( 'webpackMiddleware' );
 		expect( karmaConfig ).to.have.own.property( 'reporters' );
 		expect( karmaConfig ).to.have.own.property( 'browsers' );

--- a/packages/ckeditor5-dev-tests/tests/utils/automated-tests/getwebpackconfig.js
+++ b/packages/ckeditor5-dev-tests/tests/utils/automated-tests/getwebpackconfig.js
@@ -202,4 +202,24 @@ describe( 'getWebpackConfigForAutomatedTests()', () => {
 			noEmitOnError: true
 		} );
 	} );
+
+	it( 'should return webpack configuration with correct extension resolve order', () => {
+		const webpackConfig = getWebpackConfigForAutomatedTests( {
+			jsFirst: true
+		} );
+
+		expect( webpackConfig.resolve ).to.deep.equal( {
+			extensions: [ '.js', '.ts', '.json' ]
+		} );
+	} );
+
+	it( 'should return webpack configuration with cache enabled', () => {
+		const webpackConfig = getWebpackConfigForAutomatedTests( {
+			cache: true
+		} );
+
+		expect( webpackConfig.cache ).to.deep.equal( {
+			type: 'filesystem'
+		} );
+	} );
 } );

--- a/packages/ckeditor5-dev-tests/tests/utils/automated-tests/getwebpackconfig.js
+++ b/packages/ckeditor5-dev-tests/tests/utils/automated-tests/getwebpackconfig.js
@@ -205,7 +205,7 @@ describe( 'getWebpackConfigForAutomatedTests()', () => {
 
 	it( 'should return webpack configuration with correct extension resolve order', () => {
 		const webpackConfig = getWebpackConfigForAutomatedTests( {
-			jsFirst: true
+			resolveJsFirst: true
 		} );
 
 		expect( webpackConfig.resolve ).to.deep.equal( {

--- a/packages/ckeditor5-dev-tests/tests/utils/automated-tests/getwebpackconfig.js
+++ b/packages/ckeditor5-dev-tests/tests/utils/automated-tests/getwebpackconfig.js
@@ -222,4 +222,14 @@ describe( 'getWebpackConfigForAutomatedTests()', () => {
 			type: 'filesystem'
 		} );
 	} );
+
+	it( 'should get rid of the "webpack://" protocol to make the paths clickable in the terminal', () => {
+		const webpackConfig = getWebpackConfigForAutomatedTests( {} );
+
+		const { devtoolModuleFilenameTemplate } = webpackConfig.output;
+
+		const info = { resourcePath: 'foo/bar/baz' };
+
+		expect( devtoolModuleFilenameTemplate( info ) ).to.equal( info.resourcePath );
+	} );
 } );

--- a/packages/ckeditor5-dev-tests/tests/utils/automated-tests/parsearguments.js
+++ b/packages/ckeditor5-dev-tests/tests/utils/automated-tests/parsearguments.js
@@ -52,18 +52,21 @@ describe( 'parseArguments()', () => {
 			'--theme-path',
 			'/path/to/theme/package',
 			'--additional-languages',
-			'de,fr'
+			'de,fr',
+			'--js-first'
 		] );
 
 		expect( options[ 'source-map' ] ).to.be.undefined;
 		expect( options[ 'identity-file' ] ).to.be.undefined;
 		expect( options[ 'theme-path' ] ).to.be.undefined;
 		expect( options[ 'additional-languages' ] ).to.be.undefined;
+		expect( options[ 'js-first' ] ).to.be.undefined;
 
 		expect( options.sourceMap ).to.equal( true );
 		expect( options.identityFile ).to.equal( '/home/.secret/file.key' );
 		expect( options.themePath ).to.equal( '/path/to/theme/package' );
 		expect( options.additionalLanguages ).to.deep.equal( [ 'de', 'fr' ] );
+		expect( options.jsFirst ).to.equal( true );
 	} );
 
 	it( 'deletes all aliases keys from returned object', () => {

--- a/packages/ckeditor5-dev-tests/tests/utils/automated-tests/parsearguments.js
+++ b/packages/ckeditor5-dev-tests/tests/utils/automated-tests/parsearguments.js
@@ -53,20 +53,20 @@ describe( 'parseArguments()', () => {
 			'/path/to/theme/package',
 			'--additional-languages',
 			'de,fr',
-			'--js-first'
+			'--resolve-js-first'
 		] );
 
 		expect( options[ 'source-map' ] ).to.be.undefined;
 		expect( options[ 'identity-file' ] ).to.be.undefined;
 		expect( options[ 'theme-path' ] ).to.be.undefined;
 		expect( options[ 'additional-languages' ] ).to.be.undefined;
-		expect( options[ 'js-first' ] ).to.be.undefined;
+		expect( options[ 'resolve-js-first' ] ).to.be.undefined;
 
 		expect( options.sourceMap ).to.equal( true );
 		expect( options.identityFile ).to.equal( '/home/.secret/file.key' );
 		expect( options.themePath ).to.equal( '/path/to/theme/package' );
 		expect( options.additionalLanguages ).to.deep.equal( [ 'de', 'fr' ] );
-		expect( options.jsFirst ).to.equal( true );
+		expect( options.resolveJsFirst ).to.equal( true );
 	} );
 
 	it( 'deletes all aliases keys from returned object', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature (tests): Added the `--resolve-js-first` option that prioritizes loading `*.js` over `*.ts` files for automated tests.

Feature (tests): Added the `--cache` option that enables webpack cache for automated tests. 

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
