### PR TITLE
Added support for truncating the changelog to the requested number of entries

### DIFF
--- a/packages/ckeditor5-dev-release-tools/lib/tasks/generatechangelogformonorepository.js
+++ b/packages/ckeditor5-dev-release-tools/lib/tasks/generatechangelogformonorepository.js
@@ -477,6 +477,9 @@ module.exports = async function generateChangelogForMonoRepository( options ) {
 		// Save the changelog.
 		changelogUtils.saveChangelog( newChangelog );
 
+		// Truncate the changelog to keep the latest five release entries.
+		changelogUtils.truncateChangelog( 5 );
+
 		logInfo( 'Saved.', { indentLevel: 1 } );
 	}
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature (release-tools): Introduced util called `truncateChangelog()` that allows reducing the changelog to the requested number of entries. See ckeditor/ckeditor5#14169.

Internal: Generated changelog is truncated to the latest five release entries. Closes ckeditor/ckeditor5#14169.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
