### PR TITLE
Hidden the Puppeteer warning

### DIFF
--- a/packages/ckeditor5-dev-web-crawler/lib/runcrawler.js
+++ b/packages/ckeditor5-dev-web-crawler/lib/runcrawler.js
@@ -323,7 +323,7 @@ async function openLink( browser, { baseUrl, link, foundLinks, exclusions } ) {
 }
 
 /**
- * Finds all links in opened page and filters out external, already discovered and exlicitly excluded ones.
+ * Finds all links in opened page and filters out external, already discovered and explicitly excluded ones.
  *
  * @param {Object} page The page instance from Puppeteer.
  * @param {Object} data All data needed for crawling the link.
@@ -408,7 +408,7 @@ async function getErrorIgnorePatternsFromPage( page ) {
 }
 
 /**
- * Iterates over all found errors from given link and marks errors as ingored, if their message match the ignore pattern.
+ * Iterates over all found errors from given link and marks errors as ignored, if their message match the ignore pattern.
  *
  * @param {Array.<Error>} errors An array of errors to check.
  * @param {Map.<ErrorType, Set.<String>>} errorIgnorePatterns A map between an error type and a set of patterns.

--- a/packages/ckeditor5-dev-web-crawler/lib/runcrawler.js
+++ b/packages/ckeditor5-dev-web-crawler/lib/runcrawler.js
@@ -114,7 +114,8 @@ module.exports = async function runCrawler( options ) {
  */
 async function createBrowser( options ) {
 	const browserOptions = {
-		args: []
+		args: [],
+		headless: 'old'
 	};
 
 	if ( options.disableBrowserSandbox ) {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other (web-crawler): Puppeteer no longer prints a warning regarding the Chrome Headless browser. See ckeditor/ckeditor5#14063.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
