### PR TITLE
Add `TranslateSource` loader as the last one in the loader's chain

### DIFF
--- a/packages/ckeditor5-dev-webpack-plugin/lib/servetranslations.js
+++ b/packages/ckeditor5-dev-webpack-plugin/lib/servetranslations.js
@@ -98,7 +98,9 @@ module.exports = function serveTranslations( compiler, options, translationServi
 			const relativePathToResource = path.relative( cwd, module.resource );
 
 			if ( relativePathToResource.match( options.sourceFilesPattern ) ) {
-				module.loaders.push( {
+				// The `TranslateSource` loader must be added as the last one in the loader's chain,
+				// after any potential TypeScript file has already been compiled.
+				module.loaders.unshift( {
 					loader: path.join( __dirname, 'translatesourceloader.js' ),
 					options: { translateSource }
 				} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix (webpack-plugin): The `TranslateSource` loader is added as the last one in the loader's chain, after any potential TypeScript file has already been compiled. Closes ckeditor/ckeditor5#12735.
