### PR TITLE
Introduced new `tag-observable` plugin for TypeDoc

### DIFF
--- a/packages/ckeditor5-dev-docs/lib/docs/index.js
+++ b/packages/ckeditor5-dev-docs/lib/docs/index.js
@@ -63,7 +63,8 @@ module.exports = async function build( config ) {
 			require.resolve( '@ckeditor/typedoc-plugins/lib/module-fixer' ),
 			require.resolve( '@ckeditor/typedoc-plugins/lib/symbol-fixer' ),
 			require.resolve( '@ckeditor/typedoc-plugins/lib/tag-error' ),
-			require.resolve( '@ckeditor/typedoc-plugins/lib/tag-event' )
+			require.resolve( '@ckeditor/typedoc-plugins/lib/tag-event' ),
+			require.resolve( '@ckeditor/typedoc-plugins/lib/tag-observable' )
 		],
 
 		// TODO: Move tsconfig.json to main repo. Also: how to share it across repos? Also: Do we need to share it?

--- a/packages/typedoc-plugins/lib/tag-observable/index.js
+++ b/packages/typedoc-plugins/lib/tag-observable/index.js
@@ -96,7 +96,7 @@ function onEventEnd( context ) {
 }
 
 /**
- * Creates new type parameter reflection.
+ * Creates and returns new type parameter reflection.
  *
  * @param {require('typedoc').Context} context Current state of the converter.
  * @param {Object} options

--- a/packages/typedoc-plugins/lib/tag-observable/index.js
+++ b/packages/typedoc-plugins/lib/tag-observable/index.js
@@ -1,0 +1,126 @@
+/**
+ * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+'use strict';
+
+const { Converter, ReflectionKind, TypeParameterReflection, Comment } = require( 'typedoc' );
+const ts = require( 'typescript' );
+
+/**
+ * The `typedoc-plugin-tag-observable` handles the `@observable` tag that is assigned to the class property. If found, two new events are
+ * created and inserted as a class children: `change:{property}` and `set:{property}`, where `{property}` is the name of the observable
+ * class property.
+ *
+ * TODO: We do not support collecting types of `@param` tags associated with the `@observable`.
+ */
+module.exports = {
+	load( app ) {
+		// Search for the `@observable` tag when the whole project has been converted. It is required that the parent-child relationship
+		// already exists.
+		app.converter.on( Converter.EVENT_END, onEventEnd );
+	}
+};
+
+function onEventEnd( context ) {
+	// Get all resolved reflections that could potentially have the `@observable` tag.
+	const reflections = context.project.getReflectionsByKind( ReflectionKind.Property );
+
+	// Then, for each potential observable reflection...
+	for ( const reflection of reflections ) {
+		// ...skip it, if it does not contain the `@observable` tag.
+		if ( !reflection.comment || !reflection.comment.getTag( '@observable' ) ) {
+			continue;
+		}
+
+		// Otherwise, if the property has the `@observable` tag, get its name and its parent class.
+		const propertyName = reflection.name;
+		const classReflection = reflection.parent;
+
+		// An observable property fires two events - `change` and `set` - so two event reflections have to be inserted as a class child.
+		for ( const eventName of [ 'change', 'set' ] ) {
+			const eventReflection = context
+				.withScope( classReflection )
+				.createDeclarationReflection(
+					ReflectionKind.ObjectLiteral,
+					undefined,
+					undefined,
+					`event:${ eventName }:${ propertyName }`
+				);
+
+			eventReflection.kindString = 'Event';
+
+			const eventInfoParameter = typeParameterFactory( context, {
+				name: 'eventInfo',
+				parent: eventReflection,
+				comment: 'An object containing information about the fired event.'
+			} );
+
+			const nameParameter = typeParameterFactory( context, {
+				name: 'name',
+				parent: eventReflection,
+				kind: ts.SyntaxKind.StringKeyword,
+				comment: `Name of the changed property (\`${ propertyName }\`).`
+			} );
+
+			const valueParameter = typeParameterFactory( context, {
+				name: 'value',
+				parent: eventReflection,
+				comment: `New value of the \`${ propertyName }\` property with given key or \`null\`, if operation should remove property.`
+			} );
+
+			const oldValueParameter = typeParameterFactory( context, {
+				name: 'oldValue',
+				parent: eventReflection,
+				comment: `Old value of the \`${ propertyName }\` property with given key or \`null\`, if property was not set before.`
+			} );
+
+			// An event fired from an observable property always has 4 parameters.
+			eventReflection.typeParameters = [ eventInfoParameter, nameParameter, valueParameter, oldValueParameter ];
+
+			eventReflection.comment = new Comment( [
+				{
+					kind: 'text',
+					text: eventName === 'change' ?
+						`Fired when the \`${ propertyName }\` property changed value.` :
+						`Fired when the \`${ propertyName }\` property is going to be set but is not set yet ` +
+						'(before the `change` event is fired).'
+				}
+			] );
+
+			// Copy the source location as it is the same as the location of the reflection containing the event.
+			eventReflection.sources = [ ...reflection.sources ];
+		}
+	}
+}
+
+/**
+ * Creates new type parameter reflection.
+ *
+ * @param {require('typedoc').Context} context Current state of the converter.
+ * @param {Object} options
+ * @param {String} options.name Parameter name.
+ * @param {require('typedoc').Reflection} options.parent Parent reflection where the parameter should belong.
+ * @param {require('ts').SyntaxKind} options.kind Kind of the parameter.
+ * @param {String} options.comment Parameter comment.
+ * @returns {require('typedoc').Reflection}
+ */
+function typeParameterFactory( context, options ) {
+	const typeParameter = new TypeParameterReflection( options.name, undefined, undefined, options.parent );
+
+	const scope = context.withScope( typeParameter );
+	const type = {
+		kind: options.kind || ts.SyntaxKind.AnyKeyword
+	};
+
+	typeParameter.type = context.converter.convertType( scope, type );
+	typeParameter.comment = new Comment( [
+		{
+			kind: 'text',
+			text: options.comment
+		}
+	] );
+
+	return typeParameter;
+}

--- a/packages/typedoc-plugins/tests/tag-observable/fixtures/customexampleclass.ts
+++ b/packages/typedoc-plugins/tests/tag-observable/fixtures/customexampleclass.ts
@@ -10,17 +10,17 @@
 import { ExampleClass } from './exampleclass';
 
 export class CustomExampleClass extends ExampleClass {
-	// This class has also all inherited observable properties from ExampleClass.
+	// In the generated TypeDoc output this class will also contain all inherited observable properties from ExampleClass.
 
 	/**
-	 * Observable tag associated to a static property in a class.
+	 * Observable public property.
 	 *
 	 * @observable
 	 */
 	public property: number;
 
 	/**
-	 * Observable tag associated to a static property in a class.
+	 * Observable static property.
 	 *
 	 * @observable
 	 */

--- a/packages/typedoc-plugins/tests/tag-observable/fixtures/customexampleclass.ts
+++ b/packages/typedoc-plugins/tests/tag-observable/fixtures/customexampleclass.ts
@@ -20,6 +20,15 @@ export class CustomExampleClass extends ExampleClass {
 	public property: number;
 
 	/**
+	 * Observable public property defined in another way, with other JSDoc tags.
+	 *
+	 * @readonly
+	 * @observable
+	 * @member {Boolean}
+	 */
+	declare public anotherProperty: boolean;
+
+	/**
 	 * Observable static property.
 	 *
 	 * @observable

--- a/packages/typedoc-plugins/tests/tag-observable/fixtures/customexampleclass.ts
+++ b/packages/typedoc-plugins/tests/tag-observable/fixtures/customexampleclass.ts
@@ -1,0 +1,48 @@
+/**
+ * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/**
+ * @module fixtures/customexampleclass
+ */
+
+import { ExampleClass } from './exampleclass';
+
+export class CustomExampleClass extends ExampleClass {
+	// This class has also all inherited observable properties from ExampleClass.
+
+	/**
+	 * Observable tag associated to a static property in a class.
+	 *
+	 * @observable
+	 */
+	public property: number;
+
+	/**
+	 * Observable tag associated to a static property in a class.
+	 *
+	 * @observable
+	 */
+	public static staticProperty: number;
+
+	constructor() {
+		super();
+		this.property = 1;
+	}
+}
+
+/**
+ * Observable tag associated to a non-property statement.
+ *
+ * @observable
+ */
+export type ExampleType = {
+	name: string;
+};
+
+/**
+ * Observable tag not associated to anything in the source code.
+ *
+ * @observable
+ */

--- a/packages/typedoc-plugins/tests/tag-observable/fixtures/exampleclass.ts
+++ b/packages/typedoc-plugins/tests/tag-observable/fixtures/exampleclass.ts
@@ -14,21 +14,21 @@ export class ExampleClass {
 	public name: string;
 
 	/**
-	 * Observable tag associated to a class property.
+	 * Observable public property.
 	 *
 	 * @observable
 	 */
 	public key: number;
 
 	/**
-	 * Observable tag associated to a class property.
+	 * Observable protected property.
 	 *
 	 * @observable
 	 */
 	protected value: string;
 
 	/**
-	 * Observable tag associated to a class property.
+	 * Observable private property.
 	 *
 	 * @observable
 	 */

--- a/packages/typedoc-plugins/tests/tag-observable/fixtures/exampleclass.ts
+++ b/packages/typedoc-plugins/tests/tag-observable/fixtures/exampleclass.ts
@@ -1,0 +1,43 @@
+/**
+ * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/**
+ * @module fixtures/exampleclass
+ */
+
+export class ExampleClass {
+	/**
+	 * Non-observable class property.
+	 */
+	public name: string;
+
+	/**
+	 * Observable tag associated to a class property.
+	 *
+	 * @observable
+	 */
+	public key: number;
+
+	/**
+	 * Observable tag associated to a class property.
+	 *
+	 * @observable
+	 */
+	protected value: string;
+
+	/**
+	 * Observable tag associated to a class property.
+	 *
+	 * @observable
+	 */
+	private secret: string;
+
+	constructor() {
+		this.name = 'Example';
+		this.key = 1;
+		this.value = 'Foo';
+		this.secret = 'Secret';
+	}
+}

--- a/packages/typedoc-plugins/tests/tag-observable/fixtures/tsconfig.json
+++ b/packages/typedoc-plugins/tests/tag-observable/fixtures/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.json"
+}

--- a/packages/typedoc-plugins/tests/tag-observable/index.js
+++ b/packages/typedoc-plugins/tests/tag-observable/index.js
@@ -56,8 +56,9 @@ describe( 'typedoc-plugins/tag-observable', function() {
 		// * CustomExampleClass#key (inherited from ExampleClass)
 		// * CustomExampleClass#value (inherited from ExampleClass)
 		// * CustomExampleClass#property
+		// * CustomExampleClass#anotherProperty
 		// * CustomExampleClass.staticProperty
-		expect( reflections ).to.lengthOf( 7 );
+		expect( reflections ).to.lengthOf( 8 );
 
 		// The order of found reflections does not matter, so just check if all expected observable properties are found.
 		expect( reflections.find( ref => ref.parent.name === 'ExampleClass' && ref.name === 'key' ) ).to.not.be.undefined;
@@ -66,6 +67,7 @@ describe( 'typedoc-plugins/tag-observable', function() {
 		expect( reflections.find( ref => ref.parent.name === 'CustomExampleClass' && ref.name === 'key' ) ).to.not.be.undefined;
 		expect( reflections.find( ref => ref.parent.name === 'CustomExampleClass' && ref.name === 'value' ) ).to.not.be.undefined;
 		expect( reflections.find( ref => ref.parent.name === 'CustomExampleClass' && ref.name === 'property' ) ).to.not.be.undefined;
+		expect( reflections.find( ref => ref.parent.name === 'CustomExampleClass' && ref.name === 'anotherProperty' ) ).to.not.be.undefined;
 		expect( reflections.find( ref => ref.parent.name === 'CustomExampleClass' && ref.name === 'staticProperty' ) ).to.not.be.undefined;
 	} );
 
@@ -99,15 +101,17 @@ describe( 'typedoc-plugins/tag-observable', function() {
 			const eventDefinitions = derivedClassDefinition.children
 				.filter( children => children.name.startsWith( 'event:' ) );
 
-			expect( eventDefinitions ).to.lengthOf( 8 );
+			expect( eventDefinitions ).to.lengthOf( 10 );
 			expect( eventDefinitions.find( event => event.name === 'event:change:key' ) ).to.not.be.undefined;
 			expect( eventDefinitions.find( event => event.name === 'event:change:value' ) ).to.not.be.undefined;
+			expect( eventDefinitions.find( event => event.name === 'event:change:property' ) ).to.not.be.undefined;
+			expect( eventDefinitions.find( event => event.name === 'event:change:anotherProperty' ) ).to.not.be.undefined;
+			expect( eventDefinitions.find( event => event.name === 'event:change:staticProperty' ) ).to.not.be.undefined;
 			expect( eventDefinitions.find( event => event.name === 'event:set:key' ) ).to.not.be.undefined;
 			expect( eventDefinitions.find( event => event.name === 'event:set:value' ) ).to.not.be.undefined;
-			expect( eventDefinitions.find( event => event.name === 'event:change:property' ) ).to.not.be.undefined;
-			expect( eventDefinitions.find( event => event.name === 'event:change:staticProperty' ) ).to.not.be.undefined;
 			expect( eventDefinitions.find( event => event.name === 'event:set:property' ) ).to.not.be.undefined;
 			expect( eventDefinitions.find( event => event.name === 'event:set:staticProperty' ) ).to.not.be.undefined;
+			expect( eventDefinitions.find( event => event.name === 'event:set:anotherProperty' ) ).to.not.be.undefined;
 		} );
 
 		for ( const eventName of [ 'change', 'set' ] ) {

--- a/packages/typedoc-plugins/tests/tag-observable/index.js
+++ b/packages/typedoc-plugins/tests/tag-observable/index.js
@@ -49,40 +49,24 @@ describe( 'typedoc-plugins/tag-observable', function() {
 		const reflections = conversionResult.getReflectionsByKind( TypeDoc.ReflectionKind.Property )
 			.filter( item => item.comment && item.comment.getTag( '@observable' ) );
 
-		// There should be the following observable properties:
-		// - ExampleClass#key
-		// - ExampleClass#value
-		// - ExampleClass#secret
-		// - CustomExampleClass#key (inherited from ExampleClass)
-		// - CustomExampleClass#value (inherited from ExampleClass)
-		// - CustomExampleClass#property
-		// - CustomExampleClass.staticProperty
+		// There should be found the following observable properties:
+		// * ExampleClass#key
+		// * ExampleClass#value
+		// * ExampleClass#secret
+		// * CustomExampleClass#key (inherited from ExampleClass)
+		// * CustomExampleClass#value (inherited from ExampleClass)
+		// * CustomExampleClass#property
+		// * CustomExampleClass.staticProperty
 		expect( reflections ).to.lengthOf( 7 );
 
 		// The order of found reflections does not matter, so just check if all expected observable properties are found.
-		expect( reflections ).to.satisfy( reflections => {
-			const expected = [
-				{ parent: 'ExampleClass', property: 'key' },
-				{ parent: 'ExampleClass', property: 'value' },
-				{ parent: 'ExampleClass', property: 'secret' },
-				{ parent: 'CustomExampleClass', property: 'key' },
-				{ parent: 'CustomExampleClass', property: 'value' },
-				{ parent: 'CustomExampleClass', property: 'property' },
-				{ parent: 'CustomExampleClass', property: 'staticProperty' }
-			];
-
-			return expected.every( entry => {
-				const found = reflections.some( reflection => {
-					return reflection.name === entry.property && reflection.parent.name === entry.parent;
-				} );
-
-				if ( !found ) {
-					throw new Error( `The "${ entry.parent }#${ entry.property }" property is not detected as observable.` );
-				}
-
-				return found;
-			} );
-		} );
+		expect( reflections.find( ref => ref.parent.name === 'ExampleClass' && ref.name === 'key' ) ).to.not.be.undefined;
+		expect( reflections.find( ref => ref.parent.name === 'ExampleClass' && ref.name === 'value' ) ).to.not.be.undefined;
+		expect( reflections.find( ref => ref.parent.name === 'ExampleClass' && ref.name === 'secret' ) ).to.not.be.undefined;
+		expect( reflections.find( ref => ref.parent.name === 'CustomExampleClass' && ref.name === 'key' ) ).to.not.be.undefined;
+		expect( reflections.find( ref => ref.parent.name === 'CustomExampleClass' && ref.name === 'value' ) ).to.not.be.undefined;
+		expect( reflections.find( ref => ref.parent.name === 'CustomExampleClass' && ref.name === 'property' ) ).to.not.be.undefined;
+		expect( reflections.find( ref => ref.parent.name === 'CustomExampleClass' && ref.name === 'staticProperty' ) ).to.not.be.undefined;
 	} );
 
 	describe( 'events', () => {

--- a/packages/typedoc-plugins/tests/tag-observable/index.js
+++ b/packages/typedoc-plugins/tests/tag-observable/index.js
@@ -1,0 +1,207 @@
+/**
+ * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+const { expect } = require( 'chai' );
+const glob = require( 'fast-glob' );
+const TypeDoc = require( 'typedoc' );
+
+const utils = require( '../utils' );
+
+describe( 'typedoc-plugins/tag-observable', function() {
+	this.timeout( 10 * 1000 );
+
+	let typeDoc, conversionResult;
+
+	const FIXTURES_PATH = utils.normalizePath( utils.ROOT_TEST_DIRECTORY, 'tag-observable', 'fixtures' );
+
+	before( async () => {
+		const sourceFilePatterns = [
+			utils.normalizePath( FIXTURES_PATH, '**', '*.ts' )
+		];
+
+		const files = await glob( sourceFilePatterns );
+
+		typeDoc = new TypeDoc.Application();
+
+		expect( files ).to.not.lengthOf( 0 );
+
+		typeDoc.options.addReader( new TypeDoc.TSConfigReader() );
+		typeDoc.options.addReader( new TypeDoc.TypeDocReader() );
+
+		typeDoc.bootstrap( {
+			logLevel: 'Error',
+			entryPoints: files,
+			plugin: [
+				require.resolve( '@ckeditor/typedoc-plugins/lib/tag-observable' )
+			],
+			// TODO: To resolve once the same problem is fixed in the `@ckeditor/ckeditor5-dev-docs` package.
+			tsconfig: utils.normalizePath( FIXTURES_PATH, 'tsconfig.json' )
+		} );
+
+		conversionResult = typeDoc.convert();
+
+		expect( conversionResult ).to.be.an( 'object' );
+	} );
+
+	it( 'should find all observable class properties within the project', () => {
+		const reflections = conversionResult.getReflectionsByKind( TypeDoc.ReflectionKind.Property )
+			.filter( item => item.comment && item.comment.getTag( '@observable' ) );
+
+		// There should be the following observable properties:
+		// - ExampleClass#key
+		// - ExampleClass#value
+		// - ExampleClass#secret
+		// - CustomExampleClass#key (inherited from ExampleClass)
+		// - CustomExampleClass#value (inherited from ExampleClass)
+		// - CustomExampleClass#property
+		// - CustomExampleClass.staticProperty
+		expect( reflections ).to.lengthOf( 7 );
+
+		// The order of found reflections does not matter, so just check if all expected observable properties are found.
+		expect( reflections ).to.satisfy( reflections => {
+			const expected = [
+				{ parent: 'ExampleClass', property: 'key' },
+				{ parent: 'ExampleClass', property: 'value' },
+				{ parent: 'ExampleClass', property: 'secret' },
+				{ parent: 'CustomExampleClass', property: 'key' },
+				{ parent: 'CustomExampleClass', property: 'value' },
+				{ parent: 'CustomExampleClass', property: 'property' },
+				{ parent: 'CustomExampleClass', property: 'staticProperty' }
+			];
+
+			return expected.every( entry => {
+				const found = reflections.some( reflection => {
+					return reflection.name === entry.property && reflection.parent.name === entry.parent;
+				} );
+
+				if ( !found ) {
+					throw new Error( `The "${ entry.parent }#${ entry.property }" property is not detected as observable.` );
+				}
+
+				return found;
+			} );
+		} );
+	} );
+
+	describe( 'events', () => {
+		let baseClassDefinition, derivedClassDefinition;
+
+		before( () => {
+			baseClassDefinition = conversionResult.children
+				.find( entry => entry.name === 'exampleclass' ).children
+				.find( entry => entry.kindString === 'Class' && entry.name === 'ExampleClass' );
+
+			derivedClassDefinition = conversionResult.children
+				.find( entry => entry.name === 'customexampleclass' ).children
+				.find( entry => entry.kindString === 'Class' && entry.name === 'CustomExampleClass' );
+		} );
+
+		it( 'should find all events in the base class', () => {
+			const eventDefinitions = baseClassDefinition.children
+				.filter( children => children.name.startsWith( 'event:' ) );
+
+			expect( eventDefinitions ).to.lengthOf( 6 );
+			expect( eventDefinitions.find( event => event.name === 'event:change:key' ) ).to.not.be.undefined;
+			expect( eventDefinitions.find( event => event.name === 'event:change:value' ) ).to.not.be.undefined;
+			expect( eventDefinitions.find( event => event.name === 'event:change:secret' ) ).to.not.be.undefined;
+			expect( eventDefinitions.find( event => event.name === 'event:set:key' ) ).to.not.be.undefined;
+			expect( eventDefinitions.find( event => event.name === 'event:set:value' ) ).to.not.be.undefined;
+			expect( eventDefinitions.find( event => event.name === 'event:set:secret' ) ).to.not.be.undefined;
+		} );
+
+		it( 'should find all events in the derived class', () => {
+			const eventDefinitions = derivedClassDefinition.children
+				.filter( children => children.name.startsWith( 'event:' ) );
+
+			expect( eventDefinitions ).to.lengthOf( 8 );
+			expect( eventDefinitions.find( event => event.name === 'event:change:key' ) ).to.not.be.undefined;
+			expect( eventDefinitions.find( event => event.name === 'event:change:value' ) ).to.not.be.undefined;
+			expect( eventDefinitions.find( event => event.name === 'event:set:key' ) ).to.not.be.undefined;
+			expect( eventDefinitions.find( event => event.name === 'event:set:value' ) ).to.not.be.undefined;
+			expect( eventDefinitions.find( event => event.name === 'event:change:property' ) ).to.not.be.undefined;
+			expect( eventDefinitions.find( event => event.name === 'event:change:staticProperty' ) ).to.not.be.undefined;
+			expect( eventDefinitions.find( event => event.name === 'event:set:property' ) ).to.not.be.undefined;
+			expect( eventDefinitions.find( event => event.name === 'event:set:staticProperty' ) ).to.not.be.undefined;
+		} );
+
+		for ( const eventName of [ 'change', 'set' ] ) {
+			it( `should properly define the ${ eventName } event`, () => {
+				const eventDefinition = baseClassDefinition.children
+					.find( doclet => doclet.name === `event:${ eventName }:key` );
+
+				expect( eventDefinition ).to.not.be.undefined;
+				expect( eventDefinition.name ).to.equal( `event:${ eventName }:key` );
+				expect( eventDefinition.originalName ).to.equal( `event:${ eventName }:key` );
+				expect( eventDefinition.kindString ).to.equal( 'Event' );
+
+				expect( eventDefinition.comment ).to.have.property( 'summary' );
+				expect( eventDefinition.comment ).to.have.property( 'blockTags' );
+				expect( eventDefinition.comment ).to.have.property( 'modifierTags' );
+
+				expect( eventDefinition.comment.blockTags ).to.be.an( 'array' );
+				expect( eventDefinition.comment.blockTags ).to.lengthOf( 0 );
+				expect( eventDefinition.comment.modifierTags ).to.be.a( 'Set' );
+				expect( eventDefinition.comment.modifierTags.size ).to.equal( 0 );
+				expect( eventDefinition.comment.summary ).to.be.an( 'array' );
+				expect( eventDefinition.comment.summary ).to.lengthOf( 1 );
+				expect( eventDefinition.comment.summary[ 0 ] ).to.have.property( 'kind', 'text' );
+				expect( eventDefinition.comment.summary[ 0 ] ).to.have.property( 'text',
+					eventName === 'change' ?
+						'Fired when the `key` property changed value.' :
+						'Fired when the `key` property is going to be set but is not set yet (before the `change` event is fired).'
+				);
+
+				expect( eventDefinition.typeParameters ).to.be.an( 'array' );
+				expect( eventDefinition.typeParameters ).to.lengthOf( 4 );
+
+				expect( eventDefinition.typeParameters[ 0 ] ).to.have.property( 'name', 'eventInfo' );
+				expect( eventDefinition.typeParameters[ 0 ] ).to.have.property( 'comment' );
+				expect( eventDefinition.typeParameters[ 0 ].comment ).to.have.property( 'summary' );
+				expect( eventDefinition.typeParameters[ 0 ].comment.summary ).to.be.an( 'array' );
+				expect( eventDefinition.typeParameters[ 0 ].comment.summary[ 0 ] ).to.have.property( 'kind', 'text' );
+				expect( eventDefinition.typeParameters[ 0 ].comment.summary[ 0 ] ).to.have.property( 'text',
+					'An object containing information about the fired event.'
+				);
+
+				expect( eventDefinition.typeParameters[ 1 ] ).to.have.property( 'name', 'name' );
+				expect( eventDefinition.typeParameters[ 1 ] ).to.have.property( 'type' );
+				expect( eventDefinition.typeParameters[ 1 ].type ).to.have.property( 'name', 'string' );
+				expect( eventDefinition.typeParameters[ 1 ] ).to.have.property( 'comment' );
+				expect( eventDefinition.typeParameters[ 1 ].comment ).to.have.property( 'summary' );
+				expect( eventDefinition.typeParameters[ 1 ].comment.summary ).to.be.an( 'array' );
+				expect( eventDefinition.typeParameters[ 1 ].comment.summary[ 0 ] ).to.have.property( 'kind', 'text' );
+				expect( eventDefinition.typeParameters[ 1 ].comment.summary[ 0 ] ).to.have.property( 'text',
+					'Name of the changed property (`key`).'
+				);
+
+				expect( eventDefinition.typeParameters[ 2 ] ).to.have.property( 'name', 'value' );
+				expect( eventDefinition.typeParameters[ 2 ] ).to.have.property( 'comment' );
+				expect( eventDefinition.typeParameters[ 2 ].comment ).to.have.property( 'summary' );
+				expect( eventDefinition.typeParameters[ 2 ].comment.summary ).to.be.an( 'array' );
+				expect( eventDefinition.typeParameters[ 2 ].comment.summary[ 0 ] ).to.have.property( 'kind', 'text' );
+				expect( eventDefinition.typeParameters[ 2 ].comment.summary[ 0 ] ).to.have.property( 'text',
+					'New value of the `key` property with given key or `null`, if operation should remove property.'
+				);
+
+				expect( eventDefinition.typeParameters[ 3 ] ).to.have.property( 'name', 'oldValue' );
+				expect( eventDefinition.typeParameters[ 3 ] ).to.have.property( 'comment' );
+				expect( eventDefinition.typeParameters[ 3 ].comment ).to.have.property( 'summary' );
+				expect( eventDefinition.typeParameters[ 3 ].comment.summary ).to.be.an( 'array' );
+				expect( eventDefinition.typeParameters[ 3 ].comment.summary[ 0 ] ).to.have.property( 'kind', 'text' );
+				expect( eventDefinition.typeParameters[ 3 ].comment.summary[ 0 ] ).to.have.property( 'text',
+					'Old value of the `key` property with given key or `null`, if property was not set before.'
+				);
+
+				expect( eventDefinition.sources ).to.be.an( 'array' );
+				expect( eventDefinition.sources ).to.lengthOf( 1 );
+				expect( eventDefinition.sources[ 0 ] ).to.have.property( 'fileName', 'exampleclass.ts' );
+				expect( eventDefinition.sources[ 0 ] ).to.have.property( 'fullFileName' );
+				expect( eventDefinition.sources[ 0 ] ).to.have.property( 'line' );
+				expect( eventDefinition.sources[ 0 ] ).to.have.property( 'character' );
+				expect( eventDefinition.sources[ 0 ] ).to.have.property( 'url' );
+			} );
+		}
+	} );
+} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature (typedoc-plugins): Created the `tag-observable` plugin that parses all occurrences of the `@observable` tag associated with class properties in the CKEditor 5 code base. Closes ckeditor/ckeditor5#12527.

---

### Additional information

To detect if the property is observable from Umberto point of view, a new helper could be introduced there:
```js
function isObservable( item ) {
    // Check if the `@observable` tag is set.
    if ( item.comment && item.comment.tags ) {
        return item.comment.tags.some( tag => tag.tag === 'observable' );
    }

    return false;
};
```

Previously, I tried to add a new flag `isObservable` to TypeDoc, but it seems that it is not so easy. Flags in TypeDoc are stored as appropriate bit offsets on which some bit operations are performed, so adding a new flag from the outside may break everything.
