### PR TITLE
Introduced new `tag-event` plugin for TypeDoc

### DIFF
--- a/packages/ckeditor5-dev-docs/lib/docs/index.js
+++ b/packages/ckeditor5-dev-docs/lib/docs/index.js
@@ -61,8 +61,8 @@ module.exports = async function build( config ) {
 		plugin: [
 			'typedoc-plugin-rename-defaults',
 			require.resolve( '@ckeditor/typedoc-plugins/lib/module-fixer' ),
+			require.resolve( '@ckeditor/typedoc-plugins/lib/tag-error' ),
 			require.resolve( '@ckeditor/typedoc-plugins/lib/tag-event' )
-			// require.resolve( '@ckeditor/typedoc-plugins/lib/tag-error' ),
 		],
 
 		// TODO: Move tsconfig.json to main repo. Also: how to share it across repos? Also: Do we need to share it?

--- a/packages/ckeditor5-dev-docs/lib/docs/index.js
+++ b/packages/ckeditor5-dev-docs/lib/docs/index.js
@@ -61,7 +61,8 @@ module.exports = async function build( config ) {
 		plugin: [
 			'typedoc-plugin-rename-defaults',
 			require.resolve( '@ckeditor/typedoc-plugins/lib/module-fixer' ),
-			require.resolve( '@ckeditor/typedoc-plugins/lib/tag-error' )
+			require.resolve( '@ckeditor/typedoc-plugins/lib/tag-event' )
+			// require.resolve( '@ckeditor/typedoc-plugins/lib/tag-error' ),
 		],
 
 		// TODO: Move tsconfig.json to main repo. Also: how to share it across repos? Also: Do we need to share it?

--- a/packages/typedoc-plugins/lib/tag-event/index.js
+++ b/packages/typedoc-plugins/lib/tag-event/index.js
@@ -1,0 +1,133 @@
+/**
+ * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+'use strict';
+
+const { Converter, ReflectionKind, ParameterReflection, Comment } = require( 'typedoc' );
+
+/**
+ * TODO
+ */
+module.exports = {
+	load( app ) {
+		app.converter.on( Converter.EVENT_END, onEvent );
+	}
+};
+
+function onEvent( context ) {
+	try {
+		const reflections = context.project.getReflectionsByKind( ReflectionKind.All );
+
+		for ( const reflection of reflections ) {
+			const comment = reflection.comment;
+
+			if ( !comment || !comment.getTag( '@eventName' ) ) {
+				continue;
+			}
+
+			const eventName = reflection.comment.getTag( '@eventName' ).content[ 0 ].text;
+			const parent = findParentForEvent( eventName, reflection );
+
+			const eventReflection = context
+				.withScope( parent )
+				.createDeclarationReflection(
+					ReflectionKind.ObjectLiteral,
+					undefined,
+					undefined,
+					`event:${ eventName }`
+				);
+
+			eventReflection.comment = reflection.comment.clone();
+			eventReflection.kindString = 'Event';
+
+			// const param = new TypeParameterReflection( 'nameFoo', undefined, undefined, eventReflection );
+
+			// eventReflection.typeParameters = eventReflection.typeParameters || [];
+			// eventReflection.typeParameters.push( param );
+
+			// const param = new ParameterReflection( 'nazwa parametru', ReflectionKind.TypeLiteral, eventReflection );
+			// param.type = context.converter.convertType( context.withScope( param ), param.type );
+
+			eventReflection.parameters = comment.getTags( '@param' ).map( tag => {
+				const param = new ParameterReflection( tag.name, ReflectionKind.TypeLiteral, eventReflection );
+
+				param.type = context.converter.convertType( context.withScope( param ) );
+				param.comment = new Comment( tag.content );
+
+				return param;
+			} );
+
+			console.log(
+				'-'.repeat( 100 ) + '\n',
+				require( 'util' ).inspect( eventReflection, { showHidden: false, depth: 5, colors: true } )
+			);
+		}
+
+		// const indexes = comment.tags.reduce( ( prev, tag, index ) => {
+		// 	if ( tag.tagName === 'event' ) {
+		// 		prev.push( index );
+		// 	}
+
+		// 	return prev;
+		// }, [] );
+
+		// const length = indexes.length;
+
+		// if ( length === 1 ) {
+		// 	const index = indexes[ 0 ];
+
+		// 	comment.text += prepareExample( preferredLanguage, comment.tags[ index ].text );
+		// 	comment.tags.splice( index, 1 );
+
+		// 	continue;
+		// }
+
+		// let counter = 0;
+
+		// for ( const index of indexes ) {
+		// 	comment.text += prepareExample( preferredLanguage, comment.tags[ index ].text, ++counter );
+
+		// 	if ( counter !== length ) { comment.text += '\n'; }
+		// }
+
+		// indexes.reverse().forEach( index => comment.tags.splice( index, 1 ) );
+	} catch ( err ) {
+		console.log( err );
+	}
+}
+
+function findParentForEvent( eventName, reflection ) {
+	let parentForEvent = reflection.parent.children.find( child => {
+		if ( !child.comment ) {
+			return false;
+		}
+
+		return child.comment
+			.getTags( '@fires' )
+			.some( tag => tag.content[ 0 ].text === eventName );
+	} );
+
+	if ( parentForEvent ) {
+		return parentForEvent;
+	}
+
+	parentForEvent = reflection.parent.children.find( child => {
+		if ( child.kindString !== 'Class' ) {
+			return false;
+		}
+
+		if ( child.originalName !== 'default' ) {
+			return false;
+		}
+
+		return true;
+	} );
+
+	if ( parentForEvent ) {
+		return parentForEvent;
+	}
+
+	return reflection.parent;
+}

--- a/packages/typedoc-plugins/lib/tag-event/index.js
+++ b/packages/typedoc-plugins/lib/tag-event/index.js
@@ -67,13 +67,10 @@ function onEventEnd( context ) {
 		const classReflection = findClassForEvent( eventName, reflection );
 
 		if ( !classReflection ) {
-			const [ source ] = reflection.sources;
+			const symbol = context.project.getSymbolFromReflection( reflection );
+			const node = symbol.declarations[ 0 ];
 
-			context.logger.error(
-				`Unable to find a class for the "${ eventName }" event, defined in ${ source.fileName } (line: ${ source.line }).\n` +
-				'Make sure that the module, in which this event is defined, contains either the class that fires this event using\n' +
-				`the "@fires ${ eventName }" tag, or the module contains at least one default class.`
-			);
+			context.logger.warn( `Skipping unsupported "${ eventName }" event.`, node );
 
 			continue;
 		}

--- a/packages/typedoc-plugins/lib/tag-event/index.js
+++ b/packages/typedoc-plugins/lib/tag-event/index.js
@@ -45,11 +45,10 @@ function onEventEnd( context ) {
 
 			if ( !classReflection ) {
 				const [ source ] = reflection.sources;
-				const location = source.fullFileName + '#' + source.line;
 
 				context.logger.error(
-					`Unable to find a class for the "${ eventName }" event, defined in ${ location }\n` +
-					'Make sure that the module, in which this event is defined, has either the class that fires this event using ' +
+					`Unable to find a class for the "${ eventName }" event, defined in ${ source.fileName } (line: ${ source.line }).\n` +
+					'Make sure that the module, in which this event is defined, contains either the class that fires this event using\n' +
 					`the "@fires ${ eventName }" tag, or the module contains at least one default class.`
 				);
 
@@ -121,6 +120,10 @@ function findClassForEvent( eventName, reflection ) {
 function findReflection( reflection, callback ) {
 	if ( !reflection.parent ) {
 		return null;
+	}
+
+	if ( !reflection.parent.children ) {
+		return findReflection( reflection.parent.parent, callback );
 	}
 
 	const found = reflection.parent.children.find( callback );

--- a/packages/typedoc-plugins/lib/tag-event/index.js
+++ b/packages/typedoc-plugins/lib/tag-event/index.js
@@ -5,31 +5,46 @@
 
 'use strict';
 
-const { Converter, ReflectionKind, ParameterReflection, Comment } = require( 'typedoc' );
+const { Converter, ReflectionKind, TypeParameterReflection, Comment } = require( 'typedoc' );
 
 /**
- * TODO
+ * The `typedoc-plugin-tag-event` collects event definitions from the `@eventName` tag.
+ *
+ * The `@event` tag, known from the JSDoc, has a special meaning in the TypeDoc, and it was difficult to get it to work as we expect. Even
+ * setting it to be treated as a block tag (instead of a modifier, by default) didn't work. This is why we introduced support for the
+ * `@eventName` tag, which now replaces the old `@event`.
+ *
+ * TODO: We do not support collecting types of `@param` tags associated with the `@eventName`.
  */
 module.exports = {
 	load( app ) {
-		app.converter.on( Converter.EVENT_END, onEvent );
+		// Search for the `@eventName` tag when the whole project has been converted. It is required that the parent-child relationship
+		// already exists.
+		app.converter.on( Converter.EVENT_END, onEventEnd );
 	}
 };
 
-function onEvent( context ) {
+function onEventEnd( context ) {
 	try {
+		// Get all resolved reflections when the project has been converted.
 		const reflections = context.project.getReflectionsByKind( ReflectionKind.All );
 
+		// Then, for each reflection...
 		for ( const reflection of reflections ) {
-			const comment = reflection.comment;
-
-			if ( !comment || !comment.getTag( '@eventName' ) ) {
+			// ...skip it, if it does not contain the `@eventName` tag.
+			if ( !reflection.comment || !reflection.comment.getTag( '@eventName' ) ) {
 				continue;
 			}
 
+			// Otherwise, if there is the `@eventName` tag found in a comment, extract the event name, which is the string just after the
+			// tag name. Example: for the `@eventName foo`, the event name would be `foo`.
 			const eventName = reflection.comment.getTag( '@eventName' ).content[ 0 ].text;
+
+			// Then, try to find a parent reflection to properly associate the event in the hierarchy.
 			const parent = findParentForEvent( eventName, reflection );
 
+			// Create the new reflection object for the event, but take into account the new scope. It will cause the newly created event
+			// reflection to be automatically associated as a child of its parent.
 			const eventReflection = context
 				.withScope( parent )
 				.createDeclarationReflection(
@@ -39,19 +54,11 @@ function onEvent( context ) {
 					`event:${ eventName }`
 				);
 
-			eventReflection.comment = reflection.comment.clone();
 			eventReflection.kindString = 'Event';
 
-			// const param = new TypeParameterReflection( 'nameFoo', undefined, undefined, eventReflection );
-
-			// eventReflection.typeParameters = eventReflection.typeParameters || [];
-			// eventReflection.typeParameters.push( param );
-
-			// const param = new ParameterReflection( 'nazwa parametru', ReflectionKind.TypeLiteral, eventReflection );
-			// param.type = context.converter.convertType( context.withScope( param ), param.type );
-
-			eventReflection.parameters = comment.getTags( '@param' ).map( tag => {
-				const param = new ParameterReflection( tag.name, ReflectionKind.TypeLiteral, eventReflection );
+			// Map each found `@param` tag to the type parameter reflection.
+			eventReflection.typeParameters = reflection.comment.getTags( '@param' ).map( tag => {
+				const param = new TypeParameterReflection( tag.name, undefined, undefined, eventReflection );
 
 				param.type = context.converter.convertType( context.withScope( param ) );
 				param.comment = new Comment( tag.content );
@@ -59,74 +66,69 @@ function onEvent( context ) {
 				return param;
 			} );
 
-			console.log(
-				'-'.repeat( 100 ) + '\n',
-				require( 'util' ).inspect( eventReflection, { showHidden: false, depth: 5, colors: true } )
-			);
+			// Copy comment summary, if it exists. The `blockTags` property from the comment is not needed, as they have been already mapped
+			// to the type parameters.
+			if ( reflection.comment.summary ) {
+				eventReflection.comment = new Comment( Comment.cloneDisplayParts( reflection.comment.summary ) );
+			}
+
+			console.log( require( 'util' ).inspect( eventReflection, { showHidden: false, depth: 2, colors: true } ) );
 		}
-
-		// const indexes = comment.tags.reduce( ( prev, tag, index ) => {
-		// 	if ( tag.tagName === 'event' ) {
-		// 		prev.push( index );
-		// 	}
-
-		// 	return prev;
-		// }, [] );
-
-		// const length = indexes.length;
-
-		// if ( length === 1 ) {
-		// 	const index = indexes[ 0 ];
-
-		// 	comment.text += prepareExample( preferredLanguage, comment.tags[ index ].text );
-		// 	comment.tags.splice( index, 1 );
-
-		// 	continue;
-		// }
-
-		// let counter = 0;
-
-		// for ( const index of indexes ) {
-		// 	comment.text += prepareExample( preferredLanguage, comment.tags[ index ].text, ++counter );
-
-		// 	if ( counter !== length ) { comment.text += '\n'; }
-		// }
-
-		// indexes.reverse().forEach( index => comment.tags.splice( index, 1 ) );
 	} catch ( err ) {
 		console.log( err );
 	}
 }
 
+/**
+ * Tries to find the best parent for the event.
+ *
+ * The algorithm is as follows:
+ *
+ * (1) First, it searches for a reflection on the same nest level as the reflection containing the event. The searched reflection must
+ * contain the `@fires` tag with the same name as the event.
+ * (2) If no such reflection is found, it tries to find the default class.
+ * (3) Otherwise, it simply returns the parent of the reflection containing the event.
+ *
+ * @param {String} eventName The event name to be searched in the refelction parent.
+ * @param {require('typedoc').Reflection} reflection The reflection that contains the event name.
+ * @returns {require('typedoc').Reflection}
+ */
 function findParentForEvent( eventName, reflection ) {
-	let parentForEvent = reflection.parent.children.find( child => {
-		if ( !child.comment ) {
-			return false;
+	// todo: probbly it needs a better algorithm
+	// 1. collect all children from parent.parent.parent... hierarchy
+	// 2. find the first one that fires the event
+	// 3. otherwise, find the first default class
+	// 4. otherwise, return just the reflection.parent
+	if ( reflection.parent.children ) {
+		let parentForEvent = reflection.parent.children.find( child => {
+			if ( !child.comment ) {
+				return false;
+			}
+
+			return child.comment
+				.getTags( '@fires' )
+				.some( tag => tag.content[ 0 ].text === eventName );
+		} );
+
+		if ( parentForEvent ) {
+			return parentForEvent;
 		}
 
-		return child.comment
-			.getTags( '@fires' )
-			.some( tag => tag.content[ 0 ].text === eventName );
-	} );
+		parentForEvent = reflection.parent.children.find( child => {
+			if ( child.kindString !== 'Class' ) {
+				return false;
+			}
 
-	if ( parentForEvent ) {
-		return parentForEvent;
-	}
+			if ( child.originalName !== 'default' ) {
+				return false;
+			}
 
-	parentForEvent = reflection.parent.children.find( child => {
-		if ( child.kindString !== 'Class' ) {
-			return false;
+			return true;
+		} );
+
+		if ( parentForEvent ) {
+			return parentForEvent;
 		}
-
-		if ( child.originalName !== 'default' ) {
-			return false;
-		}
-
-		return true;
-	} );
-
-	if ( parentForEvent ) {
-		return parentForEvent;
 	}
 
 	return reflection.parent;

--- a/packages/typedoc-plugins/lib/tag-event/index.js
+++ b/packages/typedoc-plugins/lib/tag-event/index.js
@@ -91,19 +91,30 @@ function onEventEnd( context ) {
 
 		eventReflection.kindString = 'Event';
 
-		const paramTags = reflection.comment.getTags( '@param' );
+		const defaultParameter = new TypeParameterReflection( 'eventInfo', undefined, undefined, eventReflection );
 
-		if ( paramTags.length ) {
+		// TODO: The `eventInfo` parameter should have the `module:utils/eventinfo~EventInfo` type.
+		defaultParameter.type = context.converter.convertType( context.withScope( defaultParameter ) );
+		defaultParameter.comment = new Comment( [
+			{
+				kind: 'text',
+				text: 'An object containing information about the fired event.'
+			}
+		] );
+
+		eventReflection.typeParameters = [
+			// Insert the default `eventInfo` parameters as the first one.
+			defaultParameter,
 			// Map each found `@param` tag to the type parameter reflection.
-			eventReflection.typeParameters = paramTags.map( tag => {
+			...reflection.comment.getTags( '@param' ).map( tag => {
 				const param = new TypeParameterReflection( tag.name, undefined, undefined, eventReflection );
 
 				param.type = context.converter.convertType( context.withScope( param ) );
 				param.comment = new Comment( tag.content );
 
 				return param;
-			} );
-		}
+			} )
+		];
 
 		// Copy comment summary. The `blockTags` property from the comment is not needed, as it has been already mapped to the type
 		// parameters.

--- a/packages/typedoc-plugins/lib/tag-event/index.js
+++ b/packages/typedoc-plugins/lib/tag-event/index.js
@@ -48,10 +48,11 @@ module.exports = {
 };
 
 function onEventEnd( context ) {
-	// Get all resolved object literal reflections when the project has been converted.
-	const reflections = context.project.getReflectionsByKind( ReflectionKind.All );
+	// Get all resolved reflections that could be an event.
+	const eventKind = ReflectionKind.ObjectLiteral | ReflectionKind.TypeAlias;
+	const reflections = context.project.getReflectionsByKind( eventKind );
 
-	// Then, for each reflection...
+	// Then, for each potential event reflection...
 	for ( const reflection of reflections ) {
 		// ...skip it, if it does not contain the `@eventName` tag.
 		if ( !reflection.comment || !reflection.comment.getTag( '@eventName' ) ) {
@@ -70,8 +71,8 @@ function onEventEnd( context ) {
 
 			context.logger.error(
 				`Unable to find a class for the "${ eventName }" event, defined in ${ source.fileName } (line: ${ source.line }).\n` +
-					'Make sure that the module, in which this event is defined, contains either the class that fires this event using\n' +
-					`the "@fires ${ eventName }" tag, or the module contains at least one default class.`
+				'Make sure that the module, in which this event is defined, contains either the class that fires this event using\n' +
+				`the "@fires ${ eventName }" tag, or the module contains at least one default class.`
 			);
 
 			continue;
@@ -141,10 +142,6 @@ function findClassForEvent( eventName, reflection ) {
 function findReflection( reflection, callback ) {
 	if ( !reflection.parent ) {
 		return null;
-	}
-
-	if ( !reflection.parent.children ) {
-		return findReflection( reflection.parent.parent, callback );
 	}
 
 	const found = reflection.parent.children.find( callback );

--- a/packages/typedoc-plugins/tests/tag-event/fixtures/customexampleclass.ts
+++ b/packages/typedoc-plugins/tests/tag-event/fixtures/customexampleclass.ts
@@ -12,13 +12,13 @@ import ExampleClass from './exampleclass';
 export default class CustomExampleClass extends ExampleClass {
 	public static create( value: string ): ExampleClass {
 		/**
-		 * An event not related to anything in the source code. This kind of event is silently ignored by TypeDoc.
+		 * An event not associated to anything in the source code.
 		 *
 		 * @eventName event-foo-not-associated-inside-method
 		 */
 
 		/**
-		 * An event not related to a type in the source code. This kind of event is silently ignored by TypeDoc.
+		 * An event not associated to a type in the source code.
 		 *
 		 * @eventName event-foo-not-associated-to-type-inside-method
 		 */
@@ -26,9 +26,11 @@ export default class CustomExampleClass extends ExampleClass {
 	}
 }
 
+export class CustomExampleNonDefaultClass extends ExampleClass {}
+
 export function create( value: string ): ExampleClass {
 	/**
-	 * An event not related to a type in the source code. This kind of event is silently ignored by TypeDoc.
+	 * An event not associated to a type in the source code.
 	 *
 	 * @eventName event-foo-not-associated-to-type-inside-function
 	 */
@@ -36,18 +38,25 @@ export function create( value: string ): ExampleClass {
 }
 
 /**
- * @eventName event-foo-associated-with-type-no-text
+ * Normal type export.
  */
-export type FooEventNoText = {
+export type ExampleType = {
+	name: string;
+};
+
+/**
+ * @eventName event-foo-no-text
+ */
+export type EventFooNoText = {
 	name: string;
 };
 
 /**
  * An event associated with the type.
  *
- * @eventName event-foo-associated-with-type
+ * @eventName event-foo
  */
-export type FooEvent = {
+export type EventFoo = {
 	name: string;
 };
 
@@ -56,13 +65,13 @@ export type FooEvent = {
  *
  * See {@link ~CustomExampleClass} or {@link module:fixtures/customexampleclass~CustomExampleClass Custom label}. A text after.
  *
- * @eventName event-foo-associated-with-type-with-params
+ * @eventName event-foo-with-params
  *
  * @param {String} p1 Description for first param.
  * @param {module:utils/object~Object} p2 Description for second param.
  * @param p3 Complex {@link module:utils/object~Object description} for `third param`.
  */
-export type FooEventWithParams = {
+export type EventFooWithParams = {
 	name: string;
 	args: [ {
 		p1: string;
@@ -72,7 +81,7 @@ export type FooEventWithParams = {
 };
 
 /**
- * An event not related to anything in the source code. This kind of event is silently ignored by TypeDoc.
+ * An event not associated to anything in the source code.
  *
  * @eventName event-foo-not-associated-outside
  */

--- a/packages/typedoc-plugins/tests/tag-event/fixtures/customexampleclass.ts
+++ b/packages/typedoc-plugins/tests/tag-event/fixtures/customexampleclass.ts
@@ -1,0 +1,79 @@
+/**
+ * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/**
+ * @module fixtures/customexampleclass
+ */
+
+import ExampleClass from './exampleclass';
+
+export default class CustomExampleClass extends ExampleClass {
+	public static create( value: string ): ExampleClass {
+		/**
+		 * An event not related to anything in the source code. This kind of event is silently ignored by TypeDoc.
+		 *
+		 * @eventName event-foo-not-associated-inside-method
+		 */
+
+		/**
+		 * An event occurring inside a method.
+		 *
+		 * @eventName event-foo-with-params-inside-method
+		 *
+		 * @param {String} p1 A description for first param.
+		 * @param {Number} p2 A description for second param.
+		 * @param {Boolean} p3 A description for third param.
+		 */
+		return new ExampleClass( value );
+	}
+}
+
+export function create( value: string ): ExampleClass {
+	/**
+	 * An event occurring inside a function.
+	 *
+	 * @eventName event-foo-with-params-inside-function
+	 *
+	 * @param {String} p1 A description for first param.
+	 * @param {Number} p2 A description for second param.
+	 * @param {Boolean} p3 A description for third param.
+	 */
+	return new ExampleClass( value );
+}
+
+/**
+ * An event associated with the type.
+ *
+ * @eventName event-foo-associated-with-type
+ */
+export type FooEvent = {
+	name: 'foo';
+};
+
+/**
+ * An event associated with the type.
+ *
+ * Event with three params.
+ *
+ * @eventName event-foo-with-params-associated-with-type
+ *
+ * @param {String} p1 A description for first param.
+ * @param {Number} p2 A description for second param.
+ * @param {Boolean} p3 A description for third param.
+ */
+export type FooEventWithParams = {
+	name: 'foo';
+	args: [ {
+		p1: string;
+		p2: number;
+		p3: boolean;
+	} ];
+};
+
+/**
+ * An event not related to anything in the source code. This kind of event is silently ignored by TypeDoc.
+ *
+ * @eventName event-foo-not-associated-outside
+ */

--- a/packages/typedoc-plugins/tests/tag-event/fixtures/customexampleclass.ts
+++ b/packages/typedoc-plugins/tests/tag-event/fixtures/customexampleclass.ts
@@ -18,13 +18,9 @@ export default class CustomExampleClass extends ExampleClass {
 		 */
 
 		/**
-		 * An event occurring inside a method.
+		 * An event not related to a type in the source code. This kind of event is silently ignored by TypeDoc.
 		 *
-		 * @eventName event-foo-with-params-inside-method
-		 *
-		 * @param {String} p1 A description for first param.
-		 * @param {Number} p2 A description for second param.
-		 * @param {Boolean} p3 A description for third param.
+		 * @eventName event-foo-not-associated-to-type-inside-method
 		 */
 		return new ExampleClass( value );
 	}
@@ -32,16 +28,19 @@ export default class CustomExampleClass extends ExampleClass {
 
 export function create( value: string ): ExampleClass {
 	/**
-	 * An event occurring inside a function.
+	 * An event not related to a type in the source code. This kind of event is silently ignored by TypeDoc.
 	 *
-	 * @eventName event-foo-with-params-inside-function
-	 *
-	 * @param {String} p1 A description for first param.
-	 * @param {Number} p2 A description for second param.
-	 * @param {Boolean} p3 A description for third param.
+	 * @eventName event-foo-not-associated-to-type-inside-function
 	 */
 	return new ExampleClass( value );
 }
+
+/**
+ * @eventName event-foo-associated-with-type-no-text
+ */
+export type FooEventNoText = {
+	name: string;
+};
 
 /**
  * An event associated with the type.
@@ -49,22 +48,22 @@ export function create( value: string ): ExampleClass {
  * @eventName event-foo-associated-with-type
  */
 export type FooEvent = {
-	name: 'foo';
+	name: string;
 };
 
 /**
- * An event associated with the type.
+ * An event associated with the type. Event with three params.
  *
- * Event with three params.
+ * See {@link ~CustomExampleClass} or {@link module:fixtures/customexampleclass~CustomExampleClass Custom label}. A text after.
  *
- * @eventName event-foo-with-params-associated-with-type
+ * @eventName event-foo-associated-with-type-with-params
  *
- * @param {String} p1 A description for first param.
- * @param {Number} p2 A description for second param.
- * @param {Boolean} p3 A description for third param.
+ * @param {String} p1 Description for first param.
+ * @param {module:utils/object~Object} p2 Description for second param.
+ * @param p3 Complex {@link module:utils/object~Object description} for `third param`.
  */
 export type FooEventWithParams = {
-	name: 'foo';
+	name: string;
 	args: [ {
 		p1: string;
 		p2: number;

--- a/packages/typedoc-plugins/tests/tag-event/fixtures/customexampleclassfires.ts
+++ b/packages/typedoc-plugins/tests/tag-event/fixtures/customexampleclassfires.ts
@@ -1,0 +1,22 @@
+/**
+ * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/**
+ * @module fixtures/customexampleclassfires
+ */
+
+import ExampleClass from './exampleclass';
+
+/**
+ * @fires event-foo-in-class-with-fires
+ */
+export class CustomExampleClass extends ExampleClass {}
+
+/**
+ * @eventName event-foo-in-class-with-fires
+ */
+export type FooEventNoText = {
+	name: string;
+};

--- a/packages/typedoc-plugins/tests/tag-event/fixtures/customexampleclassfires.ts
+++ b/packages/typedoc-plugins/tests/tag-event/fixtures/customexampleclassfires.ts
@@ -10,13 +10,20 @@
 import ExampleClass from './exampleclass';
 
 /**
+ * Default class not related to an event.
+ */
+export default class CustomDefaultExampleClass extends ExampleClass {}
+
+/**
+ * Non-default class that fires an event.
+ *
  * @fires event-foo-in-class-with-fires
  */
-export class CustomExampleClass extends ExampleClass {}
+export class CustomExampleClassFires extends ExampleClass {}
 
 /**
  * @eventName event-foo-in-class-with-fires
  */
-export type FooEventNoText = {
+export type EventFooNoText = {
 	name: string;
 };

--- a/packages/typedoc-plugins/tests/tag-event/fixtures/custommodulewithoutclass.ts
+++ b/packages/typedoc-plugins/tests/tag-event/fixtures/custommodulewithoutclass.ts
@@ -1,0 +1,15 @@
+/**
+ * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/**
+ * @module fixtures/custommodule
+ */
+
+/**
+ * @eventName event-foo-no-class
+ */
+export type FooEventNoText = {
+	name: string;
+};

--- a/packages/typedoc-plugins/tests/tag-event/fixtures/custommodulewithoutclass.ts
+++ b/packages/typedoc-plugins/tests/tag-event/fixtures/custommodulewithoutclass.ts
@@ -10,6 +10,6 @@
 /**
  * @eventName event-foo-no-class
  */
-export type FooEventNoText = {
+export type EventFooNoText = {
 	name: string;
 };

--- a/packages/typedoc-plugins/tests/tag-event/fixtures/exampleclass.ts
+++ b/packages/typedoc-plugins/tests/tag-event/fixtures/exampleclass.ts
@@ -1,0 +1,24 @@
+/**
+ * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/**
+ * @module fixtures/exampleclass
+ */
+
+export default class ExampleClass {
+	protected _value: string;
+
+	constructor( value: string ) {
+		this._value = value;
+	}
+
+	public get value(): string {
+		return this.value;
+	}
+
+	public set value( value: string ) {
+		this._value = value;
+	}
+}

--- a/packages/typedoc-plugins/tests/tag-event/fixtures/tsconfig.json
+++ b/packages/typedoc-plugins/tests/tag-event/fixtures/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.json"
+}

--- a/packages/typedoc-plugins/tests/tag-event/index.js
+++ b/packages/typedoc-plugins/tests/tag-event/index.js
@@ -57,9 +57,9 @@ describe( 'typedoc-plugins/tag-event', function() {
 			.filter( children => children.name.startsWith( 'event:' ) );
 
 		// There should be 3 correctly defined events:
-		// 1. event-foo-associated-with-type-no-text
-		// 2. event-foo-associated-with-type
-		// 3. event-foo-associated-with-type-with-params
+		// 1. event-foo
+		// 2. event-foo-no-text
+		// 3. event-foo-with-params
 		// 4. event-foo-in-class-with-fires
 		expect( eventDefinitions ).to.lengthOf( 4 );
 	} );
@@ -69,10 +69,10 @@ describe( 'typedoc-plugins/tag-event', function() {
 		expect( typeDoc.logger.error.firstCall.args[ 0 ] ).includes( 'Unable to find a class for the "event-foo-no-class" event' );
 	} );
 
-	it( 'should find event that is fired by a non-default class', () => {
+	it( 'should first take into account the class that fires the event instead of the default class, if both exist in the module', () => {
 		const classDefinition = conversionResult.children
 			.find( entry => entry.name === 'customexampleclassfires' ).children
-			.find( entry => entry.kindString === 'Class' );
+			.find( entry => entry.kindString === 'Class' && entry.name === 'CustomExampleClassFires' );
 
 		const eventDefinition = classDefinition.children
 			.find( doclet => doclet.name === 'event:event-foo-in-class-with-fires' );
@@ -86,7 +86,7 @@ describe( 'typedoc-plugins/tag-event', function() {
 		before( () => {
 			classDefinition = conversionResult.children
 				.find( entry => entry.name === 'customexampleclass' ).children
-				.find( entry => entry.kindString === 'Class' );
+				.find( entry => entry.kindString === 'Class' && entry.name === 'default' );
 		} );
 
 		it( 'should find all event tags within the class', () => {
@@ -97,12 +97,11 @@ describe( 'typedoc-plugins/tag-event', function() {
 		} );
 
 		it( 'should find an event tag without description and parameters', () => {
-			const eventDefinition = classDefinition.children
-				.find( doclet => doclet.name === 'event:event-foo-associated-with-type-no-text' );
+			const eventDefinition = classDefinition.children.find( doclet => doclet.name === 'event:event-foo-no-text' );
 
 			expect( eventDefinition ).to.not.be.undefined;
-			expect( eventDefinition.name ).to.equal( 'event:event-foo-associated-with-type-no-text' );
-			expect( eventDefinition.originalName ).to.equal( 'event:event-foo-associated-with-type-no-text' );
+			expect( eventDefinition.name ).to.equal( 'event:event-foo-no-text' );
+			expect( eventDefinition.originalName ).to.equal( 'event:event-foo-no-text' );
 			expect( eventDefinition.kindString ).to.equal( 'Event' );
 
 			expect( eventDefinition.comment ).to.have.property( 'summary' );
@@ -128,12 +127,11 @@ describe( 'typedoc-plugins/tag-event', function() {
 		} );
 
 		it( 'should find an event tag with description and without parameters', () => {
-			const eventDefinition = classDefinition.children
-				.find( doclet => doclet.name === 'event:event-foo-associated-with-type' );
+			const eventDefinition = classDefinition.children.find( doclet => doclet.name === 'event:event-foo' );
 
 			expect( eventDefinition ).to.not.be.undefined;
-			expect( eventDefinition.name ).to.equal( 'event:event-foo-associated-with-type' );
-			expect( eventDefinition.originalName ).to.equal( 'event:event-foo-associated-with-type' );
+			expect( eventDefinition.name ).to.equal( 'event:event-foo' );
+			expect( eventDefinition.originalName ).to.equal( 'event:event-foo' );
 			expect( eventDefinition.kindString ).to.equal( 'Event' );
 
 			expect( eventDefinition.comment ).to.have.property( 'summary' );
@@ -153,12 +151,11 @@ describe( 'typedoc-plugins/tag-event', function() {
 		} );
 
 		it( 'should find an event tag with description and parameters', () => {
-			const eventDefinition = classDefinition.children
-				.find( doclet => doclet.name === 'event:event-foo-associated-with-type-with-params' );
+			const eventDefinition = classDefinition.children.find( doclet => doclet.name === 'event:event-foo-with-params' );
 
 			expect( eventDefinition ).to.not.be.undefined;
-			expect( eventDefinition.name ).to.equal( 'event:event-foo-associated-with-type-with-params' );
-			expect( eventDefinition.originalName ).to.equal( 'event:event-foo-associated-with-type-with-params' );
+			expect( eventDefinition.name ).to.equal( 'event:event-foo-with-params' );
+			expect( eventDefinition.originalName ).to.equal( 'event:event-foo-with-params' );
 			expect( eventDefinition.kindString ).to.equal( 'Event' );
 
 			expect( eventDefinition.comment ).to.have.property( 'summary' );

--- a/packages/typedoc-plugins/tests/tag-event/index.js
+++ b/packages/typedoc-plugins/tests/tag-event/index.js
@@ -123,7 +123,17 @@ describe( 'typedoc-plugins/tag-event', function() {
 			expect( eventDefinition.sources[ 0 ] ).to.have.property( 'character' );
 			expect( eventDefinition.sources[ 0 ] ).to.have.property( 'url' );
 
-			expect( eventDefinition ).to.not.have.property( 'typeParameters' );
+			expect( eventDefinition.typeParameters ).to.be.an( 'array' );
+			expect( eventDefinition.typeParameters ).to.lengthOf( 1 );
+
+			expect( eventDefinition.typeParameters[ 0 ] ).to.have.property( 'name', 'eventInfo' );
+			expect( eventDefinition.typeParameters[ 0 ] ).to.have.property( 'comment' );
+			expect( eventDefinition.typeParameters[ 0 ].comment ).to.have.property( 'summary' );
+			expect( eventDefinition.typeParameters[ 0 ].comment.summary ).to.be.an( 'array' );
+			expect( eventDefinition.typeParameters[ 0 ].comment.summary[ 0 ] ).to.have.property( 'kind', 'text' );
+			expect( eventDefinition.typeParameters[ 0 ].comment.summary[ 0 ] ).to.have.property( 'text',
+				'An object containing information about the fired event.'
+			);
 		} );
 
 		it( 'should find an event tag with description and without parameters', () => {
@@ -147,7 +157,17 @@ describe( 'typedoc-plugins/tag-event', function() {
 			expect( eventDefinition.comment.modifierTags ).to.be.a( 'Set' );
 			expect( eventDefinition.comment.modifierTags.size ).to.equal( 0 );
 
-			expect( eventDefinition ).to.not.have.property( 'typeParameters' );
+			expect( eventDefinition.typeParameters ).to.be.an( 'array' );
+			expect( eventDefinition.typeParameters ).to.lengthOf( 1 );
+
+			expect( eventDefinition.typeParameters[ 0 ] ).to.have.property( 'name', 'eventInfo' );
+			expect( eventDefinition.typeParameters[ 0 ] ).to.have.property( 'comment' );
+			expect( eventDefinition.typeParameters[ 0 ].comment ).to.have.property( 'summary' );
+			expect( eventDefinition.typeParameters[ 0 ].comment.summary ).to.be.an( 'array' );
+			expect( eventDefinition.typeParameters[ 0 ].comment.summary[ 0 ] ).to.have.property( 'kind', 'text' );
+			expect( eventDefinition.typeParameters[ 0 ].comment.summary[ 0 ] ).to.have.property( 'text',
+				'An object containing information about the fired event.'
+			);
 		} );
 
 		it( 'should find an event tag with description and parameters', () => {
@@ -192,45 +212,54 @@ describe( 'typedoc-plugins/tag-event', function() {
 			expect( eventDefinition.comment.modifierTags.size ).to.equal( 0 );
 
 			expect( eventDefinition.typeParameters ).to.be.an( 'array' );
-			expect( eventDefinition.typeParameters ).to.lengthOf( 3 );
+			expect( eventDefinition.typeParameters ).to.lengthOf( 4 );
 
-			expect( eventDefinition.typeParameters[ 0 ] ).to.have.property( 'name', 'p1' );
+			expect( eventDefinition.typeParameters[ 0 ] ).to.have.property( 'name', 'eventInfo' );
 			expect( eventDefinition.typeParameters[ 0 ] ).to.have.property( 'comment' );
 			expect( eventDefinition.typeParameters[ 0 ].comment ).to.have.property( 'summary' );
 			expect( eventDefinition.typeParameters[ 0 ].comment.summary ).to.be.an( 'array' );
 			expect( eventDefinition.typeParameters[ 0 ].comment.summary[ 0 ] ).to.have.property( 'kind', 'text' );
-			expect( eventDefinition.typeParameters[ 0 ].comment.summary[ 0 ] ).to.have.property( 'text', 'Description for first param.' );
+			expect( eventDefinition.typeParameters[ 0 ].comment.summary[ 0 ] ).to.have.property( 'text',
+				'An object containing information about the fired event.'
+			);
 
-			expect( eventDefinition.typeParameters[ 1 ] ).to.have.property( 'name', 'p2' );
+			expect( eventDefinition.typeParameters[ 1 ] ).to.have.property( 'name', 'p1' );
 			expect( eventDefinition.typeParameters[ 1 ] ).to.have.property( 'comment' );
 			expect( eventDefinition.typeParameters[ 1 ].comment ).to.have.property( 'summary' );
 			expect( eventDefinition.typeParameters[ 1 ].comment.summary ).to.be.an( 'array' );
 			expect( eventDefinition.typeParameters[ 1 ].comment.summary[ 0 ] ).to.have.property( 'kind', 'text' );
-			expect( eventDefinition.typeParameters[ 1 ].comment.summary[ 0 ] ).to.have.property( 'text', 'Description for second param.' );
+			expect( eventDefinition.typeParameters[ 1 ].comment.summary[ 0 ] ).to.have.property( 'text', 'Description for first param.' );
 
-			expect( eventDefinition.typeParameters[ 2 ] ).to.have.property( 'name', 'p3' );
+			expect( eventDefinition.typeParameters[ 2 ] ).to.have.property( 'name', 'p2' );
 			expect( eventDefinition.typeParameters[ 2 ] ).to.have.property( 'comment' );
 			expect( eventDefinition.typeParameters[ 2 ].comment ).to.have.property( 'summary' );
 			expect( eventDefinition.typeParameters[ 2 ].comment.summary ).to.be.an( 'array' );
-			expect( eventDefinition.typeParameters[ 2 ].comment.summary ).to.lengthOf( 5 );
-
 			expect( eventDefinition.typeParameters[ 2 ].comment.summary[ 0 ] ).to.have.property( 'kind', 'text' );
-			expect( eventDefinition.typeParameters[ 2 ].comment.summary[ 0 ] ).to.have.property( 'text', 'Complex ' );
+			expect( eventDefinition.typeParameters[ 2 ].comment.summary[ 0 ] ).to.have.property( 'text', 'Description for second param.' );
 
-			expect( eventDefinition.typeParameters[ 2 ].comment.summary[ 1 ] ).to.have.property( 'kind', 'inline-tag' );
-			expect( eventDefinition.typeParameters[ 2 ].comment.summary[ 1 ] ).to.have.property( 'tag', '@link' );
-			expect( eventDefinition.typeParameters[ 2 ].comment.summary[ 1 ] ).to.have.property( 'text',
+			expect( eventDefinition.typeParameters[ 3 ] ).to.have.property( 'name', 'p3' );
+			expect( eventDefinition.typeParameters[ 3 ] ).to.have.property( 'comment' );
+			expect( eventDefinition.typeParameters[ 3 ].comment ).to.have.property( 'summary' );
+			expect( eventDefinition.typeParameters[ 3 ].comment.summary ).to.be.an( 'array' );
+			expect( eventDefinition.typeParameters[ 3 ].comment.summary ).to.lengthOf( 5 );
+
+			expect( eventDefinition.typeParameters[ 3 ].comment.summary[ 0 ] ).to.have.property( 'kind', 'text' );
+			expect( eventDefinition.typeParameters[ 3 ].comment.summary[ 0 ] ).to.have.property( 'text', 'Complex ' );
+
+			expect( eventDefinition.typeParameters[ 3 ].comment.summary[ 1 ] ).to.have.property( 'kind', 'inline-tag' );
+			expect( eventDefinition.typeParameters[ 3 ].comment.summary[ 1 ] ).to.have.property( 'tag', '@link' );
+			expect( eventDefinition.typeParameters[ 3 ].comment.summary[ 1 ] ).to.have.property( 'text',
 				'module:utils/object~Object description'
 			);
 
-			expect( eventDefinition.typeParameters[ 2 ].comment.summary[ 2 ] ).to.have.property( 'kind', 'text' );
-			expect( eventDefinition.typeParameters[ 2 ].comment.summary[ 2 ] ).to.have.property( 'text', ' for ' );
+			expect( eventDefinition.typeParameters[ 3 ].comment.summary[ 2 ] ).to.have.property( 'kind', 'text' );
+			expect( eventDefinition.typeParameters[ 3 ].comment.summary[ 2 ] ).to.have.property( 'text', ' for ' );
 
-			expect( eventDefinition.typeParameters[ 2 ].comment.summary[ 3 ] ).to.have.property( 'kind', 'code' );
-			expect( eventDefinition.typeParameters[ 2 ].comment.summary[ 3 ] ).to.have.property( 'text', '`third param`' );
+			expect( eventDefinition.typeParameters[ 3 ].comment.summary[ 3 ] ).to.have.property( 'kind', 'code' );
+			expect( eventDefinition.typeParameters[ 3 ].comment.summary[ 3 ] ).to.have.property( 'text', '`third param`' );
 
-			expect( eventDefinition.typeParameters[ 2 ].comment.summary[ 4 ] ).to.have.property( 'kind', 'text' );
-			expect( eventDefinition.typeParameters[ 2 ].comment.summary[ 4 ] ).to.have.property( 'text', '.' );
+			expect( eventDefinition.typeParameters[ 3 ].comment.summary[ 4 ] ).to.have.property( 'kind', 'text' );
+			expect( eventDefinition.typeParameters[ 3 ].comment.summary[ 4 ] ).to.have.property( 'text', '.' );
 		} );
 	} );
 } );

--- a/packages/typedoc-plugins/tests/tag-event/index.js
+++ b/packages/typedoc-plugins/tests/tag-event/index.js
@@ -1,0 +1,65 @@
+/**
+ * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+const { expect } = require( 'chai' );
+const glob = require( 'fast-glob' );
+const TypeDoc = require( 'typedoc' );
+
+const utils = require( '../utils' );
+
+describe( 'typedoc-plugins/tag-event', function() {
+	this.timeout( 10 * 1000 );
+
+	let conversionResult;
+
+	const FIXTURES_PATH = utils.normalizePath( utils.ROOT_TEST_DIRECTORY, 'tag-event', 'fixtures' );
+
+	before( async () => {
+		const sourceFilePatterns = [
+			utils.normalizePath( FIXTURES_PATH, '**', '*.ts' )
+		];
+
+		const files = await glob( sourceFilePatterns );
+		const typeDoc = new TypeDoc.Application();
+
+		expect( files ).to.not.lengthOf( 0 );
+
+		typeDoc.options.addReader( new TypeDoc.TSConfigReader() );
+		typeDoc.options.addReader( new TypeDoc.TypeDocReader() );
+
+		typeDoc.bootstrap( {
+			logLevel: 'Error',
+			entryPoints: files,
+			plugin: [
+				require.resolve( '@ckeditor/typedoc-plugins/lib/tag-event' )
+			],
+			// TODO: To resolve once the same problem is fixed in the `@ckeditor/ckeditor5-dev-docs` package.
+			tsconfig: utils.normalizePath( FIXTURES_PATH, 'tsconfig.json' )
+		} );
+
+		conversionResult = typeDoc.convert();
+
+		expect( conversionResult ).to.be.an( 'object' );
+	} );
+
+	it( 'should collect the event annotations from comments and insert them as class children', () => {
+		const eventDefinitions = conversionResult.children
+			.find( entry => entry.name === 'customexampleclass' ).children
+			.find( entry => entry.kindString === 'Class' ).children
+			.filter( children => children.name.startsWith( 'event:' ) );
+
+		expect( eventDefinitions ).to.not.lengthOf( 0 );
+	} );
+
+	describe( 'event definitions', () => {
+		// let classDefinition;
+
+		// before( () => {
+		// 	classDefinition = conversionResult.children
+		// 		.find( entry => entry.name === 'customexampleclass' ).children
+		// 		.find( entry => entry.kindString === 'Class' ).children;
+		// } );
+	} );
+} );

--- a/packages/typedoc-plugins/tests/tag-event/index.js
+++ b/packages/typedoc-plugins/tests/tag-event/index.js
@@ -3,6 +3,7 @@
  * For licensing, see LICENSE.md.
  */
 
+const sinon = require( 'sinon' );
 const { expect } = require( 'chai' );
 const glob = require( 'fast-glob' );
 const TypeDoc = require( 'typedoc' );
@@ -12,7 +13,7 @@ const utils = require( '../utils' );
 describe( 'typedoc-plugins/tag-event', function() {
 	this.timeout( 10 * 1000 );
 
-	let conversionResult;
+	let typeDoc, conversionResult;
 
 	const FIXTURES_PATH = utils.normalizePath( utils.ROOT_TEST_DIRECTORY, 'tag-event', 'fixtures' );
 
@@ -22,7 +23,10 @@ describe( 'typedoc-plugins/tag-event', function() {
 		];
 
 		const files = await glob( sourceFilePatterns );
-		const typeDoc = new TypeDoc.Application();
+
+		typeDoc = new TypeDoc.Application();
+
+		sinon.stub( typeDoc.logger, 'error' );
 
 		expect( files ).to.not.lengthOf( 0 );
 
@@ -44,22 +48,192 @@ describe( 'typedoc-plugins/tag-event', function() {
 		expect( conversionResult ).to.be.an( 'object' );
 	} );
 
-	it( 'should collect the event annotations from comments and insert them as class children', () => {
-		const eventDefinitions = conversionResult.children
-			.find( entry => entry.name === 'customexampleclass' ).children
-			.find( entry => entry.kindString === 'Class' ).children
+	after( () => {
+		sinon.restore();
+	} );
+
+	it( 'should find all event tags within the project', () => {
+		const eventDefinitions = conversionResult.getReflectionsByKind( TypeDoc.ReflectionKind.All )
 			.filter( children => children.name.startsWith( 'event:' ) );
 
-		expect( eventDefinitions ).to.not.lengthOf( 0 );
+		// There should be 3 correctly defined events:
+		// 1. event-foo-associated-with-type-no-text
+		// 2. event-foo-associated-with-type
+		// 3. event-foo-associated-with-type-with-params
+		// 4. event-foo-in-class-with-fires
+		expect( eventDefinitions ).to.lengthOf( 4 );
+	} );
+
+	it( 'should inform if the class for an event has not been found', () => {
+		expect( typeDoc.logger.error.calledOnce ).to.equal( true );
+		expect( typeDoc.logger.error.firstCall.args[ 0 ] ).includes( 'Unable to find a class for the "event-foo-no-class" event' );
+	} );
+
+	it( 'should find event that is fired by a non-default class', () => {
+		const classDefinition = conversionResult.children
+			.find( entry => entry.name === 'customexampleclassfires' ).children
+			.find( entry => entry.kindString === 'Class' );
+
+		const eventDefinition = classDefinition.children
+			.find( doclet => doclet.name === 'event:event-foo-in-class-with-fires' );
+
+		expect( eventDefinition ).to.not.be.undefined;
 	} );
 
 	describe( 'event definitions', () => {
-		// let classDefinition;
+		let classDefinition;
 
-		// before( () => {
-		// 	classDefinition = conversionResult.children
-		// 		.find( entry => entry.name === 'customexampleclass' ).children
-		// 		.find( entry => entry.kindString === 'Class' ).children;
-		// } );
+		before( () => {
+			classDefinition = conversionResult.children
+				.find( entry => entry.name === 'customexampleclass' ).children
+				.find( entry => entry.kindString === 'Class' );
+		} );
+
+		it( 'should find all event tags within the class', () => {
+			const eventDefinitions = classDefinition.children
+				.filter( children => children.name.startsWith( 'event:' ) );
+
+			expect( eventDefinitions ).to.lengthOf( 3 );
+		} );
+
+		it( 'should find an event tag without description and parameters', () => {
+			const eventDefinition = classDefinition.children
+				.find( doclet => doclet.name === 'event:event-foo-associated-with-type-no-text' );
+
+			expect( eventDefinition ).to.not.be.undefined;
+			expect( eventDefinition.name ).to.equal( 'event:event-foo-associated-with-type-no-text' );
+			expect( eventDefinition.originalName ).to.equal( 'event:event-foo-associated-with-type-no-text' );
+			expect( eventDefinition.kindString ).to.equal( 'Event' );
+
+			expect( eventDefinition.comment ).to.have.property( 'summary' );
+			expect( eventDefinition.comment ).to.have.property( 'blockTags' );
+			expect( eventDefinition.comment ).to.have.property( 'modifierTags' );
+
+			expect( eventDefinition.comment.summary ).to.be.an( 'array' );
+			expect( eventDefinition.comment.summary ).to.lengthOf( 0 );
+			expect( eventDefinition.comment.blockTags ).to.be.an( 'array' );
+			expect( eventDefinition.comment.blockTags ).to.lengthOf( 0 );
+			expect( eventDefinition.comment.modifierTags ).to.be.a( 'Set' );
+			expect( eventDefinition.comment.modifierTags.size ).to.equal( 0 );
+
+			expect( eventDefinition.sources ).to.be.an( 'array' );
+			expect( eventDefinition.sources ).to.lengthOf( 1 );
+			expect( eventDefinition.sources[ 0 ] ).to.have.property( 'fileName', 'customexampleclass.ts' );
+			expect( eventDefinition.sources[ 0 ] ).to.have.property( 'fullFileName' );
+			expect( eventDefinition.sources[ 0 ] ).to.have.property( 'line' );
+			expect( eventDefinition.sources[ 0 ] ).to.have.property( 'character' );
+			expect( eventDefinition.sources[ 0 ] ).to.have.property( 'url' );
+
+			expect( eventDefinition ).to.not.have.property( 'typeParameters' );
+		} );
+
+		it( 'should find an event tag with description and without parameters', () => {
+			const eventDefinition = classDefinition.children
+				.find( doclet => doclet.name === 'event:event-foo-associated-with-type' );
+
+			expect( eventDefinition ).to.not.be.undefined;
+			expect( eventDefinition.name ).to.equal( 'event:event-foo-associated-with-type' );
+			expect( eventDefinition.originalName ).to.equal( 'event:event-foo-associated-with-type' );
+			expect( eventDefinition.kindString ).to.equal( 'Event' );
+
+			expect( eventDefinition.comment ).to.have.property( 'summary' );
+			expect( eventDefinition.comment ).to.have.property( 'blockTags' );
+			expect( eventDefinition.comment ).to.have.property( 'modifierTags' );
+
+			expect( eventDefinition.comment.summary ).to.be.an( 'array' );
+			expect( eventDefinition.comment.summary ).to.lengthOf( 1 );
+			expect( eventDefinition.comment.summary[ 0 ] ).to.have.property( 'kind', 'text' );
+			expect( eventDefinition.comment.summary[ 0 ] ).to.have.property( 'text', 'An event associated with the type.' );
+			expect( eventDefinition.comment.blockTags ).to.be.an( 'array' );
+			expect( eventDefinition.comment.blockTags ).to.lengthOf( 0 );
+			expect( eventDefinition.comment.modifierTags ).to.be.a( 'Set' );
+			expect( eventDefinition.comment.modifierTags.size ).to.equal( 0 );
+
+			expect( eventDefinition ).to.not.have.property( 'typeParameters' );
+		} );
+
+		it( 'should find an event tag with description and parameters', () => {
+			const eventDefinition = classDefinition.children
+				.find( doclet => doclet.name === 'event:event-foo-associated-with-type-with-params' );
+
+			expect( eventDefinition ).to.not.be.undefined;
+			expect( eventDefinition.name ).to.equal( 'event:event-foo-associated-with-type-with-params' );
+			expect( eventDefinition.originalName ).to.equal( 'event:event-foo-associated-with-type-with-params' );
+			expect( eventDefinition.kindString ).to.equal( 'Event' );
+
+			expect( eventDefinition.comment ).to.have.property( 'summary' );
+			expect( eventDefinition.comment ).to.have.property( 'blockTags' );
+			expect( eventDefinition.comment ).to.have.property( 'modifierTags' );
+
+			expect( eventDefinition.comment.summary ).to.be.an( 'array' );
+			expect( eventDefinition.comment.summary ).to.lengthOf( 5 );
+
+			expect( eventDefinition.comment.summary[ 0 ] ).to.have.property( 'kind', 'text' );
+			expect( eventDefinition.comment.summary[ 0 ] ).to.have.property( 'text',
+				'An event associated with the type. Event with three params.\n\nSee '
+			);
+
+			expect( eventDefinition.comment.summary[ 1 ] ).to.have.property( 'kind', 'inline-tag' );
+			expect( eventDefinition.comment.summary[ 1 ] ).to.have.property( 'tag', '@link' );
+			expect( eventDefinition.comment.summary[ 1 ] ).to.have.property( 'text', '~CustomExampleClass' );
+
+			expect( eventDefinition.comment.summary[ 2 ] ).to.have.property( 'kind', 'text' );
+			expect( eventDefinition.comment.summary[ 2 ] ).to.have.property( 'text', ' or ' );
+
+			expect( eventDefinition.comment.summary[ 3 ] ).to.have.property( 'kind', 'inline-tag' );
+			expect( eventDefinition.comment.summary[ 3 ] ).to.have.property( 'tag', '@link' );
+			expect( eventDefinition.comment.summary[ 3 ] ).to.have.property( 'text',
+				'module:fixtures/customexampleclass~CustomExampleClass Custom label'
+			);
+
+			expect( eventDefinition.comment.summary[ 4 ] ).to.have.property( 'kind', 'text' );
+			expect( eventDefinition.comment.summary[ 4 ] ).to.have.property( 'text', '. A text after.' );
+
+			expect( eventDefinition.comment.blockTags ).to.be.an( 'array' );
+			expect( eventDefinition.comment.blockTags ).to.lengthOf( 0 );
+			expect( eventDefinition.comment.modifierTags ).to.be.a( 'Set' );
+			expect( eventDefinition.comment.modifierTags.size ).to.equal( 0 );
+
+			expect( eventDefinition.typeParameters ).to.be.an( 'array' );
+			expect( eventDefinition.typeParameters ).to.lengthOf( 3 );
+
+			expect( eventDefinition.typeParameters[ 0 ] ).to.have.property( 'name', 'p1' );
+			expect( eventDefinition.typeParameters[ 0 ] ).to.have.property( 'comment' );
+			expect( eventDefinition.typeParameters[ 0 ].comment ).to.have.property( 'summary' );
+			expect( eventDefinition.typeParameters[ 0 ].comment.summary ).to.be.an( 'array' );
+			expect( eventDefinition.typeParameters[ 0 ].comment.summary[ 0 ] ).to.have.property( 'kind', 'text' );
+			expect( eventDefinition.typeParameters[ 0 ].comment.summary[ 0 ] ).to.have.property( 'text', 'Description for first param.' );
+
+			expect( eventDefinition.typeParameters[ 1 ] ).to.have.property( 'name', 'p2' );
+			expect( eventDefinition.typeParameters[ 1 ] ).to.have.property( 'comment' );
+			expect( eventDefinition.typeParameters[ 1 ].comment ).to.have.property( 'summary' );
+			expect( eventDefinition.typeParameters[ 1 ].comment.summary ).to.be.an( 'array' );
+			expect( eventDefinition.typeParameters[ 1 ].comment.summary[ 0 ] ).to.have.property( 'kind', 'text' );
+			expect( eventDefinition.typeParameters[ 1 ].comment.summary[ 0 ] ).to.have.property( 'text', 'Description for second param.' );
+
+			expect( eventDefinition.typeParameters[ 2 ] ).to.have.property( 'name', 'p3' );
+			expect( eventDefinition.typeParameters[ 2 ] ).to.have.property( 'comment' );
+			expect( eventDefinition.typeParameters[ 2 ].comment ).to.have.property( 'summary' );
+			expect( eventDefinition.typeParameters[ 2 ].comment.summary ).to.be.an( 'array' );
+			expect( eventDefinition.typeParameters[ 2 ].comment.summary ).to.lengthOf( 5 );
+
+			expect( eventDefinition.typeParameters[ 2 ].comment.summary[ 0 ] ).to.have.property( 'kind', 'text' );
+			expect( eventDefinition.typeParameters[ 2 ].comment.summary[ 0 ] ).to.have.property( 'text', 'Complex ' );
+
+			expect( eventDefinition.typeParameters[ 2 ].comment.summary[ 1 ] ).to.have.property( 'kind', 'inline-tag' );
+			expect( eventDefinition.typeParameters[ 2 ].comment.summary[ 1 ] ).to.have.property( 'tag', '@link' );
+			expect( eventDefinition.typeParameters[ 2 ].comment.summary[ 1 ] ).to.have.property( 'text',
+				'module:utils/object~Object description'
+			);
+
+			expect( eventDefinition.typeParameters[ 2 ].comment.summary[ 2 ] ).to.have.property( 'kind', 'text' );
+			expect( eventDefinition.typeParameters[ 2 ].comment.summary[ 2 ] ).to.have.property( 'text', ' for ' );
+
+			expect( eventDefinition.typeParameters[ 2 ].comment.summary[ 3 ] ).to.have.property( 'kind', 'code' );
+			expect( eventDefinition.typeParameters[ 2 ].comment.summary[ 3 ] ).to.have.property( 'text', '`third param`' );
+
+			expect( eventDefinition.typeParameters[ 2 ].comment.summary[ 4 ] ).to.have.property( 'kind', 'text' );
+			expect( eventDefinition.typeParameters[ 2 ].comment.summary[ 4 ] ).to.have.property( 'text', '.' );
+		} );
 	} );
 } );

--- a/packages/typedoc-plugins/tests/tag-event/index.js
+++ b/packages/typedoc-plugins/tests/tag-event/index.js
@@ -56,7 +56,7 @@ describe( 'typedoc-plugins/tag-event', function() {
 		const eventDefinitions = conversionResult.getReflectionsByKind( TypeDoc.ReflectionKind.All )
 			.filter( children => children.name.startsWith( 'event:' ) );
 
-		// There should be 3 correctly defined events:
+		// There should be 4 correctly defined events:
 		// 1. event-foo
 		// 2. event-foo-no-text
 		// 3. event-foo-with-params

--- a/packages/typedoc-plugins/tests/tag-event/index.js
+++ b/packages/typedoc-plugins/tests/tag-event/index.js
@@ -26,7 +26,7 @@ describe( 'typedoc-plugins/tag-event', function() {
 
 		typeDoc = new TypeDoc.Application();
 
-		sinon.stub( typeDoc.logger, 'error' );
+		sinon.stub( typeDoc.logger, 'warn' );
 
 		expect( files ).to.not.lengthOf( 0 );
 
@@ -34,7 +34,7 @@ describe( 'typedoc-plugins/tag-event', function() {
 		typeDoc.options.addReader( new TypeDoc.TypeDocReader() );
 
 		typeDoc.bootstrap( {
-			logLevel: 'Error',
+			logLevel: 'Warn',
 			entryPoints: files,
 			plugin: [
 				require.resolve( '@ckeditor/typedoc-plugins/lib/tag-event' )
@@ -65,8 +65,10 @@ describe( 'typedoc-plugins/tag-event', function() {
 	} );
 
 	it( 'should inform if the class for an event has not been found', () => {
-		expect( typeDoc.logger.error.calledOnce ).to.equal( true );
-		expect( typeDoc.logger.error.firstCall.args[ 0 ] ).includes( 'Unable to find a class for the "event-foo-no-class" event' );
+		expect( typeDoc.logger.warn.calledOnce ).to.equal( true );
+		expect( typeDoc.logger.warn.firstCall.args[ 0 ] ).to.equal( 'Skipping unsupported "event-foo-no-class" event.' );
+		expect( typeDoc.logger.warn.firstCall.args[ 1 ] ).to.have.property( 'name' );
+		expect( typeDoc.logger.warn.firstCall.args[ 1 ].name ).to.have.property( 'escapedText', 'EventFooNoText' );
 	} );
 
 	it( 'should first take into account the class that fires the event instead of the default class, if both exist in the module', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature (typedoc-plugins): Created the `tag-event` plugin that collects all occurrences of the `@eventName` tags in the CKEditor 5 code base. Closes ckeditor/ckeditor5#12526.

---

### Additional information

This plugin does not parse the `@event` tag, because it has a special meaning in the TypeDoc and it would be difficult to get it to work as we expect. This is why I added support for the custom `@eventName` tag, which now replaces the old `@event` tag.