### PR TITLE
Fixed support for referencing DLLs built from TypeScript.

### DIFF
--- a/packages/ckeditor5-dev-utils/lib/builds/getdllpluginwebpackconfig.js
+++ b/packages/ckeditor5-dev-utils/lib/builds/getdllpluginwebpackconfig.js
@@ -28,13 +28,14 @@ const CKEditorWebpackPlugin = require( '@ckeditor/ckeditor5-dev-webpack-plugin' 
 module.exports = function getDllPluginWebpackConfig( options ) {
 	const packageName = tools.readPackageName( options.packagePath );
 	const langDirExists = fs.existsSync( path.join( options.packagePath, 'lang' ) );
+	const indexTsExists = fs.existsSync( path.join( options.packagePath, 'src', 'index.ts' ) );
 
 	const webpackConfig = {
 		mode: options.isDevelopmentMode ? 'development' : 'production',
 
 		performance: { hints: false },
 
-		entry: path.join( options.packagePath, 'src', 'index.js' ),
+		entry: path.join( options.packagePath, 'src', indexTsExists ? 'index.ts' : 'index.js' ),
 
 		output: {
 			library: [ 'CKEditor5', getGlobalKeyForPackage( packageName ) ],
@@ -56,6 +57,7 @@ module.exports = function getDllPluginWebpackConfig( options ) {
 			new webpack.DllReferencePlugin( {
 				manifest: require( options.manifestPath ),
 				scope: 'ckeditor5/src',
+				extensions: [ '.ts' ],
 				name: 'CKEditor5.dll'
 			} )
 		],
@@ -109,7 +111,7 @@ module.exports = function getDllPluginWebpackConfig( options ) {
 			// UI language. Language codes follow the https://en.wikipedia.org/wiki/ISO_639-1 format.
 			language: 'en',
 			additionalLanguages: 'all',
-			sourceFilesPattern: /^src[/\\].+\.js$/,
+			sourceFilesPattern: /^src[/\\].+\.[jt]s$/,
 			skipPluralFormFunction: true
 		} ) );
 	}

--- a/packages/ckeditor5-dev-utils/tests/builds/getdllpluginwebpackconfig.js
+++ b/packages/ckeditor5-dev-utils/tests/builds/getdllpluginwebpackconfig.js
@@ -131,6 +131,32 @@ describe( 'builds/getDllPluginWebpackConfig()', () => {
 		expect( webpackConfig.output.libraryExport ).to.be.undefined;
 	} );
 
+	it( 'uses index.ts entry file if exists', () => {
+		stubs.tools.readPackageName.returns( '@ckeditor/ckeditor5-dev' );
+		stubs.fs.existsSync.callsFake( file => file == '/package/path/src/index.ts' );
+
+		const webpackConfig = getDllPluginWebpackConfig( {
+			packagePath: '/package/path',
+			themePath: '/theme/path',
+			manifestPath: '/manifest/path'
+		} );
+
+		expect( webpackConfig.entry ).to.equal( '/package/path/src/index.ts' );
+	} );
+
+	it( 'uses index.js entry file if ts file does not exists', () => {
+		stubs.tools.readPackageName.returns( '@ckeditor/ckeditor5-dev' );
+		stubs.fs.existsSync.callsFake( file => file != '/package/path/src/index.ts' );
+
+		const webpackConfig = getDllPluginWebpackConfig( {
+			packagePath: '/package/path',
+			themePath: '/theme/path',
+			manifestPath: '/manifest/path'
+		} );
+
+		expect( webpackConfig.entry ).to.equal( '/package/path/src/index.js' );
+	} );
+
 	describe( '#plugins', () => {
 		it( 'loads the webpack.DllReferencePlugin plugin', () => {
 			stubs.tools.readPackageName.returns( '@ckeditor/ckeditor5-dev' );
@@ -147,6 +173,7 @@ describe( 'builds/getDllPluginWebpackConfig()', () => {
 			expect( dllReferencePlugin.options.manifest ).to.deep.equal( manifest );
 			expect( dllReferencePlugin.options.scope ).to.equal( 'ckeditor5/src' );
 			expect( dllReferencePlugin.options.name ).to.equal( 'CKEditor5.dll' );
+			expect( dllReferencePlugin.options.extensions ).to.deep.equal( [ '.ts' ] );
 		} );
 
 		it( 'loads the CKEditorWebpackPlugin plugin when lang dir exists', () => {
@@ -167,7 +194,9 @@ describe( 'builds/getDllPluginWebpackConfig()', () => {
 			expect( ckeditor5TranslationsPlugin.options.additionalLanguages ).to.equal( 'all' );
 			expect( ckeditor5TranslationsPlugin.options.skipPluralFormFunction ).to.equal( true );
 			expect( 'src/bold.js' ).to.match( ckeditor5TranslationsPlugin.options.sourceFilesPattern );
+			expect( 'src/bold.ts' ).to.match( ckeditor5TranslationsPlugin.options.sourceFilesPattern );
 			expect( 'ckeditor5-basic-styles/src/bold.js' ).to.not.match( ckeditor5TranslationsPlugin.options.sourceFilesPattern );
+			expect( 'ckeditor5-basic-styles/src/bold.ts' ).to.not.match( ckeditor5TranslationsPlugin.options.sourceFilesPattern );
 		} );
 
 		it( 'does not load the CKEditorWebpackPlugin plugin when lang dir does not exist', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other (utils): Support for referencing DLLs built from TypeScript. Closes ckeditor/ckeditor5#12694.

---

### Additional information

This is required for https://github.com/ckeditor/ckeditor5/pull/12693.
