### PR TITLE
Improved detection of module declaration and JSDoc link in Typedoc plugins

### DIFF
--- a/packages/typedoc-plugins/lib/module-fixer/index.js
+++ b/packages/typedoc-plugins/lib/module-fixer/index.js
@@ -6,6 +6,7 @@
 'use strict';
 
 const { Converter, ReflectionKind } = require( 'typedoc' );
+const ts = require( 'typescript' );
 
 /**
  * The `typedoc-plugin-module-fixer` reads the module name specified in the `@module` tag name.
@@ -50,9 +51,7 @@ function onEventCreateDeclaration() {
 			for ( const jsDoc of statement.jsDoc ) {
 				// ...that represents a module definition.
 				const [ moduleTag ] = ( jsDoc.tags || [] ).filter( tag => {
-					// TODO: We need to find a safer solution to check if the JSDoc block code represents a module definition,
-					// because the numerical value may change between TypeDoc releases.
-					return tag.tagName.originalKeywordKind === 142;
+					return tag.tagName.originalKeywordKind === ts.SyntaxKind.ModuleKeyword;
 				} );
 
 				if ( !moduleTag ) {

--- a/packages/typedoc-plugins/lib/tag-error/index.js
+++ b/packages/typedoc-plugins/lib/tag-error/index.js
@@ -133,10 +133,7 @@ function getCommentDisplayPart( commentChildrenOrValue ) {
 			let { text } = item;
 
 			// An inline tag inside a description.
-			//
-			// TODO: We need to find a safer solution to check if the description is an inline-tag,
-			// because the numerical value may change between TypeDoc releases.
-			if ( item.kind === 327 ) {
+			if ( item.kind === ts.SyntaxKind.JSDocLink ) {
 				// A reference, e.g. "module:".
 				if ( item.name ) {
 					text = item.name.escapedText + text;


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Improved detection of module declaration and JSDoc link in Typedoc plugins. Instead of using numeric values, which are not constant, we now use enums exported from TypeScript. Closes ckeditor/ckeditor5#12877.
