### PR TITLE
Preserve `postinstall` hook in `package.json` in `cleanUpPackages()`.

### DIFF
--- a/packages/ckeditor5-dev-release-tools/lib/tasks/cleanuppackages.js
+++ b/packages/ckeditor5-dev-release-tools/lib/tasks/cleanuppackages.js
@@ -159,9 +159,13 @@ function getIgnoredFilePatterns( packageJson ) {
  */
 function cleanUpPackageJson( packageJson, packageJsonFieldsToRemove, preservePostInstallHook ) {
 	for ( const key of Object.keys( packageJson ) ) {
+		if ( !packageJsonFieldsToRemove.includes( key ) ) {
+			continue;
+		}
+
 		if ( key === 'scripts' && preservePostInstallHook && packageJson.scripts.postinstall ) {
 			packageJson.scripts = { 'postinstall': packageJson.scripts.postinstall };
-		} else if ( packageJsonFieldsToRemove.includes( key ) ) {
+		} else {
 			delete packageJson[ key ];
 		}
 	}

--- a/packages/ckeditor5-dev-release-tools/lib/tasks/cleanuppackages.js
+++ b/packages/ckeditor5-dev-release-tools/lib/tasks/cleanuppackages.js
@@ -24,11 +24,12 @@ const { glob } = require( 'glob' );
  * @param {Object} options
  * @param {String} options.packagesDirectory Relative path to a location of packages to be cleaned up.
  * @param {Array.<String>} [options.packageJsonFieldsToRemove] Fields to remove from `package.json`. If not set, a predefined list is used.
+ * @param {Boolean} [options.preservePostInstallHook] Whether to preserve the postinstall hook in `package.json`.
  * @param {String} [options.cwd] Current working directory from which all paths will be resolved.
  * @returns {Promise}
  */
 module.exports = async function cleanUpPackages( options ) {
-	const { packagesDirectory, packageJsonFieldsToRemove, cwd } = parseOptions( options );
+	const { packagesDirectory, packageJsonFieldsToRemove, preservePostInstallHook, cwd } = parseOptions( options );
 
 	const packageJsonPaths = await glob( '*/package.json', {
 		cwd: upath.join( cwd, packagesDirectory ),
@@ -41,7 +42,7 @@ module.exports = async function cleanUpPackages( options ) {
 		const packageJson = await fs.readJson( packageJsonPath );
 
 		await cleanUpPackageDirectory( packageJson, packagePath );
-		cleanUpPackageJson( packageJson, packageJsonFieldsToRemove );
+		cleanUpPackageJson( packageJson, packageJsonFieldsToRemove, preservePostInstallHook );
 
 		await fs.writeJson( packageJsonPath, packageJson, { spaces: 2 } );
 	}
@@ -53,6 +54,7 @@ module.exports = async function cleanUpPackages( options ) {
  * @param {Object} options
  * @param {String} options.packagesDirectory
  * @param {Array.<String>} [options.packageJsonFieldsToRemove=['devDependencies','depcheckIgnore','scripts','private']]
+ * @param {Boolean} [options.preservePostInstallHook]
  * @param {String} [options.cwd=process.cwd()]
  * @returns {Object}
  */
@@ -60,12 +62,14 @@ function parseOptions( options ) {
 	const {
 		packagesDirectory,
 		packageJsonFieldsToRemove = [ 'devDependencies', 'depcheckIgnore', 'scripts', 'private' ],
+		preservePostInstallHook = false,
 		cwd = process.cwd()
 	} = options;
 
 	return {
 		packagesDirectory: upath.normalizeTrim( packagesDirectory ),
 		packageJsonFieldsToRemove,
+		preservePostInstallHook,
 		cwd: upath.normalizeTrim( cwd )
 	};
 }
@@ -151,10 +155,13 @@ function getIgnoredFilePatterns( packageJson ) {
  *
  * @param {Object} packageJson
  * @param {Array.<String>} packageJsonFieldsToRemove
+ * @param {Boolean} preservePostInstallHook
  */
-function cleanUpPackageJson( packageJson, packageJsonFieldsToRemove ) {
+function cleanUpPackageJson( packageJson, packageJsonFieldsToRemove, preservePostInstallHook ) {
 	for ( const key of Object.keys( packageJson ) ) {
-		if ( packageJsonFieldsToRemove.includes( key ) ) {
+		if ( key === 'scripts' && preservePostInstallHook && packageJson.scripts.postinstall ) {
+			packageJson.scripts = { 'postinstall': packageJson.scripts.postinstall };
+		} else if ( packageJsonFieldsToRemove.includes( key ) ) {
 			delete packageJson[ key ];
 		}
 	}

--- a/packages/ckeditor5-dev-release-tools/tests/tasks/cleanuppackages.js
+++ b/packages/ckeditor5-dev-release-tools/tests/tasks/cleanuppackages.js
@@ -645,6 +645,35 @@ describe( 'dev-release-tools/tasks', () => {
 					}
 				} );
 			} );
+
+			it( 'should keep postinstall hook in `package.json` when preservePostInstallHook is set to true', async () => {
+				mockFs( {
+					'release': {
+						'ckeditor5-foo': {
+							'package.json': JSON.stringify( {
+								scripts: {
+									'postinstall': 'node my-node-script.js',
+									'build': 'tsc -p ./tsconfig.json',
+									'dll:build': 'webpack'
+								}
+							} )
+						}
+					}
+				} );
+
+				await cleanUpPackages( {
+					packagesDirectory: 'release',
+					preservePostInstallHook: true
+				} );
+
+				const call = stubs.fs.writeJson.getCall( 0 );
+
+				expect( call.args[ 1 ] ).to.deep.equal( {
+					scripts: {
+						'postinstall': 'node my-node-script.js'
+					}
+				} );
+			} );
 		} );
 	} );
 } );

--- a/packages/ckeditor5-dev-release-tools/tests/tasks/cleanuppackages.js
+++ b/packages/ckeditor5-dev-release-tools/tests/tasks/cleanuppackages.js
@@ -674,6 +674,41 @@ describe( 'dev-release-tools/tasks', () => {
 					}
 				} );
 			} );
+
+			it( 'should not remove scripts unless it is explicitly specified in packageJsonFieldsToRemove', async () => {
+				mockFs( {
+					'release': {
+						'ckeditor5-foo': {
+							'package.json': JSON.stringify( {
+								author: 'author',
+								scripts: {
+									'postinstall': 'node my-node-script.js',
+									'build': 'tsc -p ./tsconfig.json',
+									'dll:build': 'webpack'
+								}
+							} )
+						}
+					}
+				} );
+
+				await cleanUpPackages( {
+					packagesDirectory: 'release',
+					preservePostInstallHook: true,
+					packageJsonFieldsToRemove: [
+						'author'
+					]
+				} );
+
+				const call = stubs.fs.writeJson.getCall( 0 );
+
+				expect( call.args[ 1 ] ).to.deep.equal( {
+					scripts: {
+						'postinstall': 'node my-node-script.js',
+						'build': 'tsc -p ./tsconfig.json',
+						'dll:build': 'webpack'
+					}
+				} );
+			} );
 		} );
 	} );
 } );

--- a/scripts/preparepackages.js
+++ b/scripts/preparepackages.js
@@ -76,12 +76,7 @@ const tasks = new Listr( [
 		task: () => {
 			return releaseTools.cleanUpPackages( {
 				packagesDirectory: RELEASE_DIRECTORY,
-				packageJsonFieldsToRemove: [
-					// TODO: Preserve `scripts.postinstall`.
-					// See: https://github.com/ckeditor/ckeditor5/issues/14318.
-					'devDependencies',
-					'depcheckIgnore'
-				]
+				preservePostInstallHook: true
 			} );
 		}
 	},


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other (release-tools): Added the `preservePostInstallHook` option in the `cleanUpPackages()` task to preserve the `postinstall` hook in `package.json` in the published packages. Closes ckeditor/ckeditor5#14318.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
