### PR TITLE
Release tools: Add files to staging area one by one to avoid exceeding the maximum command length on Windows

### DIFF
--- a/packages/ckeditor5-dev-release-tools/tests/tasks/commitandtag.js
+++ b/packages/ckeditor5-dev-release-tools/tests/tasks/commitandtag.js
@@ -42,7 +42,15 @@ describe( 'commitAndTag()', () => {
 		sinon.restore();
 	} );
 
+	it( 'should not create a commit and tag if there are no files modified', async () => {
+		await commitAndTag( {} );
+
+		expect( stubs.tools.shExec.called ).to.equal( false );
+	} );
+
 	it( 'should allow to specify custom cwd', async () => {
+		stubs.glob.glob.resolves( [ 'package.json' ] );
+
 		await commitAndTag( { version: '1.0.0', cwd: 'my-cwd' } );
 
 		expect( stubs.tools.shExec.firstCall.args[ 1 ].cwd ).to.deep.equal( 'my-cwd' );
@@ -50,7 +58,7 @@ describe( 'commitAndTag()', () => {
 		expect( stubs.tools.shExec.thirdCall.args[ 1 ].cwd ).to.deep.equal( 'my-cwd' );
 	} );
 
-	it( 'should add provided files to git', async () => {
+	it( 'should add provided files to git one by one', async () => {
 		stubs.glob.glob.resolves( [
 			'package.json',
 			'README.md',
@@ -63,17 +71,24 @@ describe( 'commitAndTag()', () => {
 			files: [ 'package.json', 'README.md', 'packages/*/package.json', 'packages/*/README.md' ]
 		} );
 
-		expect( stubs.tools.shExec.firstCall.args[ 0 ] )
-			.to.equal( 'git add package.json README.md packages/custom-package/package.json packages/custom-package/README.md' );
+		expect( stubs.tools.shExec.callCount ).to.equal( 6 );
+		expect( stubs.tools.shExec.getCall( 0 ).args[ 0 ] ).to.equal( 'git add package.json' );
+		expect( stubs.tools.shExec.getCall( 1 ).args[ 0 ] ).to.equal( 'git add README.md' );
+		expect( stubs.tools.shExec.getCall( 2 ).args[ 0 ] ).to.equal( 'git add packages/custom-package/package.json' );
+		expect( stubs.tools.shExec.getCall( 3 ).args[ 0 ] ).to.equal( 'git add packages/custom-package/README.md' );
 	} );
 
 	it( 'should set correct commit message', async () => {
+		stubs.glob.glob.resolves( [ 'package.json' ] );
+
 		await commitAndTag( { version: '1.0.0', packagesDirectory: 'packages' } );
 
-		expect( stubs.tools.shExec.secondCall.args[ 0 ] ).to.equal( 'git commit --message "Release: v1.0.0."' );
+		expect( stubs.tools.shExec.secondCall.args[ 0 ] ).to.equal( 'git commit --message "Release: v1.0.0." --no-verify' );
 	} );
 
 	it( 'should set correct tag', async () => {
+		stubs.glob.glob.resolves( [ 'package.json' ] );
+
 		await commitAndTag( { version: '1.0.0', packagesDirectory: 'packages' } );
 
 		expect( stubs.tools.shExec.thirdCall.args[ 0 ] ).to.equal( 'git tag v1.0.0' );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix (release-tools): Add files to staging area one by one to avoid exceeding the maximum command length on Windows.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
