### PR TITLE
Created a util that allows executing a task in parallel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 coverage/**
 npm-debug.log
 yarn.lock
+executeinparallel-integration.log

--- a/packages/ckeditor5-dev-release-tools/lib/index.js
+++ b/packages/ckeditor5-dev-release-tools/lib/index.js
@@ -15,7 +15,10 @@ const updateDependenciesVersions = require( './utils/updatedependenciesversions'
 const { getLastFromChangelog, getCurrent, getLastTagFromGit } = require( './utils/versions' );
 const { getChangesForVersion, getChangelog, saveChangelog } = require( './utils/changelog' );
 
+const executeInParallel = require( './utils/executeinparallel' );
+
 module.exports = {
+	executeInParallel,
 	releaseSubRepositories,
 	preparePackages,
 	bumpVersions,

--- a/packages/ckeditor5-dev-release-tools/lib/utils/executeinparallel.js
+++ b/packages/ckeditor5-dev-release-tools/lib/utils/executeinparallel.js
@@ -27,7 +27,8 @@ const WORKER_SCRIPT = path.join( __dirname, 'parallelworker.js' );
  * @param {Object} options
  * @param {String} options.packagesDirectory Relative path to a location of packages to execute a task.
  * @param {String} options.processDescription Description of the task displayed on a screen.
- * @param {Function} options.taskToExecute A callback that is executed on all found packages. It receives an absolute path to a package as an argument. It can be synchronous or may return a promise.
+ * @param {Function} options.taskToExecute A callback that is executed on all found packages.
+ * It receives an absolute path to a package as an argument. It can be synchronous or may return a promise.
  * @param {AbortSignal} options.signal Signal to abort the asynchronous process.
  * @param {String} [options.cwd=process.cwd()] Current working directory from which all paths will be resolved.
  * @param {Number} [options.concurrency=require( 'os' ).cpus().length / 2] Number of CPUs that will execute the task.

--- a/packages/ckeditor5-dev-release-tools/lib/utils/executeinparallel.js
+++ b/packages/ckeditor5-dev-release-tools/lib/utils/executeinparallel.js
@@ -61,6 +61,11 @@ module.exports = function executeInParallel( options ) {
 		.catch( err => {
 			counter.finish( { emoji: '❌' } );
 
+			// `err` can be `undefined` if a process was aborted.
+			if ( !err ) {
+				return Promise.resolve();
+			}
+
 			return Promise.reject( err );
 		} )
 		.finally( () => {

--- a/packages/ckeditor5-dev-release-tools/lib/utils/executeinparallel.js
+++ b/packages/ckeditor5-dev-release-tools/lib/utils/executeinparallel.js
@@ -8,13 +8,13 @@
 'use strict';
 
 const crypto = require( 'crypto' );
-const path = require( 'path' );
+const upath = require( 'upath' );
 const fs = require( 'fs' );
 const { Worker } = require( 'worker_threads' );
-const glob = require( 'glob' );
+const { globSync } = require( 'glob' );
 const { tools } = require( '@ckeditor/ckeditor5-dev-utils' );
 
-const WORKER_SCRIPT = path.join( __dirname, 'parallelworker.js' );
+const WORKER_SCRIPT = upath.join( __dirname, 'parallelworker.js' );
 
 /**
  * This util allows executing a specified task in parallel using Workers. It can be helpful when executing a not resource-consuming
@@ -44,10 +44,14 @@ module.exports = function executeInParallel( options ) {
 		concurrency = require( 'os' ).cpus().length / 2
 	} = options;
 
-	const packages = glob.sync( `${ packagesDirectory }/*/`, { cwd, absolute: true } );
+	const normalizedCwd = upath.toUnix( cwd );
+	const packages = globSync( `${ packagesDirectory }/*/`, {
+		cwd: normalizedCwd,
+		absolute: true
+	} );
 	const packagesInThreads = getPackagesGroupedByThreads( packages, concurrency );
 
-	const callbackModule = path.posix.join( cwd, crypto.randomUUID() + '.js' );
+	const callbackModule = upath.join( cwd, crypto.randomUUID() + '.js' );
 	fs.writeFileSync( callbackModule, `'use strict';\nmodule.exports = ${ taskToExecute };`, 'utf-8' );
 
 	const counter = tools.createSpinner( processDescription, { total: packages.length } );

--- a/packages/ckeditor5-dev-release-tools/lib/utils/executeinparallel.js
+++ b/packages/ckeditor5-dev-release-tools/lib/utils/executeinparallel.js
@@ -38,7 +38,7 @@ module.exports = function executeInParallel( options ) {
 		packagesDirectory,
 		processDescription,
 		signal,
-		callback,
+		taskToExecute,
 		cwd = process.cwd(),
 		concurrency = require( 'os' ).cpus().length / 2
 	} = options;
@@ -47,7 +47,7 @@ module.exports = function executeInParallel( options ) {
 	const packagesInThreads = getPackagesGroupedByThreads( packages, concurrency );
 
 	const callbackModule = path.posix.join( cwd, crypto.randomUUID() + '.js' );
-	fs.writeFileSync( callbackModule, `'use strict';\nmodule.exports = ${ callback };`, 'utf-8' );
+	fs.writeFileSync( callbackModule, `'use strict';\nmodule.exports = ${ taskToExecute };`, 'utf-8' );
 
 	const counter = tools.createSpinner( processDescription, { total: packages.length } );
 	counter.start();

--- a/packages/ckeditor5-dev-release-tools/lib/utils/executeinparallel.js
+++ b/packages/ckeditor5-dev-release-tools/lib/utils/executeinparallel.js
@@ -25,12 +25,12 @@ const WORKER_SCRIPT = path.join( __dirname, 'parallelworker.js' );
  *
  * @see https://nodejs.org/api/worker_threads.html
  * @param {Object} options
- * @param {String} options.packagesDirectory
- * @param {String} options.processDescription
- * @param {Function} options.callback
- * @param {AbortSignal} options.signal
- * @param {String} [options.cwd=process.cwd()]
- * @param {Number} [options.concurrency=require( 'os' ).cpus().length / 2]
+ * @param {String} options.packagesDirectory Relative path to a location of packages to execute a task.
+ * @param {String} options.processDescription Description of the task displayed on a screen.
+ * @param {Function} options.taskToExecute A callback that is executed on all found packages. It receives an absolute path to a package as an argument. It can be synchronous or may return a promise.
+ * @param {AbortSignal} options.signal Signal to abort the asynchronous process.
+ * @param {String} [options.cwd=process.cwd()] Current working directory from which all paths will be resolved.
+ * @param {Number} [options.concurrency=require( 'os' ).cpus().length / 2] Number of CPUs that will execute the task.
  * @returns {Promise}
  */
 module.exports = function executeInParallel( options ) {

--- a/packages/ckeditor5-dev-release-tools/lib/utils/executeinparallel.js
+++ b/packages/ckeditor5-dev-release-tools/lib/utils/executeinparallel.js
@@ -1,0 +1,86 @@
+/**
+ * @license Copyright (c) 2003-2023, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+'use strict';
+
+const path = require( 'path' );
+const { Worker } = require( 'worker_threads' );
+const crypto = require( 'crypto' );
+const fs = require( 'fs-extra' );
+const glob = require( 'glob' );
+
+const WORKER_SCRIPT = path.join( __dirname, 'parallelworker.js' );
+
+/**
+ * @param {Object} options
+ * @param {String} options.packagesDirectory
+ * @param {Function} options.callback
+ * @param {String} options.processDescription
+ * @param {String} [options.cwd=process.cwd()]
+ * @param {Number} [options.concurrency=require( 'os' ).cpus().length / 2]
+ */
+module.exports = async function executeInParallel( options ) {
+	const {
+		cwd = process.cwd(),
+		packagesDirectory,
+		callback,
+		concurrency = require( 'os' ).cpus().length / 2,
+		processDescription
+	} = options;
+
+	// TODO: Create a fancy counter/spinner.
+	console.log( processDescription );
+
+	const packages = glob.sync( `${ packagesDirectory }/*/`, { cwd, absolute: true } );
+
+	const callbackModule = path.join( __dirname, crypto.randomUUID() + '.js' );
+	fs.writeFileSync( callbackModule, `'use-strict';\nmodule.exports = ${ callback };`, 'utf-8' );
+
+	// TODO: Detect CTRL+C to remove the created file.
+
+	// To avoid having packages with a common prefix in a single thread, let's use a loop for assigning/
+	// packages to threads.
+	const packagesInThreads = packages.reduce( ( collection, packageItem, index ) => {
+		const arrayIndex = index % concurrency;
+
+		if ( !collection[ arrayIndex ] ) {
+			collection.push( [] );
+		}
+
+		collection[ arrayIndex ].push( packageItem );
+
+		return collection;
+	}, [] );
+
+	const workers = packagesInThreads.map( packages => createWorker( { packages, callbackModule } ) );
+
+	return Promise.all( workers )
+		.then( () => {
+			console.log( 'Done' );
+		} )
+		.finally( () => {
+			fs.removeSync( callbackModule );
+		} );
+};
+
+function createWorker( workerData ) {
+	return new Promise( ( resolve, reject ) => {
+		const worker = new Worker( WORKER_SCRIPT, { workerData } );
+
+		worker.on( 'error', err => {
+			console.log( err );
+			reject( err );
+		} );
+		worker.on( 'message', msg => {
+			console.log( msg );
+		} );
+		worker.on( 'exit', code => {
+			console.log( 'exit', { code } );
+			resolve();
+		} );
+
+		return worker;
+	} );
+}

--- a/packages/ckeditor5-dev-release-tools/lib/utils/parallelworker.js
+++ b/packages/ckeditor5-dev-release-tools/lib/utils/parallelworker.js
@@ -1,0 +1,26 @@
+/**
+ * @license Copyright (c) 2003-2023, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+'use strict';
+
+// Required due to top-level await.
+( async () => {
+	/**
+	 * @param {String} callbackModule
+	 * @param {Array.<String>} packages
+	 */
+	const { parentPort, workerData } = require( 'worker_threads' );
+	const callback = require( workerData.callbackModule );
+
+	for ( const packagePath of workerData.packages ) {
+		await callback( packagePath );
+
+		// To increase the status log.
+		parentPort.postMessage( 'done:package:' + packagePath );
+	}
+
+	// Need to figure out if needed.
+	parentPort.postMessage( 'done' );
+} )();

--- a/packages/ckeditor5-dev-release-tools/lib/utils/parallelworker.js
+++ b/packages/ckeditor5-dev-release-tools/lib/utils/parallelworker.js
@@ -5,6 +5,8 @@
 
 'use strict';
 
+// This file is covered by the "executeInParallel() - integration" test cases.
+
 // Required due to top-level await.
 ( async () => {
 	/**

--- a/packages/ckeditor5-dev-release-tools/lib/utils/parallelworker.js
+++ b/packages/ckeditor5-dev-release-tools/lib/utils/parallelworker.js
@@ -18,9 +18,6 @@
 		await callback( packagePath );
 
 		// To increase the status log.
-		parentPort.postMessage( 'done:package:' + packagePath );
+		parentPort.postMessage( 'done:package' );
 	}
-
-	// Need to figure out if needed.
-	parentPort.postMessage( 'done' );
 } )();

--- a/packages/ckeditor5-dev-release-tools/package.json
+++ b/packages/ckeditor5-dev-release-tools/package.json
@@ -23,7 +23,8 @@
     "minimatch": "^3.0.4",
     "mkdirp": "^1.0.4",
     "parse-github-url": "^1.0.2",
-    "semver": "^7.3.2"
+    "semver": "^7.3.2",
+    "upath": "^2.0.1"
   },
   "devDependencies": {
     "chai": "^4.2.0",

--- a/packages/ckeditor5-dev-release-tools/tests/utils/executeinparallel-integration.js
+++ b/packages/ckeditor5-dev-release-tools/tests/utils/executeinparallel-integration.js
@@ -1,0 +1,123 @@
+/**
+ * @license Copyright (c) 2003-2023, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+'use strict';
+
+const expect = require( 'chai' ).expect;
+const fs = require( 'fs' );
+const path = require( 'path' );
+const sinon = require( 'sinon' );
+const glob = require( 'glob' );
+const proxyquire = require( 'proxyquire' );
+
+const REPOSITORY_ROOT = path.join( __dirname, '..', '..', '..', '..' );
+
+// This file covers the "parallelworker.js" file.
+
+describe( 'dev-release-tools/utils', () => {
+	let executeInParallel, stubs, abortController;
+
+	beforeEach( () => {
+		stubs = {
+			devUtils: {
+				tools: {
+					createSpinner: sinon.stub().callsFake( () => stubs.spinnerStub )
+				}
+			},
+			spinnerStub: {
+				start: sinon.stub(),
+				finish: sinon.stub(),
+				increase: sinon.stub()
+			}
+		};
+
+		abortController = new AbortController();
+		executeInParallel = proxyquire( '../../lib/utils/executeinparallel', {
+			// To hide the spinner/counter in tests.
+			'@ckeditor/ckeditor5-dev-utils': stubs.devUtils
+		} );
+	} );
+
+	afterEach( () => {
+		sinon.restore();
+	} );
+
+	describe( 'executeInParallel() - integration', () => {
+		it( 'should store current time in all found packages (callback returns a promise)', async () => {
+			const timeBefore = new Date().getTime();
+
+			await executeInParallel( {
+				cwd: REPOSITORY_ROOT,
+				concurrency: 2,
+				packagesDirectory: 'packages',
+				processDescription: 'Checking ckeditor5-dev paths.',
+				signal: abortController.signal,
+				callback: async packagePath => {
+					const fs = require( 'fs/promises' );
+					const path = require( 'path' );
+					const filePath = path.join( packagePath, 'executeinparallel-integration.log' );
+
+					await fs.writeFile( filePath, new Date().getTime().toString() );
+				}
+			} );
+
+			const timeAfter = new Date().getTime();
+
+			const data = glob.sync( 'packages/*/executeinparallel-integration.log', { cwd: REPOSITORY_ROOT, absolute: true } )
+				.map( logFile => {
+					return {
+						source: logFile,
+						value: parseInt( fs.readFileSync( logFile, 'utf-8' ) ),
+						packageName: logFile.split( '/' ).reverse().slice( 1, 2 ).pop()
+					};
+				} );
+
+			for ( const { value, packageName, source } of data ) {
+				expect( value > timeBefore, `comparing timeBefore (${ packageName })` ).to.equal( true );
+				expect( value < timeAfter, `comparing timeAfter (${ packageName })` ).to.equal( true );
+
+				fs.unlinkSync( source );
+			}
+		} );
+
+		it( 'should store current time in all found packages (callback returns a promise)', async () => {
+			const timeBefore = new Date().getTime();
+
+			await executeInParallel( {
+				cwd: REPOSITORY_ROOT,
+				concurrency: 2,
+				packagesDirectory: 'packages',
+				processDescription: 'Checking ckeditor5-dev paths.',
+				signal: abortController.signal,
+				callback: packagePath => {
+					const fs = require( 'fs' );
+					const path = require( 'path' );
+					const filePath = path.join( packagePath, 'executeinparallel-integration.log' );
+
+					fs.writeFileSync( filePath, new Date().getTime().toString() );
+				}
+			} );
+
+			const timeAfter = new Date().getTime();
+
+			const data = glob.sync( 'packages/*/executeinparallel-integration.log', { cwd: REPOSITORY_ROOT, absolute: true } )
+				.map( logFile => {
+					return {
+						source: logFile,
+						value: parseInt( fs.readFileSync( logFile, 'utf-8' ) ),
+						packageName: logFile.split( '/' ).reverse().slice( 1, 2 ).pop()
+					};
+				} );
+
+			for ( const { value, packageName, source } of data ) {
+				expect( value > timeBefore, `comparing timeBefore (${ packageName })` ).to.equal( true );
+				expect( value < timeAfter, `comparing timeAfter (${ packageName })` ).to.equal( true );
+
+				fs.unlinkSync( source );
+			}
+		} );
+	} );
+} );
+

--- a/packages/ckeditor5-dev-release-tools/tests/utils/executeinparallel-integration.js
+++ b/packages/ckeditor5-dev-release-tools/tests/utils/executeinparallel-integration.js
@@ -54,7 +54,7 @@ describe( 'dev-release-tools/utils', () => {
 				packagesDirectory: 'packages',
 				processDescription: 'Checking ckeditor5-dev paths.',
 				signal: abortController.signal,
-				callback: async packagePath => {
+				taskToExecute: async packagePath => {
 					const fs = require( 'fs/promises' );
 					const path = require( 'path' );
 					const filePath = path.join( packagePath, 'executeinparallel-integration.log' );
@@ -91,7 +91,7 @@ describe( 'dev-release-tools/utils', () => {
 				packagesDirectory: 'packages',
 				processDescription: 'Checking ckeditor5-dev paths.',
 				signal: abortController.signal,
-				callback: packagePath => {
+				taskToExecute: packagePath => {
 					const fs = require( 'fs' );
 					const path = require( 'path' );
 					const filePath = path.join( packagePath, 'executeinparallel-integration.log' );

--- a/packages/ckeditor5-dev-release-tools/tests/utils/executeinparallel-integration.js
+++ b/packages/ckeditor5-dev-release-tools/tests/utils/executeinparallel-integration.js
@@ -82,7 +82,7 @@ describe( 'dev-release-tools/utils', () => {
 			}
 		} );
 
-		it( 'should store current time in all found packages (callback returns a promise)', async () => {
+		it( 'should store current time in all found packages (callback is a synchronous function)', async () => {
 			const timeBefore = new Date().getTime();
 
 			await executeInParallel( {

--- a/packages/ckeditor5-dev-release-tools/tests/utils/executeinparallel.js
+++ b/packages/ckeditor5-dev-release-tools/tests/utils/executeinparallel.js
@@ -1,0 +1,517 @@
+/**
+ * @license Copyright (c) 2003-2023, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+'use strict';
+
+const expect = require( 'chai' ).expect;
+const sinon = require( 'sinon' );
+const proxyquire = require( 'proxyquire' );
+
+describe( 'dev-release-tools/utils', () => {
+	let executeInParallel, stubs, abortController, WorkerMock, defaultOptions;
+
+	beforeEach( () => {
+		WorkerMock = class {
+			constructor( script, options ) {
+				// Define a static property that keeps all instances for a particular test scenario.
+				if ( !this.constructor.instances ) {
+					this.constructor.instances = [];
+				}
+
+				this.constructor.instances.push( this );
+
+				this.workerData = options.workerData;
+				this.on = sinon.stub();
+				this.terminate = sinon.stub();
+
+				expect( script.endsWith( 'parallelworker.js' ) ).to.equal( true );
+			}
+		};
+
+		stubs = {
+			process: {
+				cwd: sinon.stub( process, 'cwd' ).returns( '/home/ckeditor' )
+			},
+			os: {
+				cpus: sinon.stub().returns( new Array( 4 ) )
+			},
+			crypto: {
+				randomUUID: sinon.stub().returns( 'uuid-4' )
+			},
+			path: {
+				posix: {
+					join: sinon.stub().callsFake( ( ...chunks ) => chunks.join( '/' ) )
+				},
+				join: sinon.stub().callsFake( ( ...chunks ) => stubs.path.posix.join( ...chunks ) )
+			},
+			fs: {
+				writeFileSync: sinon.stub(),
+				unlinkSync: sinon.stub()
+			},
+			worker_threads: {
+				Worker: WorkerMock
+			},
+			glob: {
+				sync: sinon.stub().returns( [
+					'/home/ckeditor/my-packages/package-01',
+					'/home/ckeditor/my-packages/package-02',
+					'/home/ckeditor/my-packages/package-03',
+					'/home/ckeditor/my-packages/package-04'
+				] )
+			},
+			devUtils: {
+				tools: {
+					createSpinner: sinon.stub().callsFake( () => stubs.spinnerStub )
+				}
+			},
+			spinnerStub: {
+				start: sinon.stub(),
+				finish: sinon.stub(),
+				increase: sinon.stub()
+			}
+		};
+
+		abortController = new AbortController();
+
+		defaultOptions = {
+			packagesDirectory: 'my-packages',
+			processDescription: 'Just a test.',
+			callback: packagePath => console.log( 'pwd', packagePath ),
+			signal: abortController.signal
+		};
+
+		executeInParallel = proxyquire( '../../lib/utils/executeinparallel', {
+			'@ckeditor/ckeditor5-dev-utils': stubs.devUtils,
+			os: stubs.os,
+			crypto: stubs.crypto,
+			path: stubs.path,
+			fs: stubs.fs,
+			worker_threads: stubs.worker_threads,
+			glob: stubs.glob
+		} );
+	} );
+
+	afterEach( () => {
+		sinon.restore();
+	} );
+
+	describe( 'executeInParallel()', () => {
+		it( 'should execute the specified `callback` on all packages found in the `packagesDirectory`', async () => {
+			const promise = executeInParallel( defaultOptions );
+
+			expect( stubs.glob.sync.callCount ).to.equal( 1 );
+			expect( stubs.glob.sync.firstCall.args[ 0 ] ).to.equal( 'my-packages/*/' );
+			expect( stubs.glob.sync.firstCall.args[ 1 ] ).to.be.an( 'object' );
+			expect( stubs.glob.sync.firstCall.args[ 1 ] ).to.have.property( 'cwd', '/home/ckeditor' );
+			expect( stubs.glob.sync.firstCall.args[ 1 ] ).to.have.property( 'absolute', true );
+
+			expect( stubs.fs.writeFileSync.callCount ).to.equal( 1 );
+			expect( stubs.fs.writeFileSync.firstCall.args[ 0 ] ).to.equal( '/home/ckeditor/uuid-4.js' );
+			expect( stubs.fs.writeFileSync.firstCall.args[ 1 ] ).to.equal(
+				'\'use strict\';\nmodule.exports = packagePath => console.log( \'pwd\', packagePath );'
+			);
+
+			// By default the helper uses a half of available CPUs.
+			expect( WorkerMock.instances ).to.lengthOf( 2 );
+
+			const [ firstWorker, secondWorker ] = WorkerMock.instances;
+
+			expect( firstWorker.workerData ).to.be.an( 'object' );
+			expect( firstWorker.workerData ).to.have.property( 'callbackModule', '/home/ckeditor/uuid-4.js' );
+			expect( firstWorker.workerData ).to.have.property( 'packages' );
+
+			expect( secondWorker.workerData ).to.be.an( 'object' );
+			expect( secondWorker.workerData ).to.have.property( 'callbackModule', '/home/ckeditor/uuid-4.js' );
+			expect( secondWorker.workerData ).to.have.property( 'packages' );
+
+			// Workers did not emit an error.
+			getExitCallback( firstWorker )( 0 );
+			getExitCallback( secondWorker )( 0 );
+
+			await promise;
+		} );
+
+		it( 'should use the specified `cwd` when looking for packages', async () => {
+			const options = Object.assign( {}, defaultOptions, {
+				cwd: '/custom/cwd'
+			} );
+
+			const promise = executeInParallel( options );
+
+			expect( stubs.glob.sync.callCount ).to.equal( 1 );
+			expect( stubs.glob.sync.firstCall.args[ 0 ] ).to.equal( 'my-packages/*/' );
+			expect( stubs.glob.sync.firstCall.args[ 1 ] ).to.be.an( 'object' );
+			expect( stubs.glob.sync.firstCall.args[ 1 ] ).to.have.property( 'cwd', '/custom/cwd' );
+
+			const [ firstWorker, secondWorker ] = WorkerMock.instances;
+
+			// Workers did not emit an error.
+			getExitCallback( firstWorker )( 0 );
+			getExitCallback( secondWorker )( 0 );
+
+			await promise;
+		} );
+
+		it( 'should use the specified number of threads (`concurrency`)', async () => {
+			const options = Object.assign( {}, defaultOptions, {
+				concurrency: 4
+			} );
+			const promise = executeInParallel( options );
+
+			expect( WorkerMock.instances ).to.lengthOf( 4 );
+
+			// Workers did not emit an error.
+			for ( const worker of WorkerMock.instances ) {
+				getExitCallback( worker )( 0 );
+			}
+
+			await promise;
+		} );
+
+		it( 'should reject the promise if a worker finished with a non-zero exit code (first worker)', async () => {
+			const promise = executeInParallel( defaultOptions );
+			const [ firstWorker, secondWorker ] = WorkerMock.instances;
+
+			getExitCallback( firstWorker )( 1 );
+			getExitCallback( secondWorker )( 0 );
+
+			return promise
+				.then(
+					() => {
+						throw new Error( 'Expected to be rejected.' );
+					},
+					err => {
+						// Due to non-zero exit code.
+						expect( err ).to.equal( undefined );
+					}
+				);
+		} );
+
+		it( 'should reject the promise if a worker finished with a non-zero exit code (second worker)', async () => {
+			const promise = executeInParallel( defaultOptions );
+			const [ firstWorker, secondWorker ] = WorkerMock.instances;
+
+			getExitCallback( firstWorker )( 0 );
+			getExitCallback( secondWorker )( 1 );
+
+			return promise
+				.then(
+					() => {
+						throw new Error( 'Expected to be rejected.' );
+					},
+					err => {
+						// Due to non-zero exit code.
+						expect( err ).to.equal( undefined );
+					}
+				);
+		} );
+
+		it( 'should reject the promise if a worker emitted an error (first worker)', () => {
+			const promise = executeInParallel( defaultOptions );
+			const [ firstWorker, secondWorker ] = WorkerMock.instances;
+			const error = new Error( 'Example error from a worker.' );
+
+			getErrorCallback( firstWorker )( error );
+			getExitCallback( secondWorker )( 0 );
+
+			return promise
+				.then(
+					() => {
+						throw new Error( 'Expected to be rejected.' );
+					},
+					err => {
+						expect( err ).to.equal( error );
+					}
+				);
+		} );
+
+		it( 'should reject the promise if a worker emitted an error (second worker)', () => {
+			const promise = executeInParallel( defaultOptions );
+			const [ firstWorker, secondWorker ] = WorkerMock.instances;
+			const error = new Error( 'Example error from a worker.' );
+
+			getExitCallback( firstWorker )( 0 );
+			getErrorCallback( secondWorker )( error );
+
+			return promise
+				.then(
+					() => {
+						throw new Error( 'Expected to be rejected.' );
+					},
+					err => {
+						expect( err ).to.equal( error );
+					}
+				);
+		} );
+
+		it( 'should split packages into threads one by one', async () => {
+			const promise = executeInParallel( defaultOptions );
+
+			const [ firstWorker, secondWorker ] = WorkerMock.instances;
+
+			expect( firstWorker.workerData ).to.be.an( 'object' );
+			expect( firstWorker.workerData ).to.have.property( 'packages' );
+			expect( firstWorker.workerData.packages ).to.be.an( 'array' );
+			expect( firstWorker.workerData.packages ).to.deep.equal( [
+				'/home/ckeditor/my-packages/package-01',
+				'/home/ckeditor/my-packages/package-03'
+			] );
+
+			expect( secondWorker.workerData ).to.be.an( 'object' );
+			expect( secondWorker.workerData ).to.have.property( 'packages' );
+			expect( secondWorker.workerData.packages ).to.be.an( 'array' );
+			expect( secondWorker.workerData.packages ).to.deep.equal( [
+				'/home/ckeditor/my-packages/package-02',
+				'/home/ckeditor/my-packages/package-04'
+			] );
+
+			// Workers did not emit an error.
+			getExitCallback( firstWorker )( 0 );
+			getExitCallback( secondWorker )( 0 );
+
+			await promise;
+		} );
+
+		it( 'should remove the temporary module after execution', async () => {
+			const promise = executeInParallel( defaultOptions );
+			const [ firstWorker, secondWorker ] = WorkerMock.instances;
+
+			// Workers did not emit an error.
+			getExitCallback( firstWorker )( 0 );
+			getExitCallback( secondWorker )( 0 );
+
+			await promise;
+
+			expect( stubs.fs.unlinkSync.callCount ).to.equal( 1 );
+			expect( stubs.fs.unlinkSync.firstCall.args[ 0 ] ).to.equal( '/home/ckeditor/uuid-4.js' );
+		} );
+
+		it( 'should remove the temporary module if the process is aborted', async () => {
+			const promise = executeInParallel( defaultOptions );
+			const [ firstWorker, secondWorker ] = WorkerMock.instances;
+
+			abortController.abort( 'SIGINT' );
+
+			// Simulate the "Worker#terminate()" behavior.
+			getExitCallback( firstWorker )( 0 );
+			getExitCallback( secondWorker )( 0 );
+
+			await promise;
+
+			expect( stubs.fs.unlinkSync.callCount ).to.equal( 1 );
+			expect( stubs.fs.unlinkSync.firstCall.args[ 0 ] ).to.equal( '/home/ckeditor/uuid-4.js' );
+		} );
+
+		it( 'should remove the temporary module if the promise rejected', () => {
+			const promise = executeInParallel( defaultOptions );
+			const [ firstWorker ] = WorkerMock.instances;
+
+			getExitCallback( firstWorker )( 1 );
+
+			return promise
+				.then(
+					() => {
+						throw new Error( 'Expected to be rejected.' );
+					},
+					err => {
+						// Due to non-zero exit code.
+						expect( err ).to.equal( undefined );
+
+						expect( stubs.fs.unlinkSync.callCount ).to.equal( 1 );
+						expect( stubs.fs.unlinkSync.firstCall.args[ 0 ] ).to.equal( '/home/ckeditor/uuid-4.js' );
+					}
+				);
+		} );
+
+		it( 'should terminate threads if the process is aborted', async () => {
+			const promise = executeInParallel( defaultOptions );
+			const [ firstWorker, secondWorker ] = WorkerMock.instances;
+
+			abortController.abort( 'SIGINT' );
+
+			// Simulate the "Worker#terminate()" behavior.
+			getExitCallback( firstWorker )( 0 );
+			getExitCallback( secondWorker )( 0 );
+
+			await promise;
+
+			expect( firstWorker.terminate.callCount ).to.equal( 1 );
+			expect( secondWorker.terminate.callCount ).to.equal( 1 );
+		} );
+
+		it( 'should attach listener to a worker that executes a callback once per worker', async () => {
+			const signalEvent = sinon.stub( abortController.signal, 'addEventListener' );
+			const promise = executeInParallel( defaultOptions );
+			const [ firstWorker, secondWorker ] = WorkerMock.instances;
+
+			abortController.abort( 'SIGINT' );
+
+			// Simulate the "Worker#terminate()" behavior.
+			getExitCallback( firstWorker )( 0 );
+			getExitCallback( secondWorker )( 0 );
+
+			await promise;
+
+			expect( signalEvent.callCount ).to.equal( 2 );
+
+			expect( signalEvent.firstCall.args[ 0 ] ).to.equal( 'abort' );
+			expect( signalEvent.firstCall.args[ 1 ] ).to.be.a( 'function' );
+			expect( signalEvent.firstCall.args[ 2 ] ).to.be.an( 'object' );
+			expect( signalEvent.firstCall.args[ 2 ] ).to.have.property( 'once', true );
+
+			expect( signalEvent.secondCall.args[ 0 ] ).to.equal( 'abort' );
+			expect( signalEvent.secondCall.args[ 1 ] ).to.be.a( 'function' );
+			expect( signalEvent.secondCall.args[ 2 ] ).to.be.an( 'object' );
+			expect( signalEvent.secondCall.args[ 2 ] ).to.have.property( 'once', true );
+		} );
+
+		it( 'should create a spinner that informs a user about the progress', async () => {
+			const promise = executeInParallel( defaultOptions );
+
+			expect( stubs.devUtils.tools.createSpinner.callCount ).to.equal( 1 );
+			expect( stubs.devUtils.tools.createSpinner.firstCall.args[ 0 ] ).to.equal( 'Just a test.' );
+			expect( stubs.devUtils.tools.createSpinner.firstCall.args[ 1 ] ).to.be.an( 'object' );
+			expect( stubs.devUtils.tools.createSpinner.firstCall.args[ 1 ] ).to.have.property( 'total', 4 );
+			expect( stubs.spinnerStub.start.callCount ).to.equal( 1 );
+
+			const [ firstWorker, secondWorker ] = WorkerMock.instances;
+
+			// Workers did not emit an error.
+			getExitCallback( firstWorker )( 0 );
+			getExitCallback( secondWorker )( 0 );
+
+			await promise;
+		} );
+
+		it( 'should increase the counter when a package finished executing the callback', async () => {
+			const promise = executeInParallel( defaultOptions );
+			const [ firstWorker, secondWorker ] = WorkerMock.instances;
+
+			const firstWorkerPackageDone = getMessageCallback( firstWorker );
+			const secondWorkerPackageDone = getMessageCallback( secondWorker );
+
+			expect( stubs.spinnerStub.increase.callCount ).to.equal( 0 ); // 0/4.
+			firstWorkerPackageDone( 'done:package' );
+			expect( stubs.spinnerStub.increase.callCount ).to.equal( 1 ); // 1/4.
+			secondWorkerPackageDone( 'done:package' );
+			expect( stubs.spinnerStub.increase.callCount ).to.equal( 2 ); // 2/4.
+			secondWorkerPackageDone( 'done:package' );
+			expect( stubs.spinnerStub.increase.callCount ).to.equal( 3 ); // 3/4.
+			firstWorkerPackageDone( 'done:package' );
+			expect( stubs.spinnerStub.increase.callCount ).to.equal( 4 ); // 4/4.
+
+			// Workers did not emit an error.
+			getExitCallback( firstWorker )( 0 );
+			getExitCallback( secondWorker )( 0 );
+
+			await promise;
+		} );
+
+		it( 'should ignore messages from threads unrelated to the spinner', async () => {
+			const promise = executeInParallel( defaultOptions );
+			const [ firstWorker, secondWorker ] = WorkerMock.instances;
+			const firstWorkerPackageDone = getMessageCallback( firstWorker );
+
+			expect( stubs.spinnerStub.increase.callCount ).to.equal( 0 );
+			firstWorkerPackageDone( 'foo' );
+			expect( stubs.spinnerStub.increase.callCount ).to.equal( 0 );
+
+			// Workers did not emit an error.
+			getExitCallback( firstWorker )( 0 );
+			getExitCallback( secondWorker )( 0 );
+
+			await promise;
+		} );
+
+		it( 'should mark the process as completed if workers did not emit an error', async () => {
+			const promise = executeInParallel( defaultOptions );
+			const [ firstWorker, secondWorker ] = WorkerMock.instances;
+
+			// Workers did not emit an error.
+			getExitCallback( firstWorker )( 0 );
+			getExitCallback( secondWorker )( 0 );
+
+			await promise;
+
+			expect( stubs.spinnerStub.finish.callCount ).to.equal( 1 );
+			expect( stubs.spinnerStub.finish.firstCall.args[ 0 ] ).to.be.an( 'object' );
+			expect( stubs.spinnerStub.finish.firstCall.args[ 0 ] ).to.have.property( 'emoji', '✔️ ' );
+		} );
+
+		it( 'should mark the process as errored if a worker finished with a non-zero exit code', async () => {
+			const promise = executeInParallel( defaultOptions );
+			const [ firstWorker ] = WorkerMock.instances;
+
+			getExitCallback( firstWorker )( 1 );
+
+			await promise
+				.then(
+					() => {
+						throw new Error( 'Expected to be rejected.' );
+					},
+					err => {
+						// Due to non-zero exit code.
+						expect( err ).to.equal( undefined );
+					}
+				);
+
+			expect( stubs.spinnerStub.finish.callCount ).to.equal( 1 );
+			expect( stubs.spinnerStub.finish.firstCall.args[ 0 ] ).to.be.an( 'object' );
+			expect( stubs.spinnerStub.finish.firstCall.args[ 0 ] ).to.have.property( 'emoji', '❌' );
+		} );
+
+		it( 'should mark the process as errored if a worker emitted an error', async () => {
+			const promise = executeInParallel( defaultOptions );
+			const [ firstWorker ] = WorkerMock.instances;
+			const error = new Error( 'Example error from a worker.' );
+
+			getErrorCallback( firstWorker )( error );
+
+			await promise
+				.then(
+					() => {
+						throw new Error( 'Expected to be rejected.' );
+					},
+					err => {
+						expect( err ).to.equal( error );
+					}
+				);
+
+			expect( stubs.spinnerStub.finish.callCount ).to.equal( 1 );
+			expect( stubs.spinnerStub.finish.firstCall.args[ 0 ] ).to.be.an( 'object' );
+			expect( stubs.spinnerStub.finish.firstCall.args[ 0 ] ).to.have.property( 'emoji', '❌' );
+		} );
+	} );
+} );
+
+function getExitCallback( fakeWorker ) {
+	for ( const call of fakeWorker.on.getCalls() ) {
+		const [ eventName, callback ] = call.args;
+
+		if ( eventName === 'exit' ) {
+			return callback;
+		}
+	}
+}
+
+function getMessageCallback( fakeWorker ) {
+	for ( const call of fakeWorker.on.getCalls() ) {
+		const [ eventName, callback ] = call.args;
+
+		if ( eventName === 'message' ) {
+			return callback;
+		}
+	}
+}
+
+function getErrorCallback( fakeWorker ) {
+	for ( const call of fakeWorker.on.getCalls() ) {
+		const [ eventName, callback ] = call.args;
+
+		if ( eventName === 'error' ) {
+			return callback;
+		}
+	}
+}

--- a/packages/ckeditor5-dev-release-tools/tests/utils/executeinparallel.js
+++ b/packages/ckeditor5-dev-release-tools/tests/utils/executeinparallel.js
@@ -78,7 +78,7 @@ describe( 'dev-release-tools/utils', () => {
 		defaultOptions = {
 			packagesDirectory: 'my-packages',
 			processDescription: 'Just a test.',
-			callback: packagePath => console.log( 'pwd', packagePath ),
+			taskToExecute: packagePath => console.log( 'pwd', packagePath ),
 			signal: abortController.signal
 		};
 
@@ -98,7 +98,7 @@ describe( 'dev-release-tools/utils', () => {
 	} );
 
 	describe( 'executeInParallel()', () => {
-		it( 'should execute the specified `callback` on all packages found in the `packagesDirectory`', async () => {
+		it( 'should execute the specified `taskToExecute` on all packages found in the `packagesDirectory`', async () => {
 			const promise = executeInParallel( defaultOptions );
 
 			expect( stubs.glob.sync.callCount ).to.equal( 1 );

--- a/packages/ckeditor5-dev-release-tools/tests/utils/executeinparallel.js
+++ b/packages/ckeditor5-dev-release-tools/tests/utils/executeinparallel.js
@@ -170,42 +170,24 @@ describe( 'dev-release-tools/utils', () => {
 			await promise;
 		} );
 
-		it( 'should reject the promise if a worker finished with a non-zero exit code (first worker)', async () => {
+		it( 'should resolve the promise if a worker finished (aborted) with a non-zero exit code (first worker)', async () => {
 			const promise = executeInParallel( defaultOptions );
 			const [ firstWorker, secondWorker ] = WorkerMock.instances;
 
 			getExitCallback( firstWorker )( 1 );
 			getExitCallback( secondWorker )( 0 );
 
-			return promise
-				.then(
-					() => {
-						throw new Error( 'Expected to be rejected.' );
-					},
-					err => {
-						// Due to non-zero exit code.
-						expect( err ).to.equal( undefined );
-					}
-				);
+			await promise;
 		} );
 
-		it( 'should reject the promise if a worker finished with a non-zero exit code (second worker)', async () => {
+		it( 'should resolve the promise if a worker finished (aborted) with a non-zero exit code (second worker)', async () => {
 			const promise = executeInParallel( defaultOptions );
 			const [ firstWorker, secondWorker ] = WorkerMock.instances;
 
 			getExitCallback( firstWorker )( 0 );
 			getExitCallback( secondWorker )( 1 );
 
-			return promise
-				.then(
-					() => {
-						throw new Error( 'Expected to be rejected.' );
-					},
-					err => {
-						// Due to non-zero exit code.
-						expect( err ).to.equal( undefined );
-					}
-				);
+			await promise;
 		} );
 
 		it( 'should reject the promise if a worker emitted an error (first worker)', () => {
@@ -307,18 +289,16 @@ describe( 'dev-release-tools/utils', () => {
 		it( 'should remove the temporary module if the promise rejected', () => {
 			const promise = executeInParallel( defaultOptions );
 			const [ firstWorker ] = WorkerMock.instances;
+			const error = new Error( 'Example error from a worker.' );
 
-			getExitCallback( firstWorker )( 1 );
+			getErrorCallback( firstWorker )( error );
 
 			return promise
 				.then(
 					() => {
 						throw new Error( 'Expected to be rejected.' );
 					},
-					err => {
-						// Due to non-zero exit code.
-						expect( err ).to.equal( undefined );
-
+					() => {
 						expect( stubs.fs.unlinkSync.callCount ).to.equal( 1 );
 						expect( stubs.fs.unlinkSync.firstCall.args[ 0 ] ).to.equal( '/home/ckeditor/uuid-4.js' );
 					}
@@ -446,16 +426,7 @@ describe( 'dev-release-tools/utils', () => {
 
 			getExitCallback( firstWorker )( 1 );
 
-			await promise
-				.then(
-					() => {
-						throw new Error( 'Expected to be rejected.' );
-					},
-					err => {
-						// Due to non-zero exit code.
-						expect( err ).to.equal( undefined );
-					}
-				);
+			await promise;
 
 			expect( stubs.spinnerStub.finish.callCount ).to.equal( 1 );
 			expect( stubs.spinnerStub.finish.firstCall.args[ 0 ] ).to.be.an( 'object' );

--- a/packages/ckeditor5-dev-utils/lib/tools.js
+++ b/packages/ckeditor5-dev-utils/lib/tools.js
@@ -22,14 +22,14 @@ module.exports = {
 	 * stderr) will be logged. If set as 'error', only stderr output will be logged.
 	 * @returns {String} The command output.
 	 */
-	shExec( command, options = { verbosity: 'info' } ) {
+	shExec( command, options = { verbosity: 'info', cwd: process.cwd() } ) {
 		const logger = require( './logger' );
 		const log = logger( options.verbosity );
 		const sh = require( 'shelljs' );
 
 		sh.config.silent = true;
 
-		const ret = sh.exec( command );
+		const ret = sh.exec( command, { cwd: options.cwd } );
 
 		const grey = chalk.grey;
 

--- a/packages/ckeditor5-dev-utils/lib/tools.js
+++ b/packages/ckeditor5-dev-utils/lib/tools.js
@@ -23,14 +23,19 @@ module.exports = {
 	 * @param {String} [options.cwd=process.cwd()]
 	 * @returns {String} The command output.
 	 */
-	shExec( command, options = { verbosity: 'info', cwd: process.cwd() } ) {
+	shExec( command, options = {} ) {
+		const {
+			verbosity = 'info',
+			cwd = process.cwd()
+		} = options;
+
 		const logger = require( './logger' );
-		const log = logger( options.verbosity );
+		const log = logger( verbosity );
 		const sh = require( 'shelljs' );
 
 		sh.config.silent = true;
 
-		const ret = sh.exec( command, { cwd: options.cwd } );
+		const ret = sh.exec( command, { cwd } );
 
 		const grey = chalk.grey;
 

--- a/packages/ckeditor5-dev-utils/lib/tools.js
+++ b/packages/ckeditor5-dev-utils/lib/tools.js
@@ -18,8 +18,9 @@ module.exports = {
 	 *
 	 * @param {String} command The command to be executed.
 	 * @param {Object} options
-	 * @param {String} [options.verbosity='info'] Level of the verbosity. If set as 'info' both outputs (stdout and
+	 * @param {'info'|'warning'|'error'} [options.verbosity='info'] Level of the verbosity. If set as 'info' both outputs (stdout and
 	 * stderr) will be logged. If set as 'error', only stderr output will be logged.
+	 * @param {String} [options.cwd=process.cwd()]
 	 * @returns {String} The command output.
 	 */
 	shExec( command, options = { verbosity: 'info', cwd: process.cwd() } ) {

--- a/packages/ckeditor5-dev-utils/lib/tools/createspinner.js
+++ b/packages/ckeditor5-dev-utils/lib/tools/createspinner.js
@@ -14,25 +14,31 @@ const cliCursor = require( 'cli-cursor' );
 const INDENT_SIZE = 3;
 
 /**
- * A factory function that creates an instance of a CLI spinner.
+ * A factory function that creates an instance of a CLI spinner. It supports both a spinner CLI and a spinner with a counter.
  *
- * The spinner improves UX when processing a time-consuming task.
- * A developer does not have to consider whether the process hanged on.
+ * The spinner improves UX when processing a time-consuming task. A developer does not have to consider whether the process hanged on.
  *
  * @param {String} title Description of the current processed task.
  * @param {Object} [options={}]
  * @param {Boolean} [options.isDisabled] Whether the spinner should be disabled.
  * @param {String} [options.emoji='📍'] An emoji that will replace the spinner when it finishes.
  * @param {Number} [options.indentLevel=1] The indent level.
- * @return {CKEditor5Spinner}
+ * @param {Number} [options.total] If specified, the spinner contains a counter. It starts from `0`. To increase its value,
+ * call the `#increase()` method on the returned instance of the spinner.
+ * @param {String|CKEditor5SpinnerStatus} [options.status='[title] Status: [current]/[total].'] If a spinner is a counter,
+ * this option allows customizing the displayed line.
+ * @returns {CKEditor5Spinner}
  */
 module.exports = function createSpinner( title, options = {} ) {
 	const isEnabled = !options.isDisabled && isInteractive();
 	const indentLevel = options.indentLevel || 0;
 	const indent = ' '.repeat( indentLevel * INDENT_SIZE );
 	const emoji = options.emoji || '📍';
+	const status = options.status || '[title] Status: [current]/[total].';
+	const spinnerType = typeof options.total === 'number' ? 'counter' : 'spinner';
 
 	let timerId;
+	let counter = 0;
 
 	return {
 		start() {
@@ -41,7 +47,21 @@ module.exports = function createSpinner( title, options = {} ) {
 				return;
 			}
 
-			const frames = cliSpinners.dots12.frames;
+			const { frames } = cliSpinners.dots12;
+			const getMessage = () => {
+				if ( spinnerType === 'spinner' ) {
+					return title;
+				}
+
+				if ( typeof options.status === 'function' ) {
+					return options.status( title, counter, options.total );
+				}
+
+				return `${ status }`
+					.replace( '[title]', title )
+					.replace( '[current]', counter )
+					.replace( '[total]', options.total.toString() );
+			};
 
 			let index = 0;
 			let shouldClearLastLine = false;
@@ -57,9 +77,17 @@ module.exports = function createSpinner( title, options = {} ) {
 					clearLastLine();
 				}
 
-				process.stdout.write( `${ indent }${ frames[ index++ ] } ${ title }` );
+				process.stdout.write( `${ indent }${ frames[ index++ ] } ${ getMessage() }` );
 				shouldClearLastLine = true;
 			}, cliSpinners.dots12.interval );
+		},
+
+		increase() {
+			if ( spinnerType === 'spinner' ) {
+				throw new Error( 'The \'#increase()\' method is available only when using the counter spinner.' );
+			}
+
+			counter += 1;
 		},
 
 		finish( options = {} ) {
@@ -71,6 +99,10 @@ module.exports = function createSpinner( title, options = {} ) {
 
 			clearInterval( timerId );
 			clearLastLine();
+
+			if ( spinnerType === 'counter' ) {
+				clearLastLine();
+			}
 
 			cliCursor.show();
 			console.log( `${ indent }${ finishEmoji } ${ title }` );
@@ -86,7 +118,35 @@ module.exports = function createSpinner( title, options = {} ) {
 /**
  * @typedef {Object} CKEditor5Spinner
  *
- * @property {Function} start
+ * @property {CKEditor5SpinnerStart} start
  *
- * @property {Function} finish
+ * @property {CKEditor5SpinnerIncrease} increase
+ *
+ * @property {CKEditor5SpinnerFinish} finish
+ */
+
+/**
+ * @callback CKEditor5SpinnerStart
+ */
+
+/**
+ * @callback CKEditor5SpinnerIncrease
+ */
+
+/**
+ * @callback CKEditor5SpinnerFinish
+ *
+ * @param {Object} [options={}]
+ *
+ * @param {String} [options.emoji]
+ */
+
+/**
+ * @callback CKEditor5SpinnerStatus
+ *
+ * @param {String} title
+ *
+ * @param {Number} current
+ *
+ * @param {Number} total
  */

--- a/packages/ckeditor5-dev-utils/tests/tools.js
+++ b/packages/ckeditor5-dev-utils/tests/tools.js
@@ -50,13 +50,29 @@ describe( 'utils', () => {
 		describe( 'shExec', () => {
 			it( 'should be defined', () => expect( tools.shExec ).to.be.a( 'function' ) );
 
-			it( 'should execute command', () => {
+			it( 'should execute command (default cwd)', () => {
 				const sh = require( 'shelljs' );
 				const execStub = sandbox.stub( sh, 'exec' ).returns( { code: 0 } );
+				const processStub = sandbox.stub( process, 'cwd' ).returns( '/default' );
 
 				tools.shExec( 'command' );
 
+				sinon.assert.calledOnce( processStub );
 				sinon.assert.calledOnce( execStub );
+				expect( execStub.firstCall.args[ 1 ] ).to.be.an( 'object' );
+				expect( execStub.firstCall.args[ 1 ] ).to.contain.property( 'cwd', '/default' );
+			} );
+
+			it( 'should execute command with specified cwd', () => {
+				const cwd = '/home/user';
+				const sh = require( 'shelljs' );
+				const execStub = sandbox.stub( sh, 'exec' ).returns( { code: 0 } );
+
+				tools.shExec( 'command', { cwd } );
+
+				sinon.assert.calledOnce( execStub );
+				expect( execStub.firstCall.args[ 1 ] ).to.be.an( 'object' );
+				expect( execStub.firstCall.args[ 1 ] ).to.contain.property( 'cwd', cwd );
 			} );
 
 			it( 'should throw error on unsuccessful call', () => {

--- a/packages/ckeditor5-dev-utils/tests/tools/createspinner.js
+++ b/packages/ckeditor5-dev-utils/tests/tools/createspinner.js
@@ -67,265 +67,502 @@ describe( 'lib/utils/create-spinner', () => {
 
 		expect( spinner ).to.have.property( 'finish' );
 		expect( spinner.finish ).to.be.a( 'function' );
+
+		expect( spinner ).to.have.property( 'increase' );
+		expect( spinner.increase ).to.be.a( 'function' );
 	} );
 
-	describe( '#start', () => {
+	describe( 'type: spinner', () => {
+		describe( '#start', () => {
+			beforeEach( () => {
+				stubs.isInteractive.returns( true );
+			} );
+
+			it( 'prints the specified title if spinner should be disabled', () => {
+				const spinner = createSpinner( 'Foo.', { isDisabled: true } );
+				const consoleStub = sinon.stub( console, 'log' );
+
+				spinner.start();
+
+				consoleStub.restore();
+
+				expect( consoleStub.calledOnce ).to.equal( true );
+				expect( consoleStub.firstCall.args[ 0 ] ).to.equal( '📍 Foo.' );
+			} );
+
+			it( 'prints the specified title if spinner cannot be created if CLI is not interactive', () => {
+				stubs.isInteractive.returns( false );
+
+				const spinner = createSpinner( 'Foo.' );
+				const consoleStub = sinon.stub( console, 'log' );
+
+				spinner.start();
+
+				consoleStub.restore();
+
+				expect( consoleStub.calledOnce ).to.equal( true );
+				expect( consoleStub.firstCall.args[ 0 ] ).to.equal( '📍 Foo.' );
+			} );
+
+			it( 'uses "setInterval" for creating a loop', () => {
+				const spinner = createSpinner( 'Foo.' );
+
+				spinner.start();
+
+				const timer = Object.values( clock.timers ).shift();
+
+				expect( timer ).to.be.an( 'object' );
+				expect( timer.type ).to.equal( 'Interval' );
+			} );
+
+			it( 'prints always spinner in the last line', () => {
+				const spinner = createSpinner( 'Foo.' );
+
+				spinner.start();
+
+				const writeStub = sinon.stub( process.stdout, 'write' );
+
+				clock.tick( 5 );
+				expect( writeStub.callCount ).to.equal( 1 );
+				expect( writeStub.getCall( 0 ).args[ 0 ] ).to.equal( '| Foo.' );
+
+				clock.tick( 5 );
+				expect( writeStub.callCount ).to.equal( 2 );
+				expect( writeStub.getCall( 1 ).args[ 0 ] ).to.equal( '/ Foo.' );
+
+				clock.tick( 5 );
+				expect( writeStub.callCount ).to.equal( 3 );
+				expect( writeStub.getCall( 2 ).args[ 0 ] ).to.equal( '- Foo.' );
+
+				clock.tick( 5 );
+				expect( writeStub.callCount ).to.equal( 4 );
+				expect( writeStub.getCall( 3 ).args[ 0 ] ).to.equal( '\\ Foo.' );
+
+				clock.tick( 5 );
+				expect( writeStub.callCount ).to.equal( 5 );
+				expect( writeStub.getCall( 4 ).args[ 0 ] ).to.equal( '| Foo.' );
+
+				// It does not clear the last line for an initial spin.
+				expect( stubs.readline.clearLine.callCount ).to.equal( 4 );
+				expect( stubs.readline.cursorTo.callCount ).to.equal( 4 );
+
+				expect( stubs.readline.clearLine.firstCall.args[ 0 ] ).to.equal( process.stdout );
+				expect( stubs.readline.clearLine.firstCall.args[ 1 ] ).to.equal( 1 );
+
+				expect( stubs.readline.cursorTo.firstCall.args[ 0 ] ).to.equal( process.stdout );
+				expect( stubs.readline.cursorTo.firstCall.args[ 1 ] ).to.equal( 0 );
+
+				writeStub.restore();
+			} );
+
+			it( 'hides a cursor when starting spinning', () => {
+				const spinner = createSpinner( 'Foo.' );
+
+				spinner.start();
+
+				expect( stubs.cliCursor.hide.calledOnce ).to.equal( true );
+			} );
+
+			it( 'allows indenting messages by specifying the "options.indentLevel" option', () => {
+				const spinner = createSpinner( 'Foo.', { indentLevel: 1 } );
+
+				spinner.start();
+
+				const writeStub = sinon.stub( process.stdout, 'write' );
+
+				clock.tick( 5 );
+				expect( writeStub.callCount ).to.equal( 1 );
+				expect( writeStub.getCall( 0 ).args[ 0 ] ).to.equal( '   | Foo.' );
+
+				clock.tick( 5 );
+				expect( writeStub.callCount ).to.equal( 2 );
+				expect( writeStub.getCall( 1 ).args[ 0 ] ).to.equal( '   / Foo.' );
+
+				clock.tick( 5 );
+				expect( writeStub.callCount ).to.equal( 3 );
+				expect( writeStub.getCall( 2 ).args[ 0 ] ).to.equal( '   - Foo.' );
+
+				clock.tick( 5 );
+				expect( writeStub.callCount ).to.equal( 4 );
+				expect( writeStub.getCall( 3 ).args[ 0 ] ).to.equal( '   \\ Foo.' );
+
+				clock.tick( 5 );
+				expect( writeStub.callCount ).to.equal( 5 );
+				expect( writeStub.getCall( 4 ).args[ 0 ] ).to.equal( '   | Foo.' );
+
+				writeStub.restore();
+			} );
+		} );
+
+		describe( '#finish', () => {
+			beforeEach( () => {
+				stubs.isInteractive.returns( true );
+			} );
+
+			it( 'does nothing if spinner should be disabled', () => {
+				const spinner = createSpinner( 'Foo.', { isDisabled: true } );
+				const consoleStub = sinon.stub( console, 'log' );
+
+				spinner.finish();
+
+				consoleStub.restore();
+
+				expect( consoleStub.calledOnce ).to.equal( false );
+			} );
+
+			it( 'does nothing if spinner cannot be created if CLI is not interactive', () => {
+				stubs.isInteractive.returns( false );
+
+				const spinner = createSpinner( 'Foo.' );
+				const consoleStub = sinon.stub( console, 'log' );
+
+				spinner.finish();
+
+				consoleStub.restore();
+
+				expect( consoleStub.calledOnce ).to.equal( false );
+			} );
+
+			it( 'clears the interval when finished', () => {
+				const spinner = createSpinner( 'Foo.' );
+				const consoleStub = sinon.stub( console, 'log' );
+
+				spinner.start();
+
+				const timer = Object.values( clock.timers ).shift();
+				expect( timer ).to.be.an( 'object' );
+
+				spinner.finish();
+
+				const newTimer = Object.values( clock.timers ).shift();
+
+				expect( timer ).to.be.an( 'object' );
+				expect( newTimer ).to.be.undefined;
+
+				consoleStub.restore();
+			} );
+
+			it( 'prints the specified title with a pin when finished', () => {
+				const spinner = createSpinner( 'Foo.' );
+				const consoleStub = sinon.stub( console, 'log' );
+
+				spinner.start();
+				spinner.finish();
+
+				consoleStub.restore();
+
+				expect( consoleStub.calledOnce ).to.equal( true );
+				expect( consoleStub.firstCall.args[ 0 ] ).to.equal( '📍 Foo.' );
+			} );
+
+			it( 'shows a cursor when finished spinning', () => {
+				const spinner = createSpinner( 'Foo.' );
+				const consoleStub = sinon.stub( console, 'log' );
+
+				spinner.start();
+				spinner.finish();
+
+				consoleStub.restore();
+				expect( stubs.cliCursor.show.calledOnce ).to.equal( true );
+			} );
+
+			it( 'allows indenting messages by specifying the "options.indentLevel" option', () => {
+				const spinner = createSpinner( 'Foo.', { indentLevel: 1 } );
+				const consoleStub = sinon.stub( console, 'log' );
+
+				spinner.start();
+				spinner.finish();
+
+				consoleStub.restore();
+
+				expect( consoleStub.calledOnce ).to.equal( true );
+				expect( consoleStub.firstCall.args[ 0 ] ).to.equal( '   📍 Foo.' );
+			} );
+
+			it( 'prints the specified emoji when created a spinner if it finished', () => {
+				const spinner = createSpinner( 'Foo.', { emoji: '👉' } );
+				const consoleStub = sinon.stub( console, 'log' );
+
+				spinner.start();
+				spinner.finish();
+
+				consoleStub.restore();
+
+				expect( consoleStub.calledOnce ).to.equal( true );
+				expect( consoleStub.firstCall.args[ 0 ] ).to.equal( '👉 Foo.' );
+			} );
+
+			it( 'prints the specified title if spinner cannot be created if CLI is not interactive', () => {
+				stubs.isInteractive.returns( false );
+
+				const spinner = createSpinner( 'Foo.', { emoji: '👉' } );
+				const consoleStub = sinon.stub( console, 'log' );
+
+				spinner.start();
+
+				consoleStub.restore();
+
+				expect( consoleStub.calledOnce ).to.equal( true );
+				expect( consoleStub.firstCall.args[ 0 ] ).to.equal( '👉 Foo.' );
+			} );
+
+			it( 'allows overriding the emoji (use default emoji when creating a spinner)', () => {
+				const spinner = createSpinner( 'Foo.' );
+				const consoleStub = sinon.stub( console, 'log' );
+
+				spinner.start();
+				spinner.finish( { emoji: '❌' } );
+
+				consoleStub.restore();
+
+				expect( consoleStub.calledOnce ).to.equal( true );
+				expect( consoleStub.firstCall.args[ 0 ] ).to.equal( '❌ Foo.' );
+			} );
+
+			it( 'allows overriding the emoji (passed an emoji when creating a spinner)', () => {
+				const spinner = createSpinner( 'Foo.', { emoji: '👉' } );
+				const consoleStub = sinon.stub( console, 'log' );
+
+				spinner.start();
+				spinner.finish( { emoji: '❌' } );
+
+				consoleStub.restore();
+
+				expect( consoleStub.calledOnce ).to.equal( true );
+				expect( consoleStub.firstCall.args[ 0 ] ).to.equal( '❌ Foo.' );
+			} );
+		} );
+
+		describe( '#increase', () => {
+			it( 'throws an error when increasing a counter when defined the spinner type', () => {
+				const spinner = createSpinner( 'Foo.' );
+
+				expect( () => {
+					spinner.increase();
+				} ).to.throw( Error, 'The \'#increase()\' method is available only when using the counter spinner.' );
+			} );
+		} );
+	} );
+	describe( 'type: counter', () => {
 		beforeEach( () => {
 			stubs.isInteractive.returns( true );
 		} );
 
-		it( 'prints the specified title if spinner should be disabled', () => {
-			const spinner = createSpinner( 'Foo.', { isDisabled: true } );
-			const consoleStub = sinon.stub( console, 'log' );
+		describe( '#start', () => {
+			it( 'prints the specified title if spinner cannot be created if CLI is not interactive', () => {
+				stubs.isInteractive.returns( false );
 
-			spinner.start();
+				const spinner = createSpinner( 'Foo.', { total: 10 } );
+				const consoleStub = sinon.stub( console, 'log' );
 
-			consoleStub.restore();
+				spinner.start();
 
-			expect( consoleStub.calledOnce ).to.equal( true );
-			expect( consoleStub.firstCall.args[ 0 ] ).to.equal( '📍 Foo.' );
+				consoleStub.restore();
+
+				expect( consoleStub.calledOnce ).to.equal( true );
+				expect( consoleStub.firstCall.args[ 0 ] ).to.equal( '📍 Foo.' );
+			} );
+
+			it( 'uses "setInterval" for creating a loop', () => {
+				const spinner = createSpinner( 'Foo.', { total: 10 } );
+
+				spinner.start();
+
+				const timer = Object.values( clock.timers ).shift();
+
+				expect( timer ).to.be.an( 'object' );
+				expect( timer.type ).to.equal( 'Interval' );
+			} );
+
+			it( 'prints always spinner in the last line', () => {
+				const spinner = createSpinner( 'Foo.', { total: 10 } );
+
+				spinner.start();
+
+				const writeStub = sinon.stub( process.stdout, 'write' );
+
+				clock.tick( 5 );
+				expect( writeStub.callCount ).to.equal( 1 );
+				expect( writeStub.getCall( 0 ).args[ 0 ] ).to.equal( '| Foo. Status: 0/10.' );
+
+				clock.tick( 5 );
+				expect( writeStub.callCount ).to.equal( 2 );
+				expect( writeStub.getCall( 1 ).args[ 0 ] ).to.equal( '/ Foo. Status: 0/10.' );
+
+				clock.tick( 5 );
+				expect( writeStub.callCount ).to.equal( 3 );
+				expect( writeStub.getCall( 2 ).args[ 0 ] ).to.equal( '- Foo. Status: 0/10.' );
+
+				clock.tick( 5 );
+				expect( writeStub.callCount ).to.equal( 4 );
+				expect( writeStub.getCall( 3 ).args[ 0 ] ).to.equal( '\\ Foo. Status: 0/10.' );
+
+				clock.tick( 5 );
+				expect( writeStub.callCount ).to.equal( 5 );
+				expect( writeStub.getCall( 4 ).args[ 0 ] ).to.equal( '| Foo. Status: 0/10.' );
+
+				// It does not clear the last line for an initial spin.
+				expect( stubs.readline.clearLine.callCount ).to.equal( 4 );
+				expect( stubs.readline.cursorTo.callCount ).to.equal( 4 );
+
+				expect( stubs.readline.clearLine.firstCall.args[ 0 ] ).to.equal( process.stdout );
+				expect( stubs.readline.clearLine.firstCall.args[ 1 ] ).to.equal( 1 );
+
+				expect( stubs.readline.cursorTo.firstCall.args[ 0 ] ).to.equal( process.stdout );
+				expect( stubs.readline.cursorTo.firstCall.args[ 1 ] ).to.equal( 0 );
+
+				writeStub.restore();
+			} );
+
+			it( 'allows defining a custom progress status (as a string)', () => {
+				const spinner = createSpinner( 'Foo.', { total: 10, status: '[current] ([total]) - [title]' } );
+
+				spinner.start();
+
+				const writeStub = sinon.stub( process.stdout, 'write' );
+
+				clock.tick( 5 );
+				expect( writeStub.callCount ).to.equal( 1 );
+				expect( writeStub.getCall( 0 ).args[ 0 ] ).to.equal( '| 0 (10) - Foo.' );
+
+				clock.tick( 5 );
+				expect( writeStub.callCount ).to.equal( 2 );
+				expect( writeStub.getCall( 1 ).args[ 0 ] ).to.equal( '/ 0 (10) - Foo.' );
+
+				clock.tick( 5 );
+				expect( writeStub.callCount ).to.equal( 3 );
+				expect( writeStub.getCall( 2 ).args[ 0 ] ).to.equal( '- 0 (10) - Foo.' );
+
+				clock.tick( 5 );
+				expect( writeStub.callCount ).to.equal( 4 );
+				expect( writeStub.getCall( 3 ).args[ 0 ] ).to.equal( '\\ 0 (10) - Foo.' );
+
+				clock.tick( 5 );
+				expect( writeStub.callCount ).to.equal( 5 );
+				expect( writeStub.getCall( 4 ).args[ 0 ] ).to.equal( '| 0 (10) - Foo.' );
+
+				// It does not clear the last line for an initial spin.
+				expect( stubs.readline.clearLine.callCount ).to.equal( 4 );
+				expect( stubs.readline.cursorTo.callCount ).to.equal( 4 );
+
+				expect( stubs.readline.clearLine.firstCall.args[ 0 ] ).to.equal( process.stdout );
+				expect( stubs.readline.clearLine.firstCall.args[ 1 ] ).to.equal( 1 );
+
+				expect( stubs.readline.cursorTo.firstCall.args[ 0 ] ).to.equal( process.stdout );
+				expect( stubs.readline.cursorTo.firstCall.args[ 1 ] ).to.equal( 0 );
+
+				writeStub.restore();
+			} );
+
+			it( 'allows defining a custom progress status (as a callback)', () => {
+				const spinner = createSpinner( 'Foo.', {
+					total: 10,
+					status( title, current, total ) {
+						return `${ current } (${ total }) - ${ title }`;
+					}
+				} );
+
+				spinner.start();
+
+				const writeStub = sinon.stub( process.stdout, 'write' );
+
+				clock.tick( 5 );
+				expect( writeStub.callCount ).to.equal( 1 );
+				expect( writeStub.getCall( 0 ).args[ 0 ] ).to.equal( '| 0 (10) - Foo.' );
+
+				clock.tick( 5 );
+				expect( writeStub.callCount ).to.equal( 2 );
+				expect( writeStub.getCall( 1 ).args[ 0 ] ).to.equal( '/ 0 (10) - Foo.' );
+
+				clock.tick( 5 );
+				expect( writeStub.callCount ).to.equal( 3 );
+				expect( writeStub.getCall( 2 ).args[ 0 ] ).to.equal( '- 0 (10) - Foo.' );
+
+				clock.tick( 5 );
+				expect( writeStub.callCount ).to.equal( 4 );
+				expect( writeStub.getCall( 3 ).args[ 0 ] ).to.equal( '\\ 0 (10) - Foo.' );
+
+				clock.tick( 5 );
+				expect( writeStub.callCount ).to.equal( 5 );
+				expect( writeStub.getCall( 4 ).args[ 0 ] ).to.equal( '| 0 (10) - Foo.' );
+
+				// It does not clear the last line for an initial spin.
+				expect( stubs.readline.clearLine.callCount ).to.equal( 4 );
+				expect( stubs.readline.cursorTo.callCount ).to.equal( 4 );
+
+				expect( stubs.readline.clearLine.firstCall.args[ 0 ] ).to.equal( process.stdout );
+				expect( stubs.readline.clearLine.firstCall.args[ 1 ] ).to.equal( 1 );
+
+				expect( stubs.readline.cursorTo.firstCall.args[ 0 ] ).to.equal( process.stdout );
+				expect( stubs.readline.cursorTo.firstCall.args[ 1 ] ).to.equal( 0 );
+
+				writeStub.restore();
+			} );
 		} );
 
-		it( 'prints the specified title if spinner cannot be created if CLI is not interactive', () => {
-			stubs.isInteractive.returns( false );
+		describe( '#finish', () => {
+			it( 'prints the specified title with a pin when finished', () => {
+				const spinner = createSpinner( 'Foo.', { total: 10 } );
+				const consoleStub = sinon.stub( console, 'log' );
 
-			const spinner = createSpinner( 'Foo.' );
-			const consoleStub = sinon.stub( console, 'log' );
+				spinner.start();
+				spinner.finish();
 
-			spinner.start();
+				consoleStub.restore();
 
-			consoleStub.restore();
-
-			expect( consoleStub.calledOnce ).to.equal( true );
-			expect( consoleStub.firstCall.args[ 0 ] ).to.equal( '📍 Foo.' );
+				expect( consoleStub.calledOnce ).to.equal( true );
+				expect( consoleStub.firstCall.args[ 0 ] ).to.equal( '📍 Foo.' );
+			} );
 		} );
 
-		it( 'uses "setInterval" for creating a loop', () => {
-			const spinner = createSpinner( 'Foo.' );
+		describe( '#increase', () => {
+			it( 'increases the counter', () => {
+				const spinner = createSpinner( 'Foo.', { total: 10 } );
 
-			spinner.start();
+				spinner.start();
 
-			const timer = Object.values( clock.timers ).shift();
+				const writeStub = sinon.stub( process.stdout, 'write' );
 
-			expect( timer ).to.be.an( 'object' );
-			expect( timer.type ).to.equal( 'Interval' );
-		} );
+				clock.tick( 5 );
+				expect( writeStub.callCount ).to.equal( 1 );
+				expect( writeStub.getCall( 0 ).args[ 0 ] ).to.equal( '| Foo. Status: 0/10.' );
 
-		it( 'prints always spinner in the last line', () => {
-			const spinner = createSpinner( 'Foo.' );
+				spinner.increase();
 
-			spinner.start();
+				clock.tick( 5 );
+				expect( writeStub.callCount ).to.equal( 2 );
+				expect( writeStub.getCall( 1 ).args[ 0 ] ).to.equal( '/ Foo. Status: 1/10.' );
 
-			const writeStub = sinon.stub( process.stdout, 'write' );
+				spinner.increase();
 
-			clock.tick( 5 );
-			expect( writeStub.callCount ).to.equal( 1 );
-			expect( writeStub.getCall( 0 ).args[ 0 ] ).to.equal( '| Foo.' );
+				clock.tick( 5 );
+				expect( writeStub.callCount ).to.equal( 3 );
+				expect( writeStub.getCall( 2 ).args[ 0 ] ).to.equal( '- Foo. Status: 2/10.' );
 
-			clock.tick( 5 );
-			expect( writeStub.callCount ).to.equal( 2 );
-			expect( writeStub.getCall( 1 ).args[ 0 ] ).to.equal( '/ Foo.' );
+				spinner.increase();
 
-			clock.tick( 5 );
-			expect( writeStub.callCount ).to.equal( 3 );
-			expect( writeStub.getCall( 2 ).args[ 0 ] ).to.equal( '- Foo.' );
+				clock.tick( 5 );
+				expect( writeStub.callCount ).to.equal( 4 );
+				expect( writeStub.getCall( 3 ).args[ 0 ] ).to.equal( '\\ Foo. Status: 3/10.' );
 
-			clock.tick( 5 );
-			expect( writeStub.callCount ).to.equal( 4 );
-			expect( writeStub.getCall( 3 ).args[ 0 ] ).to.equal( '\\ Foo.' );
+				spinner.increase();
 
-			clock.tick( 5 );
-			expect( writeStub.callCount ).to.equal( 5 );
-			expect( writeStub.getCall( 4 ).args[ 0 ] ).to.equal( '| Foo.' );
+				clock.tick( 5 );
+				expect( writeStub.callCount ).to.equal( 5 );
+				expect( writeStub.getCall( 4 ).args[ 0 ] ).to.equal( '| Foo. Status: 4/10.' );
 
-			// It does not clear the last line for an initial spin.
-			expect( stubs.readline.clearLine.callCount ).to.equal( 4 );
-			expect( stubs.readline.cursorTo.callCount ).to.equal( 4 );
+				// It does not clear the last line for an initial spin.
+				expect( stubs.readline.clearLine.callCount ).to.equal( 4 );
+				expect( stubs.readline.cursorTo.callCount ).to.equal( 4 );
 
-			expect( stubs.readline.clearLine.firstCall.args[ 0 ] ).to.equal( process.stdout );
-			expect( stubs.readline.clearLine.firstCall.args[ 1 ] ).to.equal( 1 );
+				expect( stubs.readline.clearLine.firstCall.args[ 0 ] ).to.equal( process.stdout );
+				expect( stubs.readline.clearLine.firstCall.args[ 1 ] ).to.equal( 1 );
 
-			expect( stubs.readline.cursorTo.firstCall.args[ 0 ] ).to.equal( process.stdout );
-			expect( stubs.readline.cursorTo.firstCall.args[ 1 ] ).to.equal( 0 );
+				expect( stubs.readline.cursorTo.firstCall.args[ 0 ] ).to.equal( process.stdout );
+				expect( stubs.readline.cursorTo.firstCall.args[ 1 ] ).to.equal( 0 );
 
-			writeStub.restore();
-		} );
-
-		it( 'hides a cursor when starting spinning', () => {
-			const spinner = createSpinner( 'Foo.' );
-
-			spinner.start();
-
-			expect( stubs.cliCursor.hide.calledOnce ).to.equal( true );
-		} );
-
-		it( 'allows indenting messages by specifying the "options.indentLevel" option', () => {
-			const spinner = createSpinner( 'Foo.', { indentLevel: 1 } );
-
-			spinner.start();
-
-			const writeStub = sinon.stub( process.stdout, 'write' );
-
-			clock.tick( 5 );
-			expect( writeStub.callCount ).to.equal( 1 );
-			expect( writeStub.getCall( 0 ).args[ 0 ] ).to.equal( '   | Foo.' );
-
-			clock.tick( 5 );
-			expect( writeStub.callCount ).to.equal( 2 );
-			expect( writeStub.getCall( 1 ).args[ 0 ] ).to.equal( '   / Foo.' );
-
-			clock.tick( 5 );
-			expect( writeStub.callCount ).to.equal( 3 );
-			expect( writeStub.getCall( 2 ).args[ 0 ] ).to.equal( '   - Foo.' );
-
-			clock.tick( 5 );
-			expect( writeStub.callCount ).to.equal( 4 );
-			expect( writeStub.getCall( 3 ).args[ 0 ] ).to.equal( '   \\ Foo.' );
-
-			clock.tick( 5 );
-			expect( writeStub.callCount ).to.equal( 5 );
-			expect( writeStub.getCall( 4 ).args[ 0 ] ).to.equal( '   | Foo.' );
-
-			writeStub.restore();
-		} );
-	} );
-
-	describe( '#finish', () => {
-		beforeEach( () => {
-			stubs.isInteractive.returns( true );
-		} );
-
-		it( 'does nothing if spinner should be disabled', () => {
-			const spinner = createSpinner( 'Foo.', { isDisabled: true } );
-			const consoleStub = sinon.stub( console, 'log' );
-
-			spinner.finish();
-
-			consoleStub.restore();
-
-			expect( consoleStub.calledOnce ).to.equal( false );
-		} );
-
-		it( 'does nothing if spinner cannot be created if CLI is not interactive', () => {
-			stubs.isInteractive.returns( false );
-
-			const spinner = createSpinner( 'Foo.' );
-			const consoleStub = sinon.stub( console, 'log' );
-
-			spinner.finish();
-
-			consoleStub.restore();
-
-			expect( consoleStub.calledOnce ).to.equal( false );
-		} );
-
-		it( 'clears the interval when finished', () => {
-			const spinner = createSpinner( 'Foo.' );
-			const consoleStub = sinon.stub( console, 'log' );
-
-			spinner.start();
-
-			const timer = Object.values( clock.timers ).shift();
-			expect( timer ).to.be.an( 'object' );
-
-			spinner.finish();
-
-			const newTimer = Object.values( clock.timers ).shift();
-
-			expect( timer ).to.be.an( 'object' );
-			expect( newTimer ).to.be.undefined;
-
-			consoleStub.restore();
-		} );
-
-		it( 'prints the specified title with a pin when finished', () => {
-			const spinner = createSpinner( 'Foo.' );
-			const consoleStub = sinon.stub( console, 'log' );
-
-			spinner.start();
-			spinner.finish();
-
-			consoleStub.restore();
-
-			expect( consoleStub.calledOnce ).to.equal( true );
-			expect( consoleStub.firstCall.args[ 0 ] ).to.equal( '📍 Foo.' );
-		} );
-
-		it( 'shows a cursor when finished spinning', () => {
-			const spinner = createSpinner( 'Foo.' );
-			const consoleStub = sinon.stub( console, 'log' );
-
-			spinner.start();
-			spinner.finish();
-
-			consoleStub.restore();
-			expect( stubs.cliCursor.show.calledOnce ).to.equal( true );
-		} );
-
-		it( 'allows indenting messages by specifying the "options.indentLevel" option', () => {
-			const spinner = createSpinner( 'Foo.', { indentLevel: 1 } );
-			const consoleStub = sinon.stub( console, 'log' );
-
-			spinner.start();
-			spinner.finish();
-
-			consoleStub.restore();
-
-			expect( consoleStub.calledOnce ).to.equal( true );
-			expect( consoleStub.firstCall.args[ 0 ] ).to.equal( '   📍 Foo.' );
-		} );
-
-		it( 'prints the specified emoji when created a spinner if it finished', () => {
-			const spinner = createSpinner( 'Foo.', { emoji: '👉' } );
-			const consoleStub = sinon.stub( console, 'log' );
-
-			spinner.start();
-			spinner.finish();
-
-			consoleStub.restore();
-
-			expect( consoleStub.calledOnce ).to.equal( true );
-			expect( consoleStub.firstCall.args[ 0 ] ).to.equal( '👉 Foo.' );
-		} );
-
-		it( 'prints the specified title if spinner cannot be created if CLI is not interactive', () => {
-			stubs.isInteractive.returns( false );
-
-			const spinner = createSpinner( 'Foo.', { emoji: '👉' } );
-			const consoleStub = sinon.stub( console, 'log' );
-
-			spinner.start();
-
-			consoleStub.restore();
-
-			expect( consoleStub.calledOnce ).to.equal( true );
-			expect( consoleStub.firstCall.args[ 0 ] ).to.equal( '👉 Foo.' );
-		} );
-
-		it( 'allows overriding the emoji (use default emoji when creating a spinner)', () => {
-			const spinner = createSpinner( 'Foo.' );
-			const consoleStub = sinon.stub( console, 'log' );
-
-			spinner.start();
-			spinner.finish( { emoji: '❌' } );
-
-			consoleStub.restore();
-
-			expect( consoleStub.calledOnce ).to.equal( true );
-			expect( consoleStub.firstCall.args[ 0 ] ).to.equal( '❌ Foo.' );
-		} );
-
-		it( 'allows overriding the emoji (passed an emoji when creating a spinner)', () => {
-			const spinner = createSpinner( 'Foo.', { emoji: '👉' } );
-			const consoleStub = sinon.stub( console, 'log' );
-
-			spinner.start();
-			spinner.finish( { emoji: '❌' } );
-
-			consoleStub.restore();
-
-			expect( consoleStub.calledOnce ).to.equal( true );
-			expect( consoleStub.firstCall.args[ 0 ] ).to.equal( '❌ Foo.' );
+				writeStub.restore();
+			} );
 		} );
 	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature (release-tools): Introduced util called `executeInParallel()` that allows executing a task in parallel in all packages found in a directory specified in the configuration. See ckeditor/ckeditor5#13970.

Feature (utils): The `tools.createSpinner()` allows for creating a counter spinner that improves UX when executing a task specified the number of times.

---

### Additional information

- Example implementation: https://github.com/ckeditor/ckeditor5/pull/14031.
