### PR TITLE
Puppeteer version bump

### DIFF
--- a/packages/ckeditor5-dev-web-crawler/package.json
+++ b/packages/ckeditor5-dev-web-crawler/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "chalk": "^4.1.0",
     "ora": "^5.2.0",
-    "puppeteer": "^13.1.3",
+    "puppeteer": "^19.7.5",
     "strip-ansi": "^6.0.0"
   },
   "engines": {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other (web-crawler): Upgraded Puppeteer to the latest version to avoid the deprecation warning when using the `@ckeditor/ckeditor5-dev-web-crawler` package. Closes ckeditor/ckeditor5#13631.

---

### Additional information

Crawler did its job properly and warning during `yarn install` is gone: [travis#598213237](https://app.travis-ci.com/github/ckeditor/ckeditor5/jobs/598213237)
