### PR TITLE
Fixed the `tag-event` plugin that crashed when trying to parse a complex events parameters

### DIFF
--- a/packages/typedoc-plugins/lib/tag-event/index.js
+++ b/packages/typedoc-plugins/lib/tag-event/index.js
@@ -5,7 +5,7 @@
 
 'use strict';
 
-const { Converter, ReflectionKind, TypeParameterReflection, Comment, ReflectionFlag } = require( 'typedoc' );
+const { Converter, ReflectionKind, TypeParameterReflection, Comment, ReflectionFlag, IntrinsicType } = require( 'typedoc' );
 
 /**
  * The `typedoc-plugin-tag-event` collects event definitions from the `@eventName` tag and assigns them as the children of the class or
@@ -155,32 +155,72 @@ function onEventEnd( context ) {
  * @returns {Array.<require('typedoc').Reflection>}
  */
 function getArgsTuple( reflection ) {
-	const typeReflection = getTargetTypeReflection( reflection.type );
+	const typeArguments = reflection.type.typeArguments || [];
 
-	if ( !typeReflection.declaration.children ) {
-		return [];
-	}
+	// The target reflection, that defines the `args` tuple, might be located in one of two (or both) places:
+	// - in the type arguments,
+	// - in the type reflection.
+	//
+	// Let's take the type arguments first, if they exist, because if the `args` tuple is defined there, this seems more desirable.
+	const targetTypeReflections = [
+		...typeArguments.flatMap( type => getTargetTypeReflections( type ) ),
+		...getTargetTypeReflections( reflection.type )
+	];
 
-	const argsTuple = typeReflection.declaration.children.find( ref => ref.name === 'args' );
+	// Then, try to find the `args` tuple.
+	const argsTuple = targetTypeReflections
+		.filter( type => {
+			// The `args` tuple is one of the reflection child. Filter out those that don't contain any children.
+			if ( !type.declaration || !type.declaration.children ) {
+				return false;
+			}
+
+			// The reflection that contains the `args` tuple should be a type literal.
+			if ( type.declaration.kind !== ReflectionKind.TypeLiteral ) {
+				return false;
+			}
+
+			return true;
+		} )
+		.flatMap( type => type.declaration.children )
+		.find( property => property.name === 'args' );
 
 	if ( !argsTuple ) {
 		return [];
+	}
+
+	// If the `args` tuple is of a "complex" type (e.g. a conditional type) without ready-to-process elements,
+	// just consider it as any type for now.
+	if ( !argsTuple.type.elements ) {
+		return [ new IntrinsicType( 'any' ) ];
 	}
 
 	return argsTuple.type.elements;
 }
 
 /**
- * Returns the type reflection for the specified reflection. If the type reflection is a reference to another one,
- * it recursively walks deep until the final declaration is reached.
+ * Returns all type reflections for the specified reflection.
+ *
+ * If the type reflection is a reference to another one, it recursively walks deep until the final declaration is reached.
+ * If the type reflection is an intersection, all member reflections are recursively checked.
  *
  * @param {require('typedoc').Reflection} reflectionType
- * @returns {require('typedoc').Reflection}
+ * @returns {Array.<require('typedoc').Reflection>}
  */
-function getTargetTypeReflection( reflectionType ) {
-	return reflectionType.type === 'reference' ?
-		getTargetTypeReflection( reflectionType.reflection.type ) :
-		reflectionType;
+function getTargetTypeReflections( reflectionType ) {
+	if ( !reflectionType ) {
+		return [];
+	}
+
+	if ( reflectionType.type === 'reference' ) {
+		return getTargetTypeReflections( reflectionType.reflection.type );
+	}
+
+	if ( reflectionType.type === 'intersection' ) {
+		return reflectionType.types.flatMap( type => getTargetTypeReflections( type ) );
+	}
+
+	return [ reflectionType ];
 }
 
 /**

--- a/packages/typedoc-plugins/lib/tag-event/index.js
+++ b/packages/typedoc-plugins/lib/tag-event/index.js
@@ -159,7 +159,7 @@ function getArgsTuple( reflection ) {
 
 	// The target reflection, that defines the `args` tuple, might be located in one of two (or both) places:
 	// - in the type arguments,
-	// - in the type reflection.
+	// - in the type of the reflection.
 	//
 	// Let's take the type arguments first, if they exist, because if the `args` tuple is defined there, this seems more desirable.
 	const targetTypeReflections = [
@@ -172,11 +172,6 @@ function getArgsTuple( reflection ) {
 		.filter( type => {
 			// The `args` tuple is one of the reflection child. Filter out those that don't contain any children.
 			if ( !type.declaration || !type.declaration.children ) {
-				return false;
-			}
-
-			// The reflection that contains the `args` tuple should be a type literal.
-			if ( type.declaration.kind !== ReflectionKind.TypeLiteral ) {
 				return false;
 			}
 

--- a/packages/typedoc-plugins/tests/tag-event/fixtures/customexampleclass.ts
+++ b/packages/typedoc-plugins/tests/tag-event/fixtures/customexampleclass.ts
@@ -150,6 +150,58 @@ export type TypeReferenceLvl2 = TypeReferenceLvl1;
  */
 export type EventFooReference = TypeReferenceLvl2;
 
+export type TypeGenericLvl1<T> = T & {
+	name: 'Level 1';
+};
+
+export type TypeGenericLvl2<T> = TypeGenericLvl1<T> & {
+	name: 'Level 2';
+};
+
+export type TypeGenericLvl3<T> = TypeGenericLvl2<T> & {
+	name: 'Level 3';
+};
+
+/**
+ * @eventName event-foo-generic-from-type-arg
+ */
+export type EventFooGeneric = TypeGenericLvl3<{
+	args: [
+		p1: string,
+		p2: ExampleType
+	];
+}>;
+
+export type OtherTypeGenericLvl1<T> = T & {
+	name: 'Level 1';
+	args: [
+		p1: string,
+		p2: ExampleType
+	];
+};
+
+export type OtherTypeGenericLvl2<T> = OtherTypeGenericLvl1<T> & {
+	name: 'Level 2';
+};
+
+export type OtherTypeGenericLvl3<T = object> = OtherTypeGenericLvl2<T> & {
+	name: 'Level 3';
+};
+
+/**
+ * @eventName event-foo-generic-from-base-type
+ */
+export type OtherEventFooGeneric = OtherTypeGenericLvl3;
+
+/**
+ * @eventName event-foo-complex
+ */
+export type EventFooComplex<Param extends 'a' | 'b' | 'c' = 'a'> = {
+	args: Param extends 'c' ?
+		[ p1: string, p2: ExampleType ] :
+		[];
+};
+
 /**
  * An event not associated to anything in the source code.
  *

--- a/packages/typedoc-plugins/tests/tag-event/index.js
+++ b/packages/typedoc-plugins/tests/tag-event/index.js
@@ -55,7 +55,7 @@ describe( 'typedoc-plugins/tag-event', function() {
 		const eventDefinitions = conversionResult.getReflectionsByKind( TypeDoc.ReflectionKind.All )
 			.filter( children => children.kindString === 'Event' );
 
-		// There should be 6 correctly defined events:
+		// There should be the following correctly defined events:
 		// 1. event:event-foo
 		// 2. event:event-foo-no-text
 		// 3. event:event-foo-with-params
@@ -69,7 +69,10 @@ describe( 'typedoc-plugins/tag-event', function() {
 		// 11. event:event-foo-anonymous-args
 		// 12. event:event-foo-anonymous-optional-args
 		// 13. event:event-foo-reference
-		expect( eventDefinitions ).to.lengthOf( 13 );
+		// 14. event:event-foo-generic-from-type-arg
+		// 15. event:event-foo-generic-from-base-type
+		// 16. event:event-foo-complex
+		expect( eventDefinitions ).to.lengthOf( 16 );
 	} );
 
 	it( 'should inform if the class for an event has not been found', () => {
@@ -112,7 +115,7 @@ describe( 'typedoc-plugins/tag-event', function() {
 			const eventDefinitions = classDefinition.children
 				.filter( children => children.kindString === 'Event' );
 
-			expect( eventDefinitions ).to.lengthOf( 10 );
+			expect( eventDefinitions ).to.lengthOf( 13 );
 		} );
 
 		it( 'should find an event tag without description and parameters', () => {
@@ -411,6 +414,63 @@ describe( 'typedoc-plugins/tag-event', function() {
 				expect( eventDefinition.typeParameters[ 1 ].type ).to.have.property( 'element' );
 				expect( eventDefinition.typeParameters[ 1 ].type.element ).to.have.property( 'type', 'reference' );
 				expect( eventDefinition.typeParameters[ 1 ].type.element ).to.have.property( 'name', 'ExampleType' );
+			} );
+
+			it( 'should convert event parameter that came from a generic event definition (from type argument)', () => {
+				const eventDefinition = classDefinition.children.find( doclet => doclet.name === 'event:event-foo-generic-from-type-arg' );
+
+				expect( eventDefinition ).to.not.be.undefined;
+				expect( eventDefinition.typeParameters ).to.be.an( 'array' );
+				expect( eventDefinition.typeParameters ).to.lengthOf( 2 );
+
+				expect( eventDefinition.typeParameters[ 0 ] ).to.have.property( 'name', 'p1' );
+				expect( eventDefinition.typeParameters[ 0 ] ).to.have.property( 'type' );
+				expect( eventDefinition.typeParameters[ 0 ].type ).to.have.property( 'type', 'named-tuple-member' );
+				expect( eventDefinition.typeParameters[ 0 ].type ).to.have.property( 'element' );
+				expect( eventDefinition.typeParameters[ 0 ].type.element ).to.have.property( 'type', 'intrinsic' );
+				expect( eventDefinition.typeParameters[ 0 ].type.element ).to.have.property( 'name', 'string' );
+
+				expect( eventDefinition.typeParameters[ 1 ] ).to.have.property( 'name', 'p2' );
+				expect( eventDefinition.typeParameters[ 1 ] ).to.have.property( 'type' );
+				expect( eventDefinition.typeParameters[ 1 ].type ).to.have.property( 'type', 'named-tuple-member' );
+				expect( eventDefinition.typeParameters[ 1 ].type ).to.have.property( 'element' );
+				expect( eventDefinition.typeParameters[ 1 ].type.element ).to.have.property( 'type', 'reference' );
+				expect( eventDefinition.typeParameters[ 1 ].type.element ).to.have.property( 'name', 'ExampleType' );
+			} );
+
+			it( 'should convert event parameter that came from a generic event definition (from base type)', () => {
+				const eventDefinition = classDefinition.children.find( doclet => doclet.name === 'event:event-foo-generic-from-base-type' );
+
+				expect( eventDefinition ).to.not.be.undefined;
+				expect( eventDefinition.typeParameters ).to.be.an( 'array' );
+				expect( eventDefinition.typeParameters ).to.lengthOf( 2 );
+
+				expect( eventDefinition.typeParameters[ 0 ] ).to.have.property( 'name', 'p1' );
+				expect( eventDefinition.typeParameters[ 0 ] ).to.have.property( 'type' );
+				expect( eventDefinition.typeParameters[ 0 ].type ).to.have.property( 'type', 'named-tuple-member' );
+				expect( eventDefinition.typeParameters[ 0 ].type ).to.have.property( 'element' );
+				expect( eventDefinition.typeParameters[ 0 ].type.element ).to.have.property( 'type', 'intrinsic' );
+				expect( eventDefinition.typeParameters[ 0 ].type.element ).to.have.property( 'name', 'string' );
+
+				expect( eventDefinition.typeParameters[ 1 ] ).to.have.property( 'name', 'p2' );
+				expect( eventDefinition.typeParameters[ 1 ] ).to.have.property( 'type' );
+				expect( eventDefinition.typeParameters[ 1 ].type ).to.have.property( 'type', 'named-tuple-member' );
+				expect( eventDefinition.typeParameters[ 1 ].type ).to.have.property( 'element' );
+				expect( eventDefinition.typeParameters[ 1 ].type.element ).to.have.property( 'type', 'reference' );
+				expect( eventDefinition.typeParameters[ 1 ].type.element ).to.have.property( 'name', 'ExampleType' );
+			} );
+
+			it( 'should convert a complex event parameter but set its type to any', () => {
+				const eventDefinition = classDefinition.children.find( doclet => doclet.name === 'event:event-foo-complex' );
+
+				expect( eventDefinition ).to.not.be.undefined;
+				expect( eventDefinition.typeParameters ).to.be.an( 'array' );
+				expect( eventDefinition.typeParameters ).to.lengthOf( 1 );
+
+				expect( eventDefinition.typeParameters[ 0 ] ).to.have.property( 'name', '<anonymous>' );
+				expect( eventDefinition.typeParameters[ 0 ] ).to.have.property( 'type' );
+				expect( eventDefinition.typeParameters[ 0 ].type ).to.have.property( 'type', 'intrinsic' );
+				expect( eventDefinition.typeParameters[ 0 ].type ).to.have.property( 'name', 'any' );
 			} );
 		} );
 	} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix (typedoc-plugins): Fixed the `tag-event` plugin that crashed when trying to parse event parameters, which are passed as type arguments. Closes ckeditor/ckeditor5#13376.

---

### Additional information

It seems that the API docs that previously caused the crash are now generated correctly.

---

![from type arg](https://user-images.githubusercontent.com/56868128/216565436-4c7f0bd7-d8e3-4a94-8da3-16d8c5e12e8d.png)

---

![complex event arg](https://user-images.githubusercontent.com/56868128/216565462-27d1a1d0-040b-4b00-9a1e-329c3486305e.png)
