### PR TITLE
Added `change:{property}` and `set:{property}` events for the `Observable` interface

### DIFF
--- a/packages/typedoc-plugins/tests/tag-event/fixtures/observableinterface.ts
+++ b/packages/typedoc-plugins/tests/tag-event/fixtures/observableinterface.ts
@@ -1,0 +1,53 @@
+/**
+ * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/**
+ * @module fixtures/observableinterface
+ */
+
+export default class ExampleClass {}
+
+export interface NonObservable {
+	set( name: any ): void;
+}
+
+export interface Observable {
+	set( name: any ): void;
+}
+
+/**
+ * Fired when a property changed value.
+ *
+ * @eventName change:{property}
+ * @param {String} name The property name.
+ * @param {*} value The new property value.
+ * @param {*} oldValue The previous property value.
+ */
+export type ObservableChangeEvent = {
+	name: 'change' | `change:${ string }`;
+	args: [
+		name: string,
+		value: any,
+		oldValue: any
+	];
+};
+
+/**
+ * Fired when a property value is going to be set but is not set yet (before the `change` event is fired).
+ *
+ * @eventName set:{property}
+ * @param {String} name The property name.
+ * @param {*} value The new property value.
+ * @param {*} oldValue The previous property value.
+ */
+export type ObservableSetEvent = {
+	name: 'set' | `set:${ string }`;
+	args: [
+		name: string,
+		value: any,
+		oldValue: any
+	];
+	return: any;
+};

--- a/packages/typedoc-plugins/tests/tag-event/index.js
+++ b/packages/typedoc-plugins/tests/tag-event/index.js
@@ -56,19 +56,18 @@ describe( 'typedoc-plugins/tag-event', function() {
 		const eventDefinitions = conversionResult.getReflectionsByKind( TypeDoc.ReflectionKind.All )
 			.filter( children => children.kindString === 'Event' );
 
-		// There should be 4 correctly defined events:
+		// There should be 6 correctly defined events:
 		// 1. event-foo
 		// 2. event-foo-no-text
 		// 3. event-foo-with-params
 		// 4. event-foo-in-class-with-fires
-		expect( eventDefinitions ).to.lengthOf( 4 );
+		// 5. change:{property}
+		// 6. set:{property}
+		expect( eventDefinitions ).to.lengthOf( 6 );
 	} );
 
 	it( 'should inform if the class for an event has not been found', () => {
-		expect( typeDoc.logger.warn.calledOnce ).to.equal( true );
-		expect( typeDoc.logger.warn.firstCall.args[ 0 ] ).to.equal( 'Skipping unsupported "event-foo-no-class" event.' );
-		expect( typeDoc.logger.warn.firstCall.args[ 1 ] ).to.have.property( 'name' );
-		expect( typeDoc.logger.warn.firstCall.args[ 1 ].name ).to.have.property( 'escapedText', 'EventFooNoText' );
+		expect( typeDoc.logger.warn.calledWith( 'Skipping unsupported "event-foo-no-class" event.' ) ).to.be.true;
 	} );
 
 	it( 'should first take into account the class that fires the event instead of the default class, if both exist in the module', () => {
@@ -80,6 +79,18 @@ describe( 'typedoc-plugins/tag-event', function() {
 			.find( doclet => doclet.name === 'event-foo-in-class-with-fires' );
 
 		expect( eventDefinition ).to.not.be.undefined;
+	} );
+
+	it( 'should associate events to the `Observable` interface if it exists in the module, even if module has default class', () => {
+		const interfaceDefinition = conversionResult.children
+			.find( entry => entry.name === 'observableinterface' ).children
+			.find( entry => entry.kindString === 'Interface' && entry.name === 'Observable' );
+
+		const eventChange = interfaceDefinition.children.find( doclet => doclet.name === 'change:{property}' );
+		const eventSet = interfaceDefinition.children.find( doclet => doclet.name === 'set:{property}' );
+
+		expect( eventChange ).to.not.be.undefined;
+		expect( eventSet ).to.not.be.undefined;
 	} );
 
 	describe( 'event definitions', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal (typedoc-plugins): Added `change:{property}` and `set:{property}` events for the `Observable` interface. Closes ckeditor/ckeditor5#12722.

---

### Additional information

The source code in the `Observable` interface in CKEditor 5 has been aligned to required changes on the `ck/11721-build-API-from-typedoc` branch (renamed `event` → `eventName` and event docs are now associated with the exported type).

Now, both `change:{property}` and `set:{property}` events are properly associated with the `Observable` interface:

<img src="https://user-images.githubusercontent.com/56868128/197529068-c43ac799-b0e6-4515-b5cf-ff6f1d2487a2.png" width="550px">

<img src="https://user-images.githubusercontent.com/56868128/197529072-108f6189-6af6-467f-9148-1dec60ee2032.png" width="600px">
