### PR TITLE
Typedoc-plugins is now dependency free

### DIFF
--- a/packages/typedoc-plugins/lib/module-fixer/index.js
+++ b/packages/typedoc-plugins/lib/module-fixer/index.js
@@ -5,8 +5,7 @@
 
 'use strict';
 
-const { Converter, ReflectionKind } = require( 'typedoc' );
-const ts = require( 'typescript' );
+const { Converter, ReflectionKind, TypeScript } = require( 'typedoc' );
 
 /**
  * The `typedoc-plugin-module-fixer` reads the module name specified in the `@module` tag name.
@@ -51,7 +50,7 @@ function onEventCreateDeclaration() {
 			for ( const jsDoc of statement.jsDoc ) {
 				// ...that represents a module definition.
 				const [ moduleTag ] = ( jsDoc.tags || [] ).filter( tag => {
-					return tag.tagName.originalKeywordKind === ts.SyntaxKind.ModuleKeyword;
+					return tag.tagName.originalKeywordKind === TypeScript.SyntaxKind.ModuleKeyword;
 				} );
 
 				if ( !moduleTag ) {

--- a/packages/typedoc-plugins/lib/purge-private-api-docs/index.js
+++ b/packages/typedoc-plugins/lib/purge-private-api-docs/index.js
@@ -5,8 +5,7 @@
 
 'use strict';
 
-const { Converter, ReflectionKind } = require( 'typedoc' );
-const ts = require( 'typescript' );
+const { Converter, ReflectionKind, TypeScript } = require( 'typedoc' );
 const path = require( 'path' );
 const fs = require( 'fs' );
 
@@ -179,7 +178,7 @@ function isPublicApi( node ) {
 			}
 
 			return jsDoc.tags.some( tag => {
-				if ( tag.tagName.kind !== ts.SyntaxKind.Identifier ) {
+				if ( tag.tagName.kind !== TypeScript.SyntaxKind.Identifier ) {
 					return false;
 				}
 

--- a/packages/typedoc-plugins/lib/symbol-fixer/index.js
+++ b/packages/typedoc-plugins/lib/symbol-fixer/index.js
@@ -5,7 +5,6 @@
 
 'use strict';
 
-const chalk = require( 'chalk' );
 const { Converter } = require( 'typedoc' );
 
 /**
@@ -27,18 +26,15 @@ function onEventCreateDeclaration() {
 		}
 
 		const symbolName = reflection.name.slice( 1, -1 );
-		const isKnownSymbol = Symbol[ symbolName ];
 
-		if ( !isKnownSymbol ) {
+		if ( Symbol[ symbolName ] ) {
+			reflection.name = `Symbol.${ symbolName }`;
+		} else {
 			const symbol = context.project.getSymbolFromReflection( reflection );
 			const node = symbol.declarations[ 0 ];
 
-			context.logger.warn( `Non-symbol wrapped in square brackets: ${ chalk.bold( reflection.name ) }`, node );
-
-			return;
+			context.logger.warn( 'Non-symbol wrapped in square brackets', node );
 		}
-
-		reflection.name = `Symbol.${ symbolName }`;
 	};
 }
 

--- a/packages/typedoc-plugins/lib/tag-error/index.js
+++ b/packages/typedoc-plugins/lib/tag-error/index.js
@@ -5,8 +5,7 @@
 
 'use strict';
 
-const { Converter, ReflectionKind, Comment, TypeParameterReflection } = require( 'typedoc' );
-const ts = require( 'typescript' );
+const { Converter, ReflectionKind, Comment, TypeParameterReflection, TypeScript } = require( 'typedoc' );
 
 const ERROR_TAG_NAME = 'error';
 
@@ -33,7 +32,7 @@ function onEventEnd( context ) {
 		// Find all `@error` occurrences.
 		const nodes = findDescendant( sourceFile, node => {
 			// Remove non-block comment codes.
-			if ( node.kind !== ts.SyntaxKind.Identifier ) {
+			if ( node.kind !== TypeScript.SyntaxKind.Identifier ) {
 				return false;
 			}
 
@@ -97,9 +96,9 @@ function onEventEnd( context ) {
 }
 
 /**
- * @param {ts.Node} sourceFileOrNode
- * @param { ( node: ts.Node) : boolean} callback
- * @returns {Array.<ts.Node>}
+ * @param {TypeScript.Node} sourceFileOrNode
+ * @param { ( node: TypeScript.Node ) : boolean} callback
+ * @returns {Array.<TypeScript.Node>}
  */
 function findDescendant( sourceFileOrNode, callback ) {
 	const output = [];
@@ -141,7 +140,7 @@ function getCommentDisplayPart( commentChildrenOrValue ) {
 			let { text } = item;
 
 			// An inline tag inside a description.
-			if ( item.kind === ts.SyntaxKind.JSDocLink ) {
+			if ( item.kind === TypeScript.SyntaxKind.JSDocLink ) {
 				// A reference, e.g. "module:".
 				if ( item.name ) {
 					text = item.name.escapedText + text;

--- a/packages/typedoc-plugins/lib/tag-observable/index.js
+++ b/packages/typedoc-plugins/lib/tag-observable/index.js
@@ -5,8 +5,7 @@
 
 'use strict';
 
-const { Converter, ReflectionKind, TypeParameterReflection, Comment } = require( 'typedoc' );
-const ts = require( 'typescript' );
+const { Converter, ReflectionKind, TypeParameterReflection, Comment, TypeScript } = require( 'typedoc' );
 
 /**
  * The `typedoc-plugin-tag-observable` handles the `@observable` tag that is assigned to the class property. If found, two new events are
@@ -54,7 +53,7 @@ function onEventEnd( context ) {
 			const nameParameter = typeParameterFactory( context, {
 				name: 'name',
 				parent: eventReflection,
-				kind: ts.SyntaxKind.StringKeyword,
+				kind: TypeScript.SyntaxKind.StringKeyword,
 				comment: `Name of the changed property (\`${ propertyName }\`).`
 			} );
 

--- a/packages/typedoc-plugins/package.json
+++ b/packages/typedoc-plugins/package.json
@@ -3,13 +3,13 @@
   "version": "34.1.3",
   "description": "Various TypeDoc plugins developed by the CKEditor 5 team.",
   "keywords": [],
-  "dependencies": {
-    "typedoc": "^0.23.15",
-    "typescript": "^4.6.4"
-  },
   "devDependencies": {
     "chai": "^4.2.0",
     "fast-glob": "^3.2.4"
+  },
+  "peerDependencies": {
+    "typedoc": "^0.23.15",
+    "typescript": "^4.8.4"
   },
   "engines": {
     "node": ">=14.0.0",

--- a/packages/typedoc-plugins/package.json
+++ b/packages/typedoc-plugins/package.json
@@ -4,7 +4,6 @@
   "description": "Various TypeDoc plugins developed by the CKEditor 5 team.",
   "keywords": [],
   "dependencies": {
-    "chalk": "^4.0.0",
     "typedoc": "^0.23.15",
     "typescript": "^4.6.4"
   },

--- a/packages/typedoc-plugins/package.json
+++ b/packages/typedoc-plugins/package.json
@@ -8,8 +8,7 @@
     "fast-glob": "^3.2.4"
   },
   "peerDependencies": {
-    "typedoc": "^0.23.15",
-    "typescript": "^4.8.4"
+    "typedoc": "^0.23.15"
   },
   "engines": {
     "node": ">=14.0.0",

--- a/packages/typedoc-plugins/tests/symbol-fixer/index.js
+++ b/packages/typedoc-plugins/tests/symbol-fixer/index.js
@@ -61,7 +61,7 @@ describe( 'typedoc-plugins/symbol-fixer', function() {
 		expect( warning ).to.be.a( 'string' );
 
 		// Verify a message reported once find an invalid symbol.
-		expect( warning ).to.contain( 'Non-symbol wrapped in square brackets:' );
+		expect( warning ).to.contain( 'Non-symbol wrapped in square brackets' );
 
 		// Verify whether logger shows an invalid piece of the code.
 		expect( warning ).to.contain( 'public [ Symbol.fake ](): Iterable<any> {' );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other (typedoc-plugins): The package does not require any dependencies to prevent an integrator from using a specific version of `typedoc`. Instead, the integrator must install the `typedoc` package when using the `@ckeditor/typedoc-plugins` package. Closes ckeditor/ckeditor5#13511.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
