### PR TITLE
Extracted `checkVersionAvailability()` in release tools to a separate util

### DIFF
--- a/packages/ckeditor5-dev-release-tools/lib/index.js
+++ b/packages/ckeditor5-dev-release-tools/lib/index.js
@@ -20,6 +20,7 @@ const { getLastFromChangelog, getLastNightly, getNextNightly, getCurrent, getLas
 const { getChangesForVersion, getChangelog, saveChangelog } = require( './utils/changelog' );
 const executeInParallel = require( './utils/executeinparallel' );
 const validateRepositoryToRelease = require( './utils/validaterepositorytorelease' );
+const checkVersionAvailability = require( './utils/checkversionavailability' );
 
 module.exports = {
 	generateChangelogForSinglePackage,
@@ -42,5 +43,6 @@ module.exports = {
 	getChangesForVersion,
 	getChangelog,
 	saveChangelog,
-	validateRepositoryToRelease
+	validateRepositoryToRelease,
+	checkVersionAvailability
 };

--- a/packages/ckeditor5-dev-release-tools/lib/tasks/updateversions.js
+++ b/packages/ckeditor5-dev-release-tools/lib/tasks/updateversions.js
@@ -9,7 +9,7 @@ const { glob } = require( 'glob' );
 const fs = require( 'fs-extra' );
 const semver = require( 'semver' );
 const { normalizeTrim, toUnix, dirname, join } = require( 'upath' );
-const { tools } = require( '@ckeditor/ckeditor5-dev-utils' );
+const checkVersionAvailability = require( '../utils/checkversionavailability' );
 
 /**
  * The purpose of the script is to update the version of a root package found in the current working
@@ -95,23 +95,4 @@ function checkIfVersionIsValid( newVersion, currentVersion ) {
 	if ( !semver.gt( newVersion, currentVersion ) ) {
 		throw new Error( `Provided version ${ newVersion } must be greater than ${ currentVersion } or match pattern 0.0.0-nightly.` );
 	}
-}
-
-/**
- * Checks if the provided version is not used in npm and there will be no errors when calling publish.
- *
- * @param {String} version
- * @param {String} packageName
- * @returns {Promise}
- */
-async function checkVersionAvailability( version, packageName ) {
-	return tools.shExec( `npm show ${ packageName }@${ version } version`, { verbosity: 'silent', async: true } )
-		.then( () => {
-			throw new Error( `Provided version ${ version } is already used in npm by ${ packageName }.` );
-		} )
-		.catch( err => {
-			if ( !err.toString().includes( 'is not in this registry' ) ) {
-				throw err;
-			}
-		} );
 }

--- a/packages/ckeditor5-dev-release-tools/lib/tasks/updateversions.js
+++ b/packages/ckeditor5-dev-release-tools/lib/tasks/updateversions.js
@@ -38,10 +38,18 @@ module.exports = async function updateVersions( { packagesDirectory, version, cw
 	const randomPackagePath = getRandomPackagePath( pkgJsonPaths, normalizedPackagesDir );
 
 	const rootPackageJson = join( normalizedCwd, 'package.json' );
-	const randomPackageJson = join( randomPackagePath, 'package.json' );
+	const rootPackageVersion = ( await fs.readJson( rootPackageJson ) ).version;
 
-	checkIfVersionIsValid( version, ( await fs.readJson( rootPackageJson ) ).version );
-	await checkVersionAvailability( version, ( await fs.readJson( randomPackageJson ) ).name );
+	const randomPackageJson = join( randomPackagePath, 'package.json' );
+	const randomPackageName = ( await fs.readJson( randomPackageJson ) ).name;
+
+	checkIfVersionIsValid( version, rootPackageVersion );
+
+	const isVersionAvailable = await checkVersionAvailability( version, randomPackageName );
+
+	if ( !isVersionAvailable ) {
+		throw new Error( `The "${ randomPackageName }@${ version }" already exists in the npm registry.` );
+	}
 
 	for ( const pkgJsonPath of pkgJsonPaths ) {
 		const pkgJson = await fs.readJson( pkgJsonPath );

--- a/packages/ckeditor5-dev-release-tools/lib/utils/checkversionavailability.js
+++ b/packages/ckeditor5-dev-release-tools/lib/utils/checkversionavailability.js
@@ -1,0 +1,27 @@
+/**
+ * @license Copyright (c) 2003-2023, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+'use strict';
+
+const { tools } = require( '@ckeditor/ckeditor5-dev-utils' );
+
+/**
+ * Checks if the provided version is not used in npm and there will be no errors when calling publish.
+ *
+ * @param {String} version
+ * @param {String} packageName
+ * @returns {Promise}
+ */
+module.exports = async function checkVersionAvailability( version, packageName ) {
+	return tools.shExec( `npm show ${ packageName }@${ version } version`, { verbosity: 'silent', async: true } )
+		.then( () => {
+			throw new Error( `Provided version ${ version } is already used in npm by ${ packageName }.` );
+		} )
+		.catch( err => {
+			if ( !err.toString().includes( 'is not in this registry' ) ) {
+				throw err;
+			}
+		} );
+};

--- a/packages/ckeditor5-dev-release-tools/lib/utils/checkversionavailability.js
+++ b/packages/ckeditor5-dev-release-tools/lib/utils/checkversionavailability.js
@@ -10,7 +10,8 @@ const { tools } = require( '@ckeditor/ckeditor5-dev-utils' );
 /**
  * Checks if the provided version for the package exists in the npm registry.
  *
- * Returns a promise that resolves if version does not exist or rejects the promise otherwise.
+ * Returns a promise that resolves to `true` if the provided version does not exist or resolves the promise to `false` otherwise.
+ * If the `npm show` command exits with an error, it is re-thrown.
  *
  * @param {String} version
  * @param {String} packageName
@@ -19,17 +20,23 @@ const { tools } = require( '@ckeditor/ckeditor5-dev-utils' );
 module.exports = async function checkVersionAvailability( version, packageName ) {
 	return tools.shExec( `npm show ${ packageName }@${ version } version`, { verbosity: 'silent', async: true } )
 		.then( result => {
-			// Explicit check for npm < 8.13.0, which does not return anything and it exits with a zero status code when the version for the
-			// provided package does not exist in the npm registry.
+			// Explicit check for npm < 8.13.0, which does not return anything (an empty result) and it exits with a zero status code when
+			// the version for the provided package does not exist in the npm registry.
 			if ( !result ) {
-				return;
+				return true;
 			}
 
-			throw new Error( `The "${ packageName }@${ version }" already exists in npm.` );
+			// Provided version exists in the npm registry.
+			return false;
 		} )
 		.catch( error => {
+			// All errors except the "E404" are re-thrown.
 			if ( !error.toString().includes( 'npm ERR! code E404' ) ) {
 				throw error;
 			}
+
+			// Npm >= 8.13.0 throws an "E404" error if a version does not exist.
+			// Npm < 8.13.0 should never reach this line.
+			return true;
 		} );
 };

--- a/packages/ckeditor5-dev-release-tools/lib/utils/checkversionavailability.js
+++ b/packages/ckeditor5-dev-release-tools/lib/utils/checkversionavailability.js
@@ -19,8 +19,8 @@ const { tools } = require( '@ckeditor/ckeditor5-dev-utils' );
 module.exports = async function checkVersionAvailability( version, packageName ) {
 	return tools.shExec( `npm show ${ packageName }@${ version } version`, { verbosity: 'silent', async: true } )
 		.then( result => {
-			// Explicit check for npm < 8.13.0, which does not return anything exits with zero status code when the version for provided
-			// package does not exist in the npm registry.
+			// Explicit check for npm < 8.13.0, which does not return anything and it exits with a zero status code when the version for the
+			// provided package does not exist in the npm registry.
 			if ( !result ) {
 				return;
 			}

--- a/packages/ckeditor5-dev-release-tools/tests/index.js
+++ b/packages/ckeditor5-dev-release-tools/tests/index.js
@@ -198,4 +198,10 @@ describe( 'dev-release-tools/index', () => {
 			expect( index.validateRepositoryToRelease ).to.be.a( 'function' );
 		} );
 	} );
+
+	describe( 'checkVersionAvailability()', () => {
+		it( 'should be a function', () => {
+			expect( index.checkVersionAvailability ).to.be.a( 'function' );
+		} );
+	} );
 } );

--- a/packages/ckeditor5-dev-release-tools/tests/tasks/updateversions.js
+++ b/packages/ckeditor5-dev-release-tools/tests/tasks/updateversions.js
@@ -72,13 +72,13 @@ describe( 'dev-release-tools/release', () => {
 
 		it( 'should throw an error when the version is already in use', async () => {
 			stubs.readJson.resolves( { version: '1.0.0', name: 'stub-package' } );
-			stubs.checkVersionAvailability.rejects( new Error( 'Provided version 1.0.1 is already used in npm by stub-package.' ) );
+			stubs.checkVersionAvailability.rejects( new Error( 'The "stub-package@1.0.1" already exists in npm.' ) );
 
 			try {
 				await updateVersions( { version: '1.0.1' } );
 				throw new Error( 'Expected to throw.' );
 			} catch ( err ) {
-				expect( err.message ).to.equal( 'Provided version 1.0.1 is already used in npm by stub-package.' );
+				expect( err.message ).to.equal( 'The "stub-package@1.0.1" already exists in npm.' );
 			}
 		} );
 

--- a/packages/ckeditor5-dev-release-tools/tests/tasks/updateversions.js
+++ b/packages/ckeditor5-dev-release-tools/tests/tasks/updateversions.js
@@ -20,7 +20,7 @@ describe( 'dev-release-tools/release', () => {
 				outputJson: sandbox.stub(),
 				readJson: sandbox.stub().resolves( { version: '1.0.0' } ),
 				glob: sandbox.stub().resolves( [ '/ckeditor5-dev' ] ),
-				shExec: sandbox.stub().rejects( new Error( 'is not in this registry' ) )
+				checkVersionAvailability: sandbox.stub().resolves()
 			};
 
 			updateVersions = proxyquire( '../../lib/tasks/updateversions.js', {
@@ -29,11 +29,7 @@ describe( 'dev-release-tools/release', () => {
 					readJson: stubs.readJson
 				},
 				'glob': { glob: stubs.glob },
-				'@ckeditor/ckeditor5-dev-utils': {
-					tools: {
-						shExec: stubs.shExec
-					}
-				}
+				'../utils/checkversionavailability': stubs.checkVersionAvailability
 			} );
 		} );
 
@@ -76,7 +72,7 @@ describe( 'dev-release-tools/release', () => {
 
 		it( 'should throw an error when the version is already in use', async () => {
 			stubs.readJson.resolves( { version: '1.0.0', name: 'stub-package' } );
-			stubs.shExec.resolves( '' );
+			stubs.checkVersionAvailability.rejects( new Error( 'Provided version 1.0.1 is already used in npm by stub-package.' ) );
 
 			try {
 				await updateVersions( { version: '1.0.1' } );
@@ -87,25 +83,13 @@ describe( 'dev-release-tools/release', () => {
 		} );
 
 		it( 'should not throw an error when version is not in use', async () => {
-			stubs.shExec.rejects( new Error( 'is not in this registry' ) );
+			stubs.checkVersionAvailability.resolves();
 			stubs.readJson.resolves( { version: '1.0.0', name: 'stub-package' } );
 
 			try {
 				await updateVersions( { version: '1.0.1' } );
 			} catch ( err ) {
 				throw new Error( 'Expected not to throw.' );
-			}
-		} );
-
-		it( 'should throw an error when checking the version availability check rejects error', async () => {
-			stubs.shExec.rejects( new Error( 'custom error' ) );
-			stubs.readJson.resolves( { version: '1.0.0', name: 'stub-package' } );
-
-			try {
-				await updateVersions( { version: '1.0.1' } );
-				throw new Error( 'Expected to throw.' );
-			} catch ( err ) {
-				expect( err.message ).to.equal( 'custom error' );
 			}
 		} );
 
@@ -121,8 +105,8 @@ describe( 'dev-release-tools/release', () => {
 
 			await updateVersions( { version: '1.0.1', packagesDirectory: 'packages' } );
 
-			expect( stubs.shExec.callCount ).to.equal( 1 );
-			expect( stubs.shExec.firstCall.args[ 0 ] ).to.not.equal( 'npm show root-package@1.0.1 version' );
+			expect( stubs.checkVersionAvailability.callCount ).to.equal( 1 );
+			expect( stubs.checkVersionAvailability.firstCall.args[ 1 ] ).to.not.equal( 'root-package' );
 		} );
 
 		it( 'should provide the root package name when checking version availability if packagesDirectory is not provided', async () => {
@@ -131,8 +115,8 @@ describe( 'dev-release-tools/release', () => {
 
 			await updateVersions( { version: '1.0.1' } );
 
-			expect( stubs.shExec.callCount ).to.equal( 1 );
-			expect( stubs.shExec.firstCall.args[ 0 ] ).to.equal( 'npm show root-package@1.0.1 version' );
+			expect( stubs.checkVersionAvailability.callCount ).to.equal( 1 );
+			expect( stubs.checkVersionAvailability.firstCall.args[ 1 ] ).to.equal( 'root-package' );
 		} );
 
 		it( 'should accept `0.0.0-nightly*` version for nightly releases', async () => {

--- a/packages/ckeditor5-dev-release-tools/tests/utils/checkversionavailability.js
+++ b/packages/ckeditor5-dev-release-tools/tests/utils/checkversionavailability.js
@@ -1,0 +1,77 @@
+/**
+ * @license Copyright (c) 2003-2023, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+'use strict';
+
+const { expect } = require( 'chai' );
+const sinon = require( 'sinon' );
+const proxyquire = require( 'proxyquire' );
+
+describe( 'dev-release-tools/utils', () => {
+	let checkVersionAvailability, sandbox, stubs;
+
+	describe( 'checkVersionAvailability()', () => {
+		beforeEach( () => {
+			sandbox = sinon.createSandbox();
+
+			stubs = {
+				shExec: sandbox.stub()
+			};
+
+			checkVersionAvailability = proxyquire( '../../lib/utils/checkversionavailability.js', {
+				'@ckeditor/ckeditor5-dev-utils': {
+					tools: {
+						shExec: stubs.shExec
+					}
+				}
+			} );
+		} );
+
+		afterEach( () => {
+			sandbox.restore();
+		} );
+
+		it( 'should ask npm if provided version for a package already exists', async () => {
+			stubs.shExec.rejects( new Error( 'is not in this registry' ) );
+
+			await checkVersionAvailability( '1.0.1', 'stub-package' );
+
+			expect( stubs.shExec.callCount ).to.equal( 1 );
+			expect( stubs.shExec.firstCall.args[ 0 ] ).to.equal( 'npm show stub-package@1.0.1 version' );
+		} );
+
+		it( 'should throw an error when the version is already in use', async () => {
+			stubs.shExec.resolves( '' );
+
+			try {
+				await checkVersionAvailability( '1.0.1', 'stub-package' );
+				throw new Error( 'Expected to throw.' );
+			} catch ( err ) {
+				expect( err.message ).to.equal( 'Provided version 1.0.1 is already used in npm by stub-package.' );
+			}
+		} );
+
+		it( 'should not throw an error when version is not in use', async () => {
+			stubs.shExec.rejects( new Error( 'is not in this registry' ) );
+
+			try {
+				await checkVersionAvailability( '1.0.1', 'stub-package' );
+			} catch ( err ) {
+				throw new Error( 'Expected not to throw.' );
+			}
+		} );
+
+		it( 'should throw an error when checking the version availability check rejects error', async () => {
+			stubs.shExec.rejects( new Error( 'custom error' ) );
+
+			try {
+				await checkVersionAvailability( '1.0.1', 'stub-package' );
+				throw new Error( 'Expected to throw.' );
+			} catch ( err ) {
+				expect( err.message ).to.equal( 'custom error' );
+			}
+		} );
+	} );
+} );

--- a/packages/ckeditor5-dev-release-tools/tests/utils/checkversionavailability.js
+++ b/packages/ckeditor5-dev-release-tools/tests/utils/checkversionavailability.js
@@ -33,41 +33,45 @@ describe( 'dev-release-tools/utils', () => {
 			sandbox.restore();
 		} );
 
-		it( 'should resolve if version does not exist (npm >= 8.13.0)', () => {
+		it( 'should resolve to true if version does not exist (npm >= 8.13.0)', () => {
 			stubs.shExec.rejects( new Error( 'npm ERR! code E404' ) );
 
 			return checkVersionAvailability( '1.0.1', 'stub-package' )
-				.then( () => {
+				.then( result => {
 					expect( stubs.shExec.callCount ).to.equal( 1 );
 					expect( stubs.shExec.firstCall.args[ 0 ] ).to.equal( 'npm show stub-package@1.0.1 version' );
+					expect( result ).to.be.true;
 				} )
 				.catch( () => {
 					throw new Error( 'Expected to be resolved.' );
 				} );
 		} );
 
-		it( 'should resolve if version does not exist (npm < 8.13.0)', () => {
+		it( 'should resolve to true if version does not exist (npm < 8.13.0)', () => {
 			stubs.shExec.resolves();
 
 			return checkVersionAvailability( '1.0.1', 'stub-package' )
+				.then( result => {
+					expect( result ).to.be.true;
+				} )
 				.catch( () => {
 					throw new Error( 'Expected to be resolved.' );
 				} );
 		} );
 
-		it( 'should throw an error if version exists', () => {
+		it( 'should resolve to false if version exists', () => {
 			stubs.shExec.resolves( '1.0.1' );
 
 			return checkVersionAvailability( '1.0.1', 'stub-package' )
-				.then( () => {
-					throw new Error( 'Expected to be rejected.' );
+				.then( result => {
+					expect( result ).to.be.false;
 				} )
-				.catch( error => {
-					expect( error.message ).to.equal( 'The "stub-package@1.0.1" already exists in npm.' );
+				.catch( () => {
+					throw new Error( 'Expected to be resolved.' );
 				} );
 		} );
 
-		it( 'should throw an error if unknown error occured', () => {
+		it( 'should re-throw an error if unknown error occured', () => {
 			stubs.shExec.rejects( new Error( 'Unknown error.' ) );
 
 			return checkVersionAvailability( '1.0.1', 'stub-package' )


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other (release-tools): Extracted `checkVersionAvailability()` function in release tools to a separate util that checks if provided version for a package already exists in npm.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
