### PR TITLE
Added support for asynchronous command execution for `tools.shExec()`

### DIFF
--- a/packages/ckeditor5-dev-utils/tests/tools.js
+++ b/packages/ckeditor5-dev-utils/tests/tools.js
@@ -126,6 +126,89 @@ describe( 'utils', () => {
 				expect( infoSpy.calledOnce ).to.equal( false );
 				expect( errorSpy.calledOnce ).to.equal( false );
 			} );
+
+			it( 'should return a promise when executing a command in asynchronous mode', () => {
+				const sh = require( 'shelljs' );
+				const execStub = sandbox.stub( sh, 'exec' ).callsFake( ( command, options, callback ) => {
+					callback( 0 );
+				} );
+
+				return tools.shExec( 'command', { async: true } )
+					.then( () => {
+						sinon.assert.calledOnce( execStub );
+					} );
+			} );
+
+			it( 'should throw error on unsuccessful call in asynchronous mode', () => {
+				const sh = require( 'shelljs' );
+				const execStub = sandbox.stub( sh, 'exec' ).callsFake( ( command, options, callback ) => {
+					callback( 1 );
+				} );
+
+				return tools.shExec( 'command', { async: true } )
+					.then(
+						() => {
+							throw new Error( 'Expected to be rejected.' );
+						},
+						() => {
+							sinon.assert.calledOnce( execStub );
+						}
+					);
+			} );
+
+			it( 'should output using log functions when exit code is equal to 0 in asynchronous mode', () => {
+				const sh = require( 'shelljs' );
+				const execStub = sandbox.stub( sh, 'exec' ).callsFake( ( command, options, callback ) => {
+					callback( 0, 'out', 'err' );
+				} );
+
+				return tools.shExec( 'command', { async: true } )
+					.then( () => {
+						expect( loggerVerbosity ).to.equal( 'info' );
+						expect( execStub.calledOnce ).to.equal( true );
+						expect( errorSpy.called ).to.equal( false );
+						expect( infoSpy.calledTwice ).to.equal( true );
+						expect( infoSpy.firstCall.args[ 0 ] ).to.match( /out/ );
+						expect( infoSpy.secondCall.args[ 0 ] ).to.match( /err/ );
+					} );
+			} );
+
+			it( 'should output using log functions when exit code is not equal to 0 in asynchronous mode', () => {
+				const sh = require( 'shelljs' );
+				const execStub = sandbox.stub( sh, 'exec' ).callsFake( ( command, options, callback ) => {
+					callback( 1, 'out', 'err' );
+				} );
+
+				return tools.shExec( 'command', { async: true } )
+					.then(
+						() => {
+							throw new Error( 'Expected to be rejected.' );
+						},
+						() => {
+							expect( loggerVerbosity ).to.equal( 'info' );
+							expect( infoSpy.called ).to.equal( false );
+							expect( execStub.calledOnce ).to.equal( true );
+							expect( errorSpy.calledTwice ).to.equal( true );
+							expect( errorSpy.firstCall.args[ 0 ] ).to.match( /out/ );
+							expect( errorSpy.secondCall.args[ 0 ] ).to.match( /err/ );
+						}
+					);
+			} );
+
+			it( 'should not log if no output from executed command in asynchronous mode', () => {
+				const sh = require( 'shelljs' );
+				const execStub = sandbox.stub( sh, 'exec' ).callsFake( ( command, options, callback ) => {
+					callback( 0, '', '' );
+				} );
+
+				return tools.shExec( 'command', { verbosity: 'error', async: true } )
+					.then( () => {
+						expect( loggerVerbosity ).to.equal( 'error' );
+						expect( execStub.calledOnce ).to.equal( true );
+						expect( infoSpy.calledOnce ).to.equal( false );
+						expect( errorSpy.calledOnce ).to.equal( false );
+					} );
+			} );
 		} );
 
 		describe( 'linkDirectories', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal (utils): Added support for asynchronous command execution for `tools.shExec()` util. If the `async` (boolean) flag is set in command options, `tools.shExec()` returns a Promise, which is resolved with the command's output.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
