### PR TITLE
Error-like nodes should not crash the "tag-error" plugin

### DIFF
--- a/packages/typedoc-plugins/lib/tag-error/index.js
+++ b/packages/typedoc-plugins/lib/tag-error/index.js
@@ -32,14 +32,22 @@ function onEventEnd( context ) {
 
 		// Find all `@error` occurrences.
 		const nodes = findDescendant( sourceFile, node => {
+			// Remove non-block comment codes.
 			if ( node.kind !== ts.SyntaxKind.Identifier ) {
 				return false;
 			}
 
+			// Filter out non "error" nodes.
 			if ( node.escapedText !== ERROR_TAG_NAME ) {
 				return false;
 			}
 
+			// Remove error-like nodes, e.g. "@eventName error".
+			if ( node.parent.tagName && node.parent.tagName.escapedText !== ERROR_TAG_NAME ) {
+				return false;
+			}
+
+			// Filter out empty definitions.
 			if ( !node.parent.comment ) {
 				return false;
 			}

--- a/packages/typedoc-plugins/tests/tag-error/fixtures/events.ts
+++ b/packages/typedoc-plugins/tests/tag-error/fixtures/events.ts
@@ -1,0 +1,45 @@
+/**
+ * @license Copyright (c) 2003-2023, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/**
+ * @module fixtures/events
+ */
+
+/**
+ * @see https://github.com/ckeditor/ckeditor5/issues/13362
+ */
+
+/**
+ * Fired when error occurs.
+ *
+ * @eventName error
+ * @param error Error message.
+ */
+export type ErrorEvent = {
+	name: 'error';
+	args: [ error: string ];
+};
+
+/**
+ * Fired when error occurs.
+ *
+ * @eventName prefix-error
+ * @param error Error message.
+ */
+export type PrefixErrorEvent = {
+	name: 'error';
+	args: [ error: string ];
+};
+
+/**
+ * Fired when error occurs.
+ *
+ * @eventName error-suffix
+ * @param error Error message.
+ */
+export type ErrorSuffixEvent = {
+	name: 'error';
+	args: [ error: string ];
+};

--- a/packages/typedoc-plugins/tests/tag-error/index.js
+++ b/packages/typedoc-plugins/tests/tag-error/index.js
@@ -268,5 +268,13 @@ describe( 'typedoc-plugins/tag-error', function() {
 			expect( errorDefinition.typeParameters[ 1 ].comment.summary[ 0 ] ).to.have.property( 'kind', 'text' );
 			expect( errorDefinition.typeParameters[ 1 ].comment.summary[ 0 ] ).to.have.property( 'text', 'The priority of this error.' );
 		} );
+
+		it( 'should not crash when processing the "error" word in annotations', () => {
+			const errorModule = conversionResult.children.find( module => module.name === 'events' );
+
+			expect( errorModule.children.find( doclet => doclet.name === 'ErrorEvent' ) ).to.not.equal( undefined );
+			expect( errorModule.children.find( doclet => doclet.name === 'PrefixErrorEvent' ) ).to.not.equal( undefined );
+			expect( errorModule.children.find( doclet => doclet.name === 'ErrorSuffixEvent' ) ).to.not.equal( undefined );
+		} );
 	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix (typedoc-plugins): The `typedoc-plugin-tag-error` should not crash when processing error-like nodes, e.g., `@eventName error`. Closes ckeditor/ckeditor5#13362.
