### PR TITLE
Disabled the "@label" validator

### DIFF
--- a/packages/ckeditor5-dev-docs/lib/build.js
+++ b/packages/ckeditor5-dev-docs/lib/build.js
@@ -61,4 +61,12 @@ module.exports = async function build( config ) {
  * @property {String} [outputPath] A path to the place where extracted doclets will be saved. Is an optional value due to tests.
  *
  * @property {String} [extraPlugins=[]] An array of path to extra plugins that will be added to Typedoc.
+ *
+ * @property {TypedocValidator} [validatorOptions={}] An optional configuration object for validator.
+ */
+
+/**
+ * @typedef {Object} TypedocValidator
+ *
+ * @property {Boolean} [enableOverloadValidator=false] If set to `true`, the overloads validator will be enabled.
  */

--- a/packages/ckeditor5-dev-docs/lib/buildtypedoc.js
+++ b/packages/ckeditor5-dev-docs/lib/buildtypedoc.js
@@ -19,6 +19,7 @@ module.exports = async function build( config ) {
 	const sourceFilePatterns = config.sourceFiles.filter( Boolean );
 	const strictMode = config.strict || false;
 	const extraPlugins = config.extraPlugins || [];
+	const validatorOptions = config.validatorOptions || {};
 
 	const files = await glob( sourceFilePatterns );
 	const typeDoc = new TypeDoc.Application();
@@ -75,7 +76,7 @@ module.exports = async function build( config ) {
 		throw 'Something went wrong with TypeDoc.';
 	}
 
-	const validationResult = validators.validate( conversionResult, typeDoc );
+	const validationResult = validators.validate( conversionResult, typeDoc, validatorOptions );
 
 	if ( !validationResult && strictMode ) {
 		throw 'Something went wrong with TypeDoc.';

--- a/packages/ckeditor5-dev-docs/lib/validators/index.js
+++ b/packages/ckeditor5-dev-docs/lib/validators/index.js
@@ -8,8 +8,8 @@
 const seeValidator = require( './see-validator' );
 const linkValidator = require( './link-validator' );
 const firesValidator = require( './fires-validator' );
-const overloadsValidator = require( './overloads-validator' );
 const moduleValidator = require( './module-validator' );
+const overloadsValidator = require( './overloads-validator' );
 const { getNode } = require( './utils' );
 
 /**
@@ -17,17 +17,21 @@ const { getNode } = require( './utils' );
  *
  * @param {Object} project Generated output from TypeDoc to validate.
  * @param {Object} typeDoc A TypeDoc application instance.
+ * @param {TypedocValidator} [options={}] A configuration object.
  * @returns {Boolean}
  */
 module.exports = {
-	validate( project, typeDoc ) {
+	validate( project, typeDoc, options = {} ) {
 		const validators = [
 			seeValidator,
 			linkValidator,
 			firesValidator,
-			overloadsValidator,
 			moduleValidator
 		];
+
+		if ( options.enableOverloadValidator ) {
+			validators.push( overloadsValidator );
+		}
 
 		typeDoc.logger.info( 'Starting validation...' );
 

--- a/packages/ckeditor5-dev-docs/lib/validators/overloads-validator/index.js
+++ b/packages/ckeditor5-dev-docs/lib/validators/overloads-validator/index.js
@@ -8,6 +8,9 @@
 const { ReflectionKind } = require( 'typedoc' );
 const { isReflectionValid } = require( '../utils' );
 
+// The `@label` validator is currently not used.
+// See: https://github.com/ckeditor/ckeditor5/issues/13591.
+
 /**
  * Validates the output produced by TypeDoc.
  *

--- a/packages/ckeditor5-dev-docs/tests/validators/overloads-validator/index.js
+++ b/packages/ckeditor5-dev-docs/tests/validators/overloads-validator/index.js
@@ -36,7 +36,10 @@ describe( 'dev-docs/validators/overloads-validator', function() {
 			cwd: FIXTURES_PATH,
 			tsconfig: TSCONFIG_PATH,
 			sourceFiles: [ SOURCE_FILES ],
-			strict: false
+			strict: false,
+			validatorOptions: {
+				enableOverloadValidator: true
+			}
 		} );
 
 		logStub.restore();


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other (docs): By default, the `@label` (overloads) validator is disabled when building docs from TypeScript. It can be enabled by passing the `validatorOptions: { enableOverloadValidator: true }` object as the configuration for the build task. Closes ckeditor/ckeditor5#13591.
