### PR TITLE
Fixed coverage with ck-debug flags

### DIFF
--- a/packages/ckeditor5-dev-tests/tests/utils/automated-tests/getwebpackconfig.js
+++ b/packages/ckeditor5-dev-tests/tests/utils/automated-tests/getwebpackconfig.js
@@ -63,22 +63,41 @@ describe( 'getWebpackConfigForAutomatedTests()', () => {
 			files: [ '**/*.js' ]
 		} );
 
-		const coverageLoader = webpackConfig.module.rules
-			.find( rule => rule.loader === 'babel-loader' );
+		const coverageLoader = webpackConfig.module.rules[ 0 ];
 
-		expect( coverageLoader ).to.deep.equal( {
-			test: /\.[jt]s$/,
-			loader: 'babel-loader',
-			include: [],
-			exclude: [
-				new RegExp( `${ escapedPathSep }(lib)${ escapedPathSep }` )
-			],
-			options: {
-				plugins: [
-					'babel-plugin-istanbul'
-				]
-			}
+		expect( coverageLoader ).to.not.equal( undefined );
+		expect( '/path/to/javascript.js' ).to.match( coverageLoader.test );
+		expect( '/path/to/typescript.ts' ).to.match( coverageLoader.test );
+
+		expect( coverageLoader.include ).to.be.an( 'array' );
+		expect( coverageLoader.include ).to.lengthOf( 0 );
+		expect( coverageLoader.exclude ).to.be.an( 'array' );
+		expect( coverageLoader.exclude ).to.lengthOf( 1 );
+
+		expect( coverageLoader.use ).to.be.an( 'array' );
+		expect( coverageLoader.use ).to.lengthOf.above( 1 );
+
+		const babelLoader = coverageLoader.use[ 0 ];
+
+		expect( babelLoader.loader ).to.equal( 'babel-loader' );
+	} );
+
+	it( 'should include the ck-debug-loader when checking the coverage', () => {
+		const webpackConfig = getWebpackConfigForAutomatedTests( {
+			coverage: true,
+			files: [ '**/*.js' ]
 		} );
+
+		const coverageLoader = webpackConfig.module.rules[ 0 ];
+
+		expect( coverageLoader ).to.not.equal( undefined );
+
+		expect( coverageLoader.use ).to.be.an( 'array' );
+		expect( coverageLoader.use ).to.lengthOf( 2 );
+
+		const ckDebugLoader = coverageLoader.use[ 1 ];
+
+		expect( ckDebugLoader.loader ).to.contain( 'ck-debug-loader' );
 	} );
 
 	it( 'should return webpack configuration containing a loader for measuring the coverage (include check)', () => {
@@ -91,9 +110,11 @@ describe( 'getWebpackConfigForAutomatedTests()', () => {
 			]
 		} );
 
-		const coverageLoader = webpackConfig.module.rules
-			.find( rule => rule.loader === 'babel-loader' );
+		const coverageLoader = webpackConfig.module.rules[ 0 ];
 
+		expect( coverageLoader ).to.not.equal( undefined );
+
+		expect( coverageLoader.include ).to.be.an( 'array' );
 		expect( coverageLoader.include ).to.deep.equal( [
 			new RegExp( [ 'ckeditor5-utils', 'src', '' ].join( escapedPathSep ) )
 		] );
@@ -109,9 +130,11 @@ describe( 'getWebpackConfigForAutomatedTests()', () => {
 			]
 		} );
 
-		const coverageLoader = webpackConfig.module.rules
-			.find( rule => rule.loader === 'babel-loader' );
+		const coverageLoader = webpackConfig.module.rules[ 0 ];
 
+		expect( coverageLoader ).to.not.equal( undefined );
+
+		expect( coverageLoader.include ).to.be.an( 'array' );
 		expect( coverageLoader.include ).to.deep.equal( [
 			new RegExp( [ 'ckeditor5-!(utils)', 'src', '' ].join( escapedPathSep ) )
 		] );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix (tests): The `ck-debug-loader` should not be included in TypeScript files to avoid the "Unable to lookup source" error when checking the coverage. Instead, `babel-loader` should handle the `CK_DEBUG` flags. Closes ckeditor/ckeditor5#13529.
