### PR TITLE
Do not execute `readdirSync` if directory does not exist for running tests

### DIFF
--- a/packages/ckeditor5-dev-tests/lib/utils/transformfileoptiontotestglob.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/transformfileoptiontotestglob.js
@@ -77,6 +77,10 @@ function getExternalRepositoryGlob( pattern, { isManualTest } ) {
  * @returns {Boolean}
  */
 function doesPatternMatchExternalRepositoryName( pattern ) {
+	if ( !fs.existsSync( EXTERNAL_DIR_PATH ) ) {
+		return false;
+	}
+
 	return fs.readdirSync( EXTERNAL_DIR_PATH )
 		.filter( externalDir => fs.statSync( path.join( EXTERNAL_DIR_PATH, externalDir ) ).isDirectory() )
 		.includes( pattern );

--- a/packages/ckeditor5-dev-tests/tests/utils/transformfileoptiontotestglob.js
+++ b/packages/ckeditor5-dev-tests/tests/utils/transformfileoptiontotestglob.js
@@ -11,7 +11,7 @@ const sinon = require( 'sinon' );
 const fs = require( 'fs' );
 
 describe( 'dev-tests/utils', () => {
-	let transformFileOptionToTestGlob, sandbox, readdirSyncStub, statSyncStub;
+	let transformFileOptionToTestGlob, sandbox, readdirSyncStub, existsSyncStub, statSyncStub;
 
 	beforeEach( () => {
 		sandbox = sinon.createSandbox();
@@ -20,6 +20,7 @@ describe( 'dev-tests/utils', () => {
 		sandbox.stub( process, 'cwd' ).returns( '/workspace' );
 		statSyncStub = sandbox.stub( fs, 'statSync' ).returns( { isDirectory: () => true } );
 		readdirSyncStub = sandbox.stub( fs, 'readdirSync' ).returns( [ 'external-directory' ] );
+		existsSyncStub = sandbox.stub( fs, 'existsSync' ).returns( true );
 
 		transformFileOptionToTestGlob = require( '../../lib/utils/transformfileoptiontotestglob' );
 	} );
@@ -280,5 +281,13 @@ describe( 'dev-tests/utils', () => {
 				'/workspace/external/*/packages/ckeditor-test-external-directory/tests/manual/**/*.js'
 			] );
 		} );
+	} );
+
+	it( 'should not call readdirSync if directory does not exist', () => {
+		existsSyncStub.returns( false );
+
+		transformFileOptionToTestGlob( 'test-random-directory' );
+
+		expect( readdirSyncStub.called ).to.equal( false );
 	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Do not execute `readdirSync` if directory does not exist for running tests.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
