### PR TITLE
Release tools support defining npm tag

### DIFF
--- a/packages/ckeditor5-dev-release-tools/lib/utils/cli.js
+++ b/packages/ckeditor5-dev-release-tools/lib/utils/cli.js
@@ -314,6 +314,31 @@ const cli = {
 						return options;
 					} );
 			} );
+	},
+
+	/**
+	 * Asks a user for a confirmation for updating and tagging versions of the packages.
+	 *
+	 * @param {String} versionTag A version tag based on a package version specified in `package.json`.
+	 * @param {String} npmTag A tag typed by the user when using the release tools.
+	 * @returns {Promise.<Boolean>}
+	 */
+	confirmNpmTag( versionTag, npmTag ) {
+		const areVersionsEqual = versionTag === npmTag;
+		const color = areVersionsEqual ? chalk.magenta : chalk.red;
+
+		// eslint-disable-next-line max-len
+		const message = `The next release bumps the "${ color( versionTag ) }" version. Should it be published to npm as "${ color( npmTag ) }"?`;
+
+		const confirmQuestion = {
+			message,
+			type: 'confirm',
+			name: 'confirm',
+			default: areVersionsEqual
+		};
+
+		return inquirer.prompt( [ confirmQuestion ] )
+			.then( answers => answers.confirm );
 	}
 };
 

--- a/packages/ckeditor5-dev-release-tools/tests/utils/cli.js
+++ b/packages/ckeditor5-dev-release-tools/tests/utils/cli.js
@@ -10,13 +10,23 @@ const sinon = require( 'sinon' );
 const mockery = require( 'mockery' );
 
 describe( 'dev-release-tools/utils', () => {
-	let cli, sandbox, questionItems, userAnswer;
+	let cli, sandbox, questionItems, userAnswer, stub;
 
 	describe( 'cli', () => {
 		beforeEach( () => {
 			userAnswer = undefined;
 			sandbox = sinon.createSandbox();
 			questionItems = [];
+
+			stub = {
+				chalk: {
+					red: sandbox.stub().callsFake( str => str ),
+					magenta: sandbox.stub().callsFake( str => str ),
+					cyan: sandbox.stub().callsFake( str => str ),
+					underline: sandbox.stub().callsFake( str => str ),
+					gray: sandbox.stub().callsFake( str => str )
+				}
+			};
 
 			mockery.enable( {
 				useCleanCache: true,
@@ -35,6 +45,8 @@ describe( 'dev-release-tools/utils', () => {
 					} );
 				}
 			} );
+
+			mockery.registerMock( 'chalk', stub.chalk );
 
 			cli = require( '../../lib/utils/cli' );
 		} );
@@ -426,6 +438,36 @@ describe( 'dev-release-tools/utils', () => {
 							npm: true,
 							github: false
 						} );
+					} );
+			} );
+		} );
+
+		describe( 'confirmNpmTag()', () => {
+			it( 'should ask user if continue the release process when passing the same versions', () => {
+				return cli.confirmNpmTag( 'latest', 'latest' )
+					.then( () => {
+						const question = questionItems[ 0 ];
+
+						expect( question.message ).to.equal(
+							'The next release bumps the "latest" version. Should it be published to npm as "latest"?'
+						);
+						expect( question.type ).to.equal( 'confirm' );
+						expect( question.default ).to.equal( true );
+						expect( stub.chalk.magenta.callCount ).to.equal( 2 );
+					} );
+			} );
+
+			it( 'should ask user if continue the release process when passing different versions', () => {
+				return cli.confirmNpmTag( 'latest', 'alpha' )
+					.then( () => {
+						const question = questionItems[ 0 ];
+
+						expect( question.message ).to.equal(
+							'The next release bumps the "latest" version. Should it be published to npm as "alpha"?'
+						);
+						expect( question.type ).to.equal( 'confirm' );
+						expect( question.default ).to.equal( false );
+						expect( stub.chalk.red.callCount ).to.equal( 2 );
 					} );
 			} );
 		} );

--- a/packages/ckeditor5-dev-release-tools/tests/utils/cli.js
+++ b/packages/ckeditor5-dev-release-tools/tests/utils/cli.js
@@ -52,8 +52,9 @@ describe( 'dev-release-tools/utils', () => {
 		} );
 
 		afterEach( () => {
-			sandbox.restore();
+			mockery.deregisterAll();
 			mockery.disable();
+			sandbox.restore();
 		} );
 
 		describe( 'INDENT_SIZE', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature (release-tools): Added a new option for the `releaseSubRepositories()` task that specifies the npm tag used when publishing packages to npm. Closes ckeditor/ckeditor5#13533.