### PR TITLE
Unified the structures produced by `tag-error`

### DIFF
--- a/packages/typedoc-plugins/lib/module-fixer/index.js
+++ b/packages/typedoc-plugins/lib/module-fixer/index.js
@@ -50,6 +50,8 @@ function onEventCreateDeclaration() {
 			for ( const jsDoc of statement.jsDoc ) {
 				// ...that represents a module definition.
 				const [ moduleTag ] = ( jsDoc.tags || [] ).filter( tag => {
+					// TODO: We need to find a safer solution to check if the JSDoc block code represents a module definition,
+					// because the numerical value may change between TypeDoc releases.
 					return tag.tagName.originalKeywordKind === 142;
 				} );
 

--- a/packages/typedoc-plugins/lib/module-fixer/index.js
+++ b/packages/typedoc-plugins/lib/module-fixer/index.js
@@ -50,7 +50,7 @@ function onEventCreateDeclaration() {
 			for ( const jsDoc of statement.jsDoc ) {
 				// ...that represents a module definition.
 				const [ moduleTag ] = ( jsDoc.tags || [] ).filter( tag => {
-					return tag.tagName.originalKeywordKind === 141;
+					return tag.tagName.originalKeywordKind === 142;
 				} );
 
 				if ( !moduleTag ) {

--- a/packages/typedoc-plugins/tests/tag-error/index.js
+++ b/packages/typedoc-plugins/tests/tag-error/index.js
@@ -47,7 +47,7 @@ describe( 'typedoc-plugins/tag-error', function() {
 	it( 'should not collect variable called "error', () => {
 		const errorModule = conversionResult.children.find( module => module.name === 'error' );
 
-		const errorDefinitions = errorModule.children.filter( children => children.originalName === 'ErrorDeclaration' );
+		const errorDefinitions = errorModule.children.filter( children => children.kindString === 'Error' );
 
 		expect( errorDefinitions ).to.lengthOf( 0 );
 	} );
@@ -55,7 +55,7 @@ describe( 'typedoc-plugins/tag-error', function() {
 	it( 'should collect the `@error` annotations from block comment codes', () => {
 		const errorModule = conversionResult.children.find( module => module.name === 'customerror' );
 
-		const errorDefinitions = errorModule.children.filter( children => children.originalName === 'ErrorDeclaration' );
+		const errorDefinitions = errorModule.children.filter( children => children.kindString === 'Error' );
 
 		expect( errorDefinitions ).to.not.lengthOf( 0 );
 	} );
@@ -72,7 +72,8 @@ describe( 'typedoc-plugins/tag-error', function() {
 
 			expect( errorDefinition ).to.not.be.undefined;
 			expect( errorDefinition.name ).to.equal( 'customerror-inside-method-no-text' );
-			expect( errorDefinition.originalName ).to.equal( 'ErrorDeclaration' );
+			expect( errorDefinition.originalName ).to.equal( 'customerror-inside-method-no-text' );
+			expect( errorDefinition.kindString ).to.equal( 'Error' );
 
 			expect( errorDefinition.comment ).to.have.property( 'summary' );
 			expect( errorDefinition.comment ).to.have.property( 'blockTags' );
@@ -91,7 +92,8 @@ describe( 'typedoc-plugins/tag-error', function() {
 
 			expect( errorDefinition ).to.not.be.undefined;
 			expect( errorDefinition.name ).to.equal( 'customerror-before-module' );
-			expect( errorDefinition.originalName ).to.equal( 'ErrorDeclaration' );
+			expect( errorDefinition.originalName ).to.equal( 'customerror-before-module' );
+			expect( errorDefinition.kindString ).to.equal( 'Error' );
 			expect( errorDefinition.comment.summary ).to.lengthOf( 1 );
 			expect( errorDefinition.comment.summary[ 0 ] ).to.have.property( 'kind', 'text' );
 			expect( errorDefinition.comment.summary[ 0 ] ).to.have.property( 'text',
@@ -104,7 +106,8 @@ describe( 'typedoc-plugins/tag-error', function() {
 
 			expect( errorDefinition ).to.not.be.undefined;
 			expect( errorDefinition.name ).to.equal( 'customerror-before-module-with-links' );
-			expect( errorDefinition.originalName ).to.equal( 'ErrorDeclaration' );
+			expect( errorDefinition.originalName ).to.equal( 'customerror-before-module-with-links' );
+			expect( errorDefinition.kindString ).to.equal( 'Error' );
 			expect( errorDefinition.comment ).to.have.property( 'summary' );
 			expect( errorDefinition.comment.summary ).to.lengthOf( 5 );
 			expect( errorDefinition.comment.summary[ 0 ] ).to.have.property( 'kind', 'text' );
@@ -133,7 +136,8 @@ describe( 'typedoc-plugins/tag-error', function() {
 			const errorDefinition = errorModule.children.find( doclet => doclet.name === 'customerror-after-module' );
 
 			expect( errorDefinition ).to.not.be.undefined;
-			expect( errorDefinition.originalName ).to.equal( 'ErrorDeclaration' );
+			expect( errorDefinition.originalName ).to.equal( 'customerror-after-module' );
+			expect( errorDefinition.kindString ).to.equal( 'Error' );
 			expect( errorDefinition.comment.summary ).to.lengthOf( 1 );
 			expect( errorDefinition.comment.summary[ 0 ] ).to.have.property( 'kind', 'text' );
 			expect( errorDefinition.comment.summary[ 0 ] ).to.have.property( 'text',
@@ -159,7 +163,8 @@ describe( 'typedoc-plugins/tag-error', function() {
 			const errorDefinition = errorModule.children.find( doclet => doclet.name === 'customerror-before-export' );
 
 			expect( errorDefinition ).to.not.be.undefined;
-			expect( errorDefinition.originalName ).to.equal( 'ErrorDeclaration' );
+			expect( errorDefinition.originalName ).to.equal( 'customerror-before-export' );
+			expect( errorDefinition.kindString ).to.equal( 'Error' );
 			expect( errorDefinition.comment.summary ).to.lengthOf( 1 );
 			expect( errorDefinition.comment.summary[ 0 ] ).to.have.property( 'kind', 'text' );
 			expect( errorDefinition.comment.summary[ 0 ] ).to.have.property( 'text',
@@ -171,7 +176,8 @@ describe( 'typedoc-plugins/tag-error', function() {
 			const errorDefinition = errorModule.children.find( doclet => doclet.name === 'customerror-after-export' );
 
 			expect( errorDefinition ).to.not.be.undefined;
-			expect( errorDefinition.originalName ).to.equal( 'ErrorDeclaration' );
+			expect( errorDefinition.originalName ).to.equal( 'customerror-after-export' );
+			expect( errorDefinition.kindString ).to.equal( 'Error' );
 			expect( errorDefinition.comment.summary ).to.lengthOf( 1 );
 			expect( errorDefinition.comment.summary[ 0 ] ).to.have.property( 'kind', 'text' );
 			expect( errorDefinition.comment.summary[ 0 ] ).to.have.property( 'text',
@@ -184,7 +190,8 @@ describe( 'typedoc-plugins/tag-error', function() {
 
 			expect( errorDefinition ).to.not.be.undefined;
 			expect( errorDefinition.name ).to.equal( 'customerror-inside-method' );
-			expect( errorDefinition.originalName ).to.equal( 'ErrorDeclaration' );
+			expect( errorDefinition.originalName ).to.equal( 'customerror-inside-method' );
+			expect( errorDefinition.kindString ).to.equal( 'Error' );
 			expect( errorDefinition.comment ).to.have.property( 'summary' );
 			expect( errorDefinition.comment.summary ).to.be.an( 'array' );
 			expect( errorDefinition.comment.summary ).to.lengthOf( 1 );
@@ -237,7 +244,8 @@ describe( 'typedoc-plugins/tag-error', function() {
 
 			expect( errorDefinition ).to.not.be.undefined;
 			expect( errorDefinition.name ).to.equal( 'customerror-inside-function' );
-			expect( errorDefinition.originalName ).to.equal( 'ErrorDeclaration' );
+			expect( errorDefinition.originalName ).to.equal( 'customerror-inside-function' );
+			expect( errorDefinition.kindString ).to.equal( 'Error' );
 			expect( errorDefinition.comment.summary ).to.lengthOf( 1 );
 			expect( errorDefinition.comment.summary[ 0 ] ).to.deep.equal( {
 				kind: 'text',


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal (typedoc-plugins): Unified the structures produced by `tag-error`. Closes ckeditor/ckeditor5#12724.

---

### Additional information

Follow-up to fix the numerical comparisons: ckeditor/ckeditor5#12877.
