### PR TITLE
Standardized the DLL build script

### DIFF
--- a/packages/ckeditor5-dev-tests/lib/tasks/runmanualtests.js
+++ b/packages/ckeditor5-dev-tests/lib/tasks/runmanualtests.js
@@ -144,6 +144,8 @@ module.exports = function runManualTests( options ) {
 				await buildDllInRepository( path.dirname( pkgJsonPath ) );
 			}
 		}
+
+		console.log( '\n📍 DLL building complete!\n' );
 	}
 
 	/**

--- a/packages/ckeditor5-dev-tests/lib/tasks/runmanualtests.js
+++ b/packages/ckeditor5-dev-tests/lib/tasks/runmanualtests.js
@@ -145,7 +145,7 @@ module.exports = function runManualTests( options ) {
 			}
 		}
 
-		console.log( '\n📍 DLL building complete!\n' );
+		console.log( '\n📍 DLL building complete.\n' );
 	}
 
 	/**


### PR DESCRIPTION
Internal (tests): Print a log once the DLL building process is finished.