### PR TITLE
Translate source loader should pass through the source map object

### DIFF
--- a/packages/ckeditor5-dev-webpack-plugin/lib/translatesourceloader.js
+++ b/packages/ckeditor5-dev-webpack-plugin/lib/translatesourceloader.js
@@ -9,9 +9,11 @@
  * Very simple loader that runs the translateSource function only on the source.
  * translateSource is provided by the CKEditorWebpackPlugin.
  *
- * @param {String} source Source which will be translated.
- * @returns {String}
+ * @param {String} source Content of the resource file
+ * @param {Object} map A source map consumed by the `source-map` package.
  */
-module.exports = function translateSourceLoader( source ) {
-	return this.query.translateSource( source, this.resourcePath );
+module.exports = function translateSourceLoader( source, map ) {
+	const output = this.query.translateSource( source, this.resourcePath );
+
+	this.callback( null, output, map );
 };

--- a/packages/ckeditor5-dev-webpack-plugin/tests/translatesourceloader.js
+++ b/packages/ckeditor5-dev-webpack-plugin/tests/translatesourceloader.js
@@ -21,14 +21,19 @@ describe( 'webpack-plugin/translateSourceLoader()', () => {
 			query: {
 				translateSource: sandbox.spy( () => 'output' )
 			},
-			resourcePath: 'file.js'
+			resourcePath: 'file.js',
+			callback: sinon.stub()
 		};
 
-		const result = translateSourceLoader.call( ctx, 'Source' );
+		const map = {};
+		translateSourceLoader.call( ctx, 'Source', map );
 
 		sinon.assert.calledOnce( ctx.query.translateSource );
 		sinon.assert.calledWithExactly( ctx.query.translateSource, 'Source', 'file.js' );
 
-		expect( result ).to.equal( 'output' );
+		expect( ctx.callback.calledOnce ).to.equal( true );
+		expect( ctx.callback.firstCall.args[ 0 ] ).to.equal( null );
+		expect( ctx.callback.firstCall.args[ 1 ] ).to.equal( 'output' );
+		expect( ctx.callback.firstCall.args[ 2 ] ).to.equal( map );
 	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix (webpack-plugin): Fixed generating source maps after switching the order of loaders in the CKEditor 5 translations webpack plugin. The source loader should pass through the source map object to avoid generating a new one. Closes ckeditor/ckeditor5#12928.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
