### PR TITLE
Manual tests should not load zoomed out on iOS

### DIFF
--- a/packages/ckeditor5-dev-tests/lib/utils/manual-tests/template.html
+++ b/packages/ckeditor5-dev-tests/lib/utils/manual-tests/template.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 	<meta charset="UTF-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no"/>
+	<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 	<meta http-equiv="Content-Security-Policy" content="default-src 'none'; connect-src 'self' https://cksource.com http://*.cke-cs.com; script-src 'self' https://cksource.com; img-src * data:; style-src 'self' 'unsafe-inline'; frame-src *">
 	<title>Manual Test</title>
 	<style>

--- a/packages/ckeditor5-dev-tests/lib/utils/manual-tests/template.html
+++ b/packages/ckeditor5-dev-tests/lib/utils/manual-tests/template.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 	<meta charset="UTF-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no"/>
 	<meta http-equiv="Content-Security-Policy" content="default-src 'none'; connect-src 'self' https://cksource.com http://*.cke-cs.com; script-src 'self' https://cksource.com; img-src * data:; style-src 'self' 'unsafe-inline'; frame-src *">
 	<title>Manual Test</title>
 	<style>


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other (tests): Manual tests should not load zoomed out on iOS. Closes ckeditor/ckeditor5#12438.
