### PR TITLE
Fetching version from npm now takes tag into account.

### DIFF
--- a/packages/ckeditor5-dev-release-tools/lib/tasks/releasesubrepositories.js
+++ b/packages/ckeditor5-dev-release-tools/lib/tasks/releasesubrepositories.js
@@ -427,7 +427,7 @@ module.exports = async function releaseSubRepositories( options ) {
 					throw new Error( MISSING_FILES_MESSAGE );
 				}
 
-				const npmVersion = getVersionFromNpm( packageJson.name );
+				const npmVersion = getVersionFromNpm( packageJson.name, npmTag );
 
 				logDryRun( `Versions: package.json: "${ releaseDetails.version }", npm: "${ npmVersion || 'initial release' }".` );
 
@@ -545,9 +545,9 @@ module.exports = async function releaseSubRepositories( options ) {
 		// Checks whether specified `packageName` has been published on npm.
 		// If so, returns its version. Otherwise returns `null` which means that
 		// this package will be published for the first time.
-		function getVersionFromNpm( packageName ) {
+		function getVersionFromNpm( packageName, npmTag ) {
 			try {
-				return exec( `npm show ${ packageName } version` ).trim();
+				return exec( `npm show ${ packageName }@${ npmTag } version` ).trim();
 			} catch ( err ) {
 				if ( err.message.match( /npm ERR! 404/ ) ) {
 					return null;


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix (release-tools): The `releaseSubRepositories()` task will now check the correct tag when checking what version is currently published on npm. Closes ckeditor/ckeditor5#13737.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
