### PR TITLE
Fixed message in case of bot action

### DIFF
--- a/packages/ckeditor5-dev-ci/lib/format-message.js
+++ b/packages/ckeditor5-dev-ci/lib/format-message.js
@@ -81,13 +81,13 @@ function getNotifierMessage( options ) {
 		return '_The author of the commit was hidden. <https://github.com/ckeditor/ckeditor5/issues/9252|Read more about why.>_';
 	}
 
+	if ( bots.includes( options.githubAccount ) ) {
+		return '_This commit is a result of merging a branch into another branch._';
+	}
+
 	// If the author of the commit could not be obtained, let's ping the entire team.
 	if ( !slackAccount ) {
 		return `@channel (${ options.commitAuthor }), could you take a look?`;
-	}
-
-	if ( bots.includes( options.githubAccount ) ) {
-		return '_This commit is a result of merging a branch into another branch._';
 	}
 
 	return `<@${ slackAccount }>, could you take a look?`;

--- a/packages/ckeditor5-dev-ci/lib/format-message.js
+++ b/packages/ckeditor5-dev-ci/lib/format-message.js
@@ -87,7 +87,7 @@ function getNotifierMessage( options ) {
 
 	// If the author of the commit could not be obtained, let's ping the entire team.
 	if ( !slackAccount ) {
-		return `@channel (${ options.commitAuthor }), could you take a look?`;
+		return `<!channel> (${ options.commitAuthor }), could you take a look?`;
 	}
 
 	return `<@${ slackAccount }>, could you take a look?`;


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix (ci): Fixed Slack notifiers displaying an incorrect message in case of a bot action. Closes ckeditor/ckeditor5#14669.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
