### PR TITLE
Fixed missing accessor reflections

### DIFF
--- a/packages/typedoc-plugins/lib/tag-observable/index.js
+++ b/packages/typedoc-plugins/lib/tag-observable/index.js
@@ -22,11 +22,8 @@ module.exports = {
 
 function onEventEnd( context ) {
 	// Get all resolved reflections that could potentially have the `@observable` tag.
-	const reflections = [
-		...context.project.getReflectionsByKind( ReflectionKind.Property ),
-		...context.project.getReflectionsByKind( ReflectionKind.GetSignature ),
-		...context.project.getReflectionsByKind( ReflectionKind.SetSignature )
-	];
+	const kinds = ReflectionKind.Property | ReflectionKind.GetSignature | ReflectionKind.SetSignature;
+	const reflections = context.project.getReflectionsByKind( kinds );
 
 	// Then, for each potential observable reflection...
 	for ( const reflection of reflections ) {

--- a/packages/typedoc-plugins/tests/tag-observable/fixtures/exampleclass.ts
+++ b/packages/typedoc-plugins/tests/tag-observable/fixtures/exampleclass.ts
@@ -32,7 +32,7 @@ export class ExampleClass {
 	 *
 	 * @observable
 	 */
-	private secret: string;
+	private secret: string | undefined;
 
 	/**
 	 * Observable getter.
@@ -42,6 +42,16 @@ export class ExampleClass {
 	 */
 	public get hasSecret(): boolean {
 		return Boolean( this.secret );
+	}
+
+	/**
+	 * Observable setter.
+	 *
+	 * @readonly
+	 * @observable
+	 */
+	public set setSecret( string: string | undefined ) {
+		this.secret = string;
 	}
 
 	constructor() {

--- a/packages/typedoc-plugins/tests/tag-observable/fixtures/exampleclass.ts
+++ b/packages/typedoc-plugins/tests/tag-observable/fixtures/exampleclass.ts
@@ -34,6 +34,16 @@ export class ExampleClass {
 	 */
 	private secret: string;
 
+	/**
+	 * Observable getter.
+	 *
+	 * @readonly
+	 * @observable
+	 */
+	public get hasSecret(): boolean {
+		return Boolean( this.secret );
+	}
+
 	constructor() {
 		this.name = 'Example';
 		this.key = 1;

--- a/packages/typedoc-plugins/tests/tag-observable/index.js
+++ b/packages/typedoc-plugins/tests/tag-observable/index.js
@@ -88,30 +88,46 @@ describe( 'typedoc-plugins/tag-observable', function() {
 			const eventDefinitions = baseClassDefinition.children
 				.filter( children => children.kindString === 'Event' );
 
-			expect( eventDefinitions ).to.lengthOf( 8 );
-			expect( eventDefinitions.find( event => event.name === 'event:change:key' ) ).to.not.be.undefined;
-			expect( eventDefinitions.find( event => event.name === 'event:change:value' ) ).to.not.be.undefined;
-			expect( eventDefinitions.find( event => event.name === 'event:change:secret' ) ).to.not.be.undefined;
-			expect( eventDefinitions.find( event => event.name === 'event:set:key' ) ).to.not.be.undefined;
-			expect( eventDefinitions.find( event => event.name === 'event:set:value' ) ).to.not.be.undefined;
-			expect( eventDefinitions.find( event => event.name === 'event:set:secret' ) ).to.not.be.undefined;
+			expect( eventDefinitions ).to.lengthOf( 10 );
+
+			expect( eventDefinitions.map( event => event.name ) ).to.have.members( [
+				'event:change:key',
+				'event:change:value',
+				'event:change:secret',
+				'event:change:setSecret',
+				'event:change:hasSecret',
+
+				'event:set:key',
+				'event:set:value',
+				'event:set:secret',
+				'event:set:setSecret',
+				'event:set:hasSecret'
+			] );
 		} );
 
 		it( 'should find all events in the derived class', () => {
 			const eventDefinitions = derivedClassDefinition.children
 				.filter( children => children.kindString === 'Event' );
 
-			expect( eventDefinitions ).to.lengthOf( 12 );
-			expect( eventDefinitions.find( event => event.name === 'event:change:key' ) ).to.not.be.undefined;
-			expect( eventDefinitions.find( event => event.name === 'event:change:value' ) ).to.not.be.undefined;
-			expect( eventDefinitions.find( event => event.name === 'event:change:property' ) ).to.not.be.undefined;
-			expect( eventDefinitions.find( event => event.name === 'event:change:anotherProperty' ) ).to.not.be.undefined;
-			expect( eventDefinitions.find( event => event.name === 'event:change:staticProperty' ) ).to.not.be.undefined;
-			expect( eventDefinitions.find( event => event.name === 'event:set:key' ) ).to.not.be.undefined;
-			expect( eventDefinitions.find( event => event.name === 'event:set:value' ) ).to.not.be.undefined;
-			expect( eventDefinitions.find( event => event.name === 'event:set:property' ) ).to.not.be.undefined;
-			expect( eventDefinitions.find( event => event.name === 'event:set:staticProperty' ) ).to.not.be.undefined;
-			expect( eventDefinitions.find( event => event.name === 'event:set:anotherProperty' ) ).to.not.be.undefined;
+			expect( eventDefinitions ).to.lengthOf( 14 );
+
+			expect( eventDefinitions.map( event => event.name ) ).to.have.members( [
+				'event:change:key',
+				'event:change:value',
+				'event:change:property',
+				'event:change:staticProperty',
+				'event:change:anotherProperty',
+				'event:change:setSecret',
+				'event:change:hasSecret',
+
+				'event:set:key',
+				'event:set:value',
+				'event:set:property',
+				'event:set:staticProperty',
+				'event:set:anotherProperty',
+				'event:set:setSecret',
+				'event:set:hasSecret'
+			] );
 		} );
 
 		for ( const eventName of [ 'key', 'hasSecret' ] ) {

--- a/packages/typedoc-plugins/tests/tag-observable/index.js
+++ b/packages/typedoc-plugins/tests/tag-observable/index.js
@@ -88,7 +88,7 @@ describe( 'typedoc-plugins/tag-observable', function() {
 			const eventDefinitions = baseClassDefinition.children
 				.filter( children => children.kindString === 'Event' );
 
-			expect( eventDefinitions ).to.lengthOf( 6 );
+			expect( eventDefinitions ).to.lengthOf( 8 );
 			expect( eventDefinitions.find( event => event.name === 'event:change:key' ) ).to.not.be.undefined;
 			expect( eventDefinitions.find( event => event.name === 'event:change:value' ) ).to.not.be.undefined;
 			expect( eventDefinitions.find( event => event.name === 'event:change:secret' ) ).to.not.be.undefined;
@@ -101,7 +101,7 @@ describe( 'typedoc-plugins/tag-observable', function() {
 			const eventDefinitions = derivedClassDefinition.children
 				.filter( children => children.kindString === 'Event' );
 
-			expect( eventDefinitions ).to.lengthOf( 10 );
+			expect( eventDefinitions ).to.lengthOf( 12 );
 			expect( eventDefinitions.find( event => event.name === 'event:change:key' ) ).to.not.be.undefined;
 			expect( eventDefinitions.find( event => event.name === 'event:change:value' ) ).to.not.be.undefined;
 			expect( eventDefinitions.find( event => event.name === 'event:change:property' ) ).to.not.be.undefined;
@@ -114,73 +114,77 @@ describe( 'typedoc-plugins/tag-observable', function() {
 			expect( eventDefinitions.find( event => event.name === 'event:set:anotherProperty' ) ).to.not.be.undefined;
 		} );
 
-		for ( const eventName of [ 'event:change', 'event:set' ] ) {
-			it( `should properly define the ${ eventName } event`, () => {
-				const eventDefinition = baseClassDefinition.children
-					.find( doclet => doclet.name === `${ eventName }:key` );
+		for ( const eventName of [ 'key', 'hasSecret' ] ) {
+			for ( const eventType of [ 'change', 'set' ] ) {
+				it( `should properly define the "event:${ eventType }:${ eventName }" event`, () => {
+					const eventDefinition = baseClassDefinition.children
+						.find( doclet => doclet.name === `event:${ eventType }:${ eventName }` );
 
-				expect( eventDefinition ).to.not.be.undefined;
-				expect( eventDefinition.name ).to.equal( `${ eventName }:key` );
-				expect( eventDefinition.originalName ).to.equal( `${ eventName }:key` );
-				expect( eventDefinition.kindString ).to.equal( 'Event' );
+					const expectedCommentSummary = `Fired when the \`${ eventName }\` property ` + (
+						eventType === 'change' ?
+							'changed value.' :
+							'is going to be set but is not set yet (before the `change` event is fired).'
+					);
 
-				expect( eventDefinition.comment ).to.have.property( 'summary' );
-				expect( eventDefinition.comment ).to.have.property( 'blockTags' );
-				expect( eventDefinition.comment ).to.have.property( 'modifierTags' );
+					expect( eventDefinition ).to.not.be.undefined;
+					expect( eventDefinition.name ).to.equal( `event:${ eventType }:${ eventName }` );
+					expect( eventDefinition.originalName ).to.equal( `event:${ eventType }:${ eventName }` );
+					expect( eventDefinition.kindString ).to.equal( 'Event' );
 
-				expect( eventDefinition.comment.blockTags ).to.be.an( 'array' );
-				expect( eventDefinition.comment.blockTags ).to.lengthOf( 0 );
-				expect( eventDefinition.comment.modifierTags ).to.be.a( 'Set' );
-				expect( eventDefinition.comment.modifierTags.size ).to.equal( 0 );
-				expect( eventDefinition.comment.summary ).to.be.an( 'array' );
-				expect( eventDefinition.comment.summary ).to.lengthOf( 1 );
-				expect( eventDefinition.comment.summary[ 0 ] ).to.have.property( 'kind', 'text' );
-				expect( eventDefinition.comment.summary[ 0 ] ).to.have.property( 'text',
-					eventName === 'event:change' ?
-						'Fired when the `key` property changed value.' :
-						'Fired when the `key` property is going to be set but is not set yet (before the `change` event is fired).'
-				);
+					expect( eventDefinition.comment ).to.have.property( 'summary' );
+					expect( eventDefinition.comment ).to.have.property( 'blockTags' );
+					expect( eventDefinition.comment ).to.have.property( 'modifierTags' );
 
-				expect( eventDefinition.typeParameters ).to.be.an( 'array' );
-				expect( eventDefinition.typeParameters ).to.lengthOf( 3 );
+					expect( eventDefinition.comment.blockTags ).to.be.an( 'array' );
+					expect( eventDefinition.comment.blockTags ).to.lengthOf( 0 );
+					expect( eventDefinition.comment.modifierTags ).to.be.a( 'Set' );
+					expect( eventDefinition.comment.modifierTags.size ).to.equal( 0 );
+					expect( eventDefinition.comment.summary ).to.be.an( 'array' );
+					expect( eventDefinition.comment.summary ).to.lengthOf( 1 );
+					expect( eventDefinition.comment.summary[ 0 ] ).to.have.property( 'kind', 'text' );
+					expect( eventDefinition.comment.summary[ 0 ] ).to.have.property( 'text', expectedCommentSummary );
 
-				expect( eventDefinition.typeParameters[ 0 ] ).to.have.property( 'name', 'name' );
-				expect( eventDefinition.typeParameters[ 0 ] ).to.have.property( 'type' );
-				expect( eventDefinition.typeParameters[ 0 ].type ).to.have.property( 'name', 'string' );
-				expect( eventDefinition.typeParameters[ 0 ] ).to.have.property( 'comment' );
-				expect( eventDefinition.typeParameters[ 0 ].comment ).to.have.property( 'summary' );
-				expect( eventDefinition.typeParameters[ 0 ].comment.summary ).to.be.an( 'array' );
-				expect( eventDefinition.typeParameters[ 0 ].comment.summary[ 0 ] ).to.have.property( 'kind', 'text' );
-				expect( eventDefinition.typeParameters[ 0 ].comment.summary[ 0 ] ).to.have.property( 'text',
-					'Name of the changed property (`key`).'
-				);
+					expect( eventDefinition.typeParameters ).to.be.an( 'array' );
+					expect( eventDefinition.typeParameters ).to.lengthOf( 3 );
 
-				expect( eventDefinition.typeParameters[ 1 ] ).to.have.property( 'name', 'value' );
-				expect( eventDefinition.typeParameters[ 1 ] ).to.have.property( 'comment' );
-				expect( eventDefinition.typeParameters[ 1 ].comment ).to.have.property( 'summary' );
-				expect( eventDefinition.typeParameters[ 1 ].comment.summary ).to.be.an( 'array' );
-				expect( eventDefinition.typeParameters[ 1 ].comment.summary[ 0 ] ).to.have.property( 'kind', 'text' );
-				expect( eventDefinition.typeParameters[ 1 ].comment.summary[ 0 ] ).to.have.property( 'text',
-					'New value of the `key` property with given key or `null`, if operation should remove property.'
-				);
+					expect( eventDefinition.typeParameters[ 0 ] ).to.have.property( 'name', 'name' );
+					expect( eventDefinition.typeParameters[ 0 ] ).to.have.property( 'type' );
+					expect( eventDefinition.typeParameters[ 0 ].type ).to.have.property( 'name', 'string' );
+					expect( eventDefinition.typeParameters[ 0 ] ).to.have.property( 'comment' );
+					expect( eventDefinition.typeParameters[ 0 ].comment ).to.have.property( 'summary' );
+					expect( eventDefinition.typeParameters[ 0 ].comment.summary ).to.be.an( 'array' );
+					expect( eventDefinition.typeParameters[ 0 ].comment.summary[ 0 ] ).to.have.property( 'kind', 'text' );
+					expect( eventDefinition.typeParameters[ 0 ].comment.summary[ 0 ] ).to.have.property( 'text',
+						`Name of the changed property (\`${ eventName }\`).`
+					);
 
-				expect( eventDefinition.typeParameters[ 2 ] ).to.have.property( 'name', 'oldValue' );
-				expect( eventDefinition.typeParameters[ 2 ] ).to.have.property( 'comment' );
-				expect( eventDefinition.typeParameters[ 2 ].comment ).to.have.property( 'summary' );
-				expect( eventDefinition.typeParameters[ 2 ].comment.summary ).to.be.an( 'array' );
-				expect( eventDefinition.typeParameters[ 2 ].comment.summary[ 0 ] ).to.have.property( 'kind', 'text' );
-				expect( eventDefinition.typeParameters[ 2 ].comment.summary[ 0 ] ).to.have.property( 'text',
-					'Old value of the `key` property with given key or `null`, if property was not set before.'
-				);
+					expect( eventDefinition.typeParameters[ 1 ] ).to.have.property( 'name', 'value' );
+					expect( eventDefinition.typeParameters[ 1 ] ).to.have.property( 'comment' );
+					expect( eventDefinition.typeParameters[ 1 ].comment ).to.have.property( 'summary' );
+					expect( eventDefinition.typeParameters[ 1 ].comment.summary ).to.be.an( 'array' );
+					expect( eventDefinition.typeParameters[ 1 ].comment.summary[ 0 ] ).to.have.property( 'kind', 'text' );
+					expect( eventDefinition.typeParameters[ 1 ].comment.summary[ 0 ] ).to.have.property( 'text',
+						`New value of the \`${ eventName }\` property with given key or \`null\`, if operation should remove property.`
+					);
 
-				expect( eventDefinition.sources ).to.be.an( 'array' );
-				expect( eventDefinition.sources ).to.lengthOf( 1 );
-				expect( eventDefinition.sources[ 0 ] ).to.have.property( 'fileName', 'exampleclass.ts' );
-				expect( eventDefinition.sources[ 0 ] ).to.have.property( 'fullFileName' );
-				expect( eventDefinition.sources[ 0 ] ).to.have.property( 'line' );
-				expect( eventDefinition.sources[ 0 ] ).to.have.property( 'character' );
-				expect( eventDefinition.sources[ 0 ] ).to.have.property( 'url' );
-			} );
+					expect( eventDefinition.typeParameters[ 2 ] ).to.have.property( 'name', 'oldValue' );
+					expect( eventDefinition.typeParameters[ 2 ] ).to.have.property( 'comment' );
+					expect( eventDefinition.typeParameters[ 2 ].comment ).to.have.property( 'summary' );
+					expect( eventDefinition.typeParameters[ 2 ].comment.summary ).to.be.an( 'array' );
+					expect( eventDefinition.typeParameters[ 2 ].comment.summary[ 0 ] ).to.have.property( 'kind', 'text' );
+					expect( eventDefinition.typeParameters[ 2 ].comment.summary[ 0 ] ).to.have.property( 'text',
+						`Old value of the \`${ eventName }\` property with given key or \`null\`, if property was not set before.`
+					);
+
+					expect( eventDefinition.sources ).to.be.an( 'array' );
+					expect( eventDefinition.sources ).to.lengthOf( 1 );
+					expect( eventDefinition.sources[ 0 ] ).to.have.property( 'fileName', 'exampleclass.ts' );
+					expect( eventDefinition.sources[ 0 ] ).to.have.property( 'fullFileName' );
+					expect( eventDefinition.sources[ 0 ] ).to.have.property( 'line' );
+					expect( eventDefinition.sources[ 0 ] ).to.have.property( 'character' );
+					expect( eventDefinition.sources[ 0 ] ).to.have.property( 'url' );
+				} );
+			}
 		}
 
 		it( 'should define the `inheritedFrom` property for an inherited observable property (change:${ property })', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix (typedoc-plugins): Properties with the `@observable` annotation hooked into accessor reflections were not processed when creating the `change:*` and `set:*` events.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
