### PR TITLE
Disabled Chrome backgrounding optimizations in Karma config for automated tests

### DIFF
--- a/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getkarmaconfig.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getkarmaconfig.js
@@ -104,11 +104,11 @@ module.exports = function getKarmaConfig( options ) {
 		customLaunchers: {
 			CHROME_TRAVIS_CI: {
 				base: 'Chrome',
-				flags: [ '--no-sandbox', '--disable-background-timer-throttling', '--js-flags="--expose-gc"' ]
+				flags: getFlagsForBrowser( 'CHROME_TRAVIS_CI' )
 			},
 			CHROME_LOCAL: {
 				base: 'Chrome',
-				flags: [ '--disable-background-timer-throttling', '--js-flags="--expose-gc"', '--remote-debugging-port=9222' ]
+				flags: getFlagsForBrowser( 'CHROME_LOCAL' )
 			}
 		},
 
@@ -209,4 +209,29 @@ function getBrowsers( options ) {
 
 		return process.env.TRAVIS ? 'CHROME_TRAVIS_CI' : 'CHROME_LOCAL';
 	} );
+}
+
+// Returns the array of configuration flags for given browser.
+//
+// @param {String} browser
+// @returns {Array.<String>}
+function getFlagsForBrowser( browser ) {
+	const commonFlags = [
+		'--disable-background-timer-throttling',
+		'--js-flags="--expose-gc"',
+		'--disable-renderer-backgrounding',
+		'--disable-backgrounding-occluded-windows'
+	];
+
+	if ( browser === 'CHROME_TRAVIS_CI' ) {
+		return [
+			...commonFlags,
+			'--no-sandbox'
+		];
+	}
+
+	return [
+		...commonFlags,
+		'--remote-debugging-port=9222'
+	];
 }

--- a/packages/ckeditor5-dev-tests/tests/utils/automated-tests/getkarmaconfig.js
+++ b/packages/ckeditor5-dev-tests/tests/utils/automated-tests/getkarmaconfig.js
@@ -182,4 +182,39 @@ describe( 'getKarmaConfig()', () => {
 		expect( loaders ).to.not.contain( 'babel-loader' );
 		expect( loaders ).to.contain( 'other-loader' );
 	} );
+
+	it( 'should return custom launchers with flags', () => {
+		const options = {
+			reporter: 'mocha',
+			globPatterns: {
+				'*': 'workspace/packages/ckeditor5-*/tests/**/*.js'
+			}
+		};
+
+		const karmaConfig = getKarmaConfig( options );
+
+		expect( karmaConfig ).to.have.own.property( 'customLaunchers' );
+		expect( karmaConfig.customLaunchers ).to.have.own.property( 'CHROME_TRAVIS_CI' );
+		expect( karmaConfig.customLaunchers ).to.have.own.property( 'CHROME_LOCAL' );
+
+		expect( karmaConfig.customLaunchers.CHROME_TRAVIS_CI ).to.have.own.property( 'base', 'Chrome' );
+		expect( karmaConfig.customLaunchers.CHROME_TRAVIS_CI ).to.have.own.property( 'flags' );
+		expect( karmaConfig.customLaunchers.CHROME_TRAVIS_CI.flags ).to.deep.equal( [
+			'--disable-background-timer-throttling',
+			'--js-flags="--expose-gc"',
+			'--disable-renderer-backgrounding',
+			'--disable-backgrounding-occluded-windows',
+			'--no-sandbox'
+		] );
+
+		expect( karmaConfig.customLaunchers.CHROME_LOCAL ).to.have.own.property( 'base', 'Chrome' );
+		expect( karmaConfig.customLaunchers.CHROME_LOCAL ).to.have.own.property( 'flags' );
+		expect( karmaConfig.customLaunchers.CHROME_LOCAL.flags ).to.deep.equal( [
+			'--disable-background-timer-throttling',
+			'--js-flags="--expose-gc"',
+			'--disable-renderer-backgrounding',
+			'--disable-backgrounding-occluded-windows',
+			'--remote-debugging-port=9222'
+		] );
+	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix (tests): Disabled Chrome backgrounding optimizations in Karma config for automated tests to make the tests run in a stable environment that does not depend on the state of the browser window (focus vs. blur). Closes ckeditor/ckeditor5#13407.