### PR TITLE
Fixed manual tests reloading twice on every save

### DIFF
--- a/packages/ckeditor5-dev-tests/lib/utils/manual-tests/getwebpackconfig.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/manual-tests/getwebpackconfig.js
@@ -29,6 +29,10 @@ module.exports = function getWebpackConfigForManualTests( options ) {
 	const webpackConfig = {
 		mode: 'none',
 
+		watchOptions: {
+			aggregateTimeout: 500
+		},
+
 		entry: options.entries,
 
 		output: {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix (tests): Fixed manual tests reloading twice on every save. Closes ckeditor/ckeditor5#12216.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
