### PR TITLE
Load `DllReferencePlugin` when processing manual tests with DLL builds - next try

### DIFF
--- a/packages/ckeditor5-dev-tests/lib/utils/manual-tests/getwebpackconfig.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/manual-tests/getwebpackconfig.js
@@ -42,7 +42,10 @@ module.exports = function getWebpackConfigForManualTests( options ) {
 		},
 
 		plugins: [
-			new WebpackNotifierPlugin( options.onTestCompilationStatus ),
+			new WebpackNotifierPlugin( {
+				onTestCompilationStatus: options.onTestCompilationStatus,
+				processName: options.requireDll ? 'DLL' : 'non-DLL'
+			} ),
 			new CKEditorWebpackPlugin( {
 				// See https://ckeditor.com/docs/ckeditor5/latest/features/ui-language.html
 				language: options.language,

--- a/packages/ckeditor5-dev-tests/lib/utils/manual-tests/getwebpackconfig.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/manual-tests/getwebpackconfig.js
@@ -14,6 +14,8 @@ const getDefinitionsFromFile = require( '../getdefinitionsfromfile' );
 
 /**
  * @param {Object} options
+ * @param {String} options.cwd Current working directory. Usually it points to the CKEditor 5 root directory.
+ * @param {Boolean} options.requireDll A flag describing whether DLL builds are required for starting the manual test server.
  * @param {Object} options.entries
  * @param {String} options.buildDir
  * @param {String} options.themePath
@@ -166,6 +168,24 @@ module.exports = function getWebpackConfigForManualTests( options ) {
 			} )
 		);
 		webpackConfig.watch = true;
+	}
+
+	if ( options.requireDll ) {
+		// When processing manual tests, if any of them require a DLL build, the manual test server adds the `DllReferencePlugin` plugin
+		// to the configuration to avoid the duplicated modules error when using an import statement behind the `CK_DEBUG_*` flags.
+		//
+		// Otherwise, webpack tries to import a file from a file system instead of the DLL build.
+		// It leads to the CKEditor 5 duplicated modules error.
+		//
+		// See: https://github.com/ckeditor/ckeditor5/issues/12791.
+		const manifestPath = path.join( options.cwd, 'build', 'ckeditor5-dll.manifest.json' );
+		const dllReferencePlugin = new webpack.DllReferencePlugin( {
+			manifest: require( manifestPath ),
+			scope: 'ckeditor5/src',
+			name: 'CKEditor5.dll'
+		} );
+
+		webpackConfig.plugins.push( dllReferencePlugin );
 	}
 
 	return webpackConfig;

--- a/packages/ckeditor5-dev-tests/lib/utils/manual-tests/webpacknotifierplugin.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/manual-tests/webpacknotifierplugin.js
@@ -11,9 +11,15 @@ const { logger } = require( '@ckeditor/ckeditor5-dev-utils' );
  * Plugin for Webpack which helps to inform the developer about processes.
  */
 module.exports = class WebpackNotifierPlugin {
-	constructor( onTestCompilationStatus ) {
+	/**
+	 * @param {Object} options
+	 * @param {Function} options.onTestCompilationStatus
+	 * @param {String} options.processName
+	 */
+	constructor( options ) {
 		this.log = logger();
-		this.onTestCompilationStatus = onTestCompilationStatus;
+		this.onTestCompilationStatus = options.onTestCompilationStatus;
+		this.processName = options.processName;
 	}
 
 	/**
@@ -24,8 +30,8 @@ module.exports = class WebpackNotifierPlugin {
 	 */
 	apply( compiler ) {
 		compiler.hooks.compile.tap( this.constructor.name, () => {
-			this.log.info( '[Webpack] Starting scripts compilation...' );
-			this.onTestCompilationStatus( 'start' );
+			this.log.info( `[Webpack] Starting scripts compilation (${ this.processName })...` );
+			this.onTestCompilationStatus( `start:${ this.processName }` );
 		} );
 
 		compiler.hooks.done.tap( this.constructor.name, stats => {
@@ -41,13 +47,13 @@ module.exports = class WebpackNotifierPlugin {
 				}
 			}
 
-			this.log.info( '[Webpack] Finished the compilation.' );
+			this.log.info( `[Webpack] Finished the compilation (${ this.processName }).` );
 
 			if ( !stats.compilation.options.watch ) {
-				this.log.info( '[Webpack] File watcher is disabled.' );
+				this.log.info( `[Webpack] File watcher is disabled (${ this.processName }).` );
 			}
 
-			this.onTestCompilationStatus( 'finished' );
+			this.onTestCompilationStatus( `finished:${ this.processName }` );
 		} );
 	}
 };

--- a/packages/ckeditor5-dev-tests/lib/utils/manual-tests/websocket.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/manual-tests/websocket.js
@@ -11,12 +11,20 @@
 	let wasDisconnected = false;
 
 	socket.on( 'testCompilationStatus', status => {
-		if ( status === 'start' ) {
+		const isOnDll = window.location.href.toString().includes( '-dll.html' );
+		const [ eventName, processName ] = status.split( ':' );
+		const isDllStatus = processName === 'DLL';
+
+		if ( isOnDll !== isDllStatus ) {
+			return;
+		}
+
+		if ( eventName === 'start' ) {
 			showToast( 'info', toastElement => {
 				const text = document.createTextNode( 'Compiling tests…' );
 				toastElement.insertBefore( text, toastElement.firstChild );
 			} );
-		} else if ( status === 'finished' ) {
+		} else if ( eventName === 'finished' ) {
 			showUpdateAvailableToast();
 		}
 	} );

--- a/packages/ckeditor5-dev-tests/lib/utils/requiredll.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/requiredll.js
@@ -1,0 +1,18 @@
+/**
+ * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+'use strict';
+
+/**
+ * Returns `true` if any of the source files represent a DLL test.
+ *
+ * @param {String|Array.<String>} sourceFiles
+ * @returns {Boolean}
+ */
+module.exports = function requireDll( sourceFiles ) {
+	sourceFiles = Array.isArray( sourceFiles ) ? sourceFiles : [ sourceFiles ];
+
+	return sourceFiles.some( filePath => /-dll.[jt]s$/.test( filePath ) );
+};

--- a/packages/ckeditor5-dev-tests/tests/tasks/runmanualtests.js
+++ b/packages/ckeditor5-dev-tests/tests/tasks/runmanualtests.js
@@ -129,6 +129,9 @@ describe( 'runManualTests', () => {
 				logInfo: sandbox.stub()
 			},
 			isInteractive: sandbox.stub(),
+			requireDll: sandbox.stub().callsFake( sourceFiles => {
+				return sourceFiles.some( filePath => /-dll.[jt]s$/.test( filePath ) );
+			} ),
 			server: sandbox.stub(),
 			htmlFileCompiler: sandbox.spy( () => Promise.resolve() ),
 			scriptCompiler: sandbox.spy( () => Promise.resolve() ),
@@ -152,6 +155,7 @@ describe( 'runManualTests', () => {
 		mockery.registerMock( '../utils/manual-tests/removedir', spies.removeDir );
 		mockery.registerMock( '../utils/manual-tests/copyassets', spies.copyAssets );
 		mockery.registerMock( '../utils/transformfileoptiontotestglob', spies.transformFileOptionToTestGlob );
+		mockery.registerMock( '../utils/requiredll', spies.requireDll );
 
 		sandbox.stub( process, 'cwd' ).returns( 'workspace' );
 
@@ -199,6 +203,7 @@ describe( 'runManualTests', () => {
 
 				expect( spies.scriptCompiler.calledOnce ).to.equal( true );
 				sinon.assert.calledWith( spies.scriptCompiler.firstCall, {
+					cwd: 'workspace',
 					buildDir: 'workspace/build/.manual-tests',
 					sourceFiles: [
 						'workspace/packages/ckeditor5-foo/tests/manual/feature-a.js',
@@ -262,6 +267,7 @@ describe( 'runManualTests', () => {
 
 				expect( spies.scriptCompiler.calledOnce ).to.equal( true );
 				sinon.assert.calledWith( spies.scriptCompiler.firstCall, {
+					cwd: 'workspace',
 					buildDir: 'workspace/build/.manual-tests',
 					sourceFiles: [
 						'workspace/packages/ckeditor5-foo/tests/manual/feature-a.js',
@@ -324,6 +330,7 @@ describe( 'runManualTests', () => {
 
 				expect( spies.scriptCompiler.calledOnce ).to.equal( true );
 				sinon.assert.calledWith( spies.scriptCompiler.firstCall, {
+					cwd: 'workspace',
 					buildDir: 'workspace/build/.manual-tests',
 					sourceFiles: [
 						'workspace/packages/ckeditor5-foo/tests/manual/feature-a.js',
@@ -383,6 +390,7 @@ describe( 'runManualTests', () => {
 				expect( spies.server.firstCall.args[ 0 ] ).to.equal( 'workspace/build/.manual-tests' );
 
 				sinon.assert.calledWith( spies.scriptCompiler.firstCall, {
+					cwd: 'workspace',
 					buildDir: 'workspace/build/.manual-tests',
 					sourceFiles: [
 						'workspace/packages/ckeditor5-foo/tests/manual/feature-a.js',
@@ -419,6 +427,7 @@ describe( 'runManualTests', () => {
 				expect( spies.server.firstCall.args[ 0 ] ).to.equal( 'workspace/build/.manual-tests' );
 
 				sinon.assert.calledWith( spies.scriptCompiler.firstCall, {
+					cwd: 'workspace',
 					buildDir: 'workspace/build/.manual-tests',
 					sourceFiles: [
 						'workspace/packages/ckeditor5-foo/tests/manual/feature-a.js',
@@ -471,6 +480,7 @@ describe( 'runManualTests', () => {
 
 				expect( spies.scriptCompiler.calledOnce ).to.equal( true );
 				sinon.assert.calledWith( spies.scriptCompiler.firstCall, {
+					cwd: 'workspace',
 					buildDir: 'workspace/build/.manual-tests',
 					sourceFiles: [
 						'workspace/packages/ckeditor5-foo/tests/manual/feature-a.js',
@@ -522,6 +532,7 @@ describe( 'runManualTests', () => {
 
 				expect( spies.scriptCompiler.calledOnce ).to.equal( true );
 				sinon.assert.calledWith( spies.scriptCompiler.firstCall, {
+					cwd: 'workspace',
 					buildDir: 'workspace/build/.manual-tests',
 					sourceFiles: [
 						'workspace/packages/ckeditor5-foo/tests/manual/feature-a.js',
@@ -572,6 +583,7 @@ describe( 'runManualTests', () => {
 
 				expect( spies.scriptCompiler.calledOnce ).to.equal( true );
 				sinon.assert.calledWith( spies.scriptCompiler.firstCall, {
+					cwd: 'workspace',
 					buildDir: 'workspace/build/.manual-tests',
 					sourceFiles: [
 						'workspace/packages/ckeditor-foo/tests/manual/feature-c.js',
@@ -1120,6 +1132,7 @@ describe( 'runManualTests', () => {
 
 					sinon.assert.calledOnce( spies.scriptCompiler );
 					sinon.assert.calledWith( spies.scriptCompiler.firstCall, {
+						cwd: 'workspace',
 						buildDir: 'workspace/build/.manual-tests',
 						sourceFiles: [
 							'workspace\\packages\\ckeditor5-foo\\tests\\manual\\feature-a.js',

--- a/packages/ckeditor5-dev-tests/tests/utils/manual-tests/compilescripts.js
+++ b/packages/ckeditor5-dev-tests/tests/utils/manual-tests/compilescripts.js
@@ -47,12 +47,13 @@ describe( 'compileManualTestScripts', () => {
 		mockery.disable();
 	} );
 
-	it( 'should compile manual test scripts', () => {
-		return compileManualTestScripts( {
+	it( 'should compile manual test scripts (DLL only)', async () => {
+		await compileManualTestScripts( {
+			cwd: 'workspace',
 			buildDir: 'buildDir',
 			sourceFiles: [
-				'ckeditor5-foo/manual/file1',
-				'ckeditor5-foo/manual/file2'
+				'ckeditor5-foo/manual/file1-dll.js',
+				'ckeditor5-foo/manual/file2-dll.js'
 			],
 			themePath: 'path/to/theme',
 			language: 'en',
@@ -60,37 +61,152 @@ describe( 'compileManualTestScripts', () => {
 			additionalLanguages: [ 'pl', 'ar' ],
 			debug: [ 'CK_DEBUG' ],
 			disableWatch: false
-		} ).then( () => {
-			expect( stubs.getWebpackConfig.calledOnce ).to.equal( true );
+		} );
 
-			sinon.assert.calledWith( stubs.getWebpackConfig.firstCall, {
-				buildDir: 'buildDir',
-				themePath: 'path/to/theme',
-				language: 'en',
-				onTestCompilationStatus: stubs.onTestCompilationStatus,
-				additionalLanguages: [ 'pl', 'ar' ],
-				entries: {
-					'ckeditor5-foo/manual/file1': 'ckeditor5-foo/manual/file1',
-					'ckeditor5-foo/manual/file2': 'ckeditor5-foo/manual/file2'
-				},
-				debug: [ 'CK_DEBUG' ],
-				disableWatch: false,
-				identityFile: undefined
-			} );
+		expect( stubs.getWebpackConfig.calledOnce ).to.equal( true );
 
-			expect( stubs.webpack.calledOnce ).to.equal( true );
-			expect( stubs.webpack.firstCall.args[ 0 ] ).to.deep.equal( {
-				buildDir: 'buildDir',
-				entries: {
-					'ckeditor5-foo/manual/file1': 'ckeditor5-foo/manual/file1',
-					'ckeditor5-foo/manual/file2': 'ckeditor5-foo/manual/file2'
-				}
-			} );
+		sinon.assert.calledWith( stubs.getWebpackConfig.firstCall, {
+			cwd: 'workspace',
+			requireDll: true,
+			buildDir: 'buildDir',
+			themePath: 'path/to/theme',
+			language: 'en',
+			onTestCompilationStatus: stubs.onTestCompilationStatus,
+			additionalLanguages: [ 'pl', 'ar' ],
+			entries: {
+				'ckeditor5-foo/manual/file1-dll': 'ckeditor5-foo/manual/file1-dll.js',
+				'ckeditor5-foo/manual/file2-dll': 'ckeditor5-foo/manual/file2-dll.js'
+			},
+			debug: [ 'CK_DEBUG' ],
+			disableWatch: false,
+			identityFile: undefined
+		} );
+
+		expect( stubs.webpack.calledOnce ).to.equal( true );
+		expect( stubs.webpack.firstCall.args[ 0 ] ).to.deep.equal( {
+			buildDir: 'buildDir',
+			entries: {
+				'ckeditor5-foo/manual/file1-dll': 'ckeditor5-foo/manual/file1-dll.js',
+				'ckeditor5-foo/manual/file2-dll': 'ckeditor5-foo/manual/file2-dll.js'
+			}
 		} );
 	} );
 
-	it( 'should compile multiple manual test scripts', () => {
-		return compileManualTestScripts( {
+	it( 'should compile manual test scripts (non-DLL only)', async () => {
+		await compileManualTestScripts( {
+			cwd: 'workspace',
+			buildDir: 'buildDir',
+			sourceFiles: [
+				'ckeditor5-foo/manual/file1.js',
+				'ckeditor5-foo/manual/file2.js'
+			],
+			themePath: 'path/to/theme',
+			language: 'en',
+			onTestCompilationStatus: stubs.onTestCompilationStatus,
+			additionalLanguages: [ 'pl', 'ar' ],
+			debug: [ 'CK_DEBUG' ],
+			disableWatch: false
+		} );
+
+		expect( stubs.getWebpackConfig.calledOnce ).to.equal( true );
+
+		sinon.assert.calledWith( stubs.getWebpackConfig.firstCall, {
+			cwd: 'workspace',
+			requireDll: false,
+			buildDir: 'buildDir',
+			themePath: 'path/to/theme',
+			language: 'en',
+			onTestCompilationStatus: stubs.onTestCompilationStatus,
+			additionalLanguages: [ 'pl', 'ar' ],
+			entries: {
+				'ckeditor5-foo/manual/file1': 'ckeditor5-foo/manual/file1.js',
+				'ckeditor5-foo/manual/file2': 'ckeditor5-foo/manual/file2.js'
+			},
+			debug: [ 'CK_DEBUG' ],
+			disableWatch: false,
+			identityFile: undefined
+		} );
+
+		expect( stubs.webpack.calledOnce ).to.equal( true );
+		expect( stubs.webpack.firstCall.args[ 0 ] ).to.deep.equal( {
+			buildDir: 'buildDir',
+			entries: {
+				'ckeditor5-foo/manual/file1': 'ckeditor5-foo/manual/file1.js',
+				'ckeditor5-foo/manual/file2': 'ckeditor5-foo/manual/file2.js'
+			}
+		} );
+	} );
+
+	it( 'should compile manual test scripts (DLL and non-DLL)', async () => {
+		await compileManualTestScripts( {
+			cwd: 'workspace',
+			buildDir: 'buildDir',
+			sourceFiles: [
+				'ckeditor5-foo/manual/file1.js',
+				'ckeditor5-foo/manual/file2-dll.js'
+			],
+			themePath: 'path/to/theme',
+			language: 'en',
+			onTestCompilationStatus: stubs.onTestCompilationStatus,
+			additionalLanguages: [ 'pl', 'ar' ],
+			debug: [ 'CK_DEBUG' ],
+			disableWatch: false
+		} );
+
+		expect( stubs.getWebpackConfig.calledTwice ).to.equal( true );
+
+		sinon.assert.calledWith( stubs.getWebpackConfig.firstCall, {
+			cwd: 'workspace',
+			requireDll: true,
+			buildDir: 'buildDir',
+			themePath: 'path/to/theme',
+			language: 'en',
+			onTestCompilationStatus: stubs.onTestCompilationStatus,
+			additionalLanguages: [ 'pl', 'ar' ],
+			entries: {
+				'ckeditor5-foo/manual/file2-dll': 'ckeditor5-foo/manual/file2-dll.js'
+			},
+			debug: [ 'CK_DEBUG' ],
+			disableWatch: false,
+			identityFile: undefined
+		} );
+
+		sinon.assert.calledWith( stubs.getWebpackConfig.secondCall, {
+			cwd: 'workspace',
+			requireDll: false,
+			buildDir: 'buildDir',
+			themePath: 'path/to/theme',
+			language: 'en',
+			onTestCompilationStatus: stubs.onTestCompilationStatus,
+			additionalLanguages: [ 'pl', 'ar' ],
+			entries: {
+				'ckeditor5-foo/manual/file1': 'ckeditor5-foo/manual/file1.js'
+			},
+			debug: [ 'CK_DEBUG' ],
+			disableWatch: false,
+			identityFile: undefined
+		} );
+
+		expect( stubs.webpack.calledTwice ).to.equal( true );
+
+		expect( stubs.webpack.firstCall.args[ 0 ] ).to.deep.equal( {
+			buildDir: 'buildDir',
+			entries: {
+				'ckeditor5-foo/manual/file2-dll': 'ckeditor5-foo/manual/file2-dll.js'
+			}
+		} );
+
+		expect( stubs.webpack.secondCall.args[ 0 ] ).to.deep.equal( {
+			buildDir: 'buildDir',
+			entries: {
+				'ckeditor5-foo/manual/file1': 'ckeditor5-foo/manual/file1.js'
+			}
+		} );
+	} );
+
+	it( 'should compile multiple manual test scripts', async () => {
+		await compileManualTestScripts( {
+			cwd: 'workspace',
 			buildDir: 'buildDir',
 			sourceFiles: [
 				'ckeditor5-build-classic/tests/manual/ckeditor.js',
@@ -101,27 +217,27 @@ describe( 'compileManualTestScripts', () => {
 			language: null,
 			onTestCompilationStatus: stubs.onTestCompilationStatus,
 			additionalLanguages: null
-		} ).then( () => {
-			expect( stubs.getWebpackConfig.calledOnce ).to.equal( true );
-
-			expect( stubs.getRelativeFilePath.calledThrice ).to.equal( true );
-			expect( stubs.getRelativeFilePath.firstCall.args[ 0 ] )
-				.to.equal( 'ckeditor5-build-classic/tests/manual/ckeditor.js' );
-			expect( stubs.getRelativeFilePath.secondCall.args[ 0 ] )
-				.to.equal( 'ckeditor5-build-classic/tests/manual/ckeditor.compcat.js' );
-			expect( stubs.getRelativeFilePath.thirdCall.args[ 0 ] )
-				.to.equal( 'ckeditor5-editor-classic/tests/manual/classic.js' );
 		} );
+
+		expect( stubs.getWebpackConfig.calledOnce ).to.equal( true );
+
+		expect( stubs.getRelativeFilePath.calledThrice ).to.equal( true );
+		expect( stubs.getRelativeFilePath.firstCall.args[ 0 ] )
+			.to.equal( 'ckeditor5-build-classic/tests/manual/ckeditor.js' );
+		expect( stubs.getRelativeFilePath.secondCall.args[ 0 ] )
+			.to.equal( 'ckeditor5-build-classic/tests/manual/ckeditor.compcat.js' );
+		expect( stubs.getRelativeFilePath.thirdCall.args[ 0 ] )
+			.to.equal( 'ckeditor5-editor-classic/tests/manual/classic.js' );
 	} );
 
-	it( 'rejects if Webpack threw an error', () => {
+	it( 'rejects if webpack threw an error', () => {
 		webpackError = new Error( 'Unexpected error.' );
 
 		return compileManualTestScripts( {
 			buildDir: 'buildDir',
 			sourceFiles: [
-				'ckeditor5-foo/manual/file1',
-				'ckeditor5-foo/manual/file2'
+				'ckeditor5-foo/manual/file1.js',
+				'ckeditor5-foo/manual/file2.js'
 			],
 			themePath: 'path/to/theme',
 			language: null,
@@ -137,8 +253,8 @@ describe( 'compileManualTestScripts', () => {
 		);
 	} );
 
-	it( 'works on Windows environments', () => {
-		return compileManualTestScripts( {
+	it( 'works on Windows environments', async () => {
+		await compileManualTestScripts( {
 			buildDir: 'buildDir',
 			sourceFiles: [
 				'ckeditor5-build-classic\\tests\\manual\\ckeditor.js'
@@ -147,21 +263,21 @@ describe( 'compileManualTestScripts', () => {
 			language: null,
 			onTestCompilationStatus: stubs.onTestCompilationStatus,
 			additionalLanguages: null
-		} ).then( () => {
-			expect( stubs.getRelativeFilePath.calledOnce ).to.equal( true );
-			expect( stubs.getRelativeFilePath.firstCall.args[ 0 ] )
-				.to.equal( 'ckeditor5-build-classic\\tests\\manual\\ckeditor.js' );
 		} );
+
+		expect( stubs.getRelativeFilePath.calledOnce ).to.equal( true );
+		expect( stubs.getRelativeFilePath.firstCall.args[ 0 ] ).to.equal( 'ckeditor5-build-classic\\tests\\manual\\ckeditor.js' );
 	} );
 
-	it( 'should pass identity file to webpack configuration factory', () => {
+	it( 'should pass identity file to webpack configuration factory', async () => {
 		const identityFile = '/foo/bar.js';
 
-		return compileManualTestScripts( {
+		await compileManualTestScripts( {
+			cwd: 'workspace',
 			buildDir: 'buildDir',
 			sourceFiles: [
-				'ckeditor5-foo/manual/file1',
-				'ckeditor5-foo/manual/file2'
+				'ckeditor5-foo/manual/file1.js',
+				'ckeditor5-foo/manual/file2.js'
 			],
 			themePath: 'path/to/theme',
 			language: 'en',
@@ -170,40 +286,43 @@ describe( 'compileManualTestScripts', () => {
 			debug: [ 'CK_DEBUG' ],
 			identityFile,
 			disableWatch: false
-		} ).then( () => {
-			expect( stubs.getWebpackConfig.calledOnce ).to.equal( true );
+		} );
 
-			sinon.assert.calledWith( stubs.getWebpackConfig.firstCall, {
-				buildDir: 'buildDir',
-				themePath: 'path/to/theme',
-				language: 'en',
-				onTestCompilationStatus: stubs.onTestCompilationStatus,
-				additionalLanguages: [ 'pl', 'ar' ],
-				entries: {
-					'ckeditor5-foo/manual/file1': 'ckeditor5-foo/manual/file1',
-					'ckeditor5-foo/manual/file2': 'ckeditor5-foo/manual/file2'
-				},
-				debug: [ 'CK_DEBUG' ],
-				identityFile,
-				disableWatch: false
-			} );
+		expect( stubs.getWebpackConfig.calledOnce ).to.equal( true );
 
-			expect( stubs.webpack.calledOnce ).to.equal( true );
-			expect( stubs.webpack.firstCall.args[ 0 ] ).to.deep.equal( {
-				buildDir: 'buildDir',
-				entries: {
-					'ckeditor5-foo/manual/file1': 'ckeditor5-foo/manual/file1',
-					'ckeditor5-foo/manual/file2': 'ckeditor5-foo/manual/file2'
-				}
-			} );
+		sinon.assert.calledWith( stubs.getWebpackConfig.firstCall, {
+			cwd: 'workspace',
+			requireDll: false,
+			buildDir: 'buildDir',
+			themePath: 'path/to/theme',
+			language: 'en',
+			onTestCompilationStatus: stubs.onTestCompilationStatus,
+			additionalLanguages: [ 'pl', 'ar' ],
+			entries: {
+				'ckeditor5-foo/manual/file1': 'ckeditor5-foo/manual/file1.js',
+				'ckeditor5-foo/manual/file2': 'ckeditor5-foo/manual/file2.js'
+			},
+			debug: [ 'CK_DEBUG' ],
+			identityFile,
+			disableWatch: false
+		} );
+
+		expect( stubs.webpack.calledOnce ).to.equal( true );
+		expect( stubs.webpack.firstCall.args[ 0 ] ).to.deep.equal( {
+			buildDir: 'buildDir',
+			entries: {
+				'ckeditor5-foo/manual/file1': 'ckeditor5-foo/manual/file1.js',
+				'ckeditor5-foo/manual/file2': 'ckeditor5-foo/manual/file2.js'
+			}
 		} );
 	} );
 
-	it( 'should pass the "disableWatch" option to webpack configuration factory', () => {
-		return compileManualTestScripts( {
+	it( 'should pass the "disableWatch" option to webpack configuration factory', async () => {
+		await compileManualTestScripts( {
+			cwd: 'workspace',
 			buildDir: 'buildDir',
 			sourceFiles: [
-				'ckeditor5-foo/manual/file1'
+				'ckeditor5-foo/manual/file1.js'
 			],
 			themePath: 'path/to/theme',
 			language: 'en',
@@ -211,30 +330,32 @@ describe( 'compileManualTestScripts', () => {
 			additionalLanguages: [ 'pl', 'ar' ],
 			debug: [ 'CK_DEBUG' ],
 			disableWatch: true
-		} ).then( () => {
-			expect( stubs.getWebpackConfig.calledOnce ).to.equal( true );
+		} );
 
-			sinon.assert.calledWith( stubs.getWebpackConfig.firstCall, {
-				buildDir: 'buildDir',
-				themePath: 'path/to/theme',
-				language: 'en',
-				onTestCompilationStatus: stubs.onTestCompilationStatus,
-				additionalLanguages: [ 'pl', 'ar' ],
-				entries: {
-					'ckeditor5-foo/manual/file1': 'ckeditor5-foo/manual/file1'
-				},
-				debug: [ 'CK_DEBUG' ],
-				identityFile: undefined,
-				disableWatch: true
-			} );
+		expect( stubs.getWebpackConfig.calledOnce ).to.equal( true );
 
-			expect( stubs.webpack.calledOnce ).to.equal( true );
-			expect( stubs.webpack.firstCall.args[ 0 ] ).to.deep.equal( {
-				buildDir: 'buildDir',
-				entries: {
-					'ckeditor5-foo/manual/file1': 'ckeditor5-foo/manual/file1'
-				}
-			} );
+		sinon.assert.calledWith( stubs.getWebpackConfig.firstCall, {
+			cwd: 'workspace',
+			requireDll: false,
+			buildDir: 'buildDir',
+			themePath: 'path/to/theme',
+			language: 'en',
+			onTestCompilationStatus: stubs.onTestCompilationStatus,
+			additionalLanguages: [ 'pl', 'ar' ],
+			entries: {
+				'ckeditor5-foo/manual/file1': 'ckeditor5-foo/manual/file1.js'
+			},
+			debug: [ 'CK_DEBUG' ],
+			identityFile: undefined,
+			disableWatch: true
+		} );
+
+		expect( stubs.webpack.calledOnce ).to.equal( true );
+		expect( stubs.webpack.firstCall.args[ 0 ] ).to.deep.equal( {
+			buildDir: 'buildDir',
+			entries: {
+				'ckeditor5-foo/manual/file1': 'ckeditor5-foo/manual/file1.js'
+			}
 		} );
 	} );
 } );

--- a/packages/ckeditor5-dev-tests/tests/utils/requiredll.js
+++ b/packages/ckeditor5-dev-tests/tests/utils/requiredll.js
@@ -1,0 +1,105 @@
+/**
+ * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+'use strict';
+
+const sinon = require( 'sinon' );
+const { expect } = require( 'chai' );
+
+describe( 'dev-tests/utils', () => {
+	let requireDll;
+
+	beforeEach( () => {
+		requireDll = require( '../../lib/utils/requiredll' );
+	} );
+
+	describe( 'requireDll()', () => {
+		let sandbox;
+
+		beforeEach( () => {
+			sandbox = sinon.createSandbox();
+		} );
+
+		afterEach( () => {
+			sandbox.restore();
+		} );
+
+		it( 'should return true when loads JavaScript DLL file (Unix)', () => {
+			const files = [
+				'/workspace/ckeditor5/tests/manual/all-features-dll.js'
+			];
+
+			expect( requireDll( files ) ).to.equal( true );
+		} );
+
+		it( 'should return true when loads single JavaScript DLL file (Unix)', () => {
+			const file = '/workspace/ckeditor5/tests/manual/all-features-dll.js';
+
+			expect( requireDll( file ) ).to.equal( true );
+		} );
+
+		it( 'should return true when loads TypeScript DLL file (Unix)', () => {
+			const files = [
+				'/workspace/ckeditor5/tests/manual/all-features-dll.ts'
+			];
+
+			expect( requireDll( files ) ).to.equal( true );
+		} );
+
+		it( 'should return true when loads JavaScript DLL file (Windows)', () => {
+			const files = [
+				'C:\\workspace\\ckeditor5\\tests\\manual\\all-features-dll.js'
+			];
+
+			expect( requireDll( files ) ).to.equal( true );
+		} );
+
+		it( 'should return true when loads TypeScript DLL file (Windows)', () => {
+			const files = [
+				'C:\\workspace\\ckeditor5\\tests\\manual\\all-features-dll.ts'
+			];
+
+			expect( requireDll( files ) ).to.equal( true );
+		} );
+
+		it( 'should return false when loads JavaScript non-DLL file (Unix)', () => {
+			const files = [
+				'/workspace/ckeditor5/tests/manual/article.js'
+			];
+
+			expect( requireDll( files ) ).to.equal( false );
+		} );
+
+		it( 'should return false when loads single JavaScript non-DLL file (Unix)', () => {
+			const file = '/workspace/ckeditor5/tests/manual/article.js';
+
+			expect( requireDll( file ) ).to.equal( false );
+		} );
+
+		it( 'should return false when loads TypeScript non-DLL file (Unix)', () => {
+			const files = [
+				'/workspace/ckeditor5/tests/manual/article.ts'
+			];
+
+			expect( requireDll( files ) ).to.equal( false );
+		} );
+
+		it( 'should return false when loads JavaScript non-DLL file (Windows)', () => {
+			const files = [
+				'C:\\workspace\\ckeditor5\\tests\\manual\\article.js'
+			];
+
+			expect( requireDll( files ) ).to.equal( false );
+		} );
+
+		it( 'should return false when loads TypeScript non-DLL file (Windows)', () => {
+			const files = [
+				'C:\\workspace\\ckeditor5\\tests\\manual\\article.ts'
+			];
+
+			expect( requireDll( files ) ).to.equal( false );
+		} );
+	} );
+} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix (tests): When processing manual tests, if any of them require a DLL build, the manual test server adds the `DllReferencePlugin` plugin to the webpack configuration to avoid the duplicated modules error when using an import statement behind the `CK_DEBUG_*` flags. Closes ckeditor/ckeditor5#12791.

Other (tests): Split DLL and non-DLL manual tests to run separate webpack processes for both groups. They need to be compiled separately because DLL tests require `DllReferencePlugin`, and non-DLL ones must not have it.

---

### Additional information

Most of the code is taken from the ckeditor/ckeditor5-dev#809.
