### PR TITLE
Cleanup after removed `ckeditor5-dev-env` and add missing exports for `web-crawler`, `transifex` and `release-tools`.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ script:
   - yarn run coverage
 after_script:
   - export END_TIME=$( date +%s )
-  - ./packages/ckeditor5-dev-tests/bin/notify-travis-status.js
+  - ./packages/ckeditor5-dev-ci/bin/notifytravisstatus.js
 after_success:
   - yarn add coveralls --ignore-workspace-root-check
   - cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js

--- a/package.json
+++ b/package.json
@@ -2,9 +2,6 @@
   "name": "ckeditor5-dev",
   "version": "31.1.13",
   "private": true,
-  "dependencies": {
-    "@ckeditor/ckeditor5-dev-env": "^31.1.13"
-  },
   "devDependencies": {
     "eslint": "^7.0.0",
     "eslint-config-ckeditor5": "^4.0.0",

--- a/packages/ckeditor5-dev-bump-year/package.json
+++ b/packages/ckeditor5-dev-bump-year/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ckeditor/ckeditor5-dev-bump-year",
-  "version": "31.1.13",
+  "version": "32.0.0",
   "description": "Used to bump year in the licence text specified at the top of the file.",
   "keywords": [],
   "main": "lib/index.js",

--- a/packages/ckeditor5-dev-ci/package.json
+++ b/packages/ckeditor5-dev-ci/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ckeditor/ckeditor5-dev-ci",
-  "version": "31.1.13",
+  "version": "32.0.0",
   "description": "Utils for CKEditor5 CI builds.",
   "keywords": [],
   "dependencies": {

--- a/packages/ckeditor5-dev-dependency-checker/package.json
+++ b/packages/ckeditor5-dev-dependency-checker/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@ckeditor/ckeditor5-dev-dependency-checker",
-  "version": "31.1.13",
+  "version": "32.0.0",
   "description": "Contains tools for validating dependencies specified in package.json.",
   "keywords": [],
   "dependencies": {
-    "@ckeditor/ckeditor5-dev-utils": "^31.1.13",
+    "@ckeditor/ckeditor5-dev-utils": "^32.0.0",
     "chalk": "^4.1.0",
     "depcheck": "^1.3.1",
     "glob": "^7.1.6",

--- a/packages/ckeditor5-dev-docs/package.json
+++ b/packages/ckeditor5-dev-docs/package.json
@@ -1,12 +1,12 @@
 {
   "name": "@ckeditor/ckeditor5-dev-docs",
-  "version": "31.1.13",
+  "version": "32.0.0",
   "description": "Tasks used to build and verify the documentation for CKEditor 5.",
   "keywords": [],
   "main": "lib/index.js",
   "dependencies": {
-    "@ckeditor/ckeditor5-dev-utils": "^31.1.13",
-    "@ckeditor/jsdoc-plugins": "^31.1.13",
+    "@ckeditor/ckeditor5-dev-utils": "^32.0.0",
+    "@ckeditor/jsdoc-plugins": "^32.0.0",
     "fast-glob": "^3.2.4",
     "fs-extra": "^9.0.0",
     "jsdoc": "ckeditor/jsdoc#fixed-trailing-comment-doclets",

--- a/packages/ckeditor5-dev-release-tools/lib/index.js
+++ b/packages/ckeditor5-dev-release-tools/lib/index.js
@@ -10,11 +10,19 @@ const bumpVersions = require( './tasks/bumpversions' );
 const generateChangelogForSinglePackage = require( './tasks/generatechangelogforsinglepackage' );
 const generateChangelogForMonoRepository = require( './tasks/generatechangelogformonorepository' );
 const updateCKEditor5Dependencies = require( './tasks/updateckeditor5dependencies' );
+const { getLastFromChangelog, getCurrent, getLastTagFromGit } = require( './utils/versions' );
+const { getChangesForVersion, getChangelog, saveChangelog } = require( './utils/changelog' );
 
 module.exports = {
 	releaseSubRepositories,
 	bumpVersions,
 	generateChangelogForSinglePackage,
 	generateChangelogForMonoRepository,
-	updateCKEditor5Dependencies
+	updateCKEditor5Dependencies,
+	getLastFromChangelog,
+	getCurrent,
+	getLastTagFromGit,
+	getChangesForVersion,
+	getChangelog,
+	saveChangelog
 };

--- a/packages/ckeditor5-dev-release-tools/lib/tasks/releasesubrepositories.js
+++ b/packages/ckeditor5-dev-release-tools/lib/tasks/releasesubrepositories.js
@@ -64,7 +64,7 @@ const additionalFiles = [
  *
  * Example usage:
  *
- *     require( '@ckeditor/ckeditor5-dev-env' )
+ *     require( '@ckeditor/ckeditor5-release-tools' )
  *         .releaseSubRepositories( {
  *		        cwd: process.cwd(),
  *		        packages: 'packages',

--- a/packages/ckeditor5-dev-release-tools/package.json
+++ b/packages/ckeditor5-dev-release-tools/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@ckeditor/ckeditor5-dev-release-tools",
-  "version": "31.1.13",
+  "version": "32.0.0",
   "description": "Tools used for releasing CKEditor 5 and related packages.",
   "keywords": [],
   "main": "lib/index.js",
   "dependencies": {
-    "@ckeditor/ckeditor5-dev-utils": "^31.1.13",
+    "@ckeditor/ckeditor5-dev-utils": "^32.0.0",
     "@octokit/rest": "^17.9.2",
     "chalk": "^4.0.0",
     "cli-table": "^0.3.1",

--- a/packages/ckeditor5-dev-tests/bin/intellijkarmarunner/bin/karma
+++ b/packages/ckeditor5-dev-tests/bin/intellijkarmarunner/bin/karma
@@ -33,4 +33,4 @@ const intellijConfig = process.argv.find( item => item.includes( 'intellij.conf.
 process.argv.push( '--karma-config-overrides=' + intellijConfig );
 
 // Now running the tests.
-require( '../../test' );
+require( '../../testautomated' );

--- a/packages/ckeditor5-dev-tests/package.json
+++ b/packages/ckeditor5-dev-tests/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@ckeditor/ckeditor5-dev-tests",
-  "version": "31.1.13",
+  "version": "32.0.0",
   "description": "Testing environment for CKEditor 5.",
   "keywords": [],
   "main": "lib/index.js",
   "dependencies": {
     "@babel/core": "^7.15.8",
-    "@ckeditor/ckeditor5-dev-utils": "^31.1.13",
-    "@ckeditor/ckeditor5-dev-translations": "^31.1.13",
+    "@ckeditor/ckeditor5-dev-utils": "^32.0.0",
+    "@ckeditor/ckeditor5-dev-translations": "^32.0.0",
     "@ckeditor/ckeditor5-inspector": "^4.0.0",
     "assertion-error": "^1.1.0",
     "babel-core": "^6.26.3",

--- a/packages/ckeditor5-dev-transifex/lib/index.js
+++ b/packages/ckeditor5-dev-transifex/lib/index.js
@@ -9,10 +9,14 @@ const createPotFiles = require( './createpotfiles' );
 const uploadPotFiles = require( './upload' );
 const downloadTranslations = require( './download' );
 const getToken = require( './gettoken' );
+const transifexService = require( './transifexservice' );
+const transifexUtils = require( './utils' );
 
 module.exports = {
 	createPotFiles,
 	uploadPotFiles,
 	downloadTranslations,
-	getToken
+	getToken,
+	transifexService,
+	transifexUtils
 };

--- a/packages/ckeditor5-dev-transifex/lib/index.js
+++ b/packages/ckeditor5-dev-transifex/lib/index.js
@@ -8,9 +8,11 @@
 const createPotFiles = require( './createpotfiles' );
 const uploadPotFiles = require( './upload' );
 const downloadTranslations = require( './download' );
+const getToken = require( './gettoken' );
 
 module.exports = {
 	createPotFiles,
 	uploadPotFiles,
-	downloadTranslations
+	downloadTranslations,
+	getToken
 };

--- a/packages/ckeditor5-dev-transifex/package.json
+++ b/packages/ckeditor5-dev-transifex/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@ckeditor/ckeditor5-dev-transifex",
-  "version": "31.1.13",
+  "version": "32.0.0",
   "description": "Used to download and upload translations using the Transifex service.",
   "keywords": [],
   "main": "lib/index.js",
   "dependencies": {
     "fs-extra": "^9.0.0",
     "del": "^5.1.0",
-    "@ckeditor/ckeditor5-dev-utils": "^31.1.13",
-    "@ckeditor/ckeditor5-dev-translations": "^31.1.13",
+    "@ckeditor/ckeditor5-dev-utils": "^32.0.0",
+    "@ckeditor/ckeditor5-dev-translations": "^32.0.0",
     "chalk": "^4.0.0",
     "inquirer": "^7.1.0",
     "@transifex/api": "^4.2.1",

--- a/packages/ckeditor5-dev-translations/package.json
+++ b/packages/ckeditor5-dev-translations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ckeditor/ckeditor5-dev-translations",
-  "version": "31.1.13",
+  "version": "32.0.0",
   "description": "CKEditor 5 translations plugin for webpack.",
   "keywords": [],
   "main": "lib/index.js",

--- a/packages/ckeditor5-dev-utils/package.json
+++ b/packages/ckeditor5-dev-utils/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@ckeditor/ckeditor5-dev-utils",
-  "version": "31.1.13",
+  "version": "32.0.0",
   "description": "Utils for CKEditor 5 development tools packages.",
   "keywords": [],
   "main": "lib/index.js",
   "dependencies": {
-    "@ckeditor/ckeditor5-dev-translations": "^31.1.13",
+    "@ckeditor/ckeditor5-dev-translations": "^32.0.0",
     "chalk": "^3.0.0",
     "cli-cursor": "^3.1.0",
     "cli-spinners": "^2.6.1",

--- a/packages/ckeditor5-dev-web-crawler/lib/index.js
+++ b/packages/ckeditor5-dev-web-crawler/lib/index.js
@@ -8,7 +8,13 @@
 /* eslint-env node */
 
 const runCrawler = require( './runcrawler' );
+const { getBaseUrl, isUrlValid, toArray } = require( './utils' );
+const { DEFAULT_CONCURRENCY } = require( './constants' );
 
 module.exports = {
-	runCrawler
+	DEFAULT_CONCURRENCY,
+	runCrawler,
+	getBaseUrl,
+	isUrlValid,
+	toArray
 };

--- a/packages/ckeditor5-dev-web-crawler/package.json
+++ b/packages/ckeditor5-dev-web-crawler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ckeditor/ckeditor5-dev-web-crawler",
-  "version": "31.1.13",
+  "version": "32.0.0",
   "description": "Used to run a web crawler that checks for errors on specified pages.",
   "keywords": [],
   "main": "lib/index.js",

--- a/packages/jsdoc-plugins/package.json
+++ b/packages/jsdoc-plugins/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ckeditor/jsdoc-plugins",
-  "version": "31.1.13",
+  "version": "32.0.0",
   "description": "Various JSDoc plugins developed by the CKEditor 5 team.",
   "keywords": [
     "jsdoc",


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Cleanup after removed `ckeditor5-dev-env` and add missing exports for `web-crawler`, `transifex` and `release-tools`.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
