### PR TITLE
Load `DllReferencePlugin` when processing manual tests with DLL builds

### DIFF
--- a/packages/ckeditor5-dev-tests/lib/utils/manual-tests/compilescripts.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/manual-tests/compilescripts.js
@@ -8,9 +8,11 @@
 const webpack = require( 'webpack' );
 const getWebpackConfigForManualTests = require( './getwebpackconfig' );
 const getRelativeFilePath = require( '../getrelativefilepath' );
+const requireDll = require( '../requiredll' );
 
 /**
  * @param {Object} options
+ * @param {String} options.cwd Current working directory. Usually it points to the CKEditor 5 root directory.
  * @param {String} options.buildDir A path where compiled files will be saved.
  * @param {Array.<String>} options.sourceFiles An array of paths to JavaScript files from manual tests to be compiled.
  * @param {String} options.themePath A path to the theme the PostCSS theme-importer plugin is supposed to load.
@@ -26,6 +28,8 @@ module.exports = function compileManualTestScripts( options ) {
 	const entryFiles = options.sourceFiles;
 	const entries = getWebpackEntryPoints( entryFiles );
 	const webpackConfig = getWebpackConfigForManualTests( {
+		cwd: options.cwd,
+		requireDll: requireDll( entryFiles ),
 		entries,
 		buildDir: options.buildDir,
 		themePath: options.themePath,

--- a/packages/ckeditor5-dev-tests/lib/utils/manual-tests/getwebpackconfig.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/manual-tests/getwebpackconfig.js
@@ -171,10 +171,10 @@ module.exports = function getWebpackConfigForManualTests( options ) {
 	}
 
 	if ( options.requireDll ) {
-		// When processing DLL manual tests, extra imports might appear in the code due to
-		// usage of `CK_DEBUG_*` flags. In such a case, webpack requires the `DllReferencePlugin` plugin.
+		// When processing manual tests, if any of them require a DLL build, the manual test server adds the `DllReferencePlugin` plugin
+		// to the configuration to avoid the duplicated modules error when using an import statement behind the `CK_DEBUG_*` flags.
 		//
-		// Otherwise, it tries to import a file from a file system instead of the DLL build.
+		// Otherwise, webpack tries to import a file from a file system instead of the DLL build.
 		// It leads to the CKEditor 5 duplicated modules error.
 		//
 		// See: https://github.com/ckeditor/ckeditor5/issues/12791.

--- a/packages/ckeditor5-dev-tests/lib/utils/requiredll.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/requiredll.js
@@ -1,0 +1,16 @@
+/**
+ * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+'use strict';
+
+/**
+ * Returns `true` if any of the source files represent a DLL test.
+ *
+ * @param {Array.<String>} sourceFiles
+ * @returns {Boolean}
+ */
+module.exports = function requireDll( sourceFiles ) {
+	return sourceFiles.some( filePath => /-dll.[jt]s$/.test( filePath ) );
+};

--- a/packages/ckeditor5-dev-tests/tests/tasks/runmanualtests.js
+++ b/packages/ckeditor5-dev-tests/tests/tasks/runmanualtests.js
@@ -129,6 +129,9 @@ describe( 'runManualTests', () => {
 				logInfo: sandbox.stub()
 			},
 			isInteractive: sandbox.stub(),
+			requireDll: sandbox.stub().callsFake( sourceFiles => {
+				return sourceFiles.some( filePath => /-dll.[jt]s$/.test( filePath ) );
+			} ),
 			server: sandbox.stub(),
 			htmlFileCompiler: sandbox.spy( () => Promise.resolve() ),
 			scriptCompiler: sandbox.spy( () => Promise.resolve() ),
@@ -152,6 +155,7 @@ describe( 'runManualTests', () => {
 		mockery.registerMock( '../utils/manual-tests/removedir', spies.removeDir );
 		mockery.registerMock( '../utils/manual-tests/copyassets', spies.copyAssets );
 		mockery.registerMock( '../utils/transformfileoptiontotestglob', spies.transformFileOptionToTestGlob );
+		mockery.registerMock( '../utils/requiredll', spies.requireDll );
 
 		sandbox.stub( process, 'cwd' ).returns( 'workspace' );
 
@@ -199,6 +203,7 @@ describe( 'runManualTests', () => {
 
 				expect( spies.scriptCompiler.calledOnce ).to.equal( true );
 				sinon.assert.calledWith( spies.scriptCompiler.firstCall, {
+					cwd: 'workspace',
 					buildDir: 'workspace/build/.manual-tests',
 					sourceFiles: [
 						'workspace/packages/ckeditor5-foo/tests/manual/feature-a.js',
@@ -262,6 +267,7 @@ describe( 'runManualTests', () => {
 
 				expect( spies.scriptCompiler.calledOnce ).to.equal( true );
 				sinon.assert.calledWith( spies.scriptCompiler.firstCall, {
+					cwd: 'workspace',
 					buildDir: 'workspace/build/.manual-tests',
 					sourceFiles: [
 						'workspace/packages/ckeditor5-foo/tests/manual/feature-a.js',
@@ -324,6 +330,7 @@ describe( 'runManualTests', () => {
 
 				expect( spies.scriptCompiler.calledOnce ).to.equal( true );
 				sinon.assert.calledWith( spies.scriptCompiler.firstCall, {
+					cwd: 'workspace',
 					buildDir: 'workspace/build/.manual-tests',
 					sourceFiles: [
 						'workspace/packages/ckeditor5-foo/tests/manual/feature-a.js',
@@ -383,6 +390,7 @@ describe( 'runManualTests', () => {
 				expect( spies.server.firstCall.args[ 0 ] ).to.equal( 'workspace/build/.manual-tests' );
 
 				sinon.assert.calledWith( spies.scriptCompiler.firstCall, {
+					cwd: 'workspace',
 					buildDir: 'workspace/build/.manual-tests',
 					sourceFiles: [
 						'workspace/packages/ckeditor5-foo/tests/manual/feature-a.js',
@@ -419,6 +427,7 @@ describe( 'runManualTests', () => {
 				expect( spies.server.firstCall.args[ 0 ] ).to.equal( 'workspace/build/.manual-tests' );
 
 				sinon.assert.calledWith( spies.scriptCompiler.firstCall, {
+					cwd: 'workspace',
 					buildDir: 'workspace/build/.manual-tests',
 					sourceFiles: [
 						'workspace/packages/ckeditor5-foo/tests/manual/feature-a.js',
@@ -471,6 +480,7 @@ describe( 'runManualTests', () => {
 
 				expect( spies.scriptCompiler.calledOnce ).to.equal( true );
 				sinon.assert.calledWith( spies.scriptCompiler.firstCall, {
+					cwd: 'workspace',
 					buildDir: 'workspace/build/.manual-tests',
 					sourceFiles: [
 						'workspace/packages/ckeditor5-foo/tests/manual/feature-a.js',
@@ -522,6 +532,7 @@ describe( 'runManualTests', () => {
 
 				expect( spies.scriptCompiler.calledOnce ).to.equal( true );
 				sinon.assert.calledWith( spies.scriptCompiler.firstCall, {
+					cwd: 'workspace',
 					buildDir: 'workspace/build/.manual-tests',
 					sourceFiles: [
 						'workspace/packages/ckeditor5-foo/tests/manual/feature-a.js',
@@ -572,6 +583,7 @@ describe( 'runManualTests', () => {
 
 				expect( spies.scriptCompiler.calledOnce ).to.equal( true );
 				sinon.assert.calledWith( spies.scriptCompiler.firstCall, {
+					cwd: 'workspace',
 					buildDir: 'workspace/build/.manual-tests',
 					sourceFiles: [
 						'workspace/packages/ckeditor-foo/tests/manual/feature-c.js',
@@ -1120,6 +1132,7 @@ describe( 'runManualTests', () => {
 
 					sinon.assert.calledOnce( spies.scriptCompiler );
 					sinon.assert.calledWith( spies.scriptCompiler.firstCall, {
+						cwd: 'workspace',
 						buildDir: 'workspace/build/.manual-tests',
 						sourceFiles: [
 							'workspace\\packages\\ckeditor5-foo\\tests\\manual\\feature-a.js',

--- a/packages/ckeditor5-dev-tests/tests/utils/requiredll.js
+++ b/packages/ckeditor5-dev-tests/tests/utils/requiredll.js
@@ -1,0 +1,93 @@
+/**
+ * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+'use strict';
+
+const sinon = require( 'sinon' );
+const { expect } = require( 'chai' );
+
+describe( 'dev-tests/utils', () => {
+	let requireDll;
+
+	beforeEach( () => {
+		requireDll = require( '../../lib/utils/requiredll' );
+	} );
+
+	describe( 'requireDll()', () => {
+		let sandbox;
+
+		beforeEach( () => {
+			sandbox = sinon.createSandbox();
+		} );
+
+		afterEach( () => {
+			sandbox.restore();
+		} );
+
+		it( 'should return true when loads JavaScript DLL file (Unix)', () => {
+			const files = [
+				'/workspace/ckeditor5/tests/manual/all-features-dll.js'
+			];
+
+			expect( requireDll( files ) ).to.equal( true );
+		} );
+
+		it( 'should return true when loads TypeScript DLL file (Unix)', () => {
+			const files = [
+				'/workspace/ckeditor5/tests/manual/all-features-dll.ts'
+			];
+
+			expect( requireDll( files ) ).to.equal( true );
+		} );
+
+		it( 'should return true when loads JavaScript DLL file (Windows)', () => {
+			const files = [
+				'C:\\workspace\\ckeditor5\\tests\\manual\\all-features-dll.js'
+			];
+
+			expect( requireDll( files ) ).to.equal( true );
+		} );
+
+		it( 'should return true when loads TypeScript DLL file (Windows)', () => {
+			const files = [
+				'C:\\workspace\\ckeditor5\\tests\\manual\\all-features-dll.ts'
+			];
+
+			expect( requireDll( files ) ).to.equal( true );
+		} );
+
+		it( 'should return false when loads JavaScript non-DLL file (Unix)', () => {
+			const files = [
+				'/workspace/ckeditor5/tests/manual/article.js'
+			];
+
+			expect( requireDll( files ) ).to.equal( false );
+		} );
+
+		it( 'should return false when loads TypeScript non-DLL file (Unix)', () => {
+			const files = [
+				'/workspace/ckeditor5/tests/manual/article.ts'
+			];
+
+			expect( requireDll( files ) ).to.equal( false );
+		} );
+
+		it( 'should return false when loads JavaScript non-DLL file (Windows)', () => {
+			const files = [
+				'C:\\workspace\\ckeditor5\\tests\\manual\\article.js'
+			];
+
+			expect( requireDll( files ) ).to.equal( false );
+		} );
+
+		it( 'should return false when loads TypeScript non-DLL file (Windows)', () => {
+			const files = [
+				'C:\\workspace\\ckeditor5\\tests\\manual\\article.ts'
+			];
+
+			expect( requireDll( files ) ).to.equal( false );
+		} );
+	} );
+} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix (tests): When processing manual tests, if any of them require a DLL build, the manual test server adds the `DllReferencePlugin` plugin to the webpack configuration to avoid the duplicated modules error when using an import statement behind the `CK_DEBUG_*` flags. Closes ckeditor/ckeditor5#12791.

