### PR TITLE
Building docs when processing a non-es6 module

### DIFF
--- a/packages/ckeditor5-dev-docs/lib/validators/module-validator/index.js
+++ b/packages/ckeditor5-dev-docs/lib/validators/module-validator/index.js
@@ -8,6 +8,8 @@
 const { ReflectionKind } = require( 'typedoc' );
 const { utils } = require( '@ckeditor/typedoc-plugins' );
 
+const AUGMENTATION_MODULE_REGEXP = /[^\\/]+[\\/]src[\\/]augmentation/;
+
 /**
  * Validates the output produced by TypeDoc.
  *
@@ -20,6 +22,11 @@ module.exports = function validate( project, onError ) {
 	const reflections = project.getReflectionsByKind( ReflectionKind.Module );
 
 	for ( const reflection of reflections ) {
+		// The augmentation module does not contain the `@module` annotation. We need to skip it.
+		if ( reflection.name.match( AUGMENTATION_MODULE_REGEXP ) ) {
+			continue;
+		}
+
 		const [ packageName, ...moduleName ] = reflection.name.split( '/' );
 
 		// If there is no module name after the package name, skip it.

--- a/packages/ckeditor5-dev-docs/lib/validators/module-validator/index.js
+++ b/packages/ckeditor5-dev-docs/lib/validators/module-validator/index.js
@@ -27,7 +27,14 @@ module.exports = function validate( project, onError ) {
 			continue;
 		}
 
-		const filePath = utils.getNode( reflection ).fileName;
+		const node = utils.getNode( reflection );
+
+		// Not a ES6 module.
+		if ( !node ) {
+			continue;
+		}
+
+		const filePath = node.fileName;
 
 		if ( filePath.endsWith( 'src/augmentation.ts' ) ) {
 			continue;

--- a/packages/ckeditor5-dev-docs/tests/validators/module-validator/fixtures/ckeditor5-example/src/augmentation.ts
+++ b/packages/ckeditor5-dev-docs/tests/validators/module-validator/fixtures/ckeditor5-example/src/augmentation.ts
@@ -1,0 +1,7 @@
+/**
+ * @license Copyright (c) 2003-2023, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+declare module 'non-existing-module' {
+}

--- a/packages/ckeditor5-dev-docs/tests/validators/module-validator/fixtures/ckeditor5-utils/src/augmentation.ts
+++ b/packages/ckeditor5-dev-docs/tests/validators/module-validator/fixtures/ckeditor5-utils/src/augmentation.ts
@@ -1,0 +1,7 @@
+/**
+ * @license Copyright (c) 2003-2023, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+declare module 'non-existing-module' {
+}

--- a/packages/ckeditor5-dev-docs/tests/validators/module-validator/fixtures/tsconfig.json
+++ b/packages/ckeditor5-dev-docs/tests/validators/module-validator/fixtures/tsconfig.json
@@ -1,3 +1,6 @@
 {
-  "extends": "../../../tsconfig.json"
+  "extends": "../../../tsconfig.json",
+  "include": [
+    "./ckeditor5-*/**/*.ts"
+  ]
 }

--- a/packages/ckeditor5-dev-docs/tests/validators/module-validator/fixtures/tsconfig.json
+++ b/packages/ckeditor5-dev-docs/tests/validators/module-validator/fixtures/tsconfig.json
@@ -1,6 +1,3 @@
 {
-  "extends": "../../../tsconfig.json",
-  "include": [
-    "./ckeditor5-*/**/*.ts"
-  ]
+  "extends": "../../../tsconfig.json"
 }

--- a/packages/typedoc-plugins/lib/module-fixer/index.js
+++ b/packages/typedoc-plugins/lib/module-fixer/index.js
@@ -38,6 +38,11 @@ function onEventCreateDeclaration() {
 
 		const node = symbol.declarations[ 0 ];
 
+		// Not a module.
+		if ( !node.statements ) {
+			return;
+		}
+
 		// Iterate over statements...
 		for ( const statement of node.statements ) {
 			// TODO: No idea how to cover this line.

--- a/packages/typedoc-plugins/lib/purge-private-api-docs/index.js
+++ b/packages/typedoc-plugins/lib/purge-private-api-docs/index.js
@@ -29,15 +29,18 @@ module.exports = {
 function onEventEnd() {
 	return context => {
 		const moduleReflections = context.project.getReflectionsByKind( ReflectionKind.Module )
-			.filter( reflection => isPrivatePackageFile( reflection.sources[ 0 ].fullFileName ) );
+			.filter( reflection => {
+				// Not a module.
+				if ( !reflection.sources ) {
+					return false;
+				}
+
+				const [ { fullFileName } ] = reflection.sources;
+				return isPrivatePackageFile( fullFileName );
+			} );
 
 		for ( const reflection of moduleReflections ) {
 			const symbol = context.project.getSymbolFromReflection( reflection );
-
-			// When processing an empty file.
-			if ( !symbol ) {
-				return;
-			}
 
 			const node = symbol.declarations[ 0 ];
 

--- a/packages/typedoc-plugins/lib/tag-error/index.js
+++ b/packages/typedoc-plugins/lib/tag-error/index.js
@@ -26,6 +26,12 @@ function onEventEnd( context ) {
 	// Errors are children of a module.
 	for ( const reflection of moduleReflections ) {
 		const symbol = context.project.getSymbolFromReflection( reflection );
+
+		// Not ES6 module.
+		if ( !symbol ) {
+			continue;
+		}
+
 		const node = symbol.declarations[ 0 ];
 		const sourceFile = node.getSourceFile();
 

--- a/packages/typedoc-plugins/lib/utils/index.js
+++ b/packages/typedoc-plugins/lib/utils/index.js
@@ -116,7 +116,7 @@ function getLongNameParts( reflection ) {
  * Returns the TypeScript node from the reflection.
  *
  * @param {require('typedoc').Reflection} reflection A reflection for which we want to get its TypeScript node.
- * @returns {Object}
+ * @returns {Object|null}
  */
 function getNode( reflection ) {
 	let symbol = reflection.project.getSymbolFromReflection( reflection );
@@ -127,6 +127,11 @@ function getNode( reflection ) {
 		// symbol from its parent, which contains all nodes for each signature.
 		symbol = reflection.project.getSymbolFromReflection( reflection.parent );
 		declarationIndex = reflection.parent.signatures ? reflection.parent.signatures.indexOf( reflection ) : 0;
+	}
+
+	// Not a ES6 module.
+	if ( !symbol ) {
+		return null;
 	}
 
 	return symbol.declarations[ declarationIndex ];

--- a/packages/typedoc-plugins/tests/module-fixer/fixtures/not-valid-module.ts
+++ b/packages/typedoc-plugins/tests/module-fixer/fixtures/not-valid-module.ts
@@ -1,0 +1,6 @@
+/**
+ * @license Copyright (c) 2003-2023, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+module.exports = {};

--- a/packages/typedoc-plugins/tests/purge-private-api-docs/fixtures/private-package/src/not-valid-module.ts
+++ b/packages/typedoc-plugins/tests/purge-private-api-docs/fixtures/private-package/src/not-valid-module.ts
@@ -1,0 +1,6 @@
+/**
+ * @license Copyright (c) 2003-2023, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+module.exports = {};

--- a/packages/typedoc-plugins/tests/tag-error/fixtures/not-valid-module.ts
+++ b/packages/typedoc-plugins/tests/tag-error/fixtures/not-valid-module.ts
@@ -1,0 +1,6 @@
+/**
+ * @license Copyright (c) 2003-2023, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+module.exports = {};


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix (typedoc-plugins): The building documentation process should not crash when processing a non-es6 module file while building from the TypeScript sources. Closes ckeditor/ckeditor5#13662.

Fix (docs): The validator should not crash when processing a non-es6 module file while building from the TypeScript sources. Closes ckeditor/ckeditor5#13662.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
