### PR TITLE
Improvements for inheriting events

### DIFF
--- a/packages/typedoc-plugins/lib/tag-observable/index.js
+++ b/packages/typedoc-plugins/lib/tag-observable/index.js
@@ -11,8 +11,6 @@ const { Converter, ReflectionKind, TypeParameterReflection, Comment, TypeScript 
  * The `typedoc-plugin-tag-observable` handles the `@observable` tag that is assigned to the class property. If found, two new events are
  * created and inserted as a class children: `change:{property}` and `set:{property}`, where `{property}` is the name of the observable
  * class property.
- *
- * TODO: We do not support collecting types of `@param` tags associated with the `@observable`.
  */
 module.exports = {
 	load( app ) {
@@ -82,6 +80,10 @@ function onEventEnd( context ) {
 						'(before the `change` event is fired).'
 				}
 			] );
+
+			if ( reflection.inheritedFrom ) {
+				eventReflection.inheritedFrom = reflection.inheritedFrom;
+			}
 
 			// Copy the source location as it is the same as the location of the reflection containing the event.
 			eventReflection.sources = [ ...reflection.sources ];

--- a/packages/typedoc-plugins/tests/event-inheritance-fixer/fixtures/class-foo.ts
+++ b/packages/typedoc-plugins/tests/event-inheritance-fixer/fixtures/class-foo.ts
@@ -1,0 +1,18 @@
+/**
+ * @license Copyright (c) 2003-2023, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/**
+ * @module fixtures/class-foo
+ */
+
+export class ClassFoo {}
+
+/**
+ * @eventName ~ClassFoo#property
+ */
+export type EventProperty = {
+	name: string;
+	args: [];
+};

--- a/packages/typedoc-plugins/tests/event-inheritance-fixer/fixtures/class-mixin-foo.ts
+++ b/packages/typedoc-plugins/tests/event-inheritance-fixer/fixtures/class-mixin-foo.ts
@@ -1,0 +1,14 @@
+/**
+ * @license Copyright (c) 2003-2023, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+import Mixin from './mixin';
+import { ClassFoo } from './class-foo';
+
+/**
+ * @module fixtures/class-mixin-foo
+ */
+
+export class ClassMixinFoo extends Mixin( ClassFoo ) {
+}

--- a/packages/typedoc-plugins/tests/event-inheritance-fixer/fixtures/class-mixin-foobar.ts
+++ b/packages/typedoc-plugins/tests/event-inheritance-fixer/fixtures/class-mixin-foobar.ts
@@ -1,0 +1,13 @@
+/**
+ * @license Copyright (c) 2003-2023, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+import { ClassMixinFoo } from './class-mixin-foo';
+
+/**
+ * @module fixtures/class-mixin-foobar
+ */
+
+export class ClassMixinFooBar extends ClassMixinFoo {
+}

--- a/packages/typedoc-plugins/tests/event-inheritance-fixer/fixtures/mixin.ts
+++ b/packages/typedoc-plugins/tests/event-inheritance-fixer/fixtures/mixin.ts
@@ -1,0 +1,28 @@
+/**
+ * @license Copyright (c) 2003-2023, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/**
+ * @module fixtures/mixin
+ */
+
+// Simplified CKEditor 5 source for testing purposes only.
+
+export type Mixed<Base extends Constructor, Mixin extends object> = {
+	new ( ...args: ConstructorParameters<Base> ): InstanceType<Base> & Mixin;
+	prototype: InstanceType<Base> & Mixin;
+} & {
+	[ K in keyof Base ]: Base[ K ];
+};
+
+export type Constructor<Instance = object> = abstract new ( ...args: Array<any> ) => Instance;
+
+export default function Mixin<Base extends Constructor>( base: Base ): Mixed<Base, object>;
+
+export default function Mixin( base: Constructor ): unknown {
+	abstract class Mixin extends base {
+	}
+
+	return Mixin;
+}

--- a/packages/typedoc-plugins/tests/tag-observable/index.js
+++ b/packages/typedoc-plugins/tests/tag-observable/index.js
@@ -182,5 +182,27 @@ describe( 'typedoc-plugins/tag-observable', function() {
 				expect( eventDefinition.sources[ 0 ] ).to.have.property( 'url' );
 			} );
 		}
+
+		it( 'should define the `inheritedFrom` property for an inherited observable property (change:${ property })', () => {
+			const eventDefinitions = derivedClassDefinition.children.filter( children => children.kindString === 'Event' );
+
+			const changeKeyEvent = eventDefinitions.find( event => event.name === 'event:change:key' );
+
+			expect( changeKeyEvent ).to.not.be.undefined;
+			expect( changeKeyEvent ).to.have.property( 'inheritedFrom' );
+
+			expect( changeKeyEvent.inheritedFrom.reflection.parent ).to.equal( baseClassDefinition );
+		} );
+
+		it( 'should define the `inheritedFrom` property for an inherited observable property (set:${ property })', () => {
+			const eventDefinitions = derivedClassDefinition.children.filter( children => children.kindString === 'Event' );
+
+			const setKeyEvent = eventDefinitions.find( event => event.name === 'event:set:key' );
+
+			expect( setKeyEvent ).to.not.be.undefined;
+			expect( setKeyEvent ).to.have.property( 'inheritedFrom' );
+
+			expect( setKeyEvent.inheritedFrom.reflection.parent ).to.equal( baseClassDefinition );
+		} );
 	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix (typedoc-plugins): Improved inheriting (`typedoc-plugin-event-inheritance-fixer`) events from classes extending other classes using the mixin pattern. Closes ckeditor/ckeditor5#13739.

Fix (typedoc-plugins): Inherited observable properties (`typedoc-plugin-tag-observable`) will define the `inheritedFrom` property when an observable property is inherited. See ckeditor/ckeditor5#13739.