### PR TITLE
Typedoc plugins

### DIFF
--- a/packages/ckeditor5-dev-docs/lib/docs/index.js
+++ b/packages/ckeditor5-dev-docs/lib/docs/index.js
@@ -57,6 +57,7 @@ module.exports = async function build( config ) {
 
 	typeDoc.bootstrap( {
 		entryPoints: files,
+		logLevel: 'Error',
 		plugin: [
 			'typedoc-plugin-rename-defaults',
 			require.resolve( '@ckeditor/typedoc-plugins/lib/module-fixer' ),

--- a/packages/ckeditor5-dev-docs/lib/docs/index.js
+++ b/packages/ckeditor5-dev-docs/lib/docs/index.js
@@ -59,7 +59,8 @@ module.exports = async function build( config ) {
 		entryPoints: files,
 		plugin: [
 			'typedoc-plugin-rename-defaults',
-			require.resolve( '@ckeditor/typedoc-plugins/lib/module-fixer' )
+			require.resolve( '@ckeditor/typedoc-plugins/lib/module-fixer' ),
+			require.resolve( '@ckeditor/typedoc-plugins/lib/tag-error' )
 		],
 
 		// TODO: Move tsconfig.json to main repo. Also: how to share it across repos? Also: Do we need to share it?

--- a/packages/ckeditor5-dev-docs/package.json
+++ b/packages/ckeditor5-dev-docs/package.json
@@ -14,7 +14,7 @@
     "puppeteer": "^13.1.3",
     "strip-ansi": "^6.0.0",
     "tmp": "^0.2.1",
-    "typedoc": "^0.22.17",
+    "typedoc": "^0.23.15",
     "typedoc-plugin-rename-defaults": "^0.6.4"
   },
   "engines": {

--- a/packages/typedoc-plugins/lib/module-fixer/index.js
+++ b/packages/typedoc-plugins/lib/module-fixer/index.js
@@ -30,10 +30,18 @@ function onEventCreateDeclaration() {
 		}
 
 		const symbol = context.project.getSymbolFromReflection( reflection );
+
+		// When processing an empty file.
+		if ( !symbol ) {
+			return;
+		}
+
 		const node = symbol.declarations[ 0 ];
 
 		// Iterate over statements...
 		for ( const statement of node.statements ) {
+			// TODO: No idea how to cover this line.
+			// CKEditor 5 enters the if. However, the same code created as a fixture doesn't.
 			if ( !Array.isArray( statement.jsDoc ) ) {
 				continue;
 			}
@@ -50,12 +58,11 @@ function onEventCreateDeclaration() {
 				}
 
 				// When found, use its value as a module name.
-				if ( reflection.name !== moduleTag.comment ) {
-					reflection.originalName = reflection.name;
-					reflection.name = moduleTag.comment;
+				reflection.originalName = reflection.name;
+				reflection.name = moduleTag.comment;
 
-					return;
-				}
+				// Escape from the function. We achieved the goal.
+				return;
 			}
 		}
 	};

--- a/packages/typedoc-plugins/lib/tag-error/index.js
+++ b/packages/typedoc-plugins/lib/tag-error/index.js
@@ -1,0 +1,139 @@
+/**
+ * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+'use strict';
+
+const { Converter, ReflectionKind, DeclarationReflection, Comment, CommentTag } = require( 'typedoc' );
+const ts = require( 'typescript' );
+
+const ERROR_TAG_NAME = 'error';
+
+/**
+ * The `typedoc-plugin-module-fixer` reads the module name specified in the `@module` tag name.
+ *
+ *      @module package/file
+ *
+ * For the example specified above, a name of the parsed module should be equal to "package/file".
+ *
+ * It may happen that imports statement are specified above the "@module" block code.
+ * In such a case, built-in plugin in `typedoc` does not read its value properly.
+ */
+module.exports = {
+	load( app ) {
+		const processedModules = new Set();
+
+		app.converter.on( Converter.EVENT_CREATE_DECLARATION, function ( context, reflection, node ) {
+			try {
+				if ( reflection.kind !== ReflectionKind.Module ) {
+					return;
+				}
+
+				const sourceFile = node.getSourceFile();
+
+				// Process the same file only once.
+				if ( processedModules.has( sourceFile.resolvedPath ) ) {
+					return;
+				}
+
+				processedModules.add( sourceFile.resolvedPath );
+
+				const nodes = findDescendant( sourceFile, node => {
+					if ( node.kind !== ts.SyntaxKind.Identifier ) {
+						return false;
+					}
+
+					if ( node.escapedText !== ERROR_TAG_NAME ) {
+						return false;
+					}
+
+					if ( !node.parent.comment ) {
+						return false;
+					}
+
+					return true;
+				} );
+
+				for ( const errorNode of nodes ) {
+					const parentNode = errorNode.parent;
+					const errorName = parentNode.comment;
+
+					try {
+						const errorDeclaration = new DeclarationReflection( errorName, ReflectionKind.ObjectLiteral, reflection );
+						context.addChild( errorDeclaration );
+
+						const comment = new Comment( parentNode.parent.comment.toString() );
+
+						errorDeclaration.originalName = 'EventDeclaration';
+						errorDeclaration.kindString = 'Object literal';
+						errorDeclaration.comment = comment;
+
+						for ( const childTag of parentNode.parent.getChildren() ) {
+							if ( childTag === parentNode ) {
+								continue;
+							}
+
+							const commentTag = new CommentTag(
+								childTag.tagName.escapedText,
+								childTag.name.escapedText,
+								childTag.comment
+							);
+							comment.tags.push( commentTag );
+						}
+
+						// console.log( comment );
+
+						// const declaration = context.createDeclarationReflection(
+						// 	ReflectionKind.ObjectLiteral,
+						// 	undefined,
+						// 	// {
+						// 	// 	flags: 123,
+						// 	// 	escapedName: errorName,
+						// 	// 	declarations: [ errorNode ]
+						// 	//
+						// 	// },
+						// 	undefined
+						// );
+
+						// console.log( require( 'util' ).inspect( reflection, { showHidden: false, depth: 1, colors: true } ) );
+
+						// declaration.name = errorName;
+						// declaration.originalName = 'EventDeclaration';
+
+						// context.addChild( declaration );
+					} catch ( err ) {
+						console.log( err );
+					}
+				}
+
+				// if ( processedModules.size === 1 ) {
+				// 	console.log( require( 'util' ).inspect( context, { showHidden: false, depth: 1, colors: true } ) );
+				// }
+			} catch ( err ) {
+				console.log( err );
+			}
+		} );
+	}
+};
+
+/**
+ * @param {ts.Node} sourceFileOrNode
+ * @param { ( node: ts.Node) : boolean} callback
+ * @returns {Array.<ts.Node>}
+ */
+function findDescendant( sourceFileOrNode, callback ) {
+	const output = [];
+
+	for ( const node of sourceFileOrNode.getChildren() ) {
+		if ( node.getChildCount() ) {
+			output.push( ...findDescendant( node, callback ) );
+		} else {
+			if ( callback( node ) ) {
+				output.push( node );
+			}
+		}
+	}
+
+	return output;
+}

--- a/packages/typedoc-plugins/lib/tag-error/index.js
+++ b/packages/typedoc-plugins/lib/tag-error/index.js
@@ -5,176 +5,118 @@
 
 'use strict';
 
-const { Converter, ReflectionKind, DeclarationReflection, Comment, CommentTag } = require( 'typedoc' );
+const { Converter, ReflectionKind, DeclarationReflection, Comment, CommentTag, TypeParameterReflection } = require( 'typedoc' );
 const ts = require( 'typescript' );
 
 const ERROR_TAG_NAME = 'error';
 
 /**
- * The `typedoc-plugin-module-fixer` reads the module name specified in the `@module` tag name.
+ * The `typedoc-plugin-tag-error` collects error definitions from the `@error` tag.
  *
- *      @module package/file
- *
- * For the example specified above, a name of the parsed module should be equal to "package/file".
- *
- * It may happen that imports statement are specified above the "@module" block code.
- * In such a case, built-in plugin in `typedoc` does not read its value properly.
+ * TODO: We do not support collecting types of `@param`.
  */
 module.exports = {
 	load( app ) {
-		const processedModules = new Set();
-
-		app.converter.on( Converter.EVENT_CREATE_DECLARATION, onEventCreateDeclaration( processedModules ) );
+		app.converter.on( Converter.EVENT_CREATE_DECLARATION, onEventCreateDeclaration() );
 	}
 };
 
-function onEventCreateDeclaration( processedModules ) {
+function onEventCreateDeclaration() {
+	const processedModules = new Set();
+
 	return ( context, reflection ) => {
-		try {
-			if ( reflection.kind !== ReflectionKind.Module ) {
-				return;
+		// Run only when processing a module.
+		if ( reflection.kind !== ReflectionKind.Module ) {
+			return;
+		}
+
+		const symbol = context.project.getSymbolFromReflection( reflection );
+		const node = symbol.declarations[ 0 ];
+		const sourceFile = node.getSourceFile();
+
+		// As we iterate over all its nodes, it is enough to process the same file only once.
+		if ( processedModules.has( sourceFile.resolvedPath ) ) {
+			return;
+		}
+
+		processedModules.add( sourceFile.resolvedPath );
+
+		// Find all `@error` occurrences.
+		const nodes = findDescendant( sourceFile, node => {
+			if ( node.kind !== ts.SyntaxKind.Identifier ) {
+				return false;
 			}
 
-			const symbol = context.project.getSymbolFromReflection( reflection );
-			const node = symbol.declarations[ 0 ];
-			const sourceFile = node.getSourceFile();
-
-			// Process the same file only once.
-			if ( processedModules.has( sourceFile.resolvedPath ) ) {
-				return;
+			if ( node.escapedText !== ERROR_TAG_NAME ) {
+				return false;
 			}
 
-			processedModules.add( sourceFile.resolvedPath );
-
-			const nodes = findDescendant( sourceFile, node => {
-				if ( node.kind !== ts.SyntaxKind.Identifier ) {
-					return false;
-				}
-
-				if ( node.escapedText !== ERROR_TAG_NAME ) {
-					return false;
-				}
-
-				if ( !node.parent.comment ) {
-					return false;
-				}
-
-				return true;
-			} );
-
-			for ( const errorNode of nodes ) {
-				const parentNode = errorNode.parent;
-				const errorName = parentNode.comment;
-
-				try {
-					const errorDeclaration = new DeclarationReflection( errorName, ReflectionKind.ObjectLiteral, reflection );
-					context.addChild( errorDeclaration );
-
-					let commentSummary;
-					const commentSummaryNodes = [];
-
-					if ( typeof parentNode.parent.comment === 'string' ) {
-						commentSummaryNodes.push( parentNode.parent );
-						commentSummary = [
-							{
-								kind: 'text',
-								text: parentNode.parent.comment
-							}
-						];
-					} else {
-						commentSummaryNodes.push( ...parentNode.parent.comment );
-						commentSummary = parentNode.parent.comment.map( item => {
-							let { text } = item;
-
-							if ( item.kind === 324 ) {
-								if ( item.name ) {
-									text = item.name.escapedText + text;
-								}
-
-								return {
-									kind: 'inline-tag',
-									tag: '@link',
-									text
-								};
-							}
-
-							return {
-								kind: 'text',
-								text
-							};
-						} );
-					}
-
-					const comment = new Comment( commentSummary );
-
-					errorDeclaration.originalName = 'EventDeclaration';
-					errorDeclaration.kindString = 'Object literal';
-					errorDeclaration.comment = comment;
-
-					for ( const childTag of parentNode.parent.getChildren() ) {
-						// Do not process the `@error` tag again.
-						if ( childTag === parentNode ) {
-							continue;
-						}
-
-						// Do not process the error description.
-						if ( commentSummaryNodes.includes( childTag ) ) {
-							continue;
-						}
-
-						if ( !childTag.comment ) {
-							continue;
-						}
-
-						const errorParamTag = [];
-						let commentTag;
-
-						if ( typeof childTag.comment === 'string' ) {
-							commentTag = new CommentTag(
-								`@${ childTag.tagName.escapedText }`,
-								[
-									{
-										kind: 'text',
-										text: childTag.comment
-									}
-								]
-							);
-						} else {
-							commentTag = new CommentTag(
-								`@${ childTag.tagName.escapedText }`,
-								childTag.comment.map( item => {
-									let { text } = item;
-
-									if ( item.kind === 324 ) {
-										if ( item.name ) {
-											text = item.name.escapedText + text;
-										}
-
-										return {
-											kind: 'inline-tag',
-											tag: '@link',
-											text
-										};
-									}
-
-									return {
-										kind: 'text',
-										text
-									};
-								} )
-							);
-						}
-					}
-				} catch ( err ) {
-					console.log( err );
-				}
+			if ( !node.parent.comment ) {
+				return false;
 			}
 
-			// if ( processedModules.size === 1 ) {
-			// 	console.log( require( 'util' ).inspect( context, { showHidden: false, depth: 1, colors: true } ) );
-			// }
-		} catch ( err ) {
-			console.log( err );
+			return true;
+		} );
+
+		// Map all definitions to typedoc declarations.
+		const errorDeclarations = nodes.map( errorNode => {
+			const parentNode = errorNode.parent;
+			const errorName = parentNode.comment;
+
+			const errorDeclaration = new DeclarationReflection( errorName, ReflectionKind.ObjectLiteral, reflection );
+			const comment = new Comment( getCommentDisplayPart( parentNode.parent.comment ) );
+
+			errorDeclaration.typeParameters = [];
+
+			for ( const childTag of parentNode.parent.getChildren() ) {
+				// No comments to process.
+				if ( !childTag.comment ) {
+					continue;
+				}
+
+				// Do not process the error description.
+				if ( parentNode.parent === childTag || parentNode.parent.comment.includes( childTag ) ) {
+					// TODO: Perhaps first if is not needed.
+					continue;
+				}
+
+				// Do not process the `@error` tag again.
+				if ( childTag === parentNode ) {
+					continue;
+				}
+
+				const commentTag = getCommentDisplayPart( childTag.comment );
+
+				comment.blockTags.push(
+					new CommentTag( `@${ childTag.tagName.escapedText }`, commentTag )
+				);
+
+				const paramName = childTag.name.escapedText;
+
+				// The assumptions here is that a parameter has a single type.
+				// let type = '*';
+				//
+				// if ( childTag.typeExpression && childTag.typeExpression.type.typeName ) {
+				// 	type = childTag.typeExpression.type.typeName.escapedText;
+				// }
+
+				const param = new TypeParameterReflection( paramName, undefined, undefined, errorDeclaration, undefined );
+
+				// TODO: This line below throws. Perhaps using TypeScript would help.
+				// param.type = new ParameterReflection( type, ReflectionKind.TypeLiteral, param );
+
+				errorDeclaration.typeParameters.push( param );
+			}
+
+			errorDeclaration.comment = comment;
+			errorDeclaration.originalName = 'EventDeclaration';
+			errorDeclaration.kindString = 'Object literal';
+
+			return errorDeclaration;
+		} );
+
+		for ( const declaration of errorDeclarations ) {
+			context.addChild( declaration );
 		}
 	};
 }
@@ -198,4 +140,49 @@ function findDescendant( sourceFileOrNode, callback ) {
 	}
 
 	return output;
+}
+
+/**
+ * Transforms a node or array of node to an array of objects that follow
+ * @param {String|Object|null} commentChildrenOrValue
+ * @returns {null|Array.<require('typedoc').CommentDisplayPart> }
+ */
+function getCommentDisplayPart( commentChildrenOrValue ) {
+	if ( !commentChildrenOrValue ) {
+		return null;
+	}
+
+	if ( typeof commentChildrenOrValue === 'string' ) {
+		return [
+			{
+				kind: 'text',
+				text: commentChildrenOrValue
+			}
+		];
+	}
+
+	return commentChildrenOrValue
+		.map( item => {
+			let { text } = item;
+
+			// An inline tag inside a description.
+			if ( item.kind === 324 ) {
+				// A reference, e.g. "module:".
+				if ( item.name ) {
+					text = item.name.escapedText + text;
+				}
+
+				return {
+					text,
+					kind: 'inline-tag',
+					tag: '@link'
+				};
+			}
+
+			return {
+				text,
+				kind: 'text'
+			};
+		} )
+		.filter( ( { text } ) => text.length );
 }

--- a/packages/typedoc-plugins/lib/tag-error/index.js
+++ b/packages/typedoc-plugins/lib/tag-error/index.js
@@ -24,98 +24,115 @@ module.exports = {
 	load( app ) {
 		const processedModules = new Set();
 
-		app.converter.on( Converter.EVENT_CREATE_DECLARATION, function ( context, reflection, node ) {
-			try {
-				if ( reflection.kind !== ReflectionKind.Module ) {
-					return;
-				}
-
-				const sourceFile = node.getSourceFile();
-
-				// Process the same file only once.
-				if ( processedModules.has( sourceFile.resolvedPath ) ) {
-					return;
-				}
-
-				processedModules.add( sourceFile.resolvedPath );
-
-				const nodes = findDescendant( sourceFile, node => {
-					if ( node.kind !== ts.SyntaxKind.Identifier ) {
-						return false;
-					}
-
-					if ( node.escapedText !== ERROR_TAG_NAME ) {
-						return false;
-					}
-
-					if ( !node.parent.comment ) {
-						return false;
-					}
-
-					return true;
-				} );
-
-				for ( const errorNode of nodes ) {
-					const parentNode = errorNode.parent;
-					const errorName = parentNode.comment;
-
-					try {
-						const errorDeclaration = new DeclarationReflection( errorName, ReflectionKind.ObjectLiteral, reflection );
-						context.addChild( errorDeclaration );
-
-						const comment = new Comment( parentNode.parent.comment.toString() );
-
-						errorDeclaration.originalName = 'EventDeclaration';
-						errorDeclaration.kindString = 'Object literal';
-						errorDeclaration.comment = comment;
-
-						for ( const childTag of parentNode.parent.getChildren() ) {
-							if ( childTag === parentNode ) {
-								continue;
-							}
-
-							const commentTag = new CommentTag(
-								childTag.tagName.escapedText,
-								childTag.name.escapedText,
-								childTag.comment
-							);
-							comment.tags.push( commentTag );
-						}
-
-						// console.log( comment );
-
-						// const declaration = context.createDeclarationReflection(
-						// 	ReflectionKind.ObjectLiteral,
-						// 	undefined,
-						// 	// {
-						// 	// 	flags: 123,
-						// 	// 	escapedName: errorName,
-						// 	// 	declarations: [ errorNode ]
-						// 	//
-						// 	// },
-						// 	undefined
-						// );
-
-						// console.log( require( 'util' ).inspect( reflection, { showHidden: false, depth: 1, colors: true } ) );
-
-						// declaration.name = errorName;
-						// declaration.originalName = 'EventDeclaration';
-
-						// context.addChild( declaration );
-					} catch ( err ) {
-						console.log( err );
-					}
-				}
-
-				// if ( processedModules.size === 1 ) {
-				// 	console.log( require( 'util' ).inspect( context, { showHidden: false, depth: 1, colors: true } ) );
-				// }
-			} catch ( err ) {
-				console.log( err );
-			}
-		} );
+		app.converter.on( Converter.EVENT_CREATE_DECLARATION, onEventCreateDeclaration( processedModules ) );
 	}
 };
+
+function onEventCreateDeclaration( processedModules ) {
+	return ( context, reflection ) => {
+		try {
+			if ( reflection.kind !== ReflectionKind.Module ) {
+				return;
+			}
+
+			const symbol = context.project.getSymbolFromReflection( reflection );
+			const node = symbol.declarations[ 0 ];
+			const sourceFile = node.getSourceFile();
+
+			// Process the same file only once.
+			if ( processedModules.has( sourceFile.resolvedPath ) ) {
+				return;
+			}
+
+			processedModules.add( sourceFile.resolvedPath );
+
+			const nodes = findDescendant( sourceFile, node => {
+				if ( node.kind !== ts.SyntaxKind.Identifier ) {
+					return false;
+				}
+
+				if ( node.escapedText !== ERROR_TAG_NAME ) {
+					return false;
+				}
+
+				if ( !node.parent.comment ) {
+					return false;
+				}
+
+				return true;
+			} );
+
+			for ( const errorNode of nodes ) {
+				const parentNode = errorNode.parent;
+				const errorName = parentNode.comment;
+
+				try {
+					const errorDeclaration = new DeclarationReflection( errorName, ReflectionKind.ObjectLiteral, reflection );
+					context.addChild( errorDeclaration );
+
+					const comment = new Comment( [
+						{
+							kind: 'text',
+							text: parentNode.parent.comment.toString()
+						}
+					] );
+
+					errorDeclaration.originalName = 'EventDeclaration';
+					errorDeclaration.kindString = 'Object literal';
+					errorDeclaration.comment = comment;
+
+					for ( const childTag of parentNode.parent.getChildren() ) {
+						if ( childTag === parentNode ) {
+							continue;
+						}
+
+						const commentTag = new CommentTag(
+							`@${ childTag.tagName.escapedText }`,
+							[
+								{
+									kind: 'text',
+									text: childTag.comment
+								}
+							]
+						);
+
+						commentTag.name = childTag.name.escapedText;
+						comment.blockTags.push( commentTag );
+					}
+
+					// console.log( comment );
+
+					// const declaration = context.createDeclarationReflection(
+					// 	ReflectionKind.ObjectLiteral,
+					// 	undefined,
+					// 	// {
+					// 	// 	flags: 123,
+					// 	// 	escapedName: errorName,
+					// 	// 	declarations: [ errorNode ]
+					// 	//
+					// 	// },
+					// 	undefined
+					// );
+
+					// console.log( require( 'util' ).inspect( reflection, { showHidden: false, depth: 1, colors: true } ) );
+
+					// declaration.name = errorName;
+					// declaration.originalName = 'EventDeclaration';
+
+					// context.addChild( declaration );
+				} catch ( err ) {
+					console.log( err );
+				}
+			}
+
+			// if ( processedModules.size === 1 ) {
+			// 	console.log( require( 'util' ).inspect( context, { showHidden: false, depth: 1, colors: true } ) );
+			// }
+		} catch ( err ) {
+			console.log( err );
+		}
+	};
+}
 
 /**
  * @param {ts.Node} sourceFileOrNode

--- a/packages/typedoc-plugins/lib/tag-error/index.js
+++ b/packages/typedoc-plugins/lib/tag-error/index.js
@@ -22,8 +22,6 @@ module.exports = {
 };
 
 function onEventCreateDeclaration() {
-	const processedModules = new Set();
-
 	return ( context, reflection ) => {
 		// Run only when processing a module.
 		if ( reflection.kind !== ReflectionKind.Module ) {
@@ -33,13 +31,6 @@ function onEventCreateDeclaration() {
 		const symbol = context.project.getSymbolFromReflection( reflection );
 		const node = symbol.declarations[ 0 ];
 		const sourceFile = node.getSourceFile();
-
-		// As we iterate over all its nodes, it is enough to process the same file only once.
-		if ( processedModules.has( sourceFile.resolvedPath ) ) {
-			return;
-		}
-
-		processedModules.add( sourceFile.resolvedPath );
 
 		// Find all `@error` occurrences.
 		const nodes = findDescendant( sourceFile, node => {
@@ -70,13 +61,7 @@ function onEventCreateDeclaration() {
 
 			for ( const childTag of parentNode.parent.getChildren() ) {
 				// No comments to process.
-				if ( !childTag.comment ) {
-					continue;
-				}
-
-				// Do not process the error description.
-				if ( parentNode.parent === childTag || parentNode.parent.comment.includes( childTag ) ) {
-					// TODO: Perhaps first if is not needed.
+				if ( !childTag.comment || !parentNode.parent.comment ) {
 					continue;
 				}
 

--- a/packages/typedoc-plugins/package.json
+++ b/packages/typedoc-plugins/package.json
@@ -4,7 +4,7 @@
   "description": "Various TypeDoc plugins developed by the CKEditor 5 team.",
   "keywords": [],
   "dependencies": {
-    "typedoc": "^0.22.17"
+    "typedoc": "^0.23.15"
   },
   "devDependencies": {
     "chai": "^4.2.0",

--- a/packages/typedoc-plugins/tests/module-fixer/fixtures/customerror.ts
+++ b/packages/typedoc-plugins/tests/module-fixer/fixtures/customerror.ts
@@ -3,11 +3,11 @@
  * For licensing, see LICENSE.md.
  */
 
-import Error from './error';
-
 /**
  * @module fixtures/customerror
  */
+
+import Error from './error';
 
 export default class CustomError extends Error {
 }

--- a/packages/typedoc-plugins/tests/module-fixer/fixtures/licenseonly.ts
+++ b/packages/typedoc-plugins/tests/module-fixer/fixtures/licenseonly.ts
@@ -1,0 +1,9 @@
+/**
+ * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+export default class FooBar {
+	constructor( param: string ) {
+	}
+}

--- a/packages/typedoc-plugins/tests/module-fixer/index.js
+++ b/packages/typedoc-plugins/tests/module-fixer/index.js
@@ -9,7 +9,7 @@ const TypeDoc = require( 'typedoc' );
 
 const utils = require( '../utils' );
 
-describe( 'module-fixer', function() {
+describe( 'typedoc-plugins/module-fixer', function() {
 	this.timeout( 10 * 1000 );
 
 	let conversionResult;

--- a/packages/typedoc-plugins/tests/tag-error/fixtures/customerror.ts
+++ b/packages/typedoc-plugins/tests/tag-error/fixtures/customerror.ts
@@ -1,0 +1,62 @@
+/**
+ * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/**
+ * An error statement occurring before the "@module" definition.
+ *
+ * @error customerror-before-module
+ */
+
+/**
+ * @module fixtures/customerror
+ */
+
+/**
+ * An error statement occurring after the "@module" definition.
+ *
+ * @error customerror-after-module
+ */
+
+import Error from './error';
+
+/**
+ * An error statement occurring before the export keyword.
+ *
+ * @error customerror-before-export
+ */
+
+export default class CustomError extends Error {
+	public static create( errorName: string ): CustomError {
+		/**
+		 * An error statement occurring inside a method.
+		 *
+		 * It contains a parameter.
+		 *
+		 * @error customerror-inside-method
+		 * @param {String} errorName Description of the error.
+		 */
+		return new CustomError( errorName );
+	}
+}
+
+export function create( errorName: string ): CustomError {
+	/**
+	 * An error statement occurring inside a function.
+	 *
+	 * It contains parameters.
+	 *
+	 * @error customerror-inside-function
+	 * @param {String} errorName Description of the error.
+	 * @param {Object} priority The priority of this error.
+	 * @param {Number} priority.value A raw value of the priority.
+	 */
+	return new CustomError( errorName );
+}
+
+/**
+ * An error statement occurring after the export keyword.
+ *
+ * @error customerror-after-export
+ */

--- a/packages/typedoc-plugins/tests/tag-error/fixtures/customerror.ts
+++ b/packages/typedoc-plugins/tests/tag-error/fixtures/customerror.ts
@@ -4,9 +4,15 @@
  */
 
 /**
- * An error statement occurring before the "@module" definition.
+ * An error statement occurring before the `@module` definition. See {@link ~CustomError} or
+ * {@link module:fixtures/customerror~CustomError Custom label}. A text after.
  *
  * @error customerror-before-module
+ *
+ * @param {Number} exampleNumber Number description.
+ * @param {String|module:~CustomError} exampleString String `description`. Please, see {@link ~CustomError} or
+ * @param exampleObject {@link module:utils/object~Object} `description`. Please, see {@link ~CustomError} or
+ * {@link module:fixtures/customerror~CustomError Custom label}. A text after.
  */
 
 /**

--- a/packages/typedoc-plugins/tests/tag-error/fixtures/customerror.ts
+++ b/packages/typedoc-plugins/tests/tag-error/fixtures/customerror.ts
@@ -40,6 +40,10 @@ import Error from './error';
 export default class CustomError extends Error {
 	public static create( errorName: string ): CustomError {
 		/**
+		 * @error customerror-inside-method-no-text
+		 */
+
+		/**
 		 * An error statement occurring inside a method.
 		 *
 		 * It contains a parameter.

--- a/packages/typedoc-plugins/tests/tag-error/fixtures/customerror.ts
+++ b/packages/typedoc-plugins/tests/tag-error/fixtures/customerror.ts
@@ -50,7 +50,7 @@ export default class CustomError extends Error {
 		 *
 		 * @error customerror-inside-method
 		 *
-		 * @param {String} errorName Description of the error. Please, see {@link ~CustomError} or
+		 * @param {String} errorName Description of the error. Please, see {@link ~CustomError}.
 		 * @param {module:utils/object~Object} exampleModule Just a module.
 		 * @param exampleObject A name {@link module:utils/object~Object} `description`.
 		 */

--- a/packages/typedoc-plugins/tests/tag-error/fixtures/customerror.ts
+++ b/packages/typedoc-plugins/tests/tag-error/fixtures/customerror.ts
@@ -4,15 +4,16 @@
  */
 
 /**
+ * An error statement occurring before the `@module` definition.
+ *
+ * @error customerror-before-module
+ */
+
+/**
  * An error statement occurring before the `@module` definition. See {@link ~CustomError} or
  * {@link module:fixtures/customerror~CustomError Custom label}. A text after.
  *
- * @error customerror-before-module
- *
- * @param {Number} exampleNumber Number description.
- * @param {String|module:~CustomError} exampleString String `description`. Please, see {@link ~CustomError} or
- * @param exampleObject {@link module:utils/object~Object} `description`. Please, see {@link ~CustomError} or
- * {@link module:fixtures/customerror~CustomError Custom label}. A text after.
+ * @error customerror-before-module-with-links
  */
 
 /**
@@ -23,6 +24,9 @@
  * An error statement occurring after the "@module" definition.
  *
  * @error customerror-after-module
+ *
+ * @param {Number} exampleNumber Number description.
+ * @param {String} exampleString String `description`.
  */
 
 import Error from './error';
@@ -41,7 +45,10 @@ export default class CustomError extends Error {
 		 * It contains a parameter.
 		 *
 		 * @error customerror-inside-method
-		 * @param {String} errorName Description of the error.
+		 *
+		 * @param {String} errorName Description of the error. Please, see {@link ~CustomError} or
+		 * @param {module:utils/object~Object} exampleModule Just a module.
+		 * @param exampleObject A name {@link module:utils/object~Object} `description`.
 		 */
 		return new CustomError( errorName );
 	}
@@ -54,6 +61,7 @@ export function create( errorName: string ): CustomError {
 	 * It contains parameters.
 	 *
 	 * @error customerror-inside-function
+	 *
 	 * @param {String} errorName Description of the error.
 	 * @param {Object} priority The priority of this error.
 	 * @param {Number} priority.value A raw value of the priority.

--- a/packages/typedoc-plugins/tests/tag-error/fixtures/error.ts
+++ b/packages/typedoc-plugins/tests/tag-error/fixtures/error.ts
@@ -1,0 +1,28 @@
+/**
+ * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/**
+ * @module fixtures/error
+ */
+
+export default class Error {
+	protected errorName: string;
+
+	constructor( errorName: string ) {
+		try {
+			this.errorName = errorName;
+		} catch ( error ) {
+			this.errorName = errorName;
+		}
+	}
+
+	public get name(): string {
+		return this.errorName;
+	}
+
+	public get error(): string {
+		return this.errorName;
+	}
+}

--- a/packages/typedoc-plugins/tests/tag-error/fixtures/tsconfig.json
+++ b/packages/typedoc-plugins/tests/tag-error/fixtures/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.json"
+}

--- a/packages/typedoc-plugins/tests/tag-error/index.js
+++ b/packages/typedoc-plugins/tests/tag-error/index.js
@@ -42,99 +42,107 @@ describe( 'typedoc-plugins/tag-error', function() {
 		conversionResult = typeDoc.convert();
 
 		expect( conversionResult ).to.be.an( 'object' );
+
+		await typeDoc.generateJson( conversionResult, utils.normalizePath( __dirname, 'output.json' ) );
 	} );
 
 	it( 'should find an error tag before the module definition', () => {
 		const errorDefinition = conversionResult.children.find( doclet => doclet.name === 'customerror-before-module' );
 
 		expect( errorDefinition ).to.not.be.undefined;
+
+		// expect( errorDefinition.name ).to.equal( 'customerror-before-module' );
+		// expect( errorDefinition.originalName ).to.equal( 'EventDeclaration' );
+		// expect( errorDefinition.comment ).to.have.property( 'summary' );
+		// expect( errorDefinition.comment.summary ).to.be.an( 'array' );
+		// expect( errorDefinition.comment.summary ).to.lengthOf( 1 );
 	} );
 
-	it( 'should find an error tag after the module definition', () => {
-		const errorDefinition = conversionResult.children.find( doclet => doclet.name === 'customerror-after-module' );
+	// it( 'should find an error tag after the module definition', () => {
+	// 	const errorDefinition = conversionResult.children.find( doclet => doclet.name === 'customerror-after-module' );
+	//
+	// 	expect( errorDefinition ).to.not.be.undefined;
+	// } );
+	//
+	// it( 'should find an error tag before the export keyword', () => {
+	// 	const errorDefinition = conversionResult.children.find( doclet => doclet.name === 'customerror-before-export' );
+	//
+	// 	expect( errorDefinition ).to.not.be.undefined;
+	// } );
+	//
+	// it( 'should find an error tag after the export keyword', () => {
+	// 	const errorDefinition = conversionResult.children.find( doclet => doclet.name === 'customerror-after-export' );
+	//
+	// 	expect( errorDefinition ).to.not.be.undefined;
+	// } );
 
-		expect( errorDefinition ).to.not.be.undefined;
-	} );
-
-	it( 'should find an error tag before the export keyword', () => {
-		const errorDefinition = conversionResult.children.find( doclet => doclet.name === 'customerror-before-export' );
-
-		expect( errorDefinition ).to.not.be.undefined;
-	} );
-
-	it( 'should find an error tag after the export keyword', () => {
-		const errorDefinition = conversionResult.children.find( doclet => doclet.name === 'customerror-after-export' );
-
-		expect( errorDefinition ).to.not.be.undefined;
-	} );
-
-	it( 'should find an error tag inside a method', () => {
-		const errorDefinition = conversionResult.children.find( doclet => doclet.name === 'customerror-inside-method' );
-
-		expect( errorDefinition ).to.not.be.undefined;
-		expect( errorDefinition.name ).to.equal( 'customerror-inside-method' );
-		expect( errorDefinition.originalName ).to.equal( 'EventDeclaration' );
-		expect( errorDefinition.comment ).to.have.property( 'summary' );
-		expect( errorDefinition.comment.summary ).to.be.an( 'array' );
-		expect( errorDefinition.comment.summary ).to.lengthOf( 1 );
-		expect( errorDefinition.comment.summary[ 0 ] ).to.deep.equal( {
-			kind: 'text',
-			text: 'An error statement occurring inside a method.\n' +
-				'\n' +
-				'It contains a parameter.'
-		} );
-		expect( errorDefinition.comment ).to.have.property( 'blockTags' );
-		expect( errorDefinition.comment.blockTags ).to.be.an( 'array' );
-		expect( errorDefinition.comment.blockTags ).to.lengthOf( 1 );
-		expect( errorDefinition.comment.blockTags[ 0 ] ).to.deep.equal( {
-			tag: '@param',
-			name: 'errorName',
-			content: [
-				{
-					kind: 'text',
-					text: 'Description of the error.'
-				}
-			]
-		} );
-	} );
-
-	it( 'should find an error tag inside a function', () => {
-		const errorDefinition = conversionResult.children.find( doclet => doclet.name === 'customerror-inside-function' );
-
-		expect( errorDefinition ).to.not.be.undefined;
-		expect( errorDefinition.name ).to.equal( 'customerror-inside-function' );
-		expect( errorDefinition.originalName ).to.equal( 'EventDeclaration' );
-		expect( errorDefinition.comment ).to.have.property( 'summary' );
-		expect( errorDefinition.comment.summary ).to.be.an( 'array' );
-		expect( errorDefinition.comment.summary ).to.lengthOf( 1 );
-		expect( errorDefinition.comment.summary[ 0 ] ).to.deep.equal( {
-			kind: 'text',
-			text: 'An error statement occurring inside a function.\n' +
-				'\n' +
-				'It contains parameters.'
-		} );
-		expect( errorDefinition.comment ).to.have.property( 'blockTags' );
-		expect( errorDefinition.comment.blockTags ).to.be.an( 'array' );
-		expect( errorDefinition.comment.blockTags ).to.lengthOf( 2 );
-		expect( errorDefinition.comment.blockTags[ 0 ] ).to.deep.equal( {
-			tag: '@param',
-			name: 'errorName',
-			content: [
-				{
-					kind: 'text',
-					text: 'Description of the error.'
-				}
-			]
-		} );
-		expect( errorDefinition.comment.blockTags[ 1 ] ).to.deep.equal( {
-			tag: '@param',
-			name: 'priority',
-			content: [
-				{
-					kind: 'text',
-					text: 'The priority of this error.'
-				}
-			]
-		} );
-	} );
+	// it( 'should find an error tag inside a method', () => {
+	// 	const errorDefinition = conversionResult.children.find( doclet => doclet.name === 'customerror-inside-method' );
+	//
+	// 	expect( errorDefinition ).to.not.be.undefined;
+	// 	expect( errorDefinition.name ).to.equal( 'customerror-inside-method' );
+	// 	expect( errorDefinition.originalName ).to.equal( 'EventDeclaration' );
+	// 	expect( errorDefinition.comment ).to.have.property( 'summary' );
+	// 	expect( errorDefinition.comment.summary ).to.be.an( 'array' );
+	// 	expect( errorDefinition.comment.summary ).to.lengthOf( 1 );
+	// 	expect( errorDefinition.comment.summary[ 0 ] ).to.deep.equal( {
+	// 		kind: 'text',
+	// 		text: 'An error statement occurring inside a method.\n' +
+	// 			'\n' +
+	// 			'It contains a parameter.'
+	// 	} );
+	// 	expect( errorDefinition.comment ).to.have.property( 'blockTags' );
+	// 	expect( errorDefinition.comment.blockTags ).to.be.an( 'array' );
+	// 	expect( errorDefinition.comment.blockTags ).to.lengthOf( 1 );
+	// 	expect( errorDefinition.comment.blockTags[ 0 ] ).to.deep.equal( {
+	// 		tag: '@param',
+	// 		name: 'errorName',
+	// 		content: [
+	// 			{
+	// 				kind: 'text',
+	// 				text: 'Description of the error.'
+	// 			}
+	// 		]
+	// 	} );
+	// } );
+	//
+	// it( 'should find an error tag inside a function', () => {
+	// 	const errorDefinition = conversionResult.children.find( doclet => doclet.name === 'customerror-inside-function' );
+	//
+	// 	expect( errorDefinition ).to.not.be.undefined;
+	// 	expect( errorDefinition.name ).to.equal( 'customerror-inside-function' );
+	// 	expect( errorDefinition.originalName ).to.equal( 'EventDeclaration' );
+	// 	expect( errorDefinition.comment ).to.have.property( 'summary' );
+	// 	expect( errorDefinition.comment.summary ).to.be.an( 'array' );
+	// 	expect( errorDefinition.comment.summary ).to.lengthOf( 1 );
+	// 	expect( errorDefinition.comment.summary[ 0 ] ).to.deep.equal( {
+	// 		kind: 'text',
+	// 		text: 'An error statement occurring inside a function.\n' +
+	// 			'\n' +
+	// 			'It contains parameters.'
+	// 	} );
+	// 	expect( errorDefinition.comment ).to.have.property( 'blockTags' );
+	// 	expect( errorDefinition.comment.blockTags ).to.be.an( 'array' );
+	// 	expect( errorDefinition.comment.blockTags ).to.lengthOf( 2 );
+	// 	expect( errorDefinition.comment.blockTags[ 0 ] ).to.deep.equal( {
+	// 		tag: '@param',
+	// 		name: 'errorName',
+	// 		content: [
+	// 			{
+	// 				kind: 'text',
+	// 				text: 'Description of the error.'
+	// 			}
+	// 		]
+	// 	} );
+	// 	expect( errorDefinition.comment.blockTags[ 1 ] ).to.deep.equal( {
+	// 		tag: '@param',
+	// 		name: 'priority',
+	// 		content: [
+	// 			{
+	// 				kind: 'text',
+	// 				text: 'The priority of this error.'
+	// 			}
+	// 		]
+	// 	} );
+	// } );
 } );

--- a/packages/typedoc-plugins/tests/tag-error/index.js
+++ b/packages/typedoc-plugins/tests/tag-error/index.js
@@ -42,107 +42,229 @@ describe( 'typedoc-plugins/tag-error', function() {
 		conversionResult = typeDoc.convert();
 
 		expect( conversionResult ).to.be.an( 'object' );
-
-		await typeDoc.generateJson( conversionResult, utils.normalizePath( __dirname, 'output.json' ) );
 	} );
 
-	it( 'should find an error tag before the module definition', () => {
+	it( 'should find an error tag before the module definition (raw text)', () => {
 		const errorDefinition = conversionResult.children.find( doclet => doclet.name === 'customerror-before-module' );
 
 		expect( errorDefinition ).to.not.be.undefined;
-
-		// expect( errorDefinition.name ).to.equal( 'customerror-before-module' );
-		// expect( errorDefinition.originalName ).to.equal( 'EventDeclaration' );
-		// expect( errorDefinition.comment ).to.have.property( 'summary' );
-		// expect( errorDefinition.comment.summary ).to.be.an( 'array' );
-		// expect( errorDefinition.comment.summary ).to.lengthOf( 1 );
+		expect( errorDefinition.name ).to.equal( 'customerror-before-module' );
+		expect( errorDefinition.originalName ).to.equal( 'EventDeclaration' );
+		expect( errorDefinition.comment ).to.have.property( 'summary' );
+		expect( errorDefinition.comment.summary ).to.be.an( 'array' );
+		expect( errorDefinition.comment.summary ).to.lengthOf( 1 );
+		expect( errorDefinition.comment.summary[ 0 ] ).to.deep.equal( {
+			kind: 'text',
+			text: 'An error statement occurring before the `@module` definition.'
+		} );
+		expect( errorDefinition.comment.blockTags ).to.lengthOf( 0 );
 	} );
 
-	// it( 'should find an error tag after the module definition', () => {
-	// 	const errorDefinition = conversionResult.children.find( doclet => doclet.name === 'customerror-after-module' );
-	//
-	// 	expect( errorDefinition ).to.not.be.undefined;
-	// } );
-	//
-	// it( 'should find an error tag before the export keyword', () => {
-	// 	const errorDefinition = conversionResult.children.find( doclet => doclet.name === 'customerror-before-export' );
-	//
-	// 	expect( errorDefinition ).to.not.be.undefined;
-	// } );
-	//
-	// it( 'should find an error tag after the export keyword', () => {
-	// 	const errorDefinition = conversionResult.children.find( doclet => doclet.name === 'customerror-after-export' );
-	//
-	// 	expect( errorDefinition ).to.not.be.undefined;
-	// } );
+	it( 'should find an error tag before the module definition (with {@link})', () => {
+		const errorDefinition = conversionResult.children.find( doclet => doclet.name === 'customerror-before-module-with-links' );
 
-	// it( 'should find an error tag inside a method', () => {
-	// 	const errorDefinition = conversionResult.children.find( doclet => doclet.name === 'customerror-inside-method' );
-	//
-	// 	expect( errorDefinition ).to.not.be.undefined;
-	// 	expect( errorDefinition.name ).to.equal( 'customerror-inside-method' );
-	// 	expect( errorDefinition.originalName ).to.equal( 'EventDeclaration' );
-	// 	expect( errorDefinition.comment ).to.have.property( 'summary' );
-	// 	expect( errorDefinition.comment.summary ).to.be.an( 'array' );
-	// 	expect( errorDefinition.comment.summary ).to.lengthOf( 1 );
-	// 	expect( errorDefinition.comment.summary[ 0 ] ).to.deep.equal( {
-	// 		kind: 'text',
-	// 		text: 'An error statement occurring inside a method.\n' +
-	// 			'\n' +
-	// 			'It contains a parameter.'
-	// 	} );
-	// 	expect( errorDefinition.comment ).to.have.property( 'blockTags' );
-	// 	expect( errorDefinition.comment.blockTags ).to.be.an( 'array' );
-	// 	expect( errorDefinition.comment.blockTags ).to.lengthOf( 1 );
-	// 	expect( errorDefinition.comment.blockTags[ 0 ] ).to.deep.equal( {
-	// 		tag: '@param',
-	// 		name: 'errorName',
-	// 		content: [
-	// 			{
-	// 				kind: 'text',
-	// 				text: 'Description of the error.'
-	// 			}
-	// 		]
-	// 	} );
-	// } );
-	//
-	// it( 'should find an error tag inside a function', () => {
-	// 	const errorDefinition = conversionResult.children.find( doclet => doclet.name === 'customerror-inside-function' );
-	//
-	// 	expect( errorDefinition ).to.not.be.undefined;
-	// 	expect( errorDefinition.name ).to.equal( 'customerror-inside-function' );
-	// 	expect( errorDefinition.originalName ).to.equal( 'EventDeclaration' );
-	// 	expect( errorDefinition.comment ).to.have.property( 'summary' );
-	// 	expect( errorDefinition.comment.summary ).to.be.an( 'array' );
-	// 	expect( errorDefinition.comment.summary ).to.lengthOf( 1 );
-	// 	expect( errorDefinition.comment.summary[ 0 ] ).to.deep.equal( {
-	// 		kind: 'text',
-	// 		text: 'An error statement occurring inside a function.\n' +
-	// 			'\n' +
-	// 			'It contains parameters.'
-	// 	} );
-	// 	expect( errorDefinition.comment ).to.have.property( 'blockTags' );
-	// 	expect( errorDefinition.comment.blockTags ).to.be.an( 'array' );
-	// 	expect( errorDefinition.comment.blockTags ).to.lengthOf( 2 );
-	// 	expect( errorDefinition.comment.blockTags[ 0 ] ).to.deep.equal( {
-	// 		tag: '@param',
-	// 		name: 'errorName',
-	// 		content: [
-	// 			{
-	// 				kind: 'text',
-	// 				text: 'Description of the error.'
-	// 			}
-	// 		]
-	// 	} );
-	// 	expect( errorDefinition.comment.blockTags[ 1 ] ).to.deep.equal( {
-	// 		tag: '@param',
-	// 		name: 'priority',
-	// 		content: [
-	// 			{
-	// 				kind: 'text',
-	// 				text: 'The priority of this error.'
-	// 			}
-	// 		]
-	// 	} );
-	// } );
+		expect( errorDefinition ).to.not.be.undefined;
+		expect( errorDefinition.name ).to.equal( 'customerror-before-module-with-links' );
+		expect( errorDefinition.originalName ).to.equal( 'EventDeclaration' );
+		expect( errorDefinition.comment ).to.have.property( 'summary' );
+		expect( errorDefinition.comment.summary ).to.be.an( 'array' );
+		expect( errorDefinition.comment.summary ).to.lengthOf( 5 );
+		expect( errorDefinition.comment.summary[ 0 ] ).to.deep.equal( {
+			kind: 'text',
+			text: 'An error statement occurring before the `@module` definition. See '
+		} );
+		expect( errorDefinition.comment.summary[ 1 ] ).to.deep.equal( {
+			kind: 'inline-tag',
+			tag: '@link',
+			text: '~CustomError'
+		} );
+		expect( errorDefinition.comment.summary[ 2 ] ).to.deep.equal( {
+			kind: 'text',
+			text: ' or\n'
+		} );
+		expect( errorDefinition.comment.summary[ 3 ] ).to.deep.equal( {
+			kind: 'inline-tag',
+			tag: '@link',
+			text: 'module:fixtures/customerror~CustomError Custom label'
+		} );
+		expect( errorDefinition.comment.summary[ 4 ] ).to.deep.equal( {
+			kind: 'text',
+			text: '. A text after.'
+		} );
+		expect( errorDefinition.comment.blockTags ).to.lengthOf( 0 );
+	} );
+
+	it( 'should find an error tag after the module definition (error with params, pure text)', () => {
+		const errorDefinition = conversionResult.children.find( doclet => doclet.name === 'customerror-after-module' );
+
+		expect( errorDefinition ).to.not.be.undefined;
+		expect( errorDefinition.originalName ).to.equal( 'EventDeclaration' );
+		expect( errorDefinition.comment ).to.have.property( 'summary' );
+		expect( errorDefinition.comment.summary ).to.be.an( 'array' );
+		expect( errorDefinition.comment.summary ).to.lengthOf( 1 );
+		expect( errorDefinition.comment.summary[ 0 ] ).to.deep.equal( {
+			kind: 'text',
+			text: 'An error statement occurring after the "@module" definition.'
+		} );
+		expect( errorDefinition.comment.blockTags ).to.lengthOf( 2 );
+		expect( errorDefinition.comment.blockTags[ 0 ] ).to.deep.equal( {
+			tag: '@param',
+			content: [
+				{
+					kind: 'text',
+					text: 'Number description.'
+				}
+			]
+		} );
+		expect( errorDefinition.comment.blockTags[ 1 ] ).to.deep.equal( {
+			tag: '@param',
+			content: [
+				{
+					kind: 'text',
+					text: 'String `description`.'
+				}
+			]
+		} );
+		expect( errorDefinition.typeParameters ).to.lengthOf( 2 );
+		expect( errorDefinition.typeParameters[ 0 ] ).to.have.property( 'name', 'exampleNumber' );
+		expect( errorDefinition.typeParameters[ 1 ] ).to.have.property( 'name', 'exampleString' );
+	} );
+
+	it( 'should find an error tag before the export keyword', () => {
+		const errorDefinition = conversionResult.children.find( doclet => doclet.name === 'customerror-before-export' );
+
+		expect( errorDefinition ).to.not.be.undefined;
+		expect( errorDefinition.originalName ).to.equal( 'EventDeclaration' );
+		expect( errorDefinition.comment ).to.have.property( 'summary' );
+		expect( errorDefinition.comment.summary ).to.be.an( 'array' );
+		expect( errorDefinition.comment.summary ).to.lengthOf( 1 );
+		expect( errorDefinition.comment.summary[ 0 ] ).to.deep.equal( {
+			kind: 'text',
+			text: 'An error statement occurring before the export keyword.'
+		} );
+	} );
+
+	it( 'should find an error tag after the export keyword', () => {
+		const errorDefinition = conversionResult.children.find( doclet => doclet.name === 'customerror-after-export' );
+
+		expect( errorDefinition ).to.not.be.undefined;
+		expect( errorDefinition.originalName ).to.equal( 'EventDeclaration' );
+		expect( errorDefinition.comment ).to.have.property( 'summary' );
+		expect( errorDefinition.comment.summary ).to.be.an( 'array' );
+		expect( errorDefinition.comment.summary ).to.lengthOf( 1 );
+		expect( errorDefinition.comment.summary[ 0 ] ).to.deep.equal( {
+			kind: 'text',
+			text: 'An error statement occurring after the export keyword.'
+		} );
+	} );
+
+	it( 'should find an error tag inside a method', () => {
+		const errorDefinition = conversionResult.children.find( doclet => doclet.name === 'customerror-inside-method' );
+
+		expect( errorDefinition ).to.not.be.undefined;
+		expect( errorDefinition.name ).to.equal( 'customerror-inside-method' );
+		expect( errorDefinition.originalName ).to.equal( 'EventDeclaration' );
+		expect( errorDefinition.comment ).to.have.property( 'summary' );
+		expect( errorDefinition.comment.summary ).to.be.an( 'array' );
+		expect( errorDefinition.comment.summary ).to.lengthOf( 1 );
+		expect( errorDefinition.comment.summary[ 0 ] ).to.deep.equal( {
+			kind: 'text',
+			text: 'An error statement occurring inside a method.\n' +
+				'\n' +
+				'It contains a parameter.'
+		} );
+		expect( errorDefinition.comment ).to.have.property( 'blockTags' );
+		expect( errorDefinition.comment.blockTags ).to.be.an( 'array' );
+		expect( errorDefinition.comment.blockTags ).to.lengthOf( 3 );
+		expect( errorDefinition.comment.blockTags[ 0 ] ).to.deep.equal( {
+			tag: '@param',
+			content: [
+				{
+					kind: 'text',
+					text: 'Description of the error. Please, see '
+				},
+				{
+					kind: 'inline-tag',
+					tag: '@link',
+					text: '~CustomError'
+				},
+				{
+					kind: 'text',
+					text: ' or'
+				}
+			]
+		} );
+		expect( errorDefinition.comment.blockTags[ 1 ] ).to.deep.equal( {
+			tag: '@param',
+			content: [
+				{
+					kind: 'text',
+					text: 'Just a module.'
+				}
+			]
+		} );
+		expect( errorDefinition.comment.blockTags[ 2 ] ).to.deep.equal( {
+			tag: '@param',
+			content: [
+				{
+					kind: 'text',
+					text: 'A name '
+				},
+				{
+					kind: 'inline-tag',
+					tag: '@link',
+					text: 'module:utils/object~Object'
+				},
+				{
+					kind: 'text',
+					text: ' `description`.'
+				}
+			]
+		} );
+		expect( errorDefinition.typeParameters ).to.lengthOf( 3 );
+		expect( errorDefinition.typeParameters[ 0 ] ).to.have.property( 'name', 'errorName' );
+		expect( errorDefinition.typeParameters[ 1 ] ).to.have.property( 'name', 'exampleModule' );
+		expect( errorDefinition.typeParameters[ 2 ] ).to.have.property( 'name', 'exampleObject' );
+	} );
+
+	it( 'should find an error tag inside a function', () => {
+		const errorDefinition = conversionResult.children.find( doclet => doclet.name === 'customerror-inside-function' );
+
+		expect( errorDefinition ).to.not.be.undefined;
+		expect( errorDefinition.name ).to.equal( 'customerror-inside-function' );
+		expect( errorDefinition.originalName ).to.equal( 'EventDeclaration' );
+		expect( errorDefinition.comment ).to.have.property( 'summary' );
+		expect( errorDefinition.comment.summary ).to.be.an( 'array' );
+		expect( errorDefinition.comment.summary ).to.lengthOf( 1 );
+		expect( errorDefinition.comment.summary[ 0 ] ).to.deep.equal( {
+			kind: 'text',
+			text: 'An error statement occurring inside a function.\n' +
+				'\n' +
+				'It contains parameters.'
+		} );
+		expect( errorDefinition.comment ).to.have.property( 'blockTags' );
+		expect( errorDefinition.comment.blockTags ).to.be.an( 'array' );
+		expect( errorDefinition.comment.blockTags ).to.lengthOf( 2 );
+		expect( errorDefinition.comment.blockTags[ 0 ] ).to.deep.equal( {
+			tag: '@param',
+			content: [
+				{
+					kind: 'text',
+					text: 'Description of the error.'
+				}
+			]
+		} );
+		expect( errorDefinition.comment.blockTags[ 1 ] ).to.deep.equal( {
+			tag: '@param',
+			content: [
+				{
+					kind: 'text',
+					text: 'The priority of this error.'
+				}
+			]
+		} );
+		expect( errorDefinition.typeParameters ).to.lengthOf( 2 );
+		expect( errorDefinition.typeParameters[ 0 ] ).to.have.property( 'name', 'errorName' );
+		expect( errorDefinition.typeParameters[ 1 ] ).to.have.property( 'name', 'priority' );
+	} );
 } );

--- a/packages/typedoc-plugins/tests/tag-error/index.js
+++ b/packages/typedoc-plugins/tests/tag-error/index.js
@@ -1,0 +1,140 @@
+/**
+ * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+const { expect } = require( 'chai' );
+const glob = require( 'fast-glob' );
+const TypeDoc = require( 'typedoc' );
+
+const utils = require( '../utils' );
+
+describe( 'typedoc-plugins/tag-error', function() {
+	this.timeout( 10 * 1000 );
+
+	let conversionResult;
+
+	const FIXTURES_PATH = utils.normalizePath( utils.ROOT_TEST_DIRECTORY, 'tag-error', 'fixtures' );
+
+	before( async () => {
+		const sourceFilePatterns = [
+			utils.normalizePath( FIXTURES_PATH, '**', '*.ts' )
+		];
+
+		const files = await glob( sourceFilePatterns );
+		const typeDoc = new TypeDoc.Application();
+
+		expect( files ).to.not.lengthOf( 0 );
+
+		typeDoc.options.addReader( new TypeDoc.TSConfigReader() );
+		typeDoc.options.addReader( new TypeDoc.TypeDocReader() );
+
+		typeDoc.bootstrap( {
+			logLevel: 'Error',
+			entryPoints: files,
+			plugin: [
+				require.resolve( '@ckeditor/typedoc-plugins/lib/tag-error' )
+			],
+			// TODO: To resolve once the same problem is fixed in the `@ckeditor/ckeditor5-dev-docs` package.
+			tsconfig: utils.normalizePath( FIXTURES_PATH, 'tsconfig.json' )
+		} );
+
+		conversionResult = typeDoc.convert();
+
+		expect( conversionResult ).to.be.an( 'object' );
+	} );
+
+	it( 'should find an error tag before the module definition', () => {
+		const errorDefinition = conversionResult.children.find( doclet => doclet.name === 'customerror-before-module' );
+
+		expect( errorDefinition ).to.not.be.undefined;
+	} );
+
+	it( 'should find an error tag after the module definition', () => {
+		const errorDefinition = conversionResult.children.find( doclet => doclet.name === 'customerror-after-module' );
+
+		expect( errorDefinition ).to.not.be.undefined;
+	} );
+
+	it( 'should find an error tag before the export keyword', () => {
+		const errorDefinition = conversionResult.children.find( doclet => doclet.name === 'customerror-before-export' );
+
+		expect( errorDefinition ).to.not.be.undefined;
+	} );
+
+	it( 'should find an error tag after the export keyword', () => {
+		const errorDefinition = conversionResult.children.find( doclet => doclet.name === 'customerror-after-export' );
+
+		expect( errorDefinition ).to.not.be.undefined;
+	} );
+
+	it( 'should find an error tag inside a method', () => {
+		const errorDefinition = conversionResult.children.find( doclet => doclet.name === 'customerror-inside-method' );
+
+		expect( errorDefinition ).to.not.be.undefined;
+		expect( errorDefinition.name ).to.equal( 'customerror-inside-method' );
+		expect( errorDefinition.originalName ).to.equal( 'EventDeclaration' );
+		expect( errorDefinition.comment ).to.have.property( 'summary' );
+		expect( errorDefinition.comment.summary ).to.be.an( 'array' );
+		expect( errorDefinition.comment.summary ).to.lengthOf( 1 );
+		expect( errorDefinition.comment.summary[ 0 ] ).to.deep.equal( {
+			kind: 'text',
+			text: 'An error statement occurring inside a method.\n' +
+				'\n' +
+				'It contains a parameter.'
+		} );
+		expect( errorDefinition.comment ).to.have.property( 'blockTags' );
+		expect( errorDefinition.comment.blockTags ).to.be.an( 'array' );
+		expect( errorDefinition.comment.blockTags ).to.lengthOf( 1 );
+		expect( errorDefinition.comment.blockTags[ 0 ] ).to.deep.equal( {
+			tag: '@param',
+			name: 'errorName',
+			content: [
+				{
+					kind: 'text',
+					text: 'Description of the error.'
+				}
+			]
+		} );
+	} );
+
+	it( 'should find an error tag inside a function', () => {
+		const errorDefinition = conversionResult.children.find( doclet => doclet.name === 'customerror-inside-function' );
+
+		expect( errorDefinition ).to.not.be.undefined;
+		expect( errorDefinition.name ).to.equal( 'customerror-inside-function' );
+		expect( errorDefinition.originalName ).to.equal( 'EventDeclaration' );
+		expect( errorDefinition.comment ).to.have.property( 'summary' );
+		expect( errorDefinition.comment.summary ).to.be.an( 'array' );
+		expect( errorDefinition.comment.summary ).to.lengthOf( 1 );
+		expect( errorDefinition.comment.summary[ 0 ] ).to.deep.equal( {
+			kind: 'text',
+			text: 'An error statement occurring inside a function.\n' +
+				'\n' +
+				'It contains parameters.'
+		} );
+		expect( errorDefinition.comment ).to.have.property( 'blockTags' );
+		expect( errorDefinition.comment.blockTags ).to.be.an( 'array' );
+		expect( errorDefinition.comment.blockTags ).to.lengthOf( 2 );
+		expect( errorDefinition.comment.blockTags[ 0 ] ).to.deep.equal( {
+			tag: '@param',
+			name: 'errorName',
+			content: [
+				{
+					kind: 'text',
+					text: 'Description of the error.'
+				}
+			]
+		} );
+		expect( errorDefinition.comment.blockTags[ 1 ] ).to.deep.equal( {
+			tag: '@param',
+			name: 'priority',
+			content: [
+				{
+					kind: 'text',
+					text: 'The priority of this error.'
+				}
+			]
+		} );
+	} );
+} );

--- a/packages/typedoc-plugins/tests/tag-error/index.js
+++ b/packages/typedoc-plugins/tests/tag-error/index.js
@@ -60,6 +60,15 @@ describe( 'typedoc-plugins/tag-error', function() {
 		expect( errorDefinition.comment.blockTags ).to.lengthOf( 0 );
 	} );
 
+	it( 'should find an error tag without descriptions and parameters', () => {
+		const errorDefinition = conversionResult.children.find( doclet => doclet.name === 'customerror-inside-method-no-text' );
+
+		expect( errorDefinition ).to.not.be.undefined;
+		expect( errorDefinition.name ).to.equal( 'customerror-inside-method-no-text' );
+		expect( errorDefinition.originalName ).to.equal( 'EventDeclaration' );
+		expect( errorDefinition.comment ).to.have.property( 'summary', null );
+	} );
+
 	it( 'should find an error tag before the module definition (with {@link})', () => {
 		const errorDefinition = conversionResult.children.find( doclet => doclet.name === 'customerror-before-module-with-links' );
 

--- a/packages/typedoc-plugins/tests/tag-error/index.js
+++ b/packages/typedoc-plugins/tests/tag-error/index.js
@@ -44,236 +44,222 @@ describe( 'typedoc-plugins/tag-error', function() {
 		expect( conversionResult ).to.be.an( 'object' );
 	} );
 
-	it( 'should find an error tag before the module definition (raw text)', () => {
-		const errorDefinition = conversionResult.children.find( doclet => doclet.name === 'customerror-before-module' );
+	it( 'should not collect variable called "error', () => {
+		const errorModule = conversionResult.children.find( module => module.name === 'error' );
 
-		expect( errorDefinition ).to.not.be.undefined;
-		expect( errorDefinition.name ).to.equal( 'customerror-before-module' );
-		expect( errorDefinition.originalName ).to.equal( 'EventDeclaration' );
-		expect( errorDefinition.comment ).to.have.property( 'summary' );
-		expect( errorDefinition.comment.summary ).to.be.an( 'array' );
-		expect( errorDefinition.comment.summary ).to.lengthOf( 1 );
-		expect( errorDefinition.comment.summary[ 0 ] ).to.deep.equal( {
-			kind: 'text',
-			text: 'An error statement occurring before the `@module` definition.'
-		} );
-		expect( errorDefinition.comment.blockTags ).to.lengthOf( 0 );
+		const errorDefinitions = errorModule.children.filter( children => children.originalName === 'EventDeclaration' );
+
+		expect( errorDefinitions ).to.lengthOf( 0 );
 	} );
 
-	it( 'should find an error tag without descriptions and parameters', () => {
-		const errorDefinition = conversionResult.children.find( doclet => doclet.name === 'customerror-inside-method-no-text' );
+	it( 'should collect the `@error` annotations from block comment codes', () => {
+		const errorModule = conversionResult.children.find( module => module.name === 'customerror' );
 
-		expect( errorDefinition ).to.not.be.undefined;
-		expect( errorDefinition.name ).to.equal( 'customerror-inside-method-no-text' );
-		expect( errorDefinition.originalName ).to.equal( 'EventDeclaration' );
-		expect( errorDefinition.comment ).to.have.property( 'summary', null );
+		const errorDefinitions = errorModule.children.filter( children => children.originalName === 'EventDeclaration' );
+
+		expect( errorDefinitions ).to.not.lengthOf( 0 );
 	} );
 
-	it( 'should find an error tag before the module definition (with {@link})', () => {
-		const errorDefinition = conversionResult.children.find( doclet => doclet.name === 'customerror-before-module-with-links' );
+	describe( 'error definitions', () => {
+		let errorModule;
 
-		expect( errorDefinition ).to.not.be.undefined;
-		expect( errorDefinition.name ).to.equal( 'customerror-before-module-with-links' );
-		expect( errorDefinition.originalName ).to.equal( 'EventDeclaration' );
-		expect( errorDefinition.comment ).to.have.property( 'summary' );
-		expect( errorDefinition.comment.summary ).to.be.an( 'array' );
-		expect( errorDefinition.comment.summary ).to.lengthOf( 5 );
-		expect( errorDefinition.comment.summary[ 0 ] ).to.deep.equal( {
-			kind: 'text',
-			text: 'An error statement occurring before the `@module` definition. See '
+		before( () => {
+			errorModule = conversionResult.children.find( module => module.name === 'customerror' );
 		} );
-		expect( errorDefinition.comment.summary[ 1 ] ).to.deep.equal( {
-			kind: 'inline-tag',
-			tag: '@link',
-			text: '~CustomError'
-		} );
-		expect( errorDefinition.comment.summary[ 2 ] ).to.deep.equal( {
-			kind: 'text',
-			text: ' or\n'
-		} );
-		expect( errorDefinition.comment.summary[ 3 ] ).to.deep.equal( {
-			kind: 'inline-tag',
-			tag: '@link',
-			text: 'module:fixtures/customerror~CustomError Custom label'
-		} );
-		expect( errorDefinition.comment.summary[ 4 ] ).to.deep.equal( {
-			kind: 'text',
-			text: '. A text after.'
-		} );
-		expect( errorDefinition.comment.blockTags ).to.lengthOf( 0 );
-	} );
 
-	it( 'should find an error tag after the module definition (error with params, pure text)', () => {
-		const errorDefinition = conversionResult.children.find( doclet => doclet.name === 'customerror-after-module' );
+		it( 'should find an error tag without descriptions and parameters', () => {
+			const errorDefinition = errorModule.children.find( doclet => doclet.name === 'customerror-inside-method-no-text' );
 
-		expect( errorDefinition ).to.not.be.undefined;
-		expect( errorDefinition.originalName ).to.equal( 'EventDeclaration' );
-		expect( errorDefinition.comment ).to.have.property( 'summary' );
-		expect( errorDefinition.comment.summary ).to.be.an( 'array' );
-		expect( errorDefinition.comment.summary ).to.lengthOf( 1 );
-		expect( errorDefinition.comment.summary[ 0 ] ).to.deep.equal( {
-			kind: 'text',
-			text: 'An error statement occurring after the "@module" definition.'
+			expect( errorDefinition ).to.not.be.undefined;
+			expect( errorDefinition.name ).to.equal( 'customerror-inside-method-no-text' );
+			expect( errorDefinition.originalName ).to.equal( 'EventDeclaration' );
+
+			expect( errorDefinition.comment ).to.have.property( 'summary' );
+			expect( errorDefinition.comment ).to.have.property( 'blockTags' );
+			expect( errorDefinition.comment ).to.have.property( 'modifierTags' );
+
+			expect( errorDefinition.comment.summary ).to.be.an( 'array' );
+			expect( errorDefinition.comment.summary ).to.lengthOf( 0 );
+			expect( errorDefinition.comment.blockTags ).to.be.an( 'array' );
+			expect( errorDefinition.comment.blockTags ).to.lengthOf( 0 );
+			expect( errorDefinition.comment.modifierTags ).to.be.a( 'Set' );
+			expect( errorDefinition.comment.modifierTags.size ).to.equal( 0 );
 		} );
-		expect( errorDefinition.comment.blockTags ).to.lengthOf( 2 );
-		expect( errorDefinition.comment.blockTags[ 0 ] ).to.deep.equal( {
-			tag: '@param',
-			content: [
-				{
-					kind: 'text',
-					text: 'Number description.'
-				}
-			]
+
+		it( 'should find an error tag before the module definition (raw text)', () => {
+			const errorDefinition = errorModule.children.find( doclet => doclet.name === 'customerror-before-module' );
+
+			expect( errorDefinition ).to.not.be.undefined;
+			expect( errorDefinition.name ).to.equal( 'customerror-before-module' );
+			expect( errorDefinition.originalName ).to.equal( 'EventDeclaration' );
+			expect( errorDefinition.comment.summary ).to.lengthOf( 1 );
+			expect( errorDefinition.comment.summary[ 0 ] ).to.have.property( 'kind', 'text' );
+			expect( errorDefinition.comment.summary[ 0 ] ).to.have.property( 'text',
+				'An error statement occurring before the `@module` definition.'
+			);
 		} );
-		expect( errorDefinition.comment.blockTags[ 1 ] ).to.deep.equal( {
-			tag: '@param',
-			content: [
-				{
-					kind: 'text',
-					text: 'String `description`.'
-				}
-			]
+
+		it( 'should find an error tag before the module definition (with {@link})', () => {
+			const errorDefinition = errorModule.children.find( doclet => doclet.name === 'customerror-before-module-with-links' );
+
+			expect( errorDefinition ).to.not.be.undefined;
+			expect( errorDefinition.name ).to.equal( 'customerror-before-module-with-links' );
+			expect( errorDefinition.originalName ).to.equal( 'EventDeclaration' );
+			expect( errorDefinition.comment ).to.have.property( 'summary' );
+			expect( errorDefinition.comment.summary ).to.lengthOf( 5 );
+			expect( errorDefinition.comment.summary[ 0 ] ).to.have.property( 'kind', 'text' );
+			expect( errorDefinition.comment.summary[ 0 ] ).to.have.property( 'text',
+				'An error statement occurring before the `@module` definition. See '
+			);
+
+			expect( errorDefinition.comment.summary[ 1 ] ).to.have.property( 'kind', 'inline-tag' );
+			expect( errorDefinition.comment.summary[ 1 ] ).to.have.property( 'tag', '@link' );
+			expect( errorDefinition.comment.summary[ 1 ] ).to.have.property( 'text', '~CustomError' );
+
+			expect( errorDefinition.comment.summary[ 2 ] ).to.have.property( 'kind', 'text' );
+			expect( errorDefinition.comment.summary[ 2 ] ).to.have.property( 'text', ' or\n' );
+
+			expect( errorDefinition.comment.summary[ 3 ] ).to.have.property( 'kind', 'inline-tag' );
+			expect( errorDefinition.comment.summary[ 3 ] ).to.have.property( 'tag', '@link' );
+			expect( errorDefinition.comment.summary[ 3 ] ).to.have.property( 'text',
+				'module:fixtures/customerror~CustomError Custom label'
+			);
+
+			expect( errorDefinition.comment.summary[ 4 ] ).to.have.property( 'kind', 'text' );
+			expect( errorDefinition.comment.summary[ 4 ] ).to.have.property( 'text', '. A text after.' );
 		} );
-		expect( errorDefinition.typeParameters ).to.lengthOf( 2 );
-		expect( errorDefinition.typeParameters[ 0 ] ).to.have.property( 'name', 'exampleNumber' );
-		expect( errorDefinition.typeParameters[ 1 ] ).to.have.property( 'name', 'exampleString' );
-	} );
 
-	it( 'should find an error tag before the export keyword', () => {
-		const errorDefinition = conversionResult.children.find( doclet => doclet.name === 'customerror-before-export' );
+		it( 'should find an error tag after the module definition (error with params, pure text)', () => {
+			const errorDefinition = errorModule.children.find( doclet => doclet.name === 'customerror-after-module' );
 
-		expect( errorDefinition ).to.not.be.undefined;
-		expect( errorDefinition.originalName ).to.equal( 'EventDeclaration' );
-		expect( errorDefinition.comment ).to.have.property( 'summary' );
-		expect( errorDefinition.comment.summary ).to.be.an( 'array' );
-		expect( errorDefinition.comment.summary ).to.lengthOf( 1 );
-		expect( errorDefinition.comment.summary[ 0 ] ).to.deep.equal( {
-			kind: 'text',
-			text: 'An error statement occurring before the export keyword.'
+			expect( errorDefinition ).to.not.be.undefined;
+			expect( errorDefinition.originalName ).to.equal( 'EventDeclaration' );
+			expect( errorDefinition.comment.summary ).to.lengthOf( 1 );
+			expect( errorDefinition.comment.summary[ 0 ] ).to.have.property( 'kind', 'text' );
+			expect( errorDefinition.comment.summary[ 0 ] ).to.have.property( 'text',
+				'An error statement occurring after the "@module" definition.'
+			);
+			expect( errorDefinition.typeParameters ).to.be.an( 'array' );
+			expect( errorDefinition.typeParameters ).to.lengthOf( 2 );
+			expect( errorDefinition.typeParameters[ 0 ] ).to.have.property( 'name', 'exampleNumber' );
+			expect( errorDefinition.typeParameters[ 0 ] ).to.have.property( 'comment' );
+			expect( errorDefinition.typeParameters[ 0 ].comment ).to.have.property( 'summary' );
+			expect( errorDefinition.typeParameters[ 0 ].comment.summary ).to.be.an( 'array' );
+			expect( errorDefinition.typeParameters[ 0 ].comment.summary[ 0 ] ).to.have.property( 'kind', 'text' );
+			expect( errorDefinition.typeParameters[ 0 ].comment.summary[ 0 ] ).to.have.property( 'text', 'Number description.' );
+			expect( errorDefinition.typeParameters[ 1 ] ).to.have.property( 'name', 'exampleString' );
+			expect( errorDefinition.typeParameters[ 1 ] ).to.have.property( 'comment' );
+			expect( errorDefinition.typeParameters[ 1 ].comment ).to.have.property( 'summary' );
+			expect( errorDefinition.typeParameters[ 1 ].comment.summary ).to.be.an( 'array' );
+			expect( errorDefinition.typeParameters[ 1 ].comment.summary[ 0 ] ).to.have.property( 'kind', 'text' );
+			expect( errorDefinition.typeParameters[ 1 ].comment.summary[ 0 ] ).to.have.property( 'text', 'String `description`.' );
 		} );
-	} );
 
-	it( 'should find an error tag after the export keyword', () => {
-		const errorDefinition = conversionResult.children.find( doclet => doclet.name === 'customerror-after-export' );
+		it( 'should find an error tag before the export keyword', () => {
+			const errorDefinition = errorModule.children.find( doclet => doclet.name === 'customerror-before-export' );
 
-		expect( errorDefinition ).to.not.be.undefined;
-		expect( errorDefinition.originalName ).to.equal( 'EventDeclaration' );
-		expect( errorDefinition.comment ).to.have.property( 'summary' );
-		expect( errorDefinition.comment.summary ).to.be.an( 'array' );
-		expect( errorDefinition.comment.summary ).to.lengthOf( 1 );
-		expect( errorDefinition.comment.summary[ 0 ] ).to.deep.equal( {
-			kind: 'text',
-			text: 'An error statement occurring after the export keyword.'
+			expect( errorDefinition ).to.not.be.undefined;
+			expect( errorDefinition.originalName ).to.equal( 'EventDeclaration' );
+			expect( errorDefinition.comment.summary ).to.lengthOf( 1 );
+			expect( errorDefinition.comment.summary[ 0 ] ).to.have.property( 'kind', 'text' );
+			expect( errorDefinition.comment.summary[ 0 ] ).to.have.property( 'text',
+				'An error statement occurring before the export keyword.'
+			);
 		} );
-	} );
 
-	it( 'should find an error tag inside a method', () => {
-		const errorDefinition = conversionResult.children.find( doclet => doclet.name === 'customerror-inside-method' );
+		it( 'should find an error tag after the export keyword', () => {
+			const errorDefinition = errorModule.children.find( doclet => doclet.name === 'customerror-after-export' );
 
-		expect( errorDefinition ).to.not.be.undefined;
-		expect( errorDefinition.name ).to.equal( 'customerror-inside-method' );
-		expect( errorDefinition.originalName ).to.equal( 'EventDeclaration' );
-		expect( errorDefinition.comment ).to.have.property( 'summary' );
-		expect( errorDefinition.comment.summary ).to.be.an( 'array' );
-		expect( errorDefinition.comment.summary ).to.lengthOf( 1 );
-		expect( errorDefinition.comment.summary[ 0 ] ).to.deep.equal( {
-			kind: 'text',
-			text: 'An error statement occurring inside a method.\n' +
+			expect( errorDefinition ).to.not.be.undefined;
+			expect( errorDefinition.originalName ).to.equal( 'EventDeclaration' );
+			expect( errorDefinition.comment.summary ).to.lengthOf( 1 );
+			expect( errorDefinition.comment.summary[ 0 ] ).to.have.property( 'kind', 'text' );
+			expect( errorDefinition.comment.summary[ 0 ] ).to.have.property( 'text',
+				'An error statement occurring after the export keyword.'
+			);
+		} );
+
+		it( 'should find an error tag inside a method', () => {
+			const errorDefinition = errorModule.children.find( doclet => doclet.name === 'customerror-inside-method' );
+
+			expect( errorDefinition ).to.not.be.undefined;
+			expect( errorDefinition.name ).to.equal( 'customerror-inside-method' );
+			expect( errorDefinition.originalName ).to.equal( 'EventDeclaration' );
+			expect( errorDefinition.comment ).to.have.property( 'summary' );
+			expect( errorDefinition.comment.summary ).to.be.an( 'array' );
+			expect( errorDefinition.comment.summary ).to.lengthOf( 1 );
+			expect( errorDefinition.comment.summary[ 0 ] ).to.have.property( 'kind', 'text' );
+			expect( errorDefinition.comment.summary[ 0 ] ).to.have.property( 'text',
+				'An error statement occurring inside a method.\n' +
 				'\n' +
 				'It contains a parameter.'
-		} );
-		expect( errorDefinition.comment ).to.have.property( 'blockTags' );
-		expect( errorDefinition.comment.blockTags ).to.be.an( 'array' );
-		expect( errorDefinition.comment.blockTags ).to.lengthOf( 3 );
-		expect( errorDefinition.comment.blockTags[ 0 ] ).to.deep.equal( {
-			tag: '@param',
-			content: [
-				{
-					kind: 'text',
-					text: 'Description of the error. Please, see '
-				},
-				{
-					kind: 'inline-tag',
-					tag: '@link',
-					text: '~CustomError'
-				},
-				{
-					kind: 'text',
-					text: ' or'
-				}
-			]
-		} );
-		expect( errorDefinition.comment.blockTags[ 1 ] ).to.deep.equal( {
-			tag: '@param',
-			content: [
-				{
-					kind: 'text',
-					text: 'Just a module.'
-				}
-			]
-		} );
-		expect( errorDefinition.comment.blockTags[ 2 ] ).to.deep.equal( {
-			tag: '@param',
-			content: [
-				{
-					kind: 'text',
-					text: 'A name '
-				},
-				{
-					kind: 'inline-tag',
-					tag: '@link',
-					text: 'module:utils/object~Object'
-				},
-				{
-					kind: 'text',
-					text: ' `description`.'
-				}
-			]
-		} );
-		expect( errorDefinition.typeParameters ).to.lengthOf( 3 );
-		expect( errorDefinition.typeParameters[ 0 ] ).to.have.property( 'name', 'errorName' );
-		expect( errorDefinition.typeParameters[ 1 ] ).to.have.property( 'name', 'exampleModule' );
-		expect( errorDefinition.typeParameters[ 2 ] ).to.have.property( 'name', 'exampleObject' );
-	} );
+			);
 
-	it( 'should find an error tag inside a function', () => {
-		const errorDefinition = conversionResult.children.find( doclet => doclet.name === 'customerror-inside-function' );
+			expect( errorDefinition.typeParameters ).to.be.an( 'array' );
+			expect( errorDefinition.typeParameters ).to.lengthOf( 3 );
+			expect( errorDefinition.typeParameters[ 0 ] ).to.have.property( 'name', 'errorName' );
+			expect( errorDefinition.typeParameters[ 0 ] ).to.have.property( 'comment' );
+			expect( errorDefinition.typeParameters[ 0 ].comment ).to.have.property( 'summary' );
+			expect( errorDefinition.typeParameters[ 0 ].comment.summary ).to.be.an( 'array' );
+			expect( errorDefinition.typeParameters[ 0 ].comment.summary ).to.lengthOf( 3 );
+			expect( errorDefinition.typeParameters[ 0 ].comment.summary[ 0 ] ).to.have.property( 'kind', 'text' );
+			expect( errorDefinition.typeParameters[ 0 ].comment.summary[ 0 ] ).to.have.property( 'text',
+				'Description of the error. Please, see '
+			);
+			expect( errorDefinition.typeParameters[ 0 ].comment.summary[ 1 ] ).to.have.property( 'kind', 'inline-tag' );
+			expect( errorDefinition.typeParameters[ 0 ].comment.summary[ 1 ] ).to.have.property( 'tag', '@link' );
+			expect( errorDefinition.typeParameters[ 0 ].comment.summary[ 1 ] ).to.have.property( 'text', '~CustomError' );
+			expect( errorDefinition.typeParameters[ 0 ].comment.summary[ 2 ] ).to.have.property( 'kind', 'text' );
+			expect( errorDefinition.typeParameters[ 0 ].comment.summary[ 2 ] ).to.have.property( 'text', '.' );
+			expect( errorDefinition.typeParameters[ 1 ] ).to.have.property( 'name', 'exampleModule' );
+			expect( errorDefinition.typeParameters[ 1 ] ).to.have.property( 'comment' );
+			expect( errorDefinition.typeParameters[ 1 ].comment ).to.have.property( 'summary' );
+			expect( errorDefinition.typeParameters[ 1 ].comment.summary ).to.be.an( 'array' );
+			expect( errorDefinition.typeParameters[ 1 ].comment.summary ).to.lengthOf( 1 );
+			expect( errorDefinition.typeParameters[ 1 ].comment.summary[ 0 ] ).to.have.property( 'kind', 'text' );
+			expect( errorDefinition.typeParameters[ 1 ].comment.summary[ 0 ] ).to.have.property( 'text', 'Just a module.' );
+			expect( errorDefinition.typeParameters[ 2 ] ).to.have.property( 'name', 'exampleObject' );
+			expect( errorDefinition.typeParameters[ 2 ] ).to.have.property( 'comment' );
+			expect( errorDefinition.typeParameters[ 2 ].comment ).to.have.property( 'summary' );
+			expect( errorDefinition.typeParameters[ 2 ].comment.summary ).to.be.an( 'array' );
+			expect( errorDefinition.typeParameters[ 2 ].comment.summary ).to.lengthOf( 3 );
+			expect( errorDefinition.typeParameters[ 2 ].comment.summary[ 0 ] ).to.have.property( 'kind', 'text' );
+			expect( errorDefinition.typeParameters[ 2 ].comment.summary[ 0 ] ).to.have.property( 'text', 'A name ' );
+			expect( errorDefinition.typeParameters[ 2 ].comment.summary[ 1 ] ).to.have.property( 'kind', 'inline-tag' );
+			expect( errorDefinition.typeParameters[ 2 ].comment.summary[ 1 ] ).to.have.property( 'tag', '@link' );
+			expect( errorDefinition.typeParameters[ 2 ].comment.summary[ 1 ] ).to.have.property( 'text', 'module:utils/object~Object' );
+			expect( errorDefinition.typeParameters[ 2 ].comment.summary[ 2 ] ).to.have.property( 'kind', 'text' );
+			expect( errorDefinition.typeParameters[ 2 ].comment.summary[ 2 ] ).to.have.property( 'text', ' `description`.' );
+		} );
 
-		expect( errorDefinition ).to.not.be.undefined;
-		expect( errorDefinition.name ).to.equal( 'customerror-inside-function' );
-		expect( errorDefinition.originalName ).to.equal( 'EventDeclaration' );
-		expect( errorDefinition.comment ).to.have.property( 'summary' );
-		expect( errorDefinition.comment.summary ).to.be.an( 'array' );
-		expect( errorDefinition.comment.summary ).to.lengthOf( 1 );
-		expect( errorDefinition.comment.summary[ 0 ] ).to.deep.equal( {
-			kind: 'text',
-			text: 'An error statement occurring inside a function.\n' +
-				'\n' +
-				'It contains parameters.'
+		it( 'should find an error tag inside a function', () => {
+			const errorDefinition = errorModule.children.find( doclet => doclet.name === 'customerror-inside-function' );
+
+			expect( errorDefinition ).to.not.be.undefined;
+			expect( errorDefinition.name ).to.equal( 'customerror-inside-function' );
+			expect( errorDefinition.originalName ).to.equal( 'EventDeclaration' );
+			expect( errorDefinition.comment.summary ).to.lengthOf( 1 );
+			expect( errorDefinition.comment.summary[ 0 ] ).to.deep.equal( {
+				kind: 'text',
+				text: 'An error statement occurring inside a function.\n' +
+					'\n' +
+					'It contains parameters.'
+			} );
+			expect( errorDefinition.typeParameters ).to.lengthOf( 2 );
+			expect( errorDefinition.typeParameters[ 0 ] ).to.have.property( 'name', 'errorName' );
+			expect( errorDefinition.typeParameters[ 0 ] ).to.have.property( 'comment' );
+			expect( errorDefinition.typeParameters[ 0 ].comment ).to.have.property( 'summary' );
+			expect( errorDefinition.typeParameters[ 0 ].comment.summary ).to.be.an( 'array' );
+			expect( errorDefinition.typeParameters[ 0 ].comment.summary ).to.lengthOf( 1 );
+			expect( errorDefinition.typeParameters[ 0 ].comment.summary[ 0 ] ).to.have.property( 'kind', 'text' );
+			expect( errorDefinition.typeParameters[ 0 ].comment.summary[ 0 ] ).to.have.property( 'text', 'Description of the error.' );
+			expect( errorDefinition.typeParameters[ 1 ] ).to.have.property( 'name', 'priority' );
+			expect( errorDefinition.typeParameters[ 1 ] ).to.have.property( 'comment' );
+			expect( errorDefinition.typeParameters[ 1 ].comment ).to.have.property( 'summary' );
+			expect( errorDefinition.typeParameters[ 1 ].comment.summary ).to.be.an( 'array' );
+			expect( errorDefinition.typeParameters[ 1 ].comment.summary ).to.lengthOf( 1 );
+			expect( errorDefinition.typeParameters[ 1 ].comment.summary[ 0 ] ).to.have.property( 'kind', 'text' );
+			expect( errorDefinition.typeParameters[ 1 ].comment.summary[ 0 ] ).to.have.property( 'text', 'The priority of this error.' );
 		} );
-		expect( errorDefinition.comment ).to.have.property( 'blockTags' );
-		expect( errorDefinition.comment.blockTags ).to.be.an( 'array' );
-		expect( errorDefinition.comment.blockTags ).to.lengthOf( 2 );
-		expect( errorDefinition.comment.blockTags[ 0 ] ).to.deep.equal( {
-			tag: '@param',
-			content: [
-				{
-					kind: 'text',
-					text: 'Description of the error.'
-				}
-			]
-		} );
-		expect( errorDefinition.comment.blockTags[ 1 ] ).to.deep.equal( {
-			tag: '@param',
-			content: [
-				{
-					kind: 'text',
-					text: 'The priority of this error.'
-				}
-			]
-		} );
-		expect( errorDefinition.typeParameters ).to.lengthOf( 2 );
-		expect( errorDefinition.typeParameters[ 0 ] ).to.have.property( 'name', 'errorName' );
-		expect( errorDefinition.typeParameters[ 1 ] ).to.have.property( 'name', 'priority' );
 	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature (typedoc-plugins): Created a package containing CKEditor 5 oriented plugins for `typedoc`. Closes ckeditor/ckeditor5#12522.

Feature (typedoc-plugins): Created the `module-fixer` plugin that reads a module name from the `@module` annotation. Closes ckeditor/ckeditor5#12523.

Feature (typedoc-plugins) Created the `tag-error plugin` that collects all occurrences of the `@error` tags in the CKEditor 5 code base. Closes ckeditor/ckeditor5#12525.

Other (docs): Bumped `typedoc` to `0.23`. Closes ckeditor/ckeditor5#12528.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
