### PR TITLE
Mark GitHub release as a pre-release when publishing a non-latest version

### DIFF
--- a/packages/ckeditor5-dev-release-tools/lib/tasks/releasesubrepositories.js
+++ b/packages/ckeditor5-dev-release-tools/lib/tasks/releasesubrepositories.js
@@ -873,7 +873,8 @@ module.exports = async function releaseSubRepositories( options ) {
 			repositoryOwner: releaseDetails.repositoryOwner,
 			repositoryName: releaseDetails.repositoryName,
 			version: `v${ releaseDetails.version }`,
-			description: releaseDetails.changes
+			description: releaseDetails.changes,
+			isPrerelease: npmTag !== 'latest'
 		};
 
 		return createGithubRelease( releaseOptions.token, githubReleaseOptions )

--- a/packages/ckeditor5-dev-release-tools/lib/tasks/releasesubrepositories.js
+++ b/packages/ckeditor5-dev-release-tools/lib/tasks/releasesubrepositories.js
@@ -284,7 +284,7 @@ module.exports = async function releaseSubRepositories( options ) {
 		const packageJson = getPackageJson( options.cwd );
 		logProcess( 'Verifying the npm tag...' );
 
-		const [ versionTag ] = semver.prerelease( packageJson.version ) || [ 'latest' ];
+		const versionTag = getVersionTag( packageJson.version );
 
 		if ( versionTag !== npmTag ) {
 			log.warning( '⚠️  The version tag is different from the npm tag.' );
@@ -869,12 +869,14 @@ module.exports = async function releaseSubRepositories( options ) {
 			return Promise.resolve();
 		}
 
+		const versionTag = getVersionTag( releaseDetails.version );
+
 		const githubReleaseOptions = {
 			repositoryOwner: releaseDetails.repositoryOwner,
 			repositoryName: releaseDetails.repositoryName,
 			version: `v${ releaseDetails.version }`,
 			description: releaseDetails.changes,
-			isPrerelease: npmTag !== 'latest'
+			isPrerelease: versionTag !== 'latest'
 		};
 
 		return createGithubRelease( releaseOptions.token, githubReleaseOptions )
@@ -893,6 +895,21 @@ module.exports = async function releaseSubRepositories( options ) {
 					return Promise.resolve();
 				}
 			);
+	}
+
+	/**
+	 * Returns the version tag for the package.
+	 *
+	 * For the official release, returns the "latest" tag. For a non-official release (pre-release), returns the version tag extracted from
+	 * the package version.
+	 *
+	 * @param {String} version Version of the package to be released.
+	 * @returns {String}
+	 */
+	function getVersionTag( version ) {
+		const [ versionTag ] = semver.prerelease( version ) || [ 'latest' ];
+
+		return versionTag;
 	}
 
 	// Removes all temporary directories that were created for publishing the custom repository.

--- a/packages/ckeditor5-dev-release-tools/lib/utils/creategithubrelease.js
+++ b/packages/ckeditor5-dev-release-tools/lib/utils/creategithubrelease.js
@@ -16,6 +16,7 @@ const { Octokit } = require( '@octokit/rest' );
  * @param {String} options.repositoryName Repository name.
  * @param {String} options.version Name of tag connected with the release.
  * @param {String} options.description Description of the release.
+ * @param {Boolean} options.isPrerelease Indicates whether the release is a pre-release.
  * @returns {Promise}
  */
 module.exports = function createGithubRelease( token, options ) {
@@ -28,7 +29,8 @@ module.exports = function createGithubRelease( token, options ) {
 		owner: options.repositoryOwner,
 		repo: options.repositoryName,
 		tag_name: options.version,
-		body: options.description
+		body: options.description,
+		prerelease: options.isPrerelease
 	};
 
 	return github.repos.createRelease( releaseParams );

--- a/packages/ckeditor5-dev-release-tools/tests/utils/creategithubrelease.js
+++ b/packages/ckeditor5-dev-release-tools/tests/utils/creategithubrelease.js
@@ -54,7 +54,8 @@ describe( 'dev-release-tools/tasks', () => {
 				repositoryOwner: 'organization',
 				repositoryName: 'repository',
 				version: 'v1.0.0',
-				description: 'Changes.'
+				description: 'Changes.',
+				isPrerelease: false
 			};
 
 			return createGithubRelease( 'token-123', options )
@@ -74,7 +75,8 @@ describe( 'dev-release-tools/tasks', () => {
 				repositoryOwner: 'organization',
 				repositoryName: 'repository',
 				version: 'v1.0.0',
-				description: 'Changes.'
+				description: 'Changes.',
+				isPrerelease: true
 			};
 
 			return createGithubRelease( 'token-123', options )
@@ -86,7 +88,8 @@ describe( 'dev-release-tools/tasks', () => {
 						owner: 'organization',
 						repo: 'repository',
 						tag_name: 'v1.0.0',
-						body: 'Changes.'
+						body: 'Changes.',
+						prerelease: true
 					} );
 				} );
 		} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other (release-tools): Mark GitHub release as a pre-release when publishing a non-latest version. Closes ckeditor/ckeditor5#13664.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
