### PR TITLE
Added buffer to webpack globals

### DIFF
--- a/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getwebpackconfig.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getwebpackconfig.js
@@ -28,6 +28,7 @@ module.exports = function getWebpackConfigForAutomatedTests( options ) {
 		plugins: [
 			new webpack.DefinePlugin( definitions ),
 			new webpack.ProvidePlugin( {
+				Buffer: [ 'buffer', 'Buffer' ],
 				process: 'process/browser'
 			} )
 		],

--- a/packages/ckeditor5-dev-tests/lib/utils/manual-tests/getwebpackconfig.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/manual-tests/getwebpackconfig.js
@@ -55,6 +55,7 @@ module.exports = function getWebpackConfigForManualTests( options ) {
 			} ),
 			new webpack.DefinePlugin( definitions ),
 			new webpack.ProvidePlugin( {
+				Buffer: [ 'buffer', 'Buffer' ],
 				process: 'process/browser'
 			} )
 		],

--- a/packages/ckeditor5-dev-tests/package.json
+++ b/packages/ckeditor5-dev-tests/package.json
@@ -11,6 +11,7 @@
     "@ckeditor/ckeditor5-inspector": "^4.0.0",
     "assertion-error": "^1.1.0",
     "babel-plugin-istanbul": "^6.1.0",
+    "buffer": "^6.0.3",
     "chai": "^4.2.0",
     "chalk": "^4.0.0",
     "chokidar": "^3.4.0",


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix (tests): Fixed the reference error `Buffer is not defined`. Read more: webpack/changelog-v5#10.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
