### PR TITLE
Removing changelog elements.

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "@ckeditor/ckeditor5-dev-ci": "^38.0.1",
     "@ckeditor/ckeditor5-dev-release-tools": "^38.0.1",
     "eslint": "^7.0.0",
-    "eslint-config-ckeditor5": "^4.0.0",
+    "eslint-config-ckeditor5": "^5.0.1",
     "glob": "^10.2.5",
     "husky": "^8.0.2",
     "lint-staged": "^10.2.4",

--- a/packages/ckeditor5-dev-release-tools/lib/tasks/generatechangelogformonorepository.js
+++ b/packages/ckeditor5-dev-release-tools/lib/tasks/generatechangelogformonorepository.js
@@ -49,10 +49,6 @@ const noteInfo = `[ℹ️](${ VERSIONING_POLICY_URL }#major-and-minor-breaking-c
  *
  * @param {String} [options.from] A commit or tag name that will be the first param of the range of commits to collect.
  *
- * @param {Boolean} [options.highlightsPlaceholder=false] Whether to add a note about release highlights.
- *
- * @param {Boolean} [options.collaborationFeatures=false] Whether to add a note about collaboration features.
- *
  * @param {String} [options.releaseBranch='master'] A name of the branch that should be used for releasing packages.
  *
  * @param {Array.<ExternalRepository>} [options.externalRepositories=[]] An array of object with additional repositories
@@ -388,8 +384,6 @@ module.exports = async function generateChangelogForMonoRepository( options ) {
 			currentTag: 'v' + version,
 			previousTag: 'v' + pkgJson.version,
 			isPatch: semver.diff( version, pkgJson.version ) === 'patch',
-			highlightsPlaceholder: options.highlightsPlaceholder || false,
-			collaborationFeatures: options.collaborationFeatures || false,
 			skipCommitsLink: Boolean( options.skipLinks ),
 			skipCompareLink: Boolean( options.skipLinks )
 		};

--- a/packages/ckeditor5-dev-release-tools/lib/tasks/generatechangelogforsinglepackage.js
+++ b/packages/ckeditor5-dev-release-tools/lib/tasks/generatechangelogforsinglepackage.js
@@ -33,10 +33,6 @@ const SKIP_GENERATE_CHANGELOG = 'Typed "skip" as a new version. Aborting.';
  *
  * @param {String} [options.from] A commit or tag name that will be the first param of the range of commits to collect.
  *
- * @param {Boolean} [options.highlightsPlaceholder=false] Whether to add a note about release highlights.
- *
- * @param {Boolean} [options.collaborationFeatures=false] Whether to add a note about collaboration features.
- *
  * @param {String} [options.releaseBranch='master'] A name of the branch that should be used for releasing packages.
  *
  * @returns {Promise}
@@ -107,8 +103,6 @@ module.exports = async function generateChangelogForSinglePackage( options = {} 
 				previousTag,
 				isPatch: semver.diff( version, pkgJson.version ) === 'patch',
 				isInternalRelease,
-				highlightsPlaceholder: Boolean( options.highlightsPlaceholder ),
-				collaborationFeatures: Boolean( options.collaborationFeatures ),
 				skipCommitsLink: Boolean( options.skipLinks ),
 				skipCompareLink: Boolean( options.skipLinks )
 			};

--- a/packages/ckeditor5-dev-release-tools/lib/templates/template.hbs
+++ b/packages/ckeditor5-dev-release-tools/lib/templates/template.hbs
@@ -5,10 +5,6 @@ Internal changes only (updated dependencies, documentation, etc.).
 
 
 {{else}}
-{{#if highlightsPlaceholder}}
-### Release highlights
-
-{{/if}}
 {{> footer}}
 {{#each commitGroups}}
 ### {{title}}

--- a/packages/ckeditor5-dev-release-tools/lib/templates/template.hbs
+++ b/packages/ckeditor5-dev-release-tools/lib/templates/template.hbs
@@ -8,14 +8,6 @@ Internal changes only (updated dependencies, documentation, etc.).
 {{#if highlightsPlaceholder}}
 ### Release highlights
 
-<!-- TODO: Add a link to the blog post. -->
-
-{{/if}}
-{{#if collaborationFeatures}}
-### Collaboration features
-
-The CKEditor 5 Collaboration features changelog can be found here: https://ckeditor.com/collaboration/changelog.
-
 {{/if}}
 {{> footer}}
 {{#each commitGroups}}

--- a/packages/ckeditor5-dev-release-tools/lib/utils/generatechangelog.js
+++ b/packages/ckeditor5-dev-release-tools/lib/utils/generatechangelog.js
@@ -22,8 +22,6 @@ const UPDATED_TRANSLATION_COMMIT = '* Updated translations.';
  * @param {String} context.currentTag A tag for the current version.
  * @param {String} context.commit Commit keyword in the URL.
  * @param {String} [context.previousTag] A tag for the previous version.
- * @param {Boolean} [options.highlightsPlaceholder=false] Whether to add a note about release highlights.
- * @param {Boolean} [options.collaborationFeatures=false] Whether to add a note about collaboration features.
  * @param {Boolean} [context.skipCommitsLink=false] Whether to skip adding links to commit.
  * @param {Boolean} [context.skipCompareLink=false] Whether to remove the compare URL in the header.
  *

--- a/packages/ckeditor5-dev-release-tools/tests/utils/generatechangelog.js
+++ b/packages/ckeditor5-dev-release-tools/tests/utils/generatechangelog.js
@@ -946,15 +946,12 @@ describe( 'dev-release-tools/utils', () => {
 							'### Release highlights'
 						);
 						expect( changesAsArray[ 2 ] ).to.equal(
-							'<!-- TODO: Add a link to the blog post. -->'
-						);
-						expect( changesAsArray[ 3 ] ).to.equal(
 							'### Features'
 						);
-						expect( changesAsArray[ 4 ] ).to.equal(
+						expect( changesAsArray[ 3 ] ).to.equal(
 							'* The first an amazing feature. ([commit](https://github.com/ckeditor/ckeditor5-package/commit/xxxxxxx))'
 						);
-						expect( changesAsArray[ 5 ] ).to.equal(
+						expect( changesAsArray[ 4 ] ).to.equal(
 							'* The second an amazing feature. ([commit](https://github.com/ckeditor/ckeditor5-package/commit/zzzzzzz))'
 						);
 					} );
@@ -1007,15 +1004,12 @@ describe( 'dev-release-tools/utils', () => {
 							'### Collaboration features'
 						);
 						expect( changesAsArray[ 2 ] ).to.equal(
-							`The CKEditor 5 Collaboration features changelog can be found here: ${ changelog }.`
-						);
-						expect( changesAsArray[ 3 ] ).to.equal(
 							'### Features'
 						);
-						expect( changesAsArray[ 4 ] ).to.equal(
+						expect( changesAsArray[ 3 ] ).to.equal(
 							'* The first an amazing feature. ([commit](https://github.com/ckeditor/ckeditor5-package/commit/xxxxxxx))'
 						);
-						expect( changesAsArray[ 5 ] ).to.equal(
+						expect( changesAsArray[ 4 ] ).to.equal(
 							'* The second an amazing feature. ([commit](https://github.com/ckeditor/ckeditor5-package/commit/zzzzzzz))'
 						);
 					} );
@@ -1127,51 +1121,45 @@ describe( 'dev-release-tools/utils', () => {
 							'### Release highlights'
 						);
 						expect( changesAsArray[ 2 ] ).to.equal(
-							'<!-- TODO: Add a link to the blog post. -->'
-						);
-						expect( changesAsArray[ 3 ] ).to.equal(
 							'### Collaboration features'
 						);
-						expect( changesAsArray[ 4 ] ).to.equal(
-							`The CKEditor 5 Collaboration features changelog can be found here: ${ changelog }.`
-						);
-						expect( changesAsArray[ 5 ] ).to.equal(
+						expect( changesAsArray[ 3 ] ).to.equal(
 							'### MAJOR BREAKING CHANGES'
 						);
-						expect( changesAsArray[ 6 ] ).to.equal(
+						expect( changesAsArray[ 4 ] ).to.equal(
 							'* This change should be scoped too but the script should work if the scope is being missed.'
 						);
-						expect( changesAsArray[ 7 ] ).to.equal(
+						expect( changesAsArray[ 5 ] ).to.equal(
 							'### MINOR BREAKING CHANGES'
 						);
-						expect( changesAsArray[ 8 ] ).to.equal(
+						expect( changesAsArray[ 6 ] ).to.equal(
 							'* **engine**: Nothing but I would like to use the note - engine.'
 						);
-						expect( changesAsArray[ 9 ] ).to.equal(
+						expect( changesAsArray[ 7 ] ).to.equal(
 							'* **ui**: Nothing but I would like to use the note - ui.'
 						);
-						expect( changesAsArray[ 10 ] ).to.equal(
+						expect( changesAsArray[ 8 ] ).to.equal(
 							'### Features'
 						);
-						expect( changesAsArray[ 11 ] ).to.equal(
+						expect( changesAsArray[ 9 ] ).to.equal(
 							'* **autoformat**: It just works. ([commit](https://github.com/ckeditor/ckeditor5-package/c/bb))'
 						);
-						expect( changesAsArray[ 12 ] ).to.equal(
+						expect( changesAsArray[ 10 ] ).to.equal(
 							'* **engine**: The first an amazing feature. ([commit](https://github.com/ckeditor/ckeditor5-package/c/xx))'
 						);
-						expect( changesAsArray[ 13 ] ).to.equal(
+						expect( changesAsArray[ 11 ] ).to.equal(
 							'* The second an amazing feature. ([commit](https://github.com/ckeditor/ckeditor5-package/c/zz))'
 						);
-						expect( changesAsArray[ 14 ] ).to.equal(
+						expect( changesAsArray[ 12 ] ).to.equal(
 							'### Bug fixes'
 						);
-						expect( changesAsArray[ 15 ] ).to.equal(
+						expect( changesAsArray[ 13 ] ).to.equal(
 							'* **ui**: The first amazing bug fix. ([commit](https://github.com/ckeditor/ckeditor5-package/c/yy))'
 						);
-						expect( changesAsArray[ 16 ] ).to.equal(
+						expect( changesAsArray[ 14 ] ).to.equal(
 							'### Other changes'
 						);
-						expect( changesAsArray[ 17 ] ).to.equal(
+						expect( changesAsArray[ 15 ] ).to.equal(
 							'* Use the newest version of Node.js on CI. ([commit](https://github.com/ckeditor/ckeditor5-package/c/aa))'
 						);
 					} );

--- a/packages/ckeditor5-dev-release-tools/tests/utils/generatechangelog.js
+++ b/packages/ckeditor5-dev-release-tools/tests/utils/generatechangelog.js
@@ -900,121 +900,6 @@ describe( 'dev-release-tools/utils', () => {
 					} );
 			} );
 
-			it( 'attaches the release highlights placeholder', () => {
-				const commits = [
-					{
-						type: 'Features',
-						header: 'Feature: The first an amazing feature.',
-						subject: 'The first an amazing feature.',
-						hash: 'x'.repeat( 40 ),
-						notes: []
-					},
-					{
-						type: 'Features',
-						header: 'Feature: The second an amazing feature.',
-						subject: 'The second an amazing feature.',
-						hash: 'z'.repeat( 40 ),
-						notes: []
-					}
-				];
-
-				const context = {
-					version: '1.1.0',
-					repoUrl: url,
-					currentTag: 'v1.1.0',
-					previousTag: 'v1.0.0',
-					commit: 'commit',
-					highlightsPlaceholder: true
-				};
-
-				const options = getWriterOptions( {
-					hash: hash => hash.slice( 0, 7 )
-				} );
-
-				return generateChangelog( commits, context, options )
-					.then( changes => {
-						changes = replaceDates( changes );
-
-						const changesAsArray = changes.split( '\n' )
-							.map( line => line.trim() )
-							.filter( line => line.length );
-
-						expect( changesAsArray[ 0 ] ).to.equal(
-							'## [1.1.0](https://github.com/ckeditor/ckeditor5-package/compare/v1.0.0...v1.1.0) (0000-00-00)'
-						);
-						expect( changesAsArray[ 1 ] ).to.equal(
-							'### Release highlights'
-						);
-						expect( changesAsArray[ 2 ] ).to.equal(
-							'### Features'
-						);
-						expect( changesAsArray[ 3 ] ).to.equal(
-							'* The first an amazing feature. ([commit](https://github.com/ckeditor/ckeditor5-package/commit/xxxxxxx))'
-						);
-						expect( changesAsArray[ 4 ] ).to.equal(
-							'* The second an amazing feature. ([commit](https://github.com/ckeditor/ckeditor5-package/commit/zzzzzzz))'
-						);
-					} );
-			} );
-
-			it( 'attaches the collaboration features changelog', () => {
-				const commits = [
-					{
-						type: 'Features',
-						header: 'Feature: The first an amazing feature.',
-						subject: 'The first an amazing feature.',
-						hash: 'x'.repeat( 40 ),
-						notes: []
-					},
-					{
-						type: 'Features',
-						header: 'Feature: The second an amazing feature.',
-						subject: 'The second an amazing feature.',
-						hash: 'z'.repeat( 40 ),
-						notes: []
-					}
-				];
-
-				const context = {
-					version: '1.1.0',
-					repoUrl: url,
-					currentTag: 'v1.1.0',
-					previousTag: 'v1.0.0',
-					commit: 'commit',
-					collaborationFeatures: true
-				};
-
-				const options = getWriterOptions( {
-					hash: hash => hash.slice( 0, 7 )
-				} );
-
-				return generateChangelog( commits, context, options )
-					.then( changes => {
-						changes = replaceDates( changes );
-						const changelog = 'https://ckeditor.com/collaboration/changelog';
-
-						const changesAsArray = changes.split( '\n' )
-							.map( line => line.trim() )
-							.filter( line => line.length );
-
-						expect( changesAsArray[ 0 ] ).to.equal(
-							'## [1.1.0](https://github.com/ckeditor/ckeditor5-package/compare/v1.0.0...v1.1.0) (0000-00-00)'
-						);
-						expect( changesAsArray[ 1 ] ).to.equal(
-							'### Collaboration features'
-						);
-						expect( changesAsArray[ 2 ] ).to.equal(
-							'### Features'
-						);
-						expect( changesAsArray[ 3 ] ).to.equal(
-							'* The first an amazing feature. ([commit](https://github.com/ckeditor/ckeditor5-package/commit/xxxxxxx))'
-						);
-						expect( changesAsArray[ 4 ] ).to.equal(
-							'* The second an amazing feature. ([commit](https://github.com/ckeditor/ckeditor5-package/commit/zzzzzzz))'
-						);
-					} );
-			} );
-
 			it( 'generates complex changelog', () => {
 				const commits = [
 					{
@@ -1084,9 +969,7 @@ describe( 'dev-release-tools/utils', () => {
 					repoUrl: url,
 					currentTag: 'v1.1.0',
 					previousTag: 'v1.0.0',
-					commit: 'c',
-					highlightsPlaceholder: true,
-					collaborationFeatures: true
+					commit: 'c'
 				};
 
 				const options = getWriterOptions( {
@@ -1108,7 +991,6 @@ describe( 'dev-release-tools/utils', () => {
 				return generateChangelog( commits, context, options )
 					.then( changes => {
 						changes = replaceDates( changes );
-						const changelog = 'https://ckeditor.com/collaboration/changelog';
 
 						const changesAsArray = changes.split( '\n' )
 							.map( line => line.trim() )
@@ -1118,48 +1000,42 @@ describe( 'dev-release-tools/utils', () => {
 							'## [1.1.0](https://github.com/ckeditor/ckeditor5-package/compare/v1.0.0...v1.1.0) (0000-00-00)'
 						);
 						expect( changesAsArray[ 1 ] ).to.equal(
-							'### Release highlights'
-						);
-						expect( changesAsArray[ 2 ] ).to.equal(
-							'### Collaboration features'
-						);
-						expect( changesAsArray[ 3 ] ).to.equal(
 							'### MAJOR BREAKING CHANGES'
 						);
-						expect( changesAsArray[ 4 ] ).to.equal(
+						expect( changesAsArray[ 2 ] ).to.equal(
 							'* This change should be scoped too but the script should work if the scope is being missed.'
 						);
-						expect( changesAsArray[ 5 ] ).to.equal(
+						expect( changesAsArray[ 3 ] ).to.equal(
 							'### MINOR BREAKING CHANGES'
 						);
-						expect( changesAsArray[ 6 ] ).to.equal(
+						expect( changesAsArray[ 4 ] ).to.equal(
 							'* **engine**: Nothing but I would like to use the note - engine.'
 						);
-						expect( changesAsArray[ 7 ] ).to.equal(
+						expect( changesAsArray[ 5 ] ).to.equal(
 							'* **ui**: Nothing but I would like to use the note - ui.'
 						);
-						expect( changesAsArray[ 8 ] ).to.equal(
+						expect( changesAsArray[ 6 ] ).to.equal(
 							'### Features'
 						);
-						expect( changesAsArray[ 9 ] ).to.equal(
+						expect( changesAsArray[ 7 ] ).to.equal(
 							'* **autoformat**: It just works. ([commit](https://github.com/ckeditor/ckeditor5-package/c/bb))'
 						);
-						expect( changesAsArray[ 10 ] ).to.equal(
+						expect( changesAsArray[ 8 ] ).to.equal(
 							'* **engine**: The first an amazing feature. ([commit](https://github.com/ckeditor/ckeditor5-package/c/xx))'
 						);
-						expect( changesAsArray[ 11 ] ).to.equal(
+						expect( changesAsArray[ 9 ] ).to.equal(
 							'* The second an amazing feature. ([commit](https://github.com/ckeditor/ckeditor5-package/c/zz))'
 						);
-						expect( changesAsArray[ 12 ] ).to.equal(
+						expect( changesAsArray[ 10 ] ).to.equal(
 							'### Bug fixes'
 						);
-						expect( changesAsArray[ 13 ] ).to.equal(
+						expect( changesAsArray[ 11 ] ).to.equal(
 							'* **ui**: The first amazing bug fix. ([commit](https://github.com/ckeditor/ckeditor5-package/c/yy))'
 						);
-						expect( changesAsArray[ 14 ] ).to.equal(
+						expect( changesAsArray[ 12 ] ).to.equal(
 							'### Other changes'
 						);
-						expect( changesAsArray[ 15 ] ).to.equal(
+						expect( changesAsArray[ 13 ] ).to.equal(
 							'* Use the newest version of Node.js on CI. ([commit](https://github.com/ckeditor/ckeditor5-package/c/aa))'
 						);
 					} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other (release-tools): The `highlightsPlaceholder` and `collaborationFeatures` options are no longer available in the `generateChangelogForMonoRepository()` and `generateChangelogForSinglePackage()` tasks.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
