### PR TITLE
Allow specifying `tsconfig` path in automated tests

### DIFF
--- a/packages/ckeditor5-dev-tests/lib/tasks/runmanualtests.js
+++ b/packages/ckeditor5-dev-tests/lib/tasks/runmanualtests.js
@@ -34,6 +34,7 @@ const requireDll = require( '../utils/requiredll' );
  * @param {Array.<String>} [options.additionalLanguages] Additional languages passed to `CKEditorTranslationsPlugin`.
  * @param {Number} [options.port] A port number used by the `createManualTestServer`.
  * @param {String} [options.identityFile] A file that provides secret keys used in the test scripts.
+ * @param {String} [options.tsconfig] Path the TypeScript configuration file.
  * @param {Boolean|null} [options.dll=null] If `null`, user is asked to create DLL builds, if they are required by test files.
  * If `true`, DLL builds are created automatically, if required by test files. User is not asked.
  * If `false`, DLL builds are not created. User is not asked.
@@ -83,6 +84,7 @@ module.exports = function runManualTests( options ) {
 				language,
 				additionalLanguages,
 				debug: options.debug,
+				tsconfig: options.tsconfig,
 				identityFile: options.identityFile,
 				onTestCompilationStatus,
 				disableWatch

--- a/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getwebpackconfig.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getwebpackconfig.js
@@ -89,6 +89,9 @@ module.exports = function getWebpackConfigForAutomatedTests( options ) {
 						{
 							loader: 'ts-loader',
 							options: {
+								// Use tsconfig path specified in CLI arguments. If not present, fallback to 'tsconfig.json' which
+								// is the default value https://github.com/TypeStrong/ts-loader#configfile.
+								configFile: options.tsconfig || 'tsconfig.json',
 								// Override default settings specified in `tsconfig.json`.
 								compilerOptions: {
 									// Do not emit any JS file as these TypeScript files are just passed through webpack.

--- a/packages/ckeditor5-dev-tests/lib/utils/automated-tests/parsearguments.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/automated-tests/parsearguments.js
@@ -27,7 +27,8 @@ module.exports = function parseArguments( args ) {
 			'language',
 			'theme-path',
 			'additional-languages',
-			'identity-file'
+			'identity-file',
+			'tsconfig'
 		],
 
 		boolean: [
@@ -67,6 +68,7 @@ module.exports = function parseArguments( args ) {
 			server: false,
 			production: false,
 			'identity-file': null,
+			tsconfig: null,
 			repositories: [],
 			'theme-path': null,
 			'additional-languages': null,
@@ -101,6 +103,7 @@ module.exports = function parseArguments( args ) {
 	] );
 	parseDebugOption( options );
 	parseRepositoriesOption( options );
+	parseTsconfigPath( options );
 
 	return options;
 
@@ -192,6 +195,19 @@ module.exports = function parseArguments( args ) {
 				collection.add( directory.replace( /^ckeditor5-/, '' ) );
 			}
 		}
+	}
+
+	/**
+	 * Parses the `--tsconfig` options to be an absolute path.
+	 *
+	 * @param {Object} options
+	 */
+	function parseTsconfigPath( options ) {
+		if ( !options.tsconfig ) {
+			return;
+		}
+
+		options.tsconfig = path.resolve( process.cwd(), options.tsconfig );
 	}
 
 	/**

--- a/packages/ckeditor5-dev-tests/lib/utils/manual-tests/compilescripts.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/manual-tests/compilescripts.js
@@ -20,6 +20,7 @@ const requireDll = require( '../requiredll' );
  * @param {Boolean} options.disableWatch Whether to disable the watch mechanism. If set to true, changes in source files
  * will not trigger webpack.
  * @param {Function} options.onTestCompilationStatus A callback called whenever the script compilation occurrs.
+ * @param {String} [options.tsconfig] Path the TypeScript configuration file.
  * @param {Array.<String>} [options.additionalLanguages] Additional languages passed to `CKEditorTranslationsPlugin`.
  * @param {String} [options.identityFile] A file that provides secret keys used in the test scripts.
  * @returns {Promise}
@@ -36,6 +37,7 @@ module.exports = function compileManualTestScripts( options ) {
 		language: options.language,
 		additionalLanguages: options.additionalLanguages,
 		debug: options.debug,
+		tsconfig: options.tsconfig,
 		identityFile: options.identityFile,
 		disableWatch: options.disableWatch,
 		onTestCompilationStatus: options.onTestCompilationStatus

--- a/packages/ckeditor5-dev-tests/lib/utils/manual-tests/getwebpackconfig.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/manual-tests/getwebpackconfig.js
@@ -111,6 +111,9 @@ module.exports = function getWebpackConfigForManualTests( options ) {
 						{
 							loader: 'ts-loader',
 							options: {
+								// Use tsconfig path specified in CLI arguments. If not present, fallback to 'tsconfig.json' which
+								// is the default value https://github.com/TypeStrong/ts-loader#configfile.
+								configFile: options.tsconfig || 'tsconfig.json',
 								// Override default settings specified in `tsconfig.json`.
 								compilerOptions: {
 									// Do not emit any JS file as these TypeScript files are just passed through webpack.

--- a/packages/ckeditor5-dev-tests/lib/utils/manual-tests/getwebpackconfig.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/manual-tests/getwebpackconfig.js
@@ -20,6 +20,7 @@ const getDefinitionsFromFile = require( '../getdefinitionsfromfile' );
  * @param {String} options.buildDir
  * @param {String} options.themePath
  * @param {Boolean} options.disableWatch
+ * @param {String} [options.tsconfig]
  * @param {String} [options.language]
  * @param {Array.<String>} [options.additionalLanguages]
  * @param {String|null} [options.identityFile]

--- a/packages/ckeditor5-dev-tests/tests/tasks/runmanualtests.js
+++ b/packages/ckeditor5-dev-tests/tests/tasks/runmanualtests.js
@@ -213,6 +213,7 @@ describe( 'runManualTests', () => {
 					],
 					themePath: null,
 					language: undefined,
+					tsconfig: undefined,
 					onTestCompilationStatus: sinon.match.func,
 					additionalLanguages: undefined,
 					debug: undefined,
@@ -277,6 +278,7 @@ describe( 'runManualTests', () => {
 					],
 					themePath: 'path/to/theme',
 					language: undefined,
+					tsconfig: undefined,
 					onTestCompilationStatus: sinon.match.func,
 					additionalLanguages: undefined,
 					debug: [ 'CK_DEBUG' ],
@@ -344,6 +346,7 @@ describe( 'runManualTests', () => {
 					additionalLanguages: [ 'ar', 'en' ],
 					debug: [ 'CK_DEBUG' ],
 					disableWatch: false,
+					tsconfig: undefined,
 					identityFile: undefined
 				} );
 
@@ -400,6 +403,7 @@ describe( 'runManualTests', () => {
 					],
 					themePath: null,
 					language: undefined,
+					tsconfig: undefined,
 					onTestCompilationStatus: sinon.match.func,
 					debug: undefined,
 					additionalLanguages: undefined,
@@ -437,6 +441,7 @@ describe( 'runManualTests', () => {
 					],
 					themePath: null,
 					language: undefined,
+					tsconfig: undefined,
 					onTestCompilationStatus: sinon.match.func,
 					debug: undefined,
 					additionalLanguages: undefined,
@@ -490,6 +495,7 @@ describe( 'runManualTests', () => {
 					],
 					themePath: null,
 					language: undefined,
+					tsconfig: undefined,
 					onTestCompilationStatus: sinon.match.func,
 					additionalLanguages: undefined,
 					debug: undefined,
@@ -542,6 +548,7 @@ describe( 'runManualTests', () => {
 					],
 					themePath: null,
 					language: undefined,
+					tsconfig: undefined,
 					onTestCompilationStatus: sinon.match.func,
 					additionalLanguages: undefined,
 					debug: undefined,
@@ -591,6 +598,7 @@ describe( 'runManualTests', () => {
 					],
 					themePath: null,
 					language: undefined,
+					tsconfig: undefined,
 					onTestCompilationStatus: sinon.match.func,
 					additionalLanguages: undefined,
 					debug: undefined,
@@ -1144,6 +1152,7 @@ describe( 'runManualTests', () => {
 						],
 						themePath: null,
 						language: undefined,
+						tsconfig: undefined,
 						onTestCompilationStatus: sinon.match.func,
 						additionalLanguages: undefined,
 						debug: undefined,
@@ -1200,6 +1209,44 @@ describe( 'runManualTests', () => {
 							stdio: 'inherit'
 						}
 					);
+				} );
+		} );
+
+		it( 'allows specifying tsconfig file', () => {
+			spies.transformFileOptionToTestGlob.onFirstCall().returns( [ 'workspace/packages/ckeditor5-*/tests/**/manual/**/*.js' ] );
+			spies.transformFileOptionToTestGlob.onSecondCall().returns( [ 'workspace/packages/ckeditor-*/tests/**/manual/**/*.js' ] );
+
+			const options = {
+				files: [
+					'ckeditor5-classic',
+					'ckeditor-classic/manual/classic.js'
+				],
+				tsconfig: '/absolute/path/to/tsconfig.json'
+			};
+
+			return runManualTests( { ...defaultOptions, ...options } )
+				.then( () => {
+					expect( spies.server.calledOnce ).to.equal( true );
+					expect( spies.server.firstCall.args[ 0 ] ).to.equal( 'workspace/build/.manual-tests' );
+
+					sinon.assert.calledWith( spies.scriptCompiler.firstCall, {
+						cwd: 'workspace',
+						buildDir: 'workspace/build/.manual-tests',
+						sourceFiles: [
+							'workspace/packages/ckeditor5-foo/tests/manual/feature-a.js',
+							'workspace/packages/ckeditor5-bar/tests/manual/feature-b.js',
+							'workspace/packages/ckeditor-foo/tests/manual/feature-c.js',
+							'workspace/packages/ckeditor-bar/tests/manual/feature-d.js'
+						],
+						themePath: null,
+						language: undefined,
+						onTestCompilationStatus: sinon.match.func,
+						debug: undefined,
+						additionalLanguages: undefined,
+						disableWatch: false,
+						tsconfig: '/absolute/path/to/tsconfig.json',
+						identityFile: undefined
+					} );
 				} );
 		} );
 	} );

--- a/packages/ckeditor5-dev-tests/tests/utils/automated-tests/getwebpackconfig.js
+++ b/packages/ckeditor5-dev-tests/tests/utils/automated-tests/getwebpackconfig.js
@@ -184,7 +184,9 @@ describe( 'getWebpackConfigForAutomatedTests()', () => {
 	} );
 
 	it( 'should process TypeScript files properly', () => {
-		const webpackConfig = getWebpackConfigForAutomatedTests( {} );
+		const webpackConfig = getWebpackConfigForAutomatedTests( {
+			tsconfig: '/home/project/configs/tsconfig.json'
+		} );
 
 		const tsRule = webpackConfig.module.rules.find( rule => {
 			return rule.test.toString().endsWith( '/\\.ts$/' );
@@ -211,6 +213,8 @@ describe( 'getWebpackConfigForAutomatedTests()', () => {
 			noEmit: false,
 			noEmitOnError: true
 		} );
+		expect( tsLoader.options ).to.have.property( 'configFile' );
+		expect( tsLoader.options.configFile ).to.equal( '/home/project/configs/tsconfig.json' );
 	} );
 
 	it( 'should use "ck-debug-loader" before "ts-loader" while loading TS files', () => {

--- a/packages/ckeditor5-dev-tests/tests/utils/automated-tests/parsearguments.js
+++ b/packages/ckeditor5-dev-tests/tests/utils/automated-tests/parsearguments.js
@@ -319,4 +319,19 @@ describe( 'parseArguments()', () => {
 			expect( options.dll ).to.be.false;
 		} );
 	} );
+
+	describe( 'tsconfig', () => {
+		it( 'should set default value if no `--tsconfig` flag is set', () => {
+			const options = parseArguments( [] );
+
+			expect( options.tsconfig ).to.equal( null );
+		} );
+
+		it( 'should parse `--tsconfig` to absolute path if it is set', () => {
+			stubs.cwd.returns( '/home/project' );
+			const options = parseArguments( [ '--tsconfig', './configs/tsconfig.json' ] );
+
+			expect( options.tsconfig ).to.be.equal( '/home/project/configs/tsconfig.json' );
+		} );
+	} );
 } );

--- a/packages/ckeditor5-dev-tests/tests/utils/manual-tests/compilescripts.js
+++ b/packages/ckeditor5-dev-tests/tests/utils/manual-tests/compilescripts.js
@@ -79,7 +79,8 @@ describe( 'compileManualTestScripts', () => {
 			},
 			debug: [ 'CK_DEBUG' ],
 			disableWatch: false,
-			identityFile: undefined
+			identityFile: undefined,
+			tsconfig: undefined
 		} );
 
 		expect( stubs.webpack.calledOnce ).to.equal( true );
@@ -124,7 +125,8 @@ describe( 'compileManualTestScripts', () => {
 			},
 			debug: [ 'CK_DEBUG' ],
 			disableWatch: false,
-			identityFile: undefined
+			identityFile: undefined,
+			tsconfig: undefined
 		} );
 
 		expect( stubs.webpack.calledOnce ).to.equal( true );
@@ -168,7 +170,8 @@ describe( 'compileManualTestScripts', () => {
 			},
 			debug: [ 'CK_DEBUG' ],
 			disableWatch: false,
-			identityFile: undefined
+			identityFile: undefined,
+			tsconfig: undefined
 		} );
 
 		sinon.assert.calledWith( stubs.getWebpackConfig.secondCall, {
@@ -184,7 +187,8 @@ describe( 'compileManualTestScripts', () => {
 			},
 			debug: [ 'CK_DEBUG' ],
 			disableWatch: false,
-			identityFile: undefined
+			identityFile: undefined,
+			tsconfig: undefined
 		} );
 
 		expect( stubs.webpack.calledTwice ).to.equal( true );
@@ -216,7 +220,8 @@ describe( 'compileManualTestScripts', () => {
 			themePath: 'path/to/theme',
 			language: null,
 			onTestCompilationStatus: stubs.onTestCompilationStatus,
-			additionalLanguages: null
+			additionalLanguages: null,
+			tsconfig: undefined
 		} );
 
 		expect( stubs.getWebpackConfig.calledOnce ).to.equal( true );
@@ -304,7 +309,8 @@ describe( 'compileManualTestScripts', () => {
 			},
 			debug: [ 'CK_DEBUG' ],
 			identityFile,
-			disableWatch: false
+			disableWatch: false,
+			tsconfig: undefined
 		} );
 
 		expect( stubs.webpack.calledOnce ).to.equal( true );
@@ -347,7 +353,51 @@ describe( 'compileManualTestScripts', () => {
 			},
 			debug: [ 'CK_DEBUG' ],
 			identityFile: undefined,
-			disableWatch: true
+			disableWatch: true,
+			tsconfig: undefined
+		} );
+
+		expect( stubs.webpack.calledOnce ).to.equal( true );
+		expect( stubs.webpack.firstCall.args[ 0 ] ).to.deep.equal( {
+			buildDir: 'buildDir',
+			entries: {
+				'ckeditor5-foo/manual/file1': 'ckeditor5-foo/manual/file1.js'
+			}
+		} );
+	} );
+
+	it( 'should pass the "tsconfig" option to webpack configuration factory', async () => {
+		await compileManualTestScripts( {
+			cwd: 'workspace',
+			buildDir: 'buildDir',
+			sourceFiles: [
+				'ckeditor5-foo/manual/file1.js'
+			],
+			themePath: 'path/to/theme',
+			language: 'en',
+			onTestCompilationStatus: stubs.onTestCompilationStatus,
+			additionalLanguages: [ 'pl', 'ar' ],
+			debug: [ 'CK_DEBUG' ],
+			tsconfig: '/absolute/path/to/tsconfig.json'
+		} );
+
+		expect( stubs.getWebpackConfig.calledOnce ).to.equal( true );
+
+		sinon.assert.calledWith( stubs.getWebpackConfig.firstCall, {
+			cwd: 'workspace',
+			requireDll: false,
+			buildDir: 'buildDir',
+			themePath: 'path/to/theme',
+			language: 'en',
+			onTestCompilationStatus: stubs.onTestCompilationStatus,
+			additionalLanguages: [ 'pl', 'ar' ],
+			entries: {
+				'ckeditor5-foo/manual/file1': 'ckeditor5-foo/manual/file1.js'
+			},
+			debug: [ 'CK_DEBUG' ],
+			identityFile: undefined,
+			disableWatch: undefined,
+			tsconfig: '/absolute/path/to/tsconfig.json'
 		} );
 
 		expect( stubs.webpack.calledOnce ).to.equal( true );

--- a/packages/ckeditor5-dev-tests/tests/utils/manual-tests/getwebpackconfig.js
+++ b/packages/ckeditor5-dev-tests/tests/utils/manual-tests/getwebpackconfig.js
@@ -52,7 +52,9 @@ describe( 'getWebpackConfigForManualTests()', () => {
 	} );
 
 	it( 'should process TypeScript files properly', () => {
-		const webpackConfig = getWebpackConfigForManualTests( {} );
+		const webpackConfig = getWebpackConfigForManualTests( {
+			tsconfig: '/home/project/configs/tsconfig.json'
+		} );
 
 		const tsRule = webpackConfig.module.rules.find( rule => {
 			return rule.test.toString().endsWith( '/\\.ts$/' );
@@ -79,6 +81,8 @@ describe( 'getWebpackConfigForManualTests()', () => {
 			noEmit: false,
 			noEmitOnError: false
 		} );
+		expect( tsLoader.options ).to.have.property( 'configFile' );
+		expect( tsLoader.options.configFile ).to.equal( '/home/project/configs/tsconfig.json' );
 	} );
 
 	it( 'should use "ck-debug-loader" before "ts-loader" while loading TS files', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other (tests): Allow specifying the `tsconfig` option in automated and manual tests. The path is resolved using the current working directory). If not specified, it will be resolved to default values that the `ts-config` resolves.
