### PR TITLE
Update servetranslations.js

### DIFF
--- a/packages/ckeditor5-dev-translations/lib/servetranslations.js
+++ b/packages/ckeditor5-dev-translations/lib/servetranslations.js
@@ -31,6 +31,9 @@ const { RawSource, ConcatSource } = require( 'webpack-sources' );
 module.exports = function serveTranslations( compiler, options, translationService ) {
 	const cwd = process.cwd();
 
+	// A set of unique messages that prevents message duplications.
+	const uniqueMessages = new Set();
+
 	// Provides translateSource function for the `translatesourceloader` loader.
 	const translateSource = ( source, sourceFile ) => translationService.translateSource( source, sourceFile );
 
@@ -141,8 +144,7 @@ module.exports = function serveTranslations( compiler, options, translationServi
 		} );
 	} );
 
-	// A set of unique messages that prevents message duplications.
-	const uniqueMessages = new Set();
+
 
 	function emitError( error ) {
 		if ( uniqueMessages.has( error ) ) {

--- a/packages/ckeditor5-dev-translations/lib/servetranslations.js
+++ b/packages/ckeditor5-dev-translations/lib/servetranslations.js
@@ -144,8 +144,6 @@ module.exports = function serveTranslations( compiler, options, translationServi
 		} );
 	} );
 
-
-
 	function emitError( error ) {
 		if ( uniqueMessages.has( error ) ) {
 			return;


### PR DESCRIPTION
Fix (translations): The `serveTranslations()` function should not throw an instance of `ReferenceError` due to missing access to a collection when emitting an error when processing translations. Closes ckeditor/ckeditor5#8450.