### PR TITLE
Aligned the `tag-event` and `tag-observable` plugins to not add the `event:` prefix for the event name

### DIFF
--- a/packages/typedoc-plugins/lib/tag-event/index.js
+++ b/packages/typedoc-plugins/lib/tag-event/index.js
@@ -83,7 +83,7 @@ function onEventEnd( context ) {
 				ReflectionKind.ObjectLiteral,
 				undefined,
 				undefined,
-				`event:${ eventName }`
+				eventName
 			);
 
 		eventReflection.kindString = 'Event';

--- a/packages/typedoc-plugins/lib/tag-observable/index.js
+++ b/packages/typedoc-plugins/lib/tag-observable/index.js
@@ -46,7 +46,7 @@ function onEventEnd( context ) {
 					ReflectionKind.ObjectLiteral,
 					undefined,
 					undefined,
-					`event:${ eventName }:${ propertyName }`
+					`${ eventName }:${ propertyName }`
 				);
 
 			eventReflection.kindString = 'Event';

--- a/packages/typedoc-plugins/tests/event-inheritance-fixer/index.js
+++ b/packages/typedoc-plugins/tests/event-inheritance-fixer/index.js
@@ -70,14 +70,14 @@ describe( 'typedoc-plugins/event-inheritance-fixer', function() {
 		expect( events ).to.lengthOf( 8 );
 
 		// The order of found events does not matter, so just check if all of them are found.
-		expect( events.find( event => event.parent.name === 'ClassA' && event.name === 'event:event-1-class-a' ) ).to.not.be.undefined;
-		expect( events.find( event => event.parent.name === 'ClassA' && event.name === 'event:event-2-class-a' ) ).to.not.be.undefined;
-		expect( events.find( event => event.parent.name === 'ClassB' && event.name === 'event:event-1-class-a' ) ).to.not.be.undefined;
-		expect( events.find( event => event.parent.name === 'ClassB' && event.name === 'event:event-2-class-a' ) ).to.not.be.undefined;
-		expect( events.find( event => event.parent.name === 'ClassB' && event.name === 'event:event-3-class-b' ) ).to.not.be.undefined;
-		expect( events.find( event => event.parent.name === 'ClassC' && event.name === 'event:event-1-class-a' ) ).to.not.be.undefined;
-		expect( events.find( event => event.parent.name === 'ClassC' && event.name === 'event:event-2-class-a' ) ).to.not.be.undefined;
-		expect( events.find( event => event.parent.name === 'ClassC' && event.name === 'event:event-3-class-b' ) ).to.not.be.undefined;
+		expect( events.find( event => event.parent.name === 'ClassA' && event.name === 'event-1-class-a' ) ).to.not.be.undefined;
+		expect( events.find( event => event.parent.name === 'ClassA' && event.name === 'event-2-class-a' ) ).to.not.be.undefined;
+		expect( events.find( event => event.parent.name === 'ClassB' && event.name === 'event-1-class-a' ) ).to.not.be.undefined;
+		expect( events.find( event => event.parent.name === 'ClassB' && event.name === 'event-2-class-a' ) ).to.not.be.undefined;
+		expect( events.find( event => event.parent.name === 'ClassB' && event.name === 'event-3-class-b' ) ).to.not.be.undefined;
+		expect( events.find( event => event.parent.name === 'ClassC' && event.name === 'event-1-class-a' ) ).to.not.be.undefined;
+		expect( events.find( event => event.parent.name === 'ClassC' && event.name === 'event-2-class-a' ) ).to.not.be.undefined;
+		expect( events.find( event => event.parent.name === 'ClassC' && event.name === 'event-3-class-b' ) ).to.not.be.undefined;
 	} );
 
 	it( 'should create new events with own ids in the inherited classes', () => {
@@ -88,9 +88,9 @@ describe( 'typedoc-plugins/event-inheritance-fixer', function() {
 	} );
 
 	it( 'should clone event comment in the inherited classes', () => {
-		const baseEventClassA = events.find( event => event.parent.name === 'ClassA' && event.name === 'event:event-1-class-a' );
-		const inheritedEventClassB = events.find( event => event.parent.name === 'ClassB' && event.name === 'event:event-1-class-a' );
-		const inheritedEventClassC = events.find( event => event.parent.name === 'ClassC' && event.name === 'event:event-1-class-a' );
+		const baseEventClassA = events.find( event => event.parent.name === 'ClassA' && event.name === 'event-1-class-a' );
+		const inheritedEventClassB = events.find( event => event.parent.name === 'ClassB' && event.name === 'event-1-class-a' );
+		const inheritedEventClassC = events.find( event => event.parent.name === 'ClassC' && event.name === 'event-1-class-a' );
 
 		expect( baseEventClassA.comment ).to.not.equal( inheritedEventClassB.comment );
 		expect( baseEventClassA.comment ).to.not.equal( inheritedEventClassC.comment );
@@ -113,9 +113,9 @@ describe( 'typedoc-plugins/event-inheritance-fixer', function() {
 	} );
 
 	it( 'should clone event source in the inherited classes but keep the original source properties', () => {
-		const baseEventClassA = events.find( event => event.parent.name === 'ClassA' && event.name === 'event:event-1-class-a' );
-		const inheritedEventClassB = events.find( event => event.parent.name === 'ClassB' && event.name === 'event:event-1-class-a' );
-		const inheritedEventClassC = events.find( event => event.parent.name === 'ClassC' && event.name === 'event:event-1-class-a' );
+		const baseEventClassA = events.find( event => event.parent.name === 'ClassA' && event.name === 'event-1-class-a' );
+		const inheritedEventClassB = events.find( event => event.parent.name === 'ClassB' && event.name === 'event-1-class-a' );
+		const inheritedEventClassC = events.find( event => event.parent.name === 'ClassC' && event.name === 'event-1-class-a' );
 
 		expect( baseEventClassA.sources ).to.not.equal( inheritedEventClassB.sources );
 		expect( baseEventClassA.sources ).to.not.equal( inheritedEventClassC.sources );
@@ -143,9 +143,9 @@ describe( 'typedoc-plugins/event-inheritance-fixer', function() {
 	} );
 
 	it( 'should clone event parameters and all their properties in the inherited classes', () => {
-		const baseEventClassA = events.find( event => event.parent.name === 'ClassA' && event.name === 'event:event-1-class-a' );
-		const inheritedEventClassB = events.find( event => event.parent.name === 'ClassB' && event.name === 'event:event-1-class-a' );
-		const inheritedEventClassC = events.find( event => event.parent.name === 'ClassC' && event.name === 'event:event-1-class-a' );
+		const baseEventClassA = events.find( event => event.parent.name === 'ClassA' && event.name === 'event-1-class-a' );
+		const inheritedEventClassB = events.find( event => event.parent.name === 'ClassB' && event.name === 'event-1-class-a' );
+		const inheritedEventClassC = events.find( event => event.parent.name === 'ClassC' && event.name === 'event-1-class-a' );
 
 		expect( baseEventClassA.typeParameters ).to.not.equal( inheritedEventClassB.typeParameters );
 		expect( baseEventClassA.typeParameters ).to.not.equal( inheritedEventClassC.typeParameters );
@@ -214,8 +214,8 @@ describe( 'typedoc-plugins/event-inheritance-fixer', function() {
 	} );
 
 	it( 'should not create a new event in derived class if derived class already contains the overwritten event', () => {
-		const baseEventClassA = events.find( event => event.parent.name === 'ClassA' && event.name === 'event:event-2-class-a' );
-		const overwrittenEventClassC = events.find( event => event.parent.name === 'ClassC' && event.name === 'event:event-2-class-a' );
+		const baseEventClassA = events.find( event => event.parent.name === 'ClassA' && event.name === 'event-2-class-a' );
+		const overwrittenEventClassC = events.find( event => event.parent.name === 'ClassC' && event.name === 'event-2-class-a' );
 
 		expect( baseEventClassA.comment ).to.have.property( 'summary' );
 		expect( baseEventClassA.comment.summary ).to.be.an( 'array' );

--- a/packages/typedoc-plugins/tests/event-param-fixer/index.js
+++ b/packages/typedoc-plugins/tests/event-param-fixer/index.js
@@ -79,11 +79,11 @@ describe( 'typedoc-plugins/event-param-fixer', function() {
 		let eventFoo, eventFooNoText, eventFooWithParams, eventObservableChange, eventObservableSet, eventInfoClass;
 
 		before( () => {
-			eventFoo = conversionResult.getChildByName( [ 'fixtures/example', 'CustomExampleNonDefaultClass', 'event:event-foo' ] );
-			eventFooNoText = conversionResult.getChildByName( [ 'fixtures/example', 'ExampleClass', 'event:event-foo-no-text' ] );
-			eventFooWithParams = conversionResult.getChildByName( [ 'fixtures/example', 'ExampleClass', 'event:event-foo-with-params' ] );
-			eventObservableChange = conversionResult.getChildByName( [ 'fixtures/example', 'ExampleClass', 'event:change:key' ] );
-			eventObservableSet = conversionResult.getChildByName( [ 'fixtures/example', 'ExampleClass', 'event:set:key' ] );
+			eventFoo = conversionResult.getChildByName( [ 'fixtures/example', 'CustomExampleNonDefaultClass', 'event-foo' ] );
+			eventFooNoText = conversionResult.getChildByName( [ 'fixtures/example', 'ExampleClass', 'event-foo-no-text' ] );
+			eventFooWithParams = conversionResult.getChildByName( [ 'fixtures/example', 'ExampleClass', 'event-foo-with-params' ] );
+			eventObservableChange = conversionResult.getChildByName( [ 'fixtures/example', 'ExampleClass', 'change:key' ] );
+			eventObservableSet = conversionResult.getChildByName( [ 'fixtures/example', 'ExampleClass', 'set:key' ] );
 			eventInfoClass = conversionResult.getChildByName( [ 'utils/eventinfo', 'EventInfo' ] );
 
 			expect( eventFoo ).to.not.be.undefined;
@@ -95,8 +95,8 @@ describe( 'typedoc-plugins/event-param-fixer', function() {
 		} );
 
 		it( 'should add the "eventInfo" parameter for event without params and without comment', () => {
-			expect( eventFooNoText.name ).to.equal( 'event:event-foo-no-text' );
-			expect( eventFooNoText.originalName ).to.equal( 'event:event-foo-no-text' );
+			expect( eventFooNoText.name ).to.equal( 'event-foo-no-text' );
+			expect( eventFooNoText.originalName ).to.equal( 'event-foo-no-text' );
 			expect( eventFooNoText.kindString ).to.equal( 'Event' );
 
 			expect( eventFooNoText.typeParameters ).to.be.an( 'array' );
@@ -118,8 +118,8 @@ describe( 'typedoc-plugins/event-param-fixer', function() {
 		} );
 
 		it( 'should add the "eventInfo" parameter for event without params, but with comment', () => {
-			expect( eventFoo.name ).to.equal( 'event:event-foo' );
-			expect( eventFoo.originalName ).to.equal( 'event:event-foo' );
+			expect( eventFoo.name ).to.equal( 'event-foo' );
+			expect( eventFoo.originalName ).to.equal( 'event-foo' );
 			expect( eventFoo.kindString ).to.equal( 'Event' );
 
 			expect( eventFoo.typeParameters ).to.be.an( 'array' );
@@ -141,8 +141,8 @@ describe( 'typedoc-plugins/event-param-fixer', function() {
 		} );
 
 		it( 'should add the "eventInfo" parameter for event with params and comment', () => {
-			expect( eventFooWithParams.name ).to.equal( 'event:event-foo-with-params' );
-			expect( eventFooWithParams.originalName ).to.equal( 'event:event-foo-with-params' );
+			expect( eventFooWithParams.name ).to.equal( 'event-foo-with-params' );
+			expect( eventFooWithParams.originalName ).to.equal( 'event-foo-with-params' );
 			expect( eventFooWithParams.kindString ).to.equal( 'Event' );
 
 			expect( eventFooWithParams.typeParameters ).to.be.an( 'array' );
@@ -164,8 +164,8 @@ describe( 'typedoc-plugins/event-param-fixer', function() {
 		} );
 
 		it( 'should add the "eventInfo" parameter for the "change" event for observable property', () => {
-			expect( eventObservableChange.name ).to.equal( 'event:change:key' );
-			expect( eventObservableChange.originalName ).to.equal( 'event:change:key' );
+			expect( eventObservableChange.name ).to.equal( 'change:key' );
+			expect( eventObservableChange.originalName ).to.equal( 'change:key' );
 			expect( eventObservableChange.kindString ).to.equal( 'Event' );
 
 			expect( eventObservableChange.typeParameters ).to.be.an( 'array' );
@@ -187,8 +187,8 @@ describe( 'typedoc-plugins/event-param-fixer', function() {
 		} );
 
 		it( 'should add the "eventInfo" parameter for the "set" event for observable property', () => {
-			expect( eventObservableSet.name ).to.equal( 'event:set:key' );
-			expect( eventObservableSet.originalName ).to.equal( 'event:set:key' );
+			expect( eventObservableSet.name ).to.equal( 'set:key' );
+			expect( eventObservableSet.originalName ).to.equal( 'set:key' );
 			expect( eventObservableSet.kindString ).to.equal( 'Event' );
 
 			expect( eventObservableSet.typeParameters ).to.be.an( 'array' );

--- a/packages/typedoc-plugins/tests/tag-event/index.js
+++ b/packages/typedoc-plugins/tests/tag-event/index.js
@@ -54,7 +54,7 @@ describe( 'typedoc-plugins/tag-event', function() {
 
 	it( 'should find all event tags within the project', () => {
 		const eventDefinitions = conversionResult.getReflectionsByKind( TypeDoc.ReflectionKind.All )
-			.filter( children => children.name.startsWith( 'event:' ) );
+			.filter( children => children.kindString === 'Event' );
 
 		// There should be 4 correctly defined events:
 		// 1. event-foo
@@ -77,7 +77,7 @@ describe( 'typedoc-plugins/tag-event', function() {
 			.find( entry => entry.kindString === 'Class' && entry.name === 'CustomExampleClassFires' );
 
 		const eventDefinition = classDefinition.children
-			.find( doclet => doclet.name === 'event:event-foo-in-class-with-fires' );
+			.find( doclet => doclet.name === 'event-foo-in-class-with-fires' );
 
 		expect( eventDefinition ).to.not.be.undefined;
 	} );
@@ -93,17 +93,17 @@ describe( 'typedoc-plugins/tag-event', function() {
 
 		it( 'should find all event tags within the class', () => {
 			const eventDefinitions = classDefinition.children
-				.filter( children => children.name.startsWith( 'event:' ) );
+				.filter( children => children.kindString === 'Event' );
 
 			expect( eventDefinitions ).to.lengthOf( 3 );
 		} );
 
 		it( 'should find an event tag without description and parameters', () => {
-			const eventDefinition = classDefinition.children.find( doclet => doclet.name === 'event:event-foo-no-text' );
+			const eventDefinition = classDefinition.children.find( doclet => doclet.name === 'event-foo-no-text' );
 
 			expect( eventDefinition ).to.not.be.undefined;
-			expect( eventDefinition.name ).to.equal( 'event:event-foo-no-text' );
-			expect( eventDefinition.originalName ).to.equal( 'event:event-foo-no-text' );
+			expect( eventDefinition.name ).to.equal( 'event-foo-no-text' );
+			expect( eventDefinition.originalName ).to.equal( 'event-foo-no-text' );
 			expect( eventDefinition.kindString ).to.equal( 'Event' );
 
 			expect( eventDefinition.comment ).to.have.property( 'summary' );
@@ -129,11 +129,11 @@ describe( 'typedoc-plugins/tag-event', function() {
 		} );
 
 		it( 'should find an event tag with description and without parameters', () => {
-			const eventDefinition = classDefinition.children.find( doclet => doclet.name === 'event:event-foo' );
+			const eventDefinition = classDefinition.children.find( doclet => doclet.name === 'event-foo' );
 
 			expect( eventDefinition ).to.not.be.undefined;
-			expect( eventDefinition.name ).to.equal( 'event:event-foo' );
-			expect( eventDefinition.originalName ).to.equal( 'event:event-foo' );
+			expect( eventDefinition.name ).to.equal( 'event-foo' );
+			expect( eventDefinition.originalName ).to.equal( 'event-foo' );
 			expect( eventDefinition.kindString ).to.equal( 'Event' );
 
 			expect( eventDefinition.comment ).to.have.property( 'summary' );
@@ -153,11 +153,11 @@ describe( 'typedoc-plugins/tag-event', function() {
 		} );
 
 		it( 'should find an event tag with description and parameters', () => {
-			const eventDefinition = classDefinition.children.find( doclet => doclet.name === 'event:event-foo-with-params' );
+			const eventDefinition = classDefinition.children.find( doclet => doclet.name === 'event-foo-with-params' );
 
 			expect( eventDefinition ).to.not.be.undefined;
-			expect( eventDefinition.name ).to.equal( 'event:event-foo-with-params' );
-			expect( eventDefinition.originalName ).to.equal( 'event:event-foo-with-params' );
+			expect( eventDefinition.name ).to.equal( 'event-foo-with-params' );
+			expect( eventDefinition.originalName ).to.equal( 'event-foo-with-params' );
 			expect( eventDefinition.kindString ).to.equal( 'Event' );
 
 			expect( eventDefinition.comment ).to.have.property( 'summary' );

--- a/packages/typedoc-plugins/tests/tag-observable/index.js
+++ b/packages/typedoc-plugins/tests/tag-observable/index.js
@@ -86,42 +86,42 @@ describe( 'typedoc-plugins/tag-observable', function() {
 
 		it( 'should find all events in the base class', () => {
 			const eventDefinitions = baseClassDefinition.children
-				.filter( children => children.name.startsWith( 'event:' ) );
+				.filter( children => children.kindString === 'Event' );
 
 			expect( eventDefinitions ).to.lengthOf( 6 );
-			expect( eventDefinitions.find( event => event.name === 'event:change:key' ) ).to.not.be.undefined;
-			expect( eventDefinitions.find( event => event.name === 'event:change:value' ) ).to.not.be.undefined;
-			expect( eventDefinitions.find( event => event.name === 'event:change:secret' ) ).to.not.be.undefined;
-			expect( eventDefinitions.find( event => event.name === 'event:set:key' ) ).to.not.be.undefined;
-			expect( eventDefinitions.find( event => event.name === 'event:set:value' ) ).to.not.be.undefined;
-			expect( eventDefinitions.find( event => event.name === 'event:set:secret' ) ).to.not.be.undefined;
+			expect( eventDefinitions.find( event => event.name === 'change:key' ) ).to.not.be.undefined;
+			expect( eventDefinitions.find( event => event.name === 'change:value' ) ).to.not.be.undefined;
+			expect( eventDefinitions.find( event => event.name === 'change:secret' ) ).to.not.be.undefined;
+			expect( eventDefinitions.find( event => event.name === 'set:key' ) ).to.not.be.undefined;
+			expect( eventDefinitions.find( event => event.name === 'set:value' ) ).to.not.be.undefined;
+			expect( eventDefinitions.find( event => event.name === 'set:secret' ) ).to.not.be.undefined;
 		} );
 
 		it( 'should find all events in the derived class', () => {
 			const eventDefinitions = derivedClassDefinition.children
-				.filter( children => children.name.startsWith( 'event:' ) );
+				.filter( children => children.kindString === 'Event' );
 
 			expect( eventDefinitions ).to.lengthOf( 10 );
-			expect( eventDefinitions.find( event => event.name === 'event:change:key' ) ).to.not.be.undefined;
-			expect( eventDefinitions.find( event => event.name === 'event:change:value' ) ).to.not.be.undefined;
-			expect( eventDefinitions.find( event => event.name === 'event:change:property' ) ).to.not.be.undefined;
-			expect( eventDefinitions.find( event => event.name === 'event:change:anotherProperty' ) ).to.not.be.undefined;
-			expect( eventDefinitions.find( event => event.name === 'event:change:staticProperty' ) ).to.not.be.undefined;
-			expect( eventDefinitions.find( event => event.name === 'event:set:key' ) ).to.not.be.undefined;
-			expect( eventDefinitions.find( event => event.name === 'event:set:value' ) ).to.not.be.undefined;
-			expect( eventDefinitions.find( event => event.name === 'event:set:property' ) ).to.not.be.undefined;
-			expect( eventDefinitions.find( event => event.name === 'event:set:staticProperty' ) ).to.not.be.undefined;
-			expect( eventDefinitions.find( event => event.name === 'event:set:anotherProperty' ) ).to.not.be.undefined;
+			expect( eventDefinitions.find( event => event.name === 'change:key' ) ).to.not.be.undefined;
+			expect( eventDefinitions.find( event => event.name === 'change:value' ) ).to.not.be.undefined;
+			expect( eventDefinitions.find( event => event.name === 'change:property' ) ).to.not.be.undefined;
+			expect( eventDefinitions.find( event => event.name === 'change:anotherProperty' ) ).to.not.be.undefined;
+			expect( eventDefinitions.find( event => event.name === 'change:staticProperty' ) ).to.not.be.undefined;
+			expect( eventDefinitions.find( event => event.name === 'set:key' ) ).to.not.be.undefined;
+			expect( eventDefinitions.find( event => event.name === 'set:value' ) ).to.not.be.undefined;
+			expect( eventDefinitions.find( event => event.name === 'set:property' ) ).to.not.be.undefined;
+			expect( eventDefinitions.find( event => event.name === 'set:staticProperty' ) ).to.not.be.undefined;
+			expect( eventDefinitions.find( event => event.name === 'set:anotherProperty' ) ).to.not.be.undefined;
 		} );
 
 		for ( const eventName of [ 'change', 'set' ] ) {
 			it( `should properly define the ${ eventName } event`, () => {
 				const eventDefinition = baseClassDefinition.children
-					.find( doclet => doclet.name === `event:${ eventName }:key` );
+					.find( doclet => doclet.name === `${ eventName }:key` );
 
 				expect( eventDefinition ).to.not.be.undefined;
-				expect( eventDefinition.name ).to.equal( `event:${ eventName }:key` );
-				expect( eventDefinition.originalName ).to.equal( `event:${ eventName }:key` );
+				expect( eventDefinition.name ).to.equal( `${ eventName }:key` );
+				expect( eventDefinition.originalName ).to.equal( `${ eventName }:key` );
 				expect( eventDefinition.kindString ).to.equal( 'Event' );
 
 				expect( eventDefinition.comment ).to.have.property( 'summary' );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Aligned the `tag-event` and `tag-observable` plugins to not add the `event:` prefix for the event name.
