### PR TITLE
The DLL reference should be backward compatible.

### DIFF
--- a/packages/ckeditor5-dev-utils/lib/builds/getdllpluginwebpackconfig.js
+++ b/packages/ckeditor5-dev-utils/lib/builds/getdllpluginwebpackconfig.js
@@ -57,7 +57,6 @@ module.exports = function getDllPluginWebpackConfig( options ) {
 			new webpack.DllReferencePlugin( {
 				manifest: require( options.manifestPath ),
 				scope: 'ckeditor5/src',
-				extensions: [ '.ts' ],
 				name: 'CKEditor5.dll'
 			} )
 		],

--- a/packages/ckeditor5-dev-utils/tests/builds/getdllpluginwebpackconfig.js
+++ b/packages/ckeditor5-dev-utils/tests/builds/getdllpluginwebpackconfig.js
@@ -173,7 +173,7 @@ describe( 'builds/getDllPluginWebpackConfig()', () => {
 			expect( dllReferencePlugin.options.manifest ).to.deep.equal( manifest );
 			expect( dllReferencePlugin.options.scope ).to.equal( 'ckeditor5/src' );
 			expect( dllReferencePlugin.options.name ).to.equal( 'CKEditor5.dll' );
-			expect( dllReferencePlugin.options.extensions ).to.deep.equal( [ '.ts' ] );
+			expect( dllReferencePlugin.options.extensions ).to.be.undefined;
 		} );
 
 		it( 'loads the CKEditorWebpackPlugin plugin when lang dir exists', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix (utils): The DLL configuration should reference backward compatible `*.js` files (not `*.ts`). See ckeditor/ckeditor5#12752.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
