### PR TITLE
Split multi-scoped commit into multiple single-scoped commits

### DIFF
--- a/packages/ckeditor5-dev-env/lib/release-tools/utils/transformcommitfactory.js
+++ b/packages/ckeditor5-dev-env/lib/release-tools/utils/transformcommitfactory.js
@@ -436,10 +436,16 @@ module.exports = function transformCommitFactory( options = {} ) {
 		}
 
 		// Clone the commit as many times as there are scopes.
-		return commit.scope.map( scope => cloneDeepWith( commit, ( value, key ) => {
-			// The cloned commit should always have a single scope.
-			if ( key === 'scope' ) {
+		return commit.scope.map( ( scope, index ) => cloneDeepWith( commit, ( value, key, parent ) => {
+			// The cloned commit should always have a single scope from a commit.
+			// Do not copy scopes from commit notes.
+			if ( key === 'scope' && !parent.title ) {
 				return [ scope ];
+			}
+
+			// Do not copy breaking changes notes. It's enough to keep them in the first commit.
+			if ( index && key === 'notes' ) {
+				return [];
 			}
 		} ) );
 	}

--- a/packages/ckeditor5-dev-env/package.json
+++ b/packages/ckeditor5-dev-env/package.json
@@ -21,6 +21,7 @@
     "git-raw-commits": "^2.0.7",
     "glob": "^7.1.6",
     "inquirer": "^7.1.0",
+    "lodash": "^4.17.15",
     "minimatch": "^3.0.4",
     "mkdirp": "^1.0.4",
     "node-fetch": "^2.6.7",

--- a/packages/ckeditor5-dev-env/tests/release-tools/utils/transformcommitfactory.js
+++ b/packages/ckeditor5-dev-env/tests/release-tools/utils/transformcommitfactory.js
@@ -734,8 +734,8 @@ describe( 'dev-env/release-tools/utils', () => {
 					expect( commit[ 0 ].notes ).to.not.equal( commit[ 1 ].notes );
 
 					expect( commit[ 0 ].notes[ 0 ].scope ).to.be.an( 'Array' );
-					expect( commit[ 1 ].notes[ 0 ].scope ).to.be.an( 'Array' );
-					expect( commit[ 0 ].notes[ 0 ].scope ).to.not.equal( commit[ 1 ].notes[ 0 ].scope );
+					expect( commit[ 0 ].notes[ 0 ].scope[ 0 ] ).to.equal( 'package' );
+					expect( commit[ 1 ].notes ).to.be.an( 'Array' );
 				} );
 
 				it( 'extracts the scope from notes', () => {
@@ -793,6 +793,90 @@ describe( 'dev-env/release-tools/utils', () => {
 					expect( commit.notes[ 0 ].scope.length ).to.equal( 2 );
 					expect( commit.notes[ 0 ].scope[ 0 ] ).to.equal( 'bar' );
 					expect( commit.notes[ 0 ].scope[ 1 ] ).to.equal( 'foo' );
+				} );
+
+				it( 'does not copy notes when processing multi-scoped commit (single entry)', () => {
+					const rawCommit = {
+						hash: '76b9e058fb1c3fa00b50059cdc684997d0eb2eca',
+						header: 'Fix (scope1, scope2): Simple feature Closes #1.',
+						type: 'Fix (scope1, scope2)',
+						subject: 'Simple feature Closes #1.',
+						body: '',
+						footer: null,
+						notes: [
+							{ title: 'BREAKING CHANGE', text: 'Note 1.' },
+							{ title: 'MAJOR BREAKING CHANGES', text: 'Note 2.' }
+						]
+					};
+
+					const commit = transformCommit( rawCommit );
+
+					expect( commit.length ).to.equal( 2 );
+
+					expect( commit[ 0 ].scope ).to.be.an( 'Array' );
+					expect( commit[ 0 ].scope.length ).to.equal( 1 );
+					expect( commit[ 0 ].scope[ 0 ] ).to.equal( 'scope1' );
+					expect( commit[ 0 ].rawType ).to.equal( 'Fix' );
+					expect( commit[ 0 ].notes ).to.be.an( 'Array' );
+					expect( commit[ 0 ].notes.length ).to.equal( 2 );
+					expect( commit[ 0 ].notes[ 0 ].scope ).to.equal( null );
+					expect( commit[ 0 ].notes[ 1 ].scope ).to.equal( null );
+
+					expect( commit[ 1 ].scope ).to.be.an( 'Array' );
+					expect( commit[ 1 ].scope.length ).to.equal( 1 );
+					expect( commit[ 1 ].scope[ 0 ] ).to.equal( 'scope2' );
+					expect( commit[ 1 ].rawType ).to.equal( 'Fix' );
+					expect( commit[ 1 ].notes ).to.be.an( 'Array' );
+					expect( commit[ 1 ].notes.length ).to.equal( 0 );
+				} );
+
+				it( 'does not copy notes when processing multi-scoped commit (multi entries)', () => {
+					const rawCommit = {
+						hash: '76b9e058fb1c3fa00b50059cdc684997d0eb2eca',
+						header: 'Fix (scope1, scope2): Simple feature Closes #1.',
+						type: 'Fix (scope1, scope2)',
+						subject: 'Simple feature Closes #1.',
+						body: [
+							'Other (scope3, scope4): Simple other change. Closes ckeditor/ckeditor5#3. Closes #3.'
+						].join( '\n' ),
+						footer: null,
+						notes: [
+							{ title: 'BREAKING CHANGE', text: 'Note 1.' },
+							{ title: 'MAJOR BREAKING CHANGES', text: 'Note 2.' }
+						]
+					};
+
+					const commit = transformCommit( rawCommit );
+
+					expect( commit.length ).to.equal( 4 );
+
+					expect( commit[ 0 ].scope ).to.be.an( 'Array' );
+					expect( commit[ 0 ].scope.length ).to.equal( 1 );
+					expect( commit[ 0 ].scope[ 0 ] ).to.equal( 'scope1' );
+					expect( commit[ 0 ].rawType ).to.equal( 'Fix' );
+					expect( commit[ 0 ].notes ).to.be.an( 'Array' );
+					expect( commit[ 0 ].notes.length ).to.equal( 2 );
+
+					expect( commit[ 1 ].scope ).to.be.an( 'Array' );
+					expect( commit[ 1 ].scope.length ).to.equal( 1 );
+					expect( commit[ 1 ].scope[ 0 ] ).to.equal( 'scope2' );
+					expect( commit[ 1 ].rawType ).to.equal( 'Fix' );
+					expect( commit[ 1 ].notes ).to.be.an( 'Array' );
+					expect( commit[ 1 ].notes.length ).to.equal( 0 );
+
+					expect( commit[ 2 ].scope ).to.be.an( 'Array' );
+					expect( commit[ 2 ].scope.length ).to.equal( 1 );
+					expect( commit[ 2 ].scope[ 0 ] ).to.equal( 'scope3' );
+					expect( commit[ 2 ].rawType ).to.equal( 'Other' );
+					expect( commit[ 2 ].notes ).to.be.an( 'Array' );
+					expect( commit[ 2 ].notes.length ).to.equal( 0 );
+
+					expect( commit[ 3 ].scope ).to.be.an( 'Array' );
+					expect( commit[ 3 ].scope.length ).to.equal( 1 );
+					expect( commit[ 3 ].scope[ 0 ] ).to.equal( 'scope4' );
+					expect( commit[ 3 ].rawType ).to.equal( 'Other' );
+					expect( commit[ 3 ].notes ).to.be.an( 'Array' );
+					expect( commit[ 3 ].notes.length ).to.equal( 0 );
 				} );
 			} );
 

--- a/packages/ckeditor5-dev-env/tests/release-tools/utils/transformcommitfactory.js
+++ b/packages/ckeditor5-dev-env/tests/release-tools/utils/transformcommitfactory.js
@@ -672,6 +672,34 @@ describe( 'dev-env/release-tools/utils', () => {
 					expect( commit[ 1 ].rawType ).to.equal( 'Feature' );
 				} );
 
+				it( 'works with multi-scoped merge commit', () => {
+					const rawCommit = {
+						hash: '76b9e058fb1c3fa00b50059cdc684997d0eb2eca',
+						header: 'Feature (foo, bar): Simple fix.',
+						type: 'Feature (foo, bar)',
+						subject: 'Simple fix.',
+						merge: 'Merge pull request #7355 from ckeditor/i/6757',
+						body: null,
+						footer: null,
+						notes: []
+					};
+
+					const commit = transformCommit( rawCommit );
+
+					expect( commit ).to.be.an( 'Array' );
+					expect( commit.length ).to.equal( 2 );
+
+					expect( commit[ 0 ].scope ).to.be.an( 'Array' );
+					expect( commit[ 0 ].scope.length ).to.equal( 1 );
+					expect( commit[ 0 ].scope[ 0 ] ).to.equal( 'bar' );
+					expect( commit[ 0 ].rawType ).to.equal( 'Feature' );
+
+					expect( commit[ 1 ].scope ).to.be.an( 'Array' );
+					expect( commit[ 1 ].scope.length ).to.equal( 1 );
+					expect( commit[ 1 ].scope[ 0 ] ).to.equal( 'foo' );
+					expect( commit[ 1 ].rawType ).to.equal( 'Feature' );
+				} );
+
 				it( 'clones the commit properties for multi-scoped changes', () => {
 					const rawCommit = {
 						hash: '76b9e058fb1c3fa00b50059cdc684997d0eb2eca',

--- a/packages/ckeditor5-dev-env/tests/release-tools/utils/transformcommitfactory.js
+++ b/packages/ckeditor5-dev-env/tests/release-tools/utils/transformcommitfactory.js
@@ -658,11 +658,56 @@ describe( 'dev-env/release-tools/utils', () => {
 
 					const commit = transformCommit( rawCommit );
 
-					expect( commit.scope ).to.be.an( 'Array' );
-					expect( commit.scope.length ).to.equal( 2 );
-					expect( commit.scope[ 0 ] ).to.equal( 'bar' );
-					expect( commit.scope[ 1 ] ).to.equal( 'foo' );
-					expect( commit.rawType ).to.equal( 'Feature' );
+					expect( commit ).to.be.an( 'Array' );
+					expect( commit.length ).to.equal( 2 );
+
+					expect( commit[ 0 ].scope ).to.be.an( 'Array' );
+					expect( commit[ 0 ].scope.length ).to.equal( 1 );
+					expect( commit[ 0 ].scope[ 0 ] ).to.equal( 'bar' );
+					expect( commit[ 0 ].rawType ).to.equal( 'Feature' );
+
+					expect( commit[ 1 ].scope ).to.be.an( 'Array' );
+					expect( commit[ 1 ].scope.length ).to.equal( 1 );
+					expect( commit[ 1 ].scope[ 0 ] ).to.equal( 'foo' );
+					expect( commit[ 1 ].rawType ).to.equal( 'Feature' );
+				} );
+
+				it( 'clones the commit properties for multi-scoped changes', () => {
+					const rawCommit = {
+						hash: '76b9e058fb1c3fa00b50059cdc684997d0eb2eca',
+						header: 'Feature (foo, bar): Simple fix.',
+						type: 'Feature (foo, bar)',
+						subject: 'Simple fix.',
+						body: null,
+						footer: null,
+						notes: [
+							{
+								title: 'BREAKING CHANGES',
+								text: '(package): Foo.'
+							}
+						]
+					};
+
+					const commit = transformCommit( rawCommit );
+
+					expect( commit ).to.be.an( 'Array' );
+					expect( commit.length ).to.equal( 2 );
+
+					expect( commit[ 0 ].scope ).to.be.an( 'Array' );
+					expect( commit[ 1 ].scope ).to.be.an( 'Array' );
+					expect( commit[ 0 ].scope ).to.not.equal( commit[ 1 ].scope );
+
+					expect( commit[ 0 ].files ).to.be.an( 'Array' );
+					expect( commit[ 1 ].files ).to.be.an( 'Array' );
+					expect( commit[ 0 ].files ).to.not.equal( commit[ 1 ].files );
+
+					expect( commit[ 0 ].notes ).to.be.an( 'Array' );
+					expect( commit[ 1 ].notes ).to.be.an( 'Array' );
+					expect( commit[ 0 ].notes ).to.not.equal( commit[ 1 ].notes );
+
+					expect( commit[ 0 ].notes[ 0 ].scope ).to.be.an( 'Array' );
+					expect( commit[ 1 ].notes[ 0 ].scope ).to.be.an( 'Array' );
+					expect( commit[ 0 ].notes[ 0 ].scope ).to.not.equal( commit[ 1 ].notes[ 0 ].scope );
 				} );
 
 				it( 'extracts the scope from notes', () => {
@@ -964,12 +1009,13 @@ describe( 'dev-env/release-tools/utils', () => {
 					const commits = transformCommit( rawCommit );
 
 					expect( commits ).to.be.an( 'Array' );
-					expect( commits.length ).to.equal( 4 );
+					expect( commits.length ).to.equal( 5 );
 
 					expect( commits[ 0 ].scope ).to.equal( null );
 					expect( commits[ 1 ].scope ).to.deep.equal( [ 'foo' ] );
 					expect( commits[ 2 ].scope ).to.equal( null );
-					expect( commits[ 3 ].scope ).to.deep.equal( [ 'bar', 'foo' ] );
+					expect( commits[ 3 ].scope ).to.deep.equal( [ 'bar' ] );
+					expect( commits[ 4 ].scope ).to.deep.equal( [ 'foo' ] );
 				} );
 
 				it( 'merges "Closes" references in multi-entries commit', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature (env): Split multi-scoped commit into multiple single-scoped commits, so the changelog generator can produce entries for all touched scopes. Closes ckeditor/ckeditor5#10605.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
