### PR TITLE
Swapped order of ts-loader and ck-debug-loader

### DIFF
--- a/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getwebpackconfig.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getwebpackconfig.js
@@ -87,12 +87,6 @@ module.exports = function getWebpackConfigForAutomatedTests( options ) {
 					test: /\.ts$/,
 					use: [
 						{
-							loader: require.resolve( '../ck-debug-loader' ),
-							options: {
-								debugFlags: options.debug
-							}
-						},
-						{
 							loader: 'ts-loader',
 							options: {
 								// Override default settings specified in `tsconfig.json`.
@@ -107,6 +101,12 @@ module.exports = function getWebpackConfigForAutomatedTests( options ) {
 									// In such a case we would like to throw an error.
 									noEmitOnError: true
 								}
+							}
+						},
+						{
+							loader: require.resolve( '../ck-debug-loader' ),
+							options: {
+								debugFlags: options.debug
 							}
 						}
 					]

--- a/packages/ckeditor5-dev-tests/lib/utils/manual-tests/getwebpackconfig.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/manual-tests/getwebpackconfig.js
@@ -109,12 +109,6 @@ module.exports = function getWebpackConfigForManualTests( options ) {
 					test: /\.ts$/,
 					use: [
 						{
-							loader: require.resolve( '../ck-debug-loader' ),
-							options: {
-								debugFlags: options.debug
-							}
-						},
-						{
 							loader: 'ts-loader',
 							options: {
 								// Override default settings specified in `tsconfig.json`.
@@ -128,6 +122,12 @@ module.exports = function getWebpackConfigForManualTests( options ) {
 									// Disabling the `noEmitOnError` option fixes the problem.
 									noEmitOnError: false
 								}
+							}
+						},
+						{
+							loader: require.resolve( '../ck-debug-loader' ),
+							options: {
+								debugFlags: options.debug
 							}
 						}
 					]

--- a/packages/ckeditor5-dev-tests/tests/utils/manual-tests/getwebpackconfig.js
+++ b/packages/ckeditor5-dev-tests/tests/utils/manual-tests/getwebpackconfig.js
@@ -53,6 +53,7 @@ describe( 'getWebpackConfigForManualTests()', () => {
 
 	it( 'should process TypeScript files properly', () => {
 		const webpackConfig = getWebpackConfigForManualTests( {} );
+
 		const tsRule = webpackConfig.module.rules.find( rule => {
 			return rule.test.toString().endsWith( '/\\.ts$/' );
 		} );
@@ -61,14 +62,49 @@ describe( 'getWebpackConfigForManualTests()', () => {
 			throw new Error( 'A loader for ".ts" files was not found.' );
 		}
 
-		expect( tsRule.use[ 0 ].loader.endsWith( 'ck-debug-loader.js' ) ).to.be.true;
-		expect( tsRule.use[ 1 ] ).to.be.an( 'object' );
-		expect( tsRule.use[ 1 ] ).to.have.property( 'loader', 'ts-loader' );
-		expect( tsRule.use[ 1 ] ).to.have.property( 'options' );
-		expect( tsRule.use[ 1 ].options ).to.have.property( 'compilerOptions' );
-		expect( tsRule.use[ 1 ].options.compilerOptions ).to.deep.equal( {
+		const ckDebugLoader = tsRule.use.find( item => item.loader.endsWith( 'ck-debug-loader.js' ) );
+		const tsLoader = tsRule.use.find( item => item.loader === 'ts-loader' );
+
+		if ( !ckDebugLoader ) {
+			throw new Error( '"ck-debug-loader" missing' );
+		}
+
+		if ( !tsLoader ) {
+			throw new Error( '"ts-loader" missing' );
+		}
+
+		expect( tsLoader ).to.have.property( 'options' );
+		expect( tsLoader.options ).to.have.property( 'compilerOptions' );
+		expect( tsLoader.options.compilerOptions ).to.deep.equal( {
 			noEmit: false,
 			noEmitOnError: false
 		} );
+	} );
+
+	it( 'should use "ck-debug-loader" before "ts-loader" while loading TS files', () => {
+		const webpackConfig = getWebpackConfigForManualTests( {} );
+
+		const tsRule = webpackConfig.module.rules.find( rule => {
+			return rule.test.toString().endsWith( '/\\.ts$/' );
+		} );
+
+		if ( !tsRule ) {
+			throw new Error( 'A loader for ".ts" files was not found.' );
+		}
+
+		const ckDebugLoaderIndex = tsRule.use.findIndex( item => item.loader.endsWith( 'ck-debug-loader.js' ) );
+		const tsLoaderIndex = tsRule.use.findIndex( item => item.loader === 'ts-loader' );
+
+		if ( ckDebugLoaderIndex === undefined ) {
+			throw new Error( '"ck-debug-loader" missing' );
+		}
+
+		if ( tsLoaderIndex === undefined ) {
+			throw new Error( '"ts-loader" missing' );
+		}
+
+		// Webpack reads the "use" array from back to the front.
+		expect( ckDebugLoaderIndex ).to.equal( 1 );
+		expect( tsLoaderIndex ).to.equal( 0 );
 	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix (tests): Swapped an order of loaders when processing the TypeScript files. The `ck-debug-loader` is executed before `ts-loader` to avoid the removal of `CK_DEBUG_*` comments from the source code. See ckeditor/ckeditor5#13381.

MAJOR BREAKING CHANGE (tests): The code specified in the `CK_DEBUG_*` flags must be valid TypeScript code as it is processed before `ts-loader`.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
