### PR TITLE
Fixed code coverage report for root project named `ckeditor5-*`.

### DIFF
--- a/packages/ckeditor5-dev-utils/lib/loaders/index.js
+++ b/packages/ckeditor5-dev-utils/lib/loaders/index.js
@@ -192,7 +192,7 @@ function getPathsToIncludeForCoverage( globs ) {
 			return returnedPatterns;
 		}, [] )
 		.map( glob => {
-			const matchCKEditor5 = glob.match( /\/(ckeditor5-[^/]+)\// );
+			const matchCKEditor5 = glob.match( /\/(ckeditor5-[^/]+)\/(?!.*ckeditor5-)/ );
 
 			if ( matchCKEditor5 ) {
 				const packageName = matchCKEditor5[ 1 ]

--- a/packages/ckeditor5-dev-utils/tests/loaders/index.js
+++ b/packages/ckeditor5-dev-utils/tests/loaders/index.js
@@ -340,6 +340,21 @@ describe( 'loaders', () => {
 				new RegExp( [ 'ckeditor5-!(utils)', 'src', '' ].join( escapedPathSep ) )
 			] );
 		} );
+
+		it( 'should return a definition containing a loader for measuring the coverage (for root named ckeditor5-*)', () => {
+			const coverageLoader = loaders.getCoverageLoader( {
+				files: [
+					[ '/ckeditor5-collab/packages/ckeditor5-alignment/tests/**/*.{js,ts}' ]
+				]
+			} );
+
+			expect( coverageLoader ).to.be.an( 'object' );
+			expect( coverageLoader ).to.have.property( 'include' );
+			expect( coverageLoader.include ).to.be.an( 'array' );
+			expect( coverageLoader.include ).to.deep.equal( [
+				new RegExp( [ 'ckeditor5-alignment', 'src', '' ].join( escapedPathSep ) )
+			] );
+		} );
 	} );
 } );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix (tests): Fixed generating the code coverage report if the project root directory differs from `ckeditor5`. 

Closes cksource/ckeditor5-internal#3483.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
