### PR TITLE
Added support for running manual and automated tests written in TS.

### DIFF
--- a/packages/ckeditor5-dev-tests/lib/tasks/runautomatedtests.js
+++ b/packages/ckeditor5-dev-tests/lib/tasks/runautomatedtests.js
@@ -20,9 +20,9 @@ const transformFileOptionToTestGlob = require( '../utils/transformfileoptiontote
 // that matches to these patterns, the file will be skipped.
 const IGNORE_GLOBS = [
 	// Ignore files which are saved in `manual/` directory. There are manual tests.
-	path.join( '**', 'tests', '**', 'manual', '**', '*.js' ),
+	path.join( '**', 'tests', '**', 'manual', '**', '*.{js,ts}' ),
 	// Ignore `_utils` directory as well because there are saved utils for tests.
-	path.join( '**', 'tests', '**', '_utils', '**', '*.js' )
+	path.join( '**', 'tests', '**', '_utils', '**', '*.{js,ts}' )
 ];
 
 // An absolute path to the entry file that will be passed to Karma.

--- a/packages/ckeditor5-dev-tests/lib/utils/manual-tests/compilehtmlfiles.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/manual-tests/compilehtmlfiles.js
@@ -42,7 +42,7 @@ module.exports = function compileHtmlFiles( options ) {
 	const sourceFilePathBases = sourceMDFiles.map( mdFile => getFilePathWithoutExtension( mdFile ) );
 	const staticFiles = _.flatten( sourceDirs.map( sourceDir => {
 		return globSync( path.join( sourceDir, '**', '*.!(js|html|md)' ) );
-	} ) ).filter( file => !file.match( /\.(js|html|md)$/ ) );
+	} ) ).filter( file => !file.match( /\.(js|ts|html|md)$/ ) );
 	const languagesToLoad = [];
 
 	if ( options.additionalLanguages ) {

--- a/packages/ckeditor5-dev-tests/lib/utils/manual-tests/compilescripts.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/manual-tests/compilescripts.js
@@ -92,7 +92,7 @@ function getWebpackEntryPoints( entryFiles ) {
 	const entryObject = {};
 
 	entryFiles.forEach( file => {
-		entryObject[ getRelativeFilePath( file ).replace( /\.js$/, '' ) ] = file;
+		entryObject[ getRelativeFilePath( file ).replace( /\.[jt]s$/, '' ) ] = file;
 	} );
 
 	return entryObject;

--- a/packages/ckeditor5-dev-tests/lib/utils/transformfileoptiontotestglob.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/transformfileoptiontotestglob.js
@@ -11,7 +11,7 @@ const path = require( 'path' );
 const EXTERNAL_DIR_PATH = path.join( process.cwd(), 'external' );
 
 /**
- * Converts values of `--files` argument to proper globs. These are the supported types of values:
+ * Converts values of `--files` argument to proper globs. Handles both JS and TS files. These are the supported types of values:
  *  * "ckeditor5" - matches all root package tests.
  *  * "<external-package-name>" - matches tests in root of external package.
  *  * "*" - matches all packages' files.
@@ -64,8 +64,8 @@ module.exports = function transformFileOptionToTestGlob( pattern, isManualTest =
  */
 function getExternalRepositoryGlob( pattern, { isManualTest } ) {
 	const repositoryGlob = isManualTest ?
-		path.join( EXTERNAL_DIR_PATH, pattern, 'tests', 'manual', '**', '*' ) + '.js' :
-		path.join( EXTERNAL_DIR_PATH, pattern, 'tests', '**', '*' ) + '.js';
+		path.join( EXTERNAL_DIR_PATH, pattern, 'tests', 'manual', '**', '*' ) + '.{js,ts}' :
+		path.join( EXTERNAL_DIR_PATH, pattern, 'tests', '**', '*' ) + '.{js,ts}';
 
 	return [
 		repositoryGlob.split( path.sep ).join( path.posix.sep )
@@ -118,7 +118,7 @@ function transformSinglePattern( pattern, options ) {
 		output.push( 'manual' );
 	}
 
-	output.push( ...chunks, '**', `${ filename }.js` );
+	output.push( ...chunks, '**', `${ filename }.{js,ts}` );
 
 	return output.join( path.posix.sep );
 }

--- a/packages/ckeditor5-dev-tests/package.json
+++ b/packages/ckeditor5-dev-tests/package.json
@@ -48,7 +48,6 @@
     "sinon-chai": "^3.5.0",
     "socket.io": "^4.0.0",
     "typescript": "^4.6.4",
-    "timers": "^0.1.1",
     "webpack": "^5.58.1"
   },
   "devDependencies": {

--- a/packages/ckeditor5-dev-tests/package.json
+++ b/packages/ckeditor5-dev-tests/package.json
@@ -9,6 +9,8 @@
     "@ckeditor/ckeditor5-dev-translations": "^38.0.0-alpha.0",
     "@ckeditor/ckeditor5-dev-utils": "^38.0.0-alpha.0",
     "@ckeditor/ckeditor5-inspector": "^4.0.0",
+    "@types/chai": "^4.3.5",
+    "@types/mocha": "^10.0.1",
     "assertion-error": "^1.1.0",
     "babel-plugin-istanbul": "^6.1.0",
     "buffer": "^6.0.3",

--- a/packages/ckeditor5-dev-tests/package.json
+++ b/packages/ckeditor5-dev-tests/package.json
@@ -48,6 +48,7 @@
     "sinon-chai": "^3.5.0",
     "socket.io": "^4.0.0",
     "typescript": "^4.6.4",
+    "timers": "^0.1.1",
     "webpack": "^5.58.1"
   },
   "devDependencies": {

--- a/packages/ckeditor5-dev-tests/tests/utils/manual-tests/compilescripts.js
+++ b/packages/ckeditor5-dev-tests/tests/utils/manual-tests/compilescripts.js
@@ -366,6 +366,38 @@ describe( 'compileManualTestScripts', () => {
 		} );
 	} );
 
+	it( 'should pass correct entries object to the webpack for both JS and TS files', async () => {
+		await compileManualTestScripts( {
+			buildDir: 'buildDir',
+			patterns: [ 'manualTestPattern' ],
+			sourceFiles: [
+				'ckeditor5-foo\\manual\\file1.js',
+				'ckeditor5-foo\\manual\\file2.ts'
+			],
+			themePath: 'path/to/theme',
+			language: 'en',
+			additionalLanguages: [ 'pl', 'ar' ],
+			debug: [ 'CK_DEBUG' ],
+			disableWatch: false
+		} );
+
+		expect( stubs.getWebpackConfig.calledOnce ).to.equal( true );
+		expect( stubs.getWebpackConfig.firstCall.args[ 0 ] ).to.deep.include( {
+			entries: {
+				'ckeditor5-foo\\manual\\file1': 'ckeditor5-foo\\manual\\file1.js',
+				'ckeditor5-foo\\manual\\file2': 'ckeditor5-foo\\manual\\file2.ts'
+			}
+		} );
+
+		expect( stubs.webpack.calledOnce ).to.equal( true );
+		expect( stubs.webpack.firstCall.args[ 0 ] ).to.deep.include( {
+			entries: {
+				'ckeditor5-foo\\manual\\file1': 'ckeditor5-foo\\manual\\file1.js',
+				'ckeditor5-foo\\manual\\file2': 'ckeditor5-foo\\manual\\file2.ts'
+			}
+		} );
+	} );
+
 	it( 'should pass the "tsconfig" option to webpack configuration factory', async () => {
 		await compileManualTestScripts( {
 			cwd: 'workspace',

--- a/packages/ckeditor5-dev-tests/tests/utils/transformfileoptiontotestglob.js
+++ b/packages/ckeditor5-dev-tests/tests/utils/transformfileoptiontotestglob.js
@@ -31,30 +31,30 @@ describe( 'dev-tests/utils', () => {
 
 	describe( 'converts "ckeditor5" to pattern matching all root package tests', () => {
 		it( 'for automated tests', () => {
-			expect( transformFileOptionToTestGlob( 'ckeditor5' ) ).to.deep.equal( [ '/workspace/tests/**/*.js' ] );
+			expect( transformFileOptionToTestGlob( 'ckeditor5' ) ).to.deep.equal( [ '/workspace/tests/**/*.{js,ts}' ] );
 		} );
 
 		it( 'for manual tests', () => {
-			expect( transformFileOptionToTestGlob( 'ckeditor5', true ) ).to.deep.equal( [ '/workspace/tests/manual/**/*.js' ] );
+			expect( transformFileOptionToTestGlob( 'ckeditor5', true ) ).to.deep.equal( [ '/workspace/tests/manual/**/*.{js,ts}' ] );
 		} );
 	} );
 
 	describe( 'converts "*" to pattern matching all packages\' files', () => {
 		it( 'for automated tests', () => {
 			expect( transformFileOptionToTestGlob( '*' ) ).to.deep.equal( [
-				'/workspace/packages/ckeditor5-*/tests/**/*.js',
-				'/workspace/packages/ckeditor-*/tests/**/*.js',
-				'/workspace/external/*/packages/ckeditor5-*/tests/**/*.js',
-				'/workspace/external/*/packages/ckeditor-*/tests/**/*.js'
+				'/workspace/packages/ckeditor5-*/tests/**/*.{js,ts}',
+				'/workspace/packages/ckeditor-*/tests/**/*.{js,ts}',
+				'/workspace/external/*/packages/ckeditor5-*/tests/**/*.{js,ts}',
+				'/workspace/external/*/packages/ckeditor-*/tests/**/*.{js,ts}'
 			] );
 		} );
 
 		it( 'for manual tests', () => {
 			expect( transformFileOptionToTestGlob( '*', true ) ).to.deep.equal( [
-				'/workspace/packages/ckeditor5-*/tests/manual/**/*.js',
-				'/workspace/packages/ckeditor-*/tests/manual/**/*.js',
-				'/workspace/external/*/packages/ckeditor5-*/tests/manual/**/*.js',
-				'/workspace/external/*/packages/ckeditor-*/tests/manual/**/*.js'
+				'/workspace/packages/ckeditor5-*/tests/manual/**/*.{js,ts}',
+				'/workspace/packages/ckeditor-*/tests/manual/**/*.{js,ts}',
+				'/workspace/external/*/packages/ckeditor5-*/tests/manual/**/*.{js,ts}',
+				'/workspace/external/*/packages/ckeditor-*/tests/manual/**/*.{js,ts}'
 			] );
 		} );
 	} );
@@ -62,37 +62,37 @@ describe( 'dev-tests/utils', () => {
 	describe( 'converts "package-name" to pattern matching all tests from this package', () => {
 		it( 'for automated tests (single package)', () => {
 			expect( transformFileOptionToTestGlob( 'engine' ) ).to.deep.equal( [
-				'/workspace/packages/ckeditor5-engine/tests/**/*.js',
-				'/workspace/packages/ckeditor-engine/tests/**/*.js',
-				'/workspace/external/*/packages/ckeditor5-engine/tests/**/*.js',
-				'/workspace/external/*/packages/ckeditor-engine/tests/**/*.js'
+				'/workspace/packages/ckeditor5-engine/tests/**/*.{js,ts}',
+				'/workspace/packages/ckeditor-engine/tests/**/*.{js,ts}',
+				'/workspace/external/*/packages/ckeditor5-engine/tests/**/*.{js,ts}',
+				'/workspace/external/*/packages/ckeditor-engine/tests/**/*.{js,ts}'
 			] );
 		} );
 
 		it( 'for automated tests (wildcard support)', () => {
 			expect( transformFileOptionToTestGlob( 'build-*' ) ).to.deep.equal( [
-				'/workspace/packages/ckeditor5-build-*/tests/**/*.js',
-				'/workspace/packages/ckeditor-build-*/tests/**/*.js',
-				'/workspace/external/*/packages/ckeditor5-build-*/tests/**/*.js',
-				'/workspace/external/*/packages/ckeditor-build-*/tests/**/*.js'
+				'/workspace/packages/ckeditor5-build-*/tests/**/*.{js,ts}',
+				'/workspace/packages/ckeditor-build-*/tests/**/*.{js,ts}',
+				'/workspace/external/*/packages/ckeditor5-build-*/tests/**/*.{js,ts}',
+				'/workspace/external/*/packages/ckeditor-build-*/tests/**/*.{js,ts}'
 			] );
 		} );
 
 		it( 'for manual tests (single package)', () => {
 			expect( transformFileOptionToTestGlob( 'engine', true ) ).to.deep.equal( [
-				'/workspace/packages/ckeditor5-engine/tests/manual/**/*.js',
-				'/workspace/packages/ckeditor-engine/tests/manual/**/*.js',
-				'/workspace/external/*/packages/ckeditor5-engine/tests/manual/**/*.js',
-				'/workspace/external/*/packages/ckeditor-engine/tests/manual/**/*.js'
+				'/workspace/packages/ckeditor5-engine/tests/manual/**/*.{js,ts}',
+				'/workspace/packages/ckeditor-engine/tests/manual/**/*.{js,ts}',
+				'/workspace/external/*/packages/ckeditor5-engine/tests/manual/**/*.{js,ts}',
+				'/workspace/external/*/packages/ckeditor-engine/tests/manual/**/*.{js,ts}'
 			] );
 		} );
 
 		it( 'for manual tests (wildcard support)', () => {
 			expect( transformFileOptionToTestGlob( 'build-*', true ) ).to.deep.equal( [
-				'/workspace/packages/ckeditor5-build-*/tests/manual/**/*.js',
-				'/workspace/packages/ckeditor-build-*/tests/manual/**/*.js',
-				'/workspace/external/*/packages/ckeditor5-build-*/tests/manual/**/*.js',
-				'/workspace/external/*/packages/ckeditor-build-*/tests/manual/**/*.js'
+				'/workspace/packages/ckeditor5-build-*/tests/manual/**/*.{js,ts}',
+				'/workspace/packages/ckeditor-build-*/tests/manual/**/*.{js,ts}',
+				'/workspace/external/*/packages/ckeditor5-build-*/tests/manual/**/*.{js,ts}',
+				'/workspace/external/*/packages/ckeditor-build-*/tests/manual/**/*.{js,ts}'
 			] );
 		} );
 	} );
@@ -100,37 +100,37 @@ describe( 'dev-tests/utils', () => {
 	describe( 'converts "!package-name" to pattern matching all tests except from this package', () => {
 		it( 'for automated tests (single exclusion)', () => {
 			expect( transformFileOptionToTestGlob( '!engine' ) ).to.deep.equal( [
-				'/workspace/packages/ckeditor5-!(engine)*/tests/**/*.js',
-				'/workspace/packages/ckeditor-!(engine)*/tests/**/*.js',
-				'/workspace/external/*/packages/ckeditor5-!(engine)*/tests/**/*.js',
-				'/workspace/external/*/packages/ckeditor-!(engine)*/tests/**/*.js'
+				'/workspace/packages/ckeditor5-!(engine)*/tests/**/*.{js,ts}',
+				'/workspace/packages/ckeditor-!(engine)*/tests/**/*.{js,ts}',
+				'/workspace/external/*/packages/ckeditor5-!(engine)*/tests/**/*.{js,ts}',
+				'/workspace/external/*/packages/ckeditor-!(engine)*/tests/**/*.{js,ts}'
 			] );
 		} );
 
 		it( 'for automated tests (multiple exclusions)', () => {
 			expect( transformFileOptionToTestGlob( '!(engine|core|basic-styles)' ) ).to.deep.equal( [
-				'/workspace/packages/ckeditor5-!(engine|core|basic-styles)*/tests/**/*.js',
-				'/workspace/packages/ckeditor-!(engine|core|basic-styles)*/tests/**/*.js',
-				'/workspace/external/*/packages/ckeditor5-!(engine|core|basic-styles)*/tests/**/*.js',
-				'/workspace/external/*/packages/ckeditor-!(engine|core|basic-styles)*/tests/**/*.js'
+				'/workspace/packages/ckeditor5-!(engine|core|basic-styles)*/tests/**/*.{js,ts}',
+				'/workspace/packages/ckeditor-!(engine|core|basic-styles)*/tests/**/*.{js,ts}',
+				'/workspace/external/*/packages/ckeditor5-!(engine|core|basic-styles)*/tests/**/*.{js,ts}',
+				'/workspace/external/*/packages/ckeditor-!(engine|core|basic-styles)*/tests/**/*.{js,ts}'
 			] );
 		} );
 
 		it( 'for manual tests (single exclusion)', () => {
 			expect( transformFileOptionToTestGlob( '!engine', true ) ).to.deep.equal( [
-				'/workspace/packages/ckeditor5-!(engine)*/tests/manual/**/*.js',
-				'/workspace/packages/ckeditor-!(engine)*/tests/manual/**/*.js',
-				'/workspace/external/*/packages/ckeditor5-!(engine)*/tests/manual/**/*.js',
-				'/workspace/external/*/packages/ckeditor-!(engine)*/tests/manual/**/*.js'
+				'/workspace/packages/ckeditor5-!(engine)*/tests/manual/**/*.{js,ts}',
+				'/workspace/packages/ckeditor-!(engine)*/tests/manual/**/*.{js,ts}',
+				'/workspace/external/*/packages/ckeditor5-!(engine)*/tests/manual/**/*.{js,ts}',
+				'/workspace/external/*/packages/ckeditor-!(engine)*/tests/manual/**/*.{js,ts}'
 			] );
 		} );
 
 		it( 'for manual tests (multiple exclusions)', () => {
 			expect( transformFileOptionToTestGlob( '!(engine|core|basic-styles)', true ) ).to.deep.equal( [
-				'/workspace/packages/ckeditor5-!(engine|core|basic-styles)*/tests/manual/**/*.js',
-				'/workspace/packages/ckeditor-!(engine|core|basic-styles)*/tests/manual/**/*.js',
-				'/workspace/external/*/packages/ckeditor5-!(engine|core|basic-styles)*/tests/manual/**/*.js',
-				'/workspace/external/*/packages/ckeditor-!(engine|core|basic-styles)*/tests/manual/**/*.js'
+				'/workspace/packages/ckeditor5-!(engine|core|basic-styles)*/tests/manual/**/*.{js,ts}',
+				'/workspace/packages/ckeditor-!(engine|core|basic-styles)*/tests/manual/**/*.{js,ts}',
+				'/workspace/external/*/packages/ckeditor5-!(engine|core|basic-styles)*/tests/manual/**/*.{js,ts}',
+				'/workspace/external/*/packages/ckeditor-!(engine|core|basic-styles)*/tests/manual/**/*.{js,ts}'
 			] );
 		} );
 	} );
@@ -138,67 +138,67 @@ describe( 'dev-tests/utils', () => {
 	describe( 'converts "package-name/directory/" to pattern matching all tests from a package (or root) and a subdirectory', () => {
 		it( 'for automated tests (root)', () => {
 			expect( transformFileOptionToTestGlob( 'ckeditor5/memory/' ) ).to.deep.equal( [
-				'/workspace/tests/memory/**/*.js'
+				'/workspace/tests/memory/**/*.{js,ts}'
 			] );
 		} );
 
 		it( 'for automated tests (package)', () => {
 			expect( transformFileOptionToTestGlob( 'alignment/utils/' ) ).to.deep.equal( [
-				'/workspace/packages/ckeditor5-alignment/tests/utils/**/*.js',
-				'/workspace/packages/ckeditor-alignment/tests/utils/**/*.js',
-				'/workspace/external/*/packages/ckeditor5-alignment/tests/utils/**/*.js',
-				'/workspace/external/*/packages/ckeditor-alignment/tests/utils/**/*.js'
+				'/workspace/packages/ckeditor5-alignment/tests/utils/**/*.{js,ts}',
+				'/workspace/packages/ckeditor-alignment/tests/utils/**/*.{js,ts}',
+				'/workspace/external/*/packages/ckeditor5-alignment/tests/utils/**/*.{js,ts}',
+				'/workspace/external/*/packages/ckeditor-alignment/tests/utils/**/*.{js,ts}'
 			] );
 		} );
 
 		it( 'for automated tests (wildcard support)', () => {
 			expect( transformFileOptionToTestGlob( 'basic-styles/bold*/' ) ).to.deep.equal( [
-				'/workspace/packages/ckeditor5-basic-styles/tests/bold*/**/*.js',
-				'/workspace/packages/ckeditor-basic-styles/tests/bold*/**/*.js',
-				'/workspace/external/*/packages/ckeditor5-basic-styles/tests/bold*/**/*.js',
-				'/workspace/external/*/packages/ckeditor-basic-styles/tests/bold*/**/*.js'
+				'/workspace/packages/ckeditor5-basic-styles/tests/bold*/**/*.{js,ts}',
+				'/workspace/packages/ckeditor-basic-styles/tests/bold*/**/*.{js,ts}',
+				'/workspace/external/*/packages/ckeditor5-basic-styles/tests/bold*/**/*.{js,ts}',
+				'/workspace/external/*/packages/ckeditor-basic-styles/tests/bold*/**/*.{js,ts}'
 			] );
 		} );
 
 		it( 'for automated tests (nested directories)', () => {
 			expect( transformFileOptionToTestGlob( 'core/editor/utils/' ) ).to.deep.equal( [
-				'/workspace/packages/ckeditor5-core/tests/editor/utils/**/*.js',
-				'/workspace/packages/ckeditor-core/tests/editor/utils/**/*.js',
-				'/workspace/external/*/packages/ckeditor5-core/tests/editor/utils/**/*.js',
-				'/workspace/external/*/packages/ckeditor-core/tests/editor/utils/**/*.js'
+				'/workspace/packages/ckeditor5-core/tests/editor/utils/**/*.{js,ts}',
+				'/workspace/packages/ckeditor-core/tests/editor/utils/**/*.{js,ts}',
+				'/workspace/external/*/packages/ckeditor5-core/tests/editor/utils/**/*.{js,ts}',
+				'/workspace/external/*/packages/ckeditor-core/tests/editor/utils/**/*.{js,ts}'
 			] );
 		} );
 
 		it( 'for manual tests (root)', () => {
 			expect( transformFileOptionToTestGlob( 'ckeditor5/memory/', true ) ).to.deep.equal( [
-				'/workspace/tests/manual/memory/**/*.js'
+				'/workspace/tests/manual/memory/**/*.{js,ts}'
 			] );
 		} );
 
 		it( 'for manual tests (package)', () => {
 			expect( transformFileOptionToTestGlob( 'alignment/utils/', true ) ).to.deep.equal( [
-				'/workspace/packages/ckeditor5-alignment/tests/manual/utils/**/*.js',
-				'/workspace/packages/ckeditor-alignment/tests/manual/utils/**/*.js',
-				'/workspace/external/*/packages/ckeditor5-alignment/tests/manual/utils/**/*.js',
-				'/workspace/external/*/packages/ckeditor-alignment/tests/manual/utils/**/*.js'
+				'/workspace/packages/ckeditor5-alignment/tests/manual/utils/**/*.{js,ts}',
+				'/workspace/packages/ckeditor-alignment/tests/manual/utils/**/*.{js,ts}',
+				'/workspace/external/*/packages/ckeditor5-alignment/tests/manual/utils/**/*.{js,ts}',
+				'/workspace/external/*/packages/ckeditor-alignment/tests/manual/utils/**/*.{js,ts}'
 			] );
 		} );
 
 		it( 'for manual tests (wildcard support)', () => {
 			expect( transformFileOptionToTestGlob( 'basic-styles/bold*/', true ) ).to.deep.equal( [
-				'/workspace/packages/ckeditor5-basic-styles/tests/manual/bold*/**/*.js',
-				'/workspace/packages/ckeditor-basic-styles/tests/manual/bold*/**/*.js',
-				'/workspace/external/*/packages/ckeditor5-basic-styles/tests/manual/bold*/**/*.js',
-				'/workspace/external/*/packages/ckeditor-basic-styles/tests/manual/bold*/**/*.js'
+				'/workspace/packages/ckeditor5-basic-styles/tests/manual/bold*/**/*.{js,ts}',
+				'/workspace/packages/ckeditor-basic-styles/tests/manual/bold*/**/*.{js,ts}',
+				'/workspace/external/*/packages/ckeditor5-basic-styles/tests/manual/bold*/**/*.{js,ts}',
+				'/workspace/external/*/packages/ckeditor-basic-styles/tests/manual/bold*/**/*.{js,ts}'
 			] );
 		} );
 
 		it( 'for manual tests (nested directories)', () => {
 			expect( transformFileOptionToTestGlob( 'core/editor/utils/', true ) ).to.deep.equal( [
-				'/workspace/packages/ckeditor5-core/tests/manual/editor/utils/**/*.js',
-				'/workspace/packages/ckeditor-core/tests/manual/editor/utils/**/*.js',
-				'/workspace/external/*/packages/ckeditor5-core/tests/manual/editor/utils/**/*.js',
-				'/workspace/external/*/packages/ckeditor-core/tests/manual/editor/utils/**/*.js'
+				'/workspace/packages/ckeditor5-core/tests/manual/editor/utils/**/*.{js,ts}',
+				'/workspace/packages/ckeditor-core/tests/manual/editor/utils/**/*.{js,ts}',
+				'/workspace/external/*/packages/ckeditor5-core/tests/manual/editor/utils/**/*.{js,ts}',
+				'/workspace/external/*/packages/ckeditor-core/tests/manual/editor/utils/**/*.{js,ts}'
 			] );
 		} );
 	} );
@@ -206,49 +206,49 @@ describe( 'dev-tests/utils', () => {
 	describe( 'converts "package-name/filename" to pattern matching all tests from a package (or root) with specific filename', () => {
 		it( 'for automated tests (root)', () => {
 			expect( transformFileOptionToTestGlob( 'ckeditor5/utils' ) ).to.deep.equal( [
-				'/workspace/tests/**/utils.js'
+				'/workspace/tests/**/utils.{js,ts}'
 			] );
 		} );
 
 		it( 'for automated tests (package)', () => {
 			expect( transformFileOptionToTestGlob( 'alignment/utils' ) ).to.deep.equal( [
-				'/workspace/packages/ckeditor5-alignment/tests/**/utils.js',
-				'/workspace/packages/ckeditor-alignment/tests/**/utils.js',
-				'/workspace/external/*/packages/ckeditor5-alignment/tests/**/utils.js',
-				'/workspace/external/*/packages/ckeditor-alignment/tests/**/utils.js'
+				'/workspace/packages/ckeditor5-alignment/tests/**/utils.{js,ts}',
+				'/workspace/packages/ckeditor-alignment/tests/**/utils.{js,ts}',
+				'/workspace/external/*/packages/ckeditor5-alignment/tests/**/utils.{js,ts}',
+				'/workspace/external/*/packages/ckeditor-alignment/tests/**/utils.{js,ts}'
 			] );
 		} );
 
 		it( 'for automated tests (wildcard support)', () => {
 			expect( transformFileOptionToTestGlob( 'basic-styles/bold*' ) ).to.deep.equal( [
-				'/workspace/packages/ckeditor5-basic-styles/tests/**/bold*.js',
-				'/workspace/packages/ckeditor-basic-styles/tests/**/bold*.js',
-				'/workspace/external/*/packages/ckeditor5-basic-styles/tests/**/bold*.js',
-				'/workspace/external/*/packages/ckeditor-basic-styles/tests/**/bold*.js'
+				'/workspace/packages/ckeditor5-basic-styles/tests/**/bold*.{js,ts}',
+				'/workspace/packages/ckeditor-basic-styles/tests/**/bold*.{js,ts}',
+				'/workspace/external/*/packages/ckeditor5-basic-styles/tests/**/bold*.{js,ts}',
+				'/workspace/external/*/packages/ckeditor-basic-styles/tests/**/bold*.{js,ts}'
 			] );
 		} );
 
 		it( 'for manual tests (root)', () => {
 			expect( transformFileOptionToTestGlob( 'ckeditor5/utils', true ) ).to.deep.equal( [
-				'/workspace/tests/manual/**/utils.js'
+				'/workspace/tests/manual/**/utils.{js,ts}'
 			] );
 		} );
 
 		it( 'for manual tests (package)', () => {
 			expect( transformFileOptionToTestGlob( 'alignment/utils', true ) ).to.deep.equal( [
-				'/workspace/packages/ckeditor5-alignment/tests/manual/**/utils.js',
-				'/workspace/packages/ckeditor-alignment/tests/manual/**/utils.js',
-				'/workspace/external/*/packages/ckeditor5-alignment/tests/manual/**/utils.js',
-				'/workspace/external/*/packages/ckeditor-alignment/tests/manual/**/utils.js'
+				'/workspace/packages/ckeditor5-alignment/tests/manual/**/utils.{js,ts}',
+				'/workspace/packages/ckeditor-alignment/tests/manual/**/utils.{js,ts}',
+				'/workspace/external/*/packages/ckeditor5-alignment/tests/manual/**/utils.{js,ts}',
+				'/workspace/external/*/packages/ckeditor-alignment/tests/manual/**/utils.{js,ts}'
 			] );
 		} );
 
 		it( 'for manual tests (wildcard support)', () => {
 			expect( transformFileOptionToTestGlob( 'basic-styles/bold*', true ) ).to.deep.equal( [
-				'/workspace/packages/ckeditor5-basic-styles/tests/manual/**/bold*.js',
-				'/workspace/packages/ckeditor-basic-styles/tests/manual/**/bold*.js',
-				'/workspace/external/*/packages/ckeditor5-basic-styles/tests/manual/**/bold*.js',
-				'/workspace/external/*/packages/ckeditor-basic-styles/tests/manual/**/bold*.js'
+				'/workspace/packages/ckeditor5-basic-styles/tests/manual/**/bold*.{js,ts}',
+				'/workspace/packages/ckeditor-basic-styles/tests/manual/**/bold*.{js,ts}',
+				'/workspace/external/*/packages/ckeditor5-basic-styles/tests/manual/**/bold*.{js,ts}',
+				'/workspace/external/*/packages/ckeditor-basic-styles/tests/manual/**/bold*.{js,ts}'
 			] );
 		} );
 	} );
@@ -258,7 +258,7 @@ describe( 'dev-tests/utils', () => {
 			readdirSyncStub.returns( [ 'test-external-directory' ] );
 
 			expect( transformFileOptionToTestGlob( 'test-external-directory' ) ).to.deep.equal( [
-				'/workspace/external/test-external-directory/tests/**/*.js'
+				'/workspace/external/test-external-directory/tests/**/*.{js,ts}'
 			] );
 		} );
 
@@ -266,7 +266,7 @@ describe( 'dev-tests/utils', () => {
 			readdirSyncStub.returns( [ 'test-external-directory' ] );
 
 			expect( transformFileOptionToTestGlob( 'test-external-directory', true ) ).to.deep.equal( [
-				'/workspace/external/test-external-directory/tests/manual/**/*.js'
+				'/workspace/external/test-external-directory/tests/manual/**/*.{js,ts}'
 			] );
 		} );
 
@@ -275,10 +275,10 @@ describe( 'dev-tests/utils', () => {
 			readdirSyncStub.returns( [ 'test-external-file' ] );
 
 			expect( transformFileOptionToTestGlob( 'test-external-directory', true ) ).to.deep.equal( [
-				'/workspace/packages/ckeditor5-test-external-directory/tests/manual/**/*.js',
-				'/workspace/packages/ckeditor-test-external-directory/tests/manual/**/*.js',
-				'/workspace/external/*/packages/ckeditor5-test-external-directory/tests/manual/**/*.js',
-				'/workspace/external/*/packages/ckeditor-test-external-directory/tests/manual/**/*.js'
+				'/workspace/packages/ckeditor5-test-external-directory/tests/manual/**/*.{js,ts}',
+				'/workspace/packages/ckeditor-test-external-directory/tests/manual/**/*.{js,ts}',
+				'/workspace/external/*/packages/ckeditor5-test-external-directory/tests/manual/**/*.{js,ts}',
+				'/workspace/external/*/packages/ckeditor-test-external-directory/tests/manual/**/*.{js,ts}'
 			] );
 		} );
 	} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other (tests): Support for running manual and automated tests written in TypeScript. Remember that test runners do not validate types as we use `esbuild` which ignores it. Closes ckeditor/ckeditor5#14170, ckeditor/ckeditor5#14171.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
