### PR TITLE
Copy the entire comment from the event tag instead of just its summary

### DIFF
--- a/packages/typedoc-plugins/lib/tag-event/index.js
+++ b/packages/typedoc-plugins/lib/tag-event/index.js
@@ -104,9 +104,8 @@ function onEventEnd( context ) {
 			eventReflection.typeParameters = typeParameters;
 		}
 
-		// Copy comment summary. The `blockTags` property from the comment is not needed, as it has been already mapped to the type
-		// parameters.
-		eventReflection.comment = new Comment( Comment.cloneDisplayParts( reflection.comment.summary ) );
+		// Copy the whole comment. In addition to the comment summary, it can contain other useful data (i.e. block tags, modifier tags).
+		eventReflection.comment = reflection.comment.clone();
 
 		// Copy the source location as it is the same as the location of the reflection containing the event.
 		eventReflection.sources = [ ...reflection.sources ];

--- a/packages/typedoc-plugins/tests/tag-event/fixtures/customexampleclass.ts
+++ b/packages/typedoc-plugins/tests/tag-event/fixtures/customexampleclass.ts
@@ -70,6 +70,7 @@ export type EventFoo = {
  * @param {String} p1 Description for first param.
  * @param {module:utils/object~Object} p2 Description for second param.
  * @param p3 Complex {@link module:utils/object~Object description} for `third param`.
+ * @deprecated
  */
 export type EventFooWithParams = {
 	name: string;

--- a/packages/typedoc-plugins/tests/tag-event/index.js
+++ b/packages/typedoc-plugins/tests/tag-event/index.js
@@ -124,7 +124,8 @@ describe( 'typedoc-plugins/tag-event', function() {
 			expect( eventDefinition.comment.summary ).to.be.an( 'array' );
 			expect( eventDefinition.comment.summary ).to.lengthOf( 0 );
 			expect( eventDefinition.comment.blockTags ).to.be.an( 'array' );
-			expect( eventDefinition.comment.blockTags ).to.lengthOf( 0 );
+			expect( eventDefinition.comment.blockTags ).to.lengthOf( 1 );
+			expect( eventDefinition.comment.blockTags[ 0 ] ).to.have.property( 'tag', '@eventName' );
 			expect( eventDefinition.comment.modifierTags ).to.be.a( 'Set' );
 			expect( eventDefinition.comment.modifierTags.size ).to.equal( 0 );
 
@@ -156,7 +157,8 @@ describe( 'typedoc-plugins/tag-event', function() {
 			expect( eventDefinition.comment.summary[ 0 ] ).to.have.property( 'kind', 'text' );
 			expect( eventDefinition.comment.summary[ 0 ] ).to.have.property( 'text', 'An event associated with the type.' );
 			expect( eventDefinition.comment.blockTags ).to.be.an( 'array' );
-			expect( eventDefinition.comment.blockTags ).to.lengthOf( 0 );
+			expect( eventDefinition.comment.blockTags ).to.lengthOf( 1 );
+			expect( eventDefinition.comment.blockTags[ 0 ] ).to.have.property( 'tag', '@eventName' );
 			expect( eventDefinition.comment.modifierTags ).to.be.a( 'Set' );
 			expect( eventDefinition.comment.modifierTags.size ).to.equal( 0 );
 
@@ -200,7 +202,13 @@ describe( 'typedoc-plugins/tag-event', function() {
 			expect( eventDefinition.comment.summary[ 4 ] ).to.have.property( 'text', '. A text after.' );
 
 			expect( eventDefinition.comment.blockTags ).to.be.an( 'array' );
-			expect( eventDefinition.comment.blockTags ).to.lengthOf( 0 );
+			expect( eventDefinition.comment.blockTags ).to.lengthOf( 5 );
+			expect( eventDefinition.comment.blockTags[ 0 ] ).to.have.property( 'tag', '@eventName' );
+			expect( eventDefinition.comment.blockTags[ 1 ] ).to.have.property( 'tag', '@param' );
+			expect( eventDefinition.comment.blockTags[ 2 ] ).to.have.property( 'tag', '@param' );
+			expect( eventDefinition.comment.blockTags[ 3 ] ).to.have.property( 'tag', '@param' );
+			expect( eventDefinition.comment.blockTags[ 4 ] ).to.have.property( 'tag', '@deprecated' );
+
 			expect( eventDefinition.comment.modifierTags ).to.be.a( 'Set' );
 			expect( eventDefinition.comment.modifierTags.size ).to.equal( 0 );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal (typedoc-plugins): The `tag-event` plugin for TypeDoc now clones the entire comment found for the event tag instead of just its summary.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
