### PR TITLE
Bumped slack-notify, fixed timestamp

### DIFF
--- a/packages/ckeditor5-dev-ci/lib/notifytravisstatus.js
+++ b/packages/ckeditor5-dev-ci/lib/notifytravisstatus.js
@@ -37,7 +37,6 @@ module.exports = async function notifyTravisStatus( options ) {
 	const commitDetails = await getCommitDetails( commitUrl, options.githubToken );
 
 	const [ buildRepoOwner, buildRepoName ] = options.repositorySlug.split( '/' );
-	const execTime = getExecutionTime( options.endTime, options.startTime );
 
 	const slackAccount = members[ commitDetails.author ];
 	const shortCommit = commitUrl.split( '/' ).pop().substring( 0, 7 );
@@ -82,7 +81,7 @@ module.exports = async function notifyTravisStatus( options ) {
 					},
 					{
 						title: 'Build time',
-						value: `${ execTime.mins } min ${ execTime.secs } sec`,
+						value: getExecutionTime( options.endTime, options.startTime ),
 						short: true
 					},
 					{
@@ -97,23 +96,34 @@ module.exports = async function notifyTravisStatus( options ) {
 };
 
 /**
- * Returns an object that compares two dates.
+ * Returns string representing amount of time passed between two timestamps.
  *
  * @param {Number} endTime
  * @param {Number} startTime
- * @returns {Object}
+ * @returns {String}
  */
 function getExecutionTime( endTime, startTime ) {
-	const execTime = {
-		ms: endTime - startTime
-	};
+	const totalMs = ( endTime - startTime ) * 1000;
+	const date = new Date( totalMs );
+	const hours = date.getUTCHours();
+	const minutes = date.getUTCMinutes();
+	const seconds = date.getUTCSeconds();
 
-	execTime.days = Math.floor( execTime.ms / 86400 );
-	execTime.hours = Math.floor( ( execTime.ms - 86400 * execTime.days ) / 3600 );
-	execTime.mins = Math.floor( ( ( execTime.ms - 86400 * execTime.days ) - 3600 * execTime.hours ) / 60 );
-	execTime.secs = ( ( execTime.ms - 86400 * execTime.days ) - 3600 * execTime.hours ) - 60 * execTime.mins;
+	const stringParts = [];
 
-	return execTime;
+	if ( hours ) {
+		stringParts.push( `${ hours } hr.` );
+	}
+
+	if ( minutes ) {
+		stringParts.push( `${ minutes } min.` );
+	}
+
+	if ( seconds ) {
+		stringParts.push( `${ seconds } sec.` );
+	}
+
+	return stringParts.join( ' ' );
 }
 
 /**

--- a/packages/ckeditor5-dev-ci/lib/notifytravisstatus.js
+++ b/packages/ckeditor5-dev-ci/lib/notifytravisstatus.js
@@ -42,13 +42,7 @@ module.exports = async function notifyTravisStatus( options ) {
 	const shortCommit = commitUrl.split( '/' ).pop().substring( 0, 7 );
 	const repoMatch = commitUrl.match( REPOSITORY_REGEXP );
 
-	const slack = slackNotify( options.slackWebhookUrl );
-
-	slack.onError = err => {
-		console.log( 'API error occurred:', err );
-	};
-
-	return slack.send( {
+	const messageData = {
 		username: 'Travis CI',
 		text: getNotifierMessage( {
 			slackAccount,
@@ -92,7 +86,11 @@ module.exports = async function notifyTravisStatus( options ) {
 				]
 			}
 		]
-	} );
+	};
+
+	return slackNotify( options.slackWebhookUrl )
+		.send( messageData )
+		.catch( err => console.log( 'API error occurred:', err ) );
 };
 
 /**

--- a/packages/ckeditor5-dev-ci/package.json
+++ b/packages/ckeditor5-dev-ci/package.json
@@ -5,7 +5,7 @@
   "keywords": [],
   "dependencies": {
     "node-fetch": "^2.6.7",
-    "slack-notify": "^0.1.7"
+    "slack-notify": "^2.0.6"
   },
   "engines": {
     "node": ">=14.0.0",


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other (ci): Bumped a version of the `slack-notify` library.

Fix (ci): Fixed the `notifyTravisStatus()` function providing incorrect values for build times lasting 1 hour or longer.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
