### PR TITLE
Fix (tests): Disable watch mode for building manual when no files provided

### DIFF
--- a/packages/ckeditor5-dev-tests/bin/test-manual.js
+++ b/packages/ckeditor5-dev-tests/bin/test-manual.js
@@ -19,10 +19,6 @@ const options = tests.parseArguments( process.argv.slice( 2 ) );
 // without rebuilding it. See: https://github.com/ckeditor/ckeditor5/issues/10982.
 options.disableWatch = process.argv.includes( '--disable-watch' );
 
-if ( options.files.length === 0 ) {
-	options.files = [ '*', 'ckeditor5' ];
-}
-
 // "Lark" is the default theme for tests.
 options.themePath = path.resolve( cwd, 'packages', 'ckeditor5-theme-lark', 'theme', 'theme.css' );
 

--- a/packages/ckeditor5-dev-tests/lib/tasks/runmanualtests.js
+++ b/packages/ckeditor5-dev-tests/lib/tasks/runmanualtests.js
@@ -42,9 +42,10 @@ const transformFileOptionToTestGlob = require( '../utils/transformfileoptiontote
 module.exports = function runManualTests( options ) {
 	const log = logger();
 	const buildDir = path.join( process.cwd(), 'build', '.manual-tests' );
-	const files = ( options.files && options.files.length ) ? options.files : [ '*' ];
-	const sourceFiles = files
-		.flatMap( file => transformFileOptionToTestGlob( file, true ) )
+	const isFilesFlagProvided = ( options.files && options.files.length );
+	const files = isFilesFlagProvided ? options.files : [ '*', 'ckeditor5' ];
+	const dedupedFileTestGlobs = [ ...new Set( files.flatMap( file => transformFileOptionToTestGlob( file, true ) ) ) ];
+	const sourceFiles = dedupedFileTestGlobs
 		.reduce( ( result, manualTestPattern ) => {
 			return [
 				...result,
@@ -60,7 +61,7 @@ module.exports = function runManualTests( options ) {
 	const language = options.language;
 	const additionalLanguages = options.additionalLanguages;
 	const silent = options.silent || false;
-	const disableWatch = options.disableWatch || false;
+	const disableWatch = options.disableWatch || !isFilesFlagProvided;
 	let socketServer;
 
 	function onTestCompilationStatus( status ) {

--- a/packages/ckeditor5-dev-tests/lib/utils/manual-tests/webpacknotifierplugin.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/manual-tests/webpacknotifierplugin.js
@@ -43,6 +43,10 @@ module.exports = class WebpackNotifierPlugin {
 
 			this.log.info( '[Webpack] Finished the compilation.' );
 
+			if ( !stats.compilation.options.watch ) {
+				this.log.info( '[Webpack] File watcher is disabled.' );
+			}
+
 			this.onTestCompilationStatus( 'finished' );
 		} );
 	}

--- a/packages/ckeditor5-dev-tests/tests/tasks/runmanualtests.js
+++ b/packages/ckeditor5-dev-tests/tests/tasks/runmanualtests.js
@@ -134,7 +134,7 @@ describe( 'runManualTests', () => {
 			scriptCompiler: sandbox.spy( () => Promise.resolve() ),
 			removeDir: sandbox.spy( () => Promise.resolve() ),
 			copyAssets: sandbox.spy(),
-			transformFileOptionToTestGlob: sandbox.stub()
+			transformFileOptionToTestGlob: sandbox.stub().returns( [] )
 		};
 
 		mockery.registerMock( 'socket.io', spies.socketIO );
@@ -181,10 +181,6 @@ describe( 'runManualTests', () => {
 				expect( spies.removeDir.calledOnce ).to.equal( true );
 				expect( spies.removeDir.firstCall.args[ 0 ] ).to.equal( 'workspace/build/.manual-tests' );
 
-				expect( spies.transformFileOptionToTestGlob.calledOnce ).to.equal( true );
-				expect( spies.transformFileOptionToTestGlob.firstCall.args[ 0 ] ).to.equal( '*' );
-				expect( spies.transformFileOptionToTestGlob.firstCall.args[ 1 ] ).to.equal( true );
-
 				expect( spies.htmlFileCompiler.calledOnce ).to.equal( true );
 				sinon.assert.calledWith( spies.htmlFileCompiler.firstCall, {
 					buildDir: 'workspace/build/.manual-tests',
@@ -197,7 +193,7 @@ describe( 'runManualTests', () => {
 					language: undefined,
 					onTestCompilationStatus: sinon.match.func,
 					additionalLanguages: undefined,
-					disableWatch: false,
+					disableWatch: true,
 					silent: false
 				} );
 
@@ -215,7 +211,7 @@ describe( 'runManualTests', () => {
 					onTestCompilationStatus: sinon.match.func,
 					additionalLanguages: undefined,
 					debug: undefined,
-					disableWatch: false,
+					disableWatch: true,
 					identityFile: undefined
 				} );
 
@@ -309,12 +305,6 @@ describe( 'runManualTests', () => {
 			.then( () => {
 				expect( spies.removeDir.calledOnce ).to.equal( true );
 				expect( spies.removeDir.firstCall.args[ 0 ] ).to.equal( 'workspace/build/.manual-tests' );
-
-				expect( spies.transformFileOptionToTestGlob.calledTwice ).to.equal( true );
-				expect( spies.transformFileOptionToTestGlob.firstCall.args[ 0 ] ).to.equal( 'ckeditor5-classic' );
-				expect( spies.transformFileOptionToTestGlob.firstCall.args[ 1 ] ).to.equal( true );
-				expect( spies.transformFileOptionToTestGlob.secondCall.args[ 0 ] ).to.equal( 'ckeditor-classic/manual/classic.js' );
-				expect( spies.transformFileOptionToTestGlob.secondCall.args[ 1 ] ).to.equal( true );
 
 				expect( spies.htmlFileCompiler.calledOnce ).to.equal( true );
 				sinon.assert.calledWith( spies.htmlFileCompiler.firstCall, {
@@ -463,10 +453,6 @@ describe( 'runManualTests', () => {
 				expect( spies.removeDir.firstCall.args[ 0 ] ).to.equal( 'workspace/build/.manual-tests' );
 				expect( spies.removeDir.firstCall.args[ 1 ] ).to.deep.equal( { silent: true } );
 
-				expect( spies.transformFileOptionToTestGlob.calledOnce ).to.equal( true );
-				expect( spies.transformFileOptionToTestGlob.firstCall.args[ 0 ] ).to.equal( '*' );
-				expect( spies.transformFileOptionToTestGlob.firstCall.args[ 1 ] ).to.equal( true );
-
 				expect( spies.htmlFileCompiler.calledOnce ).to.equal( true );
 				sinon.assert.calledWith( spies.htmlFileCompiler.firstCall, {
 					buildDir: 'workspace/build/.manual-tests',
@@ -479,7 +465,7 @@ describe( 'runManualTests', () => {
 					language: undefined,
 					onTestCompilationStatus: sinon.match.func,
 					additionalLanguages: undefined,
-					disableWatch: false,
+					disableWatch: true,
 					silent: true
 				} );
 
@@ -497,7 +483,7 @@ describe( 'runManualTests', () => {
 					onTestCompilationStatus: sinon.match.func,
 					additionalLanguages: undefined,
 					debug: undefined,
-					disableWatch: false,
+					disableWatch: true,
 					identityFile: undefined
 				} );
 
@@ -518,10 +504,6 @@ describe( 'runManualTests', () => {
 
 		return runManualTests( { ...defaultOptions, ...options } )
 			.then( () => {
-				expect( spies.transformFileOptionToTestGlob.calledOnce ).to.equal( true );
-				expect( spies.transformFileOptionToTestGlob.firstCall.args[ 0 ] ).to.equal( '*' );
-				expect( spies.transformFileOptionToTestGlob.firstCall.args[ 1 ] ).to.equal( true );
-
 				expect( spies.htmlFileCompiler.calledOnce ).to.equal( true );
 				sinon.assert.calledWith( spies.htmlFileCompiler.firstCall, {
 					buildDir: 'workspace/build/.manual-tests',
@@ -574,10 +556,6 @@ describe( 'runManualTests', () => {
 
 		return runManualTests( { ...defaultOptions, ...options } )
 			.then( () => {
-				expect( spies.transformFileOptionToTestGlob.calledOnce ).to.equal( true );
-				expect( spies.transformFileOptionToTestGlob.firstCall.args[ 0 ] ).to.equal( '*' );
-				expect( spies.transformFileOptionToTestGlob.firstCall.args[ 1 ] ).to.equal( true );
-
 				expect( spies.htmlFileCompiler.calledOnce ).to.equal( true );
 				sinon.assert.calledWith( spies.htmlFileCompiler.firstCall, {
 					buildDir: 'workspace/build/.manual-tests',
@@ -627,6 +605,53 @@ describe( 'runManualTests', () => {
 			.then( () => {
 				sinon.assert.calledOnce( spies.socketIO.Server );
 				sinon.assert.calledWithExactly( spies.socketIO.Server, httpServerMock );
+			} );
+	} );
+
+	it( 'should set disableWatch to true if files flag is not provided', () => {
+		return runManualTests( defaultOptions )
+			.then( () => {
+				sinon.assert.calledWith( spies.scriptCompiler.firstCall, sinon.match.has( 'disableWatch', true ) );
+			} );
+	} );
+
+	it( 'should set disableWatch to false if files flag is provided', () => {
+		spies.transformFileOptionToTestGlob.returns( [] );
+
+		const options = {
+			files: [
+				'ckeditor5-classic',
+				'ckeditor-classic/manual/classic.js'
+			]
+		};
+
+		return runManualTests( { ...defaultOptions, ...options } )
+			.then( () => {
+				sinon.assert.calledWith( spies.scriptCompiler.firstCall, sinon.match.has( 'disableWatch', false ) );
+			} );
+	} );
+
+	it( 'should read disableWatch flag value even if files flag is provided', () => {
+		const options = {
+			files: [
+				'ckeditor5-classic',
+				'ckeditor-classic/manual/classic.js'
+			],
+			disableWatch: true
+		};
+
+		return runManualTests( { ...defaultOptions, ...options } )
+			.then( () => {
+				sinon.assert.calledWith( spies.scriptCompiler.firstCall, sinon.match.has( 'disableWatch', true ) );
+			} );
+	} );
+
+	it( 'should set default values for files', () => {
+		return runManualTests( defaultOptions )
+			.then( () => {
+				expect( spies.transformFileOptionToTestGlob.calledTwice ).to.equal( true );
+				expect( spies.transformFileOptionToTestGlob.firstCall.args[ 0 ] ).to.equal( '*' );
+				expect( spies.transformFileOptionToTestGlob.secondCall.args[ 0 ] ).to.equal( 'ckeditor5' );
 			} );
 	} );
 
@@ -1038,7 +1063,7 @@ describe( 'runManualTests', () => {
 						onTestCompilationStatus: sinon.match.func,
 						additionalLanguages: undefined,
 						debug: undefined,
-						disableWatch: false,
+						disableWatch: true,
 						identityFile: undefined
 					} );
 
@@ -1056,7 +1081,7 @@ describe( 'runManualTests', () => {
 						language: undefined,
 						onTestCompilationStatus: sinon.match.func,
 						additionalLanguages: undefined,
-						disableWatch: false,
+						disableWatch: true,
 						silent: false
 					} );
 

--- a/packages/ckeditor5-dev-tests/tests/tasks/runmanualtests.js
+++ b/packages/ckeditor5-dev-tests/tests/tasks/runmanualtests.js
@@ -616,8 +616,6 @@ describe( 'runManualTests', () => {
 	} );
 
 	it( 'should set disableWatch to false if files flag is provided', () => {
-		spies.transformFileOptionToTestGlob.returns( [] );
-
 		const options = {
 			files: [
 				'ckeditor5-classic',
@@ -652,6 +650,37 @@ describe( 'runManualTests', () => {
 				expect( spies.transformFileOptionToTestGlob.calledTwice ).to.equal( true );
 				expect( spies.transformFileOptionToTestGlob.firstCall.args[ 0 ] ).to.equal( '*' );
 				expect( spies.transformFileOptionToTestGlob.secondCall.args[ 0 ] ).to.equal( 'ckeditor5' );
+			} );
+	} );
+
+	it( 'should transform provided files to glob', () => {
+		const options = {
+			files: [
+				'ckeditor5-classic',
+				'ckeditor-classic/manual/classic.js'
+			]
+		};
+
+		return runManualTests( { ...defaultOptions, ...options } )
+			.then( () => {
+				expect( spies.transformFileOptionToTestGlob.calledTwice ).to.equal( true );
+				expect( spies.transformFileOptionToTestGlob.firstCall.args[ 0 ] ).to.equal( 'ckeditor5-classic' );
+				expect( spies.transformFileOptionToTestGlob.secondCall.args[ 0 ] ).to.equal( 'ckeditor-classic/manual/classic.js' );
+			} );
+	} );
+
+	it( 'should not duplicate glob files in the final sourceFiles array', () => {
+		spies.transformFileOptionToTestGlob.returns( [
+			'workspace/packages/ckeditor-*/tests/**/manual/**/*.js',
+			'workspace/packages/ckeditor-*/tests/**/manual/**/*.js'
+		] );
+
+		return runManualTests( defaultOptions )
+			.then( () => {
+				expect( spies.scriptCompiler.firstCall.args[ 0 ].sourceFiles ).to.deep.equal( [
+					'workspace/packages/ckeditor-foo/tests/manual/feature-c.js',
+					'workspace/packages/ckeditor-bar/tests/manual/feature-d.js'
+				] );
 			} );
 	} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix (tests): Disabled watch mode for building manual tests when no files are provided. Closes ckeditor/ckeditor5#12189.

---

### Additional information

* Moved default values for files from `bin/test-manual.js` to `lib/tasks/runmanualtests.js`.
* Added deduplication for file to test glob transform.
* Removed duplicated logic in tests
