### PR TITLE
Re-build CKEditor 5 builds after updating references in the new release process

### DIFF
--- a/packages/ckeditor5-dev-release-tools/tests/utils/executeinparallel.js
+++ b/packages/ckeditor5-dev-release-tools/tests/utils/executeinparallel.js
@@ -126,6 +126,36 @@ describe( 'dev-release-tools/utils', () => {
 			await promise;
 		} );
 
+		it( 'should execute the specified `taskToExecute` on packages found in the `packagesDirectory` that are not filtered', async () => {
+			const options = Object.assign( {}, defaultOptions, {
+				// Skip "package-02".
+				packagesDirectoryFilter: packageDirectory => !packageDirectory.endsWith( 'package-02' )
+			} );
+
+			const promise = executeInParallel( options );
+			await delay( 0 );
+
+			// By default the helper uses a half of available CPUs.
+			expect( WorkerMock.instances ).to.lengthOf( 2 );
+
+			const [ firstWorker, secondWorker ] = WorkerMock.instances;
+
+			expect( firstWorker.workerData.packages ).to.deep.equal( [
+				'/home/ckeditor/my-packages/package-01',
+				'/home/ckeditor/my-packages/package-04'
+			] );
+
+			expect( secondWorker.workerData.packages ).to.deep.equal( [
+				'/home/ckeditor/my-packages/package-03'
+			] );
+
+			// Workers did not emit an error.
+			getExitCallback( firstWorker )( 0 );
+			getExitCallback( secondWorker )( 0 );
+
+			await promise;
+		} );
+
 		it( 'should use the specified `cwd` when looking for packages', async () => {
 			const options = Object.assign( {}, defaultOptions, {
 				cwd: '/custom/cwd'


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal (release-tools): `executeInParallel()` allows filtering out packages. See ckeditor/ckeditor5#14177.

---

### Additional information

Integration with CKEditor 5 is done in https://github.com/ckeditor/ckeditor5/pull/14195.
