### PR TITLE
Do not attach husky hooks when installing a repository as a dependency (instead of cloning)

### DIFF
--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -7,4 +7,12 @@
 
 /* eslint-env node */
 
-require( 'husky' ).install();
+const path = require( 'path' );
+const fs = require( 'fs' );
+const ROOT_DIRECTORY = path.join( __dirname, '..' );
+
+// When installing a repository as a dependency, the `.git` directory does not exist.
+// In such a case, husky should not attach its hooks as npm treats it as a package, not a git repository.
+if ( fs.existsSync( path.join( ROOT_DIRECTORY, '.git' ) ) ) {
+	require( 'husky' ).install();
+}


### PR DESCRIPTION
Internal: Do not attach husky hooks when installing a repository as a dependency (instead of cloning).