### PR TITLE
When publishing packages, adds the types field to pkg.json

### DIFF
--- a/packages/ckeditor5-dev-release-tools/lib/tasks/releasesubrepositories.js
+++ b/packages/ckeditor5-dev-release-tools/lib/tasks/releasesubrepositories.js
@@ -745,7 +745,7 @@ module.exports = async function releaseSubRepositories( options ) {
 						if ( fs.existsSync( absoluteTypesPath ) ) {
 							jsonFile.types = typesPath;
 						} else {
-							log.warning( `The "${ typesPath }" file does not exist and cannot be a source of typings.` );
+							log.warning( `⚠️  The "${ typesPath }" file does not exist and cannot be a source of typings.` );
 						}
 					}
 

--- a/packages/ckeditor5-dev-release-tools/lib/tasks/releasesubrepositories.js
+++ b/packages/ckeditor5-dev-release-tools/lib/tasks/releasesubrepositories.js
@@ -727,10 +727,17 @@ module.exports = async function releaseSubRepositories( options ) {
 			// For this reason we have to temporarily replace the extension in the `main` field while the package is being published to npm.
 			// This change is then reverted.
 			const hasTypeScriptEntryPoint = packageJson.main && packageJson.main.endsWith( '.ts' );
+			const hasTypesProperty = !!packageJson.types;
 
 			if ( hasTypeScriptEntryPoint ) {
 				tools.updateJSONFile( packageJsonPath, jsonFile => {
-					jsonFile.main = jsonFile.main.replace( '.ts', '.js' );
+					const { main } = jsonFile;
+
+					jsonFile.main = main.replace( /\.ts$/, '.js' );
+
+					if ( !hasTypesProperty ) {
+						jsonFile.types = main.replace( /\.ts$/, '.d.ts' );
+					}
 
 					return jsonFile;
 				} );
@@ -756,7 +763,11 @@ module.exports = async function releaseSubRepositories( options ) {
 			// again to the `index.ts` file.
 			if ( hasTypeScriptEntryPoint ) {
 				tools.updateJSONFile( packageJsonPath, jsonFile => {
-					jsonFile.main = jsonFile.main.replace( '.js', '.ts' );
+					jsonFile.main = jsonFile.main.replace( /\.js$/, '.ts' );
+
+					if ( !hasTypesProperty ) {
+						delete jsonFile.types;
+					}
 
 					return jsonFile;
 				} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature (release-tools): The `releaseSubrepositories()` task adds the `types` field (if not specified) to `package.json` while publishing packages based on the `main` field if a package is written in TypeScript. Closes ckeditor/ckeditor5#13518.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
