### PR TITLE
Print raw strings if formatted markup is equal

### DIFF
--- a/packages/ckeditor5-dev-tests/tests/utils/automated-tests/assertions/equal-markup.js
+++ b/packages/ckeditor5-dev-tests/tests/utils/automated-tests/assertions/equal-markup.js
@@ -122,4 +122,17 @@ describe( 'equalMarkup chai assertion', () => {
 			);
 		}
 	} );
+
+	it( 'should not format strings if beautifier returns equal markups after formatting', () => {
+		try {
+			expect(
+				'<div><p><span>foo</span></p></div>'
+			).to.equalMarkup(
+				'<div><p><span>foo</span></p></div >'
+			);
+		} catch ( assertionError ) {
+			expect( assertionError.actual ).to.equal( '<div><p><span>foo</span></p></div>' );
+			expect( assertionError.expected ).to.equal( '<div><p><span>foo</span></p></div >' );
+		}
+	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix (tests): Fixed `equalMarkup` assertion to print raw (unformatted) strings if formatted markup is equal. Closes ckeditor/ckeditor5#14175.

---

### Additional information

HTML beautification tools automatically remove extra whitespace characters inside tags (e.g. between attributes, after `<`, before `>`, etc.). It seems that this behavior cannot be adjusted. Apart from the `js-beautify` which we currently use, I checked also `diffable-html` (another popular tool for beautifying HTML) and there is also no control over whitespace inside tags.

For this reason, in case the formatted strings are the same, let's just display the raw (unformatted) strings.
