### PR TITLE
Fixed source-map generation in manual and automatic tests tests

### DIFF
--- a/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getkarmaconfig.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getkarmaconfig.js
@@ -179,6 +179,17 @@ module.exports = function getKarmaConfig( options ) {
 		// Otherwise, Karma compiles sources once, and the test bundle uses old code.
 		// For the future reference: https://youtrack.jetbrains.com/issue/WEB-12496.
 		karmaConfig.webpack.watch = true;
+
+		// Remove istanbul-instrumenter if coverage reporter was removed by overrides
+		// (especially when debugging in Intellij IDE).
+		if ( !karmaConfig.reporters.includes( 'coverage' ) && karmaConfig.webpack.module ) {
+			const moduleRules = karmaConfig.webpack.module.rules;
+			const ruleIdx = moduleRules.findIndex( rule => rule.loader == 'istanbul-instrumenter-loader' );
+
+			if ( ruleIdx != -1 ) {
+				moduleRules.splice( ruleIdx, 1 );
+			}
+		}
 	}
 
 	return karmaConfig;

--- a/packages/ckeditor5-dev-tests/lib/utils/manual-tests/getwebpackconfig.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/manual-tests/getwebpackconfig.js
@@ -160,7 +160,7 @@ module.exports = function getWebpackConfigForManualTests( options ) {
 			// See https://github.com/webpack/karma-webpack/pull/76.
 			new webpack.SourceMapDevToolPlugin( {
 				columns: false,
-				module: false,
+				module: true,
 				filename: '[file].map',
 				append: '\n//# sourceMappingURL=[base].map'
 			} )


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix (ckeditor5-dev-tests): Debugging of manual tests should properly display TypeScript files. Debugging of automatic tests should remove the 'istanbul-instrumenter-loader' if the 'coverage' reporter was disabled by 'karma-config-overrides'. 

---

### Additional information
