### PR TITLE
Created the @ckeditor/typedoc-plugins package

### DIFF
--- a/packages/ckeditor5-dev-docs/lib/docs/index.js
+++ b/packages/ckeditor5-dev-docs/lib/docs/index.js
@@ -58,8 +58,8 @@ module.exports = async function build( config ) {
 	typeDoc.bootstrap( {
 		entryPoints: files,
 		plugin: [
-			require.resolve( './plugins/typedoc-plugin-module-fixer' ),
-			'typedoc-plugin-rename-defaults'
+			'typedoc-plugin-rename-defaults',
+			require.resolve( '@ckeditor/typedoc-plugins/lib/module-fixer' )
 		],
 
 		// TODO: Move tsconfig.json to main repo. Also: how to share it across repos? Also: Do we need to share it?

--- a/packages/ckeditor5-dev-docs/package.json
+++ b/packages/ckeditor5-dev-docs/package.json
@@ -6,7 +6,7 @@
   "main": "lib/index.js",
   "dependencies": {
     "@ckeditor/ckeditor5-dev-utils": "^31.1.0",
-    "@ckeditor/jsdoc-plugins": "^31.1.0",
+    "@ckeditor/typedoc-plugins": "^0.0.1",
     "chalk": "^4.1.0",
     "fast-glob": "^3.2.4",
     "fs-extra": "^9.0.0",

--- a/packages/jsdoc-plugins/LICENSE.md
+++ b/packages/jsdoc-plugins/LICENSE.md
@@ -2,7 +2,7 @@ Software License Agreement
 ==========================
 
 @ckeditor/jsdoc-plugins – Various JSDoc plugins developed by the CKEditor 5 team.
-Copyright (c) 2003-2022, CKSource – Holding sp. z o.o. All rights reserved.
+Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
 
 Licensed under the terms of the MIT License (see Appendix A):
 
@@ -18,7 +18,7 @@ Appendix A: The MIT License
 
 The MIT License (MIT)
 
-Copyright (c) 2003-2022, CKSource – Holding sp. z o.o.
+Copyright (c) 2003-2022, CKSource Holding sp. z o.o.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/typedoc-plugins/CHANGELOG.md
+++ b/packages/typedoc-plugins/CHANGELOG.md
@@ -1,0 +1,4 @@
+Changelog
+=========
+
+All changes in the package are documented in the main repository. See: https://github.com/ckeditor/ckeditor5-dev/blob/master/CHANGELOG.md.

--- a/packages/typedoc-plugins/LICENSE.md
+++ b/packages/typedoc-plugins/LICENSE.md
@@ -2,7 +2,7 @@ Software License Agreement
 ==========================
 
 @ckeditor/typedoc-plugins – Various TypeDoc plugins developed by the CKEditor 5 team.
-Copyright (c) 2003-2022, CKSource – Holding sp. z o.o. All rights reserved.
+Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
 
 Licensed under the terms of the MIT License (see Appendix A):
 
@@ -18,7 +18,7 @@ Appendix A: The MIT License
 
 The MIT License (MIT)
 
-Copyright (c) 2003-2022, CKSource – Holding sp. z o.o.
+Copyright (c) 2003-2022, CKSource Holding sp. z o.o.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/typedoc-plugins/LICENSE.md
+++ b/packages/typedoc-plugins/LICENSE.md
@@ -1,0 +1,39 @@
+Software License Agreement
+==========================
+
+@ckeditor/typedoc-plugins – Various TypeDoc plugins developed by the CKEditor 5 team.
+Copyright (c) 2003-2022, CKSource – Holding sp. z o.o. All rights reserved.
+
+Licensed under the terms of the MIT License (see Appendix A):
+
+	http://en.wikipedia.org/wiki/MIT_License
+
+Sources of Intellectual Property Included in CKEditor
+-----------------------------------------------------
+
+Where not otherwise indicated, all @ckeditor/typedoc-plugins content is authored by CKSource engineers and consists of CKSource-owned intellectual property. In some specific instances, @ckeditor/typedoc-plugins will incorporate work done by developers outside of CKSource with their express permission.
+
+Appendix A: The MIT License
+---------------------------
+
+The MIT License (MIT)
+
+Copyright (c) 2003-2022, CKSource – Holding sp. z o.o.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/packages/typedoc-plugins/README.md
+++ b/packages/typedoc-plugins/README.md
@@ -6,11 +6,42 @@
 
 ## Overview
 
-...
+This repository consists of few plugins which extend the capabilities of [TypeDoc](https://typedoc.org/).
 
-## Usage
+Before enabling plugins from the package, you need to install it first.
 
-...
+```bash
+npm install @ckeditor/typedoc-plugins
+```
+
+Below you can find the detailed overview of available plugins.
+
+### Module fixer
+
+The plugin reads the module name specified in the `@module` tag name.
+
+```ts
+import type { TypeDefinition } from '...';
+
+/**
+ * @module package/file
+ */
+```
+
+For the example specified above, a name of the parsed module should be equal to `package/file`.
+
+Imports statement may be specified above the "@module" block code. In such a case, the default module parser from `typedoc` defines the module name based on a relative to a root path in the project.
+
+To enable the plugin, add the following path to available plugins:
+
+```js
+{
+    plugin: [
+        // ...
+        require.resolve( '@ckeditor/typedoc-plugins/lib/module-fixer' )
+    ]
+}
+```
 
 ## Changelog
 

--- a/packages/typedoc-plugins/README.md
+++ b/packages/typedoc-plugins/README.md
@@ -1,0 +1,17 @@
+# TypeDoc plugins overview
+
+[![npm version](https://badge.fury.io/js/%40ckeditor%2Ftypedoc-plugins.svg)](https://www.npmjs.com/package/@ckeditor/typedoc-plugins)
+[![Build Status](https://travis-ci.com/ckeditor/ckeditor5-dev.svg?branch=master)](https://app.travis-ci.com/github/ckeditor/ckeditor5-dev)
+![Dependency Status](https://img.shields.io/librariesio/release/npm/@ckeditor/typedoc-plugins)
+
+## Overview
+
+...
+
+## Usage
+
+...
+
+## Changelog
+
+See the [`CHANGELOG.md`](https://github.com/ckeditor/ckeditor5-dev/blob/master/packages/typedoc-plugins/CHANGELOG.md) file.

--- a/packages/typedoc-plugins/README.md
+++ b/packages/typedoc-plugins/README.md
@@ -30,7 +30,7 @@ import type { TypeDefinition } from '...';
 
 For the example specified above, a name of the parsed module should be equal to `package/file`.
 
-Imports statement may be specified above the "@module" block code. In such a case, the default module parser from `typedoc` defines the module name based on a relative to a root path in the project.
+The `import` statements may be specified above the "@module" block code. In such a case, the default module parser from `typedoc` returns the module name based on a path relative to the project root.
 
 To enable the plugin, add the following path to available plugins:
 

--- a/packages/typedoc-plugins/lib/module-fixer/index.js
+++ b/packages/typedoc-plugins/lib/module-fixer/index.js
@@ -14,7 +14,7 @@ const { Converter, ReflectionKind } = require( 'typedoc' );
  *
  * For the example specified above, a name of the parsed module should be equal to "package/file".
  *
- * It may happen that imports statement are specified above the "@module" block code.
+ * It may happen that import statements are specified above the "@module" block code.
  * In such a case, built-in plugin in `typedoc` does not read its value properly.
  */
 module.exports = {

--- a/packages/typedoc-plugins/lib/module-fixer/index.js
+++ b/packages/typedoc-plugins/lib/module-fixer/index.js
@@ -1,0 +1,58 @@
+/**
+ * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+'use strict';
+
+const { Converter, ReflectionKind } = require( 'typedoc' );
+
+/**
+ * The `typedoc-plugin-module-fixer` reads the module name specified in the `@module` tag name.
+ *
+ *      @module package/file
+ *
+ * For the example specified above, a name of the parsed module should be equal to "package/file".
+ *
+ * It may happen that imports statement are specified above the "@module" block code.
+ * In such a case, built-in plugin in `typedoc` does not read its value properly.
+ */
+module.exports = {
+	load( app ) {
+		app.converter.on(
+			Converter.EVENT_CREATE_DECLARATION,
+			function( _context, reflection, node ) {
+				if ( reflection.kind !== ReflectionKind.Module ) {
+					return;
+				}
+
+				// Iterate over statements...
+				for ( const statement of node.statements ) {
+					if ( !Array.isArray( statement.jsDoc ) ) {
+						continue;
+					}
+
+					// ...to find a JSDoc block code...
+					for ( const jsDoc of statement.jsDoc ) {
+						// ...that represents a module definition.
+						const [ moduleTag ] = ( jsDoc.tags || [] ).filter( tag => {
+							return tag.tagName.originalKeywordKind === 141;
+						} );
+
+						if ( !moduleTag ) {
+							continue;
+						}
+
+						// When found, use its value as a module name.
+						if ( reflection.name !== moduleTag.comment ) {
+							reflection.originalName = reflection.name;
+							reflection.name = moduleTag.comment;
+
+							return;
+						}
+					}
+				}
+			}
+		);
+	}
+};

--- a/packages/typedoc-plugins/package.json
+++ b/packages/typedoc-plugins/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@ckeditor/typedoc-plugins",
+  "version": "0.0.1",
+  "description": "Various TypeDoc plugins developed by the CKEditor 5 team.",
+  "keywords": [],
+  "dependencies": {
+  },
+  "devDependencies": {
+  },
+  "engines": {
+    "node": ">=14.0.0",
+    "npm": ">=5.7.1"
+  },
+  "files": [
+    "lib"
+  ],
+  "author": "CKSource (http://cksource.com/)",
+  "license": "MIT",
+  "homepage": "https://github.com/ckeditor/ckeditor5-dev/tree/master/packages/typedoc-plugins",
+  "bugs": "https://github.com/ckeditor/ckeditor5/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ckeditor/ckeditor5-dev.git",
+    "directory": "packages/typedoc-plugins"
+  }
+}

--- a/packages/typedoc-plugins/package.json
+++ b/packages/typedoc-plugins/package.json
@@ -7,7 +7,8 @@
     "typedoc": "^0.22.17"
   },
   "devDependencies": {
-    "chai": "^4.2.0"
+    "chai": "^4.2.0",
+    "fast-glob": "^3.2.4"
   },
   "engines": {
     "node": ">=14.0.0",

--- a/packages/typedoc-plugins/package.json
+++ b/packages/typedoc-plugins/package.json
@@ -4,8 +4,10 @@
   "description": "Various TypeDoc plugins developed by the CKEditor 5 team.",
   "keywords": [],
   "dependencies": {
+    "typedoc": "^0.22.17"
   },
   "devDependencies": {
+    "chai": "^4.2.0"
   },
   "engines": {
     "node": ">=14.0.0",

--- a/packages/typedoc-plugins/tests/module-fixer/fixtures/customerror.ts
+++ b/packages/typedoc-plugins/tests/module-fixer/fixtures/customerror.ts
@@ -1,0 +1,13 @@
+/**
+ * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+import Error from './error';
+
+/**
+ * @module fixtures/customerror
+ */
+
+export default class CustomError extends Error {
+}

--- a/packages/typedoc-plugins/tests/module-fixer/fixtures/error.ts
+++ b/packages/typedoc-plugins/tests/module-fixer/fixtures/error.ts
@@ -1,0 +1,20 @@
+/**
+ * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/**
+ * @module fixtures/error
+ */
+
+export default class Error {
+	protected errorName: string;
+
+	constructor( errorName: string ) {
+		this.errorName = errorName;
+	}
+
+	public get name(): string {
+		return this.errorName;
+	}
+}

--- a/packages/typedoc-plugins/tests/module-fixer/fixtures/logger.ts
+++ b/packages/typedoc-plugins/tests/module-fixer/fixtures/logger.ts
@@ -1,0 +1,16 @@
+/**
+ * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+import type Error from './error';
+
+/**
+ * @module fixtures/logger
+ */
+
+export default class Logger {
+	public static error( error: Error ): void {
+		console.log( error.name );
+	}
+}

--- a/packages/typedoc-plugins/tests/module-fixer/fixtures/tsconfig.json
+++ b/packages/typedoc-plugins/tests/module-fixer/fixtures/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.json"
+}

--- a/packages/typedoc-plugins/tests/module-fixer/index.js
+++ b/packages/typedoc-plugins/tests/module-fixer/index.js
@@ -1,0 +1,63 @@
+/**
+ * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+const path = require( 'path' );
+const { expect } = require( 'chai' );
+const glob = require( 'fast-glob' );
+const TypeDoc = require( 'typedoc' );
+
+const paths = require( '../utils' );
+
+const FIXTURES_PATH = path.join( paths.ROOT_TEST_DIRECTORY, 'module-fixer', 'fixtures' );
+
+describe( 'module-fixer', () => {
+	let conversionResult;
+
+	before( async () => {
+		const sourceFilePatterns = [
+			path.join( FIXTURES_PATH, '**', '*.ts' )
+		];
+
+		const files = await glob( sourceFilePatterns );
+		const typeDoc = new TypeDoc.Application();
+
+		expect( files ).to.not.lengthOf( 0 );
+
+		typeDoc.options.addReader( new TypeDoc.TSConfigReader() );
+		typeDoc.options.addReader( new TypeDoc.TypeDocReader() );
+
+		typeDoc.bootstrap( {
+			logLevel: 'Error',
+			entryPoints: files,
+			plugin: [
+				require.resolve( '@ckeditor/typedoc-plugins/lib/module-fixer' )
+			],
+			// TODO: To resolve once the same problem is fixed in the `@ckeditor/ckeditor5-dev-docs` package.
+			tsconfig: path.join( FIXTURES_PATH, 'tsconfig.json' )
+		} );
+
+		conversionResult = typeDoc.convert();
+
+		expect( conversionResult ).to.be.an( 'object' );
+	} );
+
+	it( 'should parse the module definition from a file without import statements', () => {
+		const errorModule = conversionResult.children.find( doclet => doclet.name === 'fixtures/error' );
+
+		expect( errorModule ).to.not.be.undefined;
+	} );
+
+	it( 'should parse the module definition from a file with import type statements', () => {
+		const errorModule = conversionResult.children.find( doclet => doclet.name === 'fixtures/logger' );
+
+		expect( errorModule ).to.not.be.undefined;
+	} );
+
+	it( 'should parse the module definition from a file with import statements', () => {
+		const errorModule = conversionResult.children.find( doclet => doclet.name === 'fixtures/customerror' );
+
+		expect( errorModule ).to.not.be.undefined;
+	} );
+} );

--- a/packages/typedoc-plugins/tests/module-fixer/index.js
+++ b/packages/typedoc-plugins/tests/module-fixer/index.js
@@ -3,23 +3,22 @@
  * For licensing, see LICENSE.md.
  */
 
-const path = require( 'path' );
 const { expect } = require( 'chai' );
 const glob = require( 'fast-glob' );
 const TypeDoc = require( 'typedoc' );
 
-const paths = require( '../utils' );
-
-const FIXTURES_PATH = path.join( paths.ROOT_TEST_DIRECTORY, 'module-fixer', 'fixtures' );
+const utils = require( '../utils' );
 
 describe( 'module-fixer', function() {
 	this.timeout( 10 * 1000 );
 
 	let conversionResult;
 
+	const FIXTURES_PATH = utils.normalizePath( utils.ROOT_TEST_DIRECTORY, 'module-fixer', 'fixtures' );
+
 	before( async () => {
 		const sourceFilePatterns = [
-			path.join( FIXTURES_PATH, '**', '*.ts' )
+			utils.normalizePath( FIXTURES_PATH, '**', '*.ts' )
 		];
 
 		const files = await glob( sourceFilePatterns );
@@ -37,7 +36,7 @@ describe( 'module-fixer', function() {
 				require.resolve( '@ckeditor/typedoc-plugins/lib/module-fixer' )
 			],
 			// TODO: To resolve once the same problem is fixed in the `@ckeditor/ckeditor5-dev-docs` package.
-			tsconfig: path.join( FIXTURES_PATH, 'tsconfig.json' )
+			tsconfig: utils.normalizePath( FIXTURES_PATH, 'tsconfig.json' )
 		} );
 
 		conversionResult = typeDoc.convert();

--- a/packages/typedoc-plugins/tests/module-fixer/index.js
+++ b/packages/typedoc-plugins/tests/module-fixer/index.js
@@ -12,7 +12,9 @@ const paths = require( '../utils' );
 
 const FIXTURES_PATH = path.join( paths.ROOT_TEST_DIRECTORY, 'module-fixer', 'fixtures' );
 
-describe( 'module-fixer', () => {
+describe( 'module-fixer', function() {
+	this.timeout( 10 * 1000 );
+
 	let conversionResult;
 
 	before( async () => {

--- a/packages/typedoc-plugins/tests/tsconfig.json
+++ b/packages/typedoc-plugins/tests/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "lib": [
+      "DOM"
+    ],
+    "noImplicitAny": true,
+    "noImplicitOverride": true,
+    "strict": true,
+    "module": "es6",
+    "target": "es2020",
+    "sourceMap": true,
+    "allowJs": true,
+    "moduleResolution": "node"
+  }
+}

--- a/packages/typedoc-plugins/tests/utils.js
+++ b/packages/typedoc-plugins/tests/utils.js
@@ -10,7 +10,18 @@ const path = require( 'path' );
 const ROOT_DIRECTORY = path.join( __dirname, '..' );
 const ROOT_TEST_DIRECTORY = path.join( ROOT_DIRECTORY, 'tests' );
 
+/**
+ * Replaces Windows style paths to Unix.
+ *
+ * @param value
+ * @returns {String}
+ */
+function normalizePath( ...value ) {
+	return value.join( '/' ).replace( /\\/g, '/' );
+}
+
 module.exports = {
-	ROOT_DIRECTORY,
-	ROOT_TEST_DIRECTORY
+	normalizePath,
+	ROOT_DIRECTORY: normalizePath( ROOT_DIRECTORY ),
+	ROOT_TEST_DIRECTORY: normalizePath( ROOT_TEST_DIRECTORY )
 };

--- a/packages/typedoc-plugins/tests/utils.js
+++ b/packages/typedoc-plugins/tests/utils.js
@@ -1,0 +1,16 @@
+/**
+ * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+'use strict';
+
+const path = require( 'path' );
+
+const ROOT_DIRECTORY = path.join( __dirname, '..' );
+const ROOT_TEST_DIRECTORY = path.join( ROOT_DIRECTORY, 'tests' );
+
+module.exports = {
+	ROOT_DIRECTORY,
+	ROOT_TEST_DIRECTORY
+};

--- a/scripts/changelog.js
+++ b/scripts/changelog.js
@@ -16,6 +16,10 @@ require( '../packages/ckeditor5-dev-env' )
 				return 'https://www.npmjs.com/package/@ckeditor/jsdoc-plugins';
 			}
 
+			if ( name === 'typedoc-plugins' ) {
+				return 'https://www.npmjs.com/package/@ckeditor/typedoc-plugins';
+			}
+
 			return 'https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-' + name;
 		}
 	} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature (typedoc-plugins): Created the `@ckeditor/typedoc-plugins` package that contains plugins for the TypeDoc project.

Feature (typedoc-plugins): Added a module-fixer plugin that ensures a module name contains a proper value.
