### PR TITLE
Modified `engines` property to be removed by default in the release p…

### DIFF
--- a/packages/ckeditor5-dev-release-tools/lib/tasks/cleanuppackages.js
+++ b/packages/ckeditor5-dev-release-tools/lib/tasks/cleanuppackages.js
@@ -53,7 +53,7 @@ module.exports = async function cleanUpPackages( options ) {
  *
  * @param {Object} options
  * @param {String} options.packagesDirectory
- * @param {Array.<String>} [options.packageJsonFieldsToRemove=['devDependencies','depcheckIgnore','scripts','private']]
+ * @param {Array.<String>} [options.packageJsonFieldsToRemove=['devDependencies','depcheckIgnore','scripts','private','engines']]
  * @param {Boolean} [options.preservePostInstallHook]
  * @param {String} [options.cwd=process.cwd()]
  * @returns {Object}
@@ -61,7 +61,7 @@ module.exports = async function cleanUpPackages( options ) {
 function parseOptions( options ) {
 	const {
 		packagesDirectory,
-		packageJsonFieldsToRemove = [ 'devDependencies', 'depcheckIgnore', 'scripts', 'private' ],
+		packageJsonFieldsToRemove = [ 'devDependencies', 'depcheckIgnore', 'scripts', 'private', 'engines' ],
 		preservePostInstallHook = false,
 		cwd = process.cwd()
 	} = options;

--- a/packages/ckeditor5-dev-release-tools/lib/tasks/cleanuppackages.js
+++ b/packages/ckeditor5-dev-release-tools/lib/tasks/cleanuppackages.js
@@ -23,7 +23,8 @@ const { glob } = require( 'glob' );
  *
  * @param {Object} options
  * @param {String} options.packagesDirectory Relative path to a location of packages to be cleaned up.
- * @param {Array.<String>} [options.packageJsonFieldsToRemove] Fields to remove from `package.json`. If not set, a predefined list is used.
+ * @param {Array.<String>|PackageJsonFieldsToRemoveCallback} [options.packageJsonFieldsToRemove] Fields to remove from `package.json`.
+ * If not set, a predefined list is used. If the callback is used, the first argument is the list with defaults.
  * @param {Boolean} [options.preservePostInstallHook] Whether to preserve the postinstall hook in `package.json`.
  * @param {String} [options.cwd] Current working directory from which all paths will be resolved.
  * @returns {Promise}
@@ -53,15 +54,18 @@ module.exports = async function cleanUpPackages( options ) {
  *
  * @param {Object} options
  * @param {String} options.packagesDirectory
- * @param {Array.<String>} [options.packageJsonFieldsToRemove=['devDependencies','depcheckIgnore','scripts','private','engines']]
+ * @param {Array.<String>|PackageJsonFieldsToRemoveCallback} [options.packageJsonFieldsToRemove=DefaultFieldsToRemove]
  * @param {Boolean} [options.preservePostInstallHook]
  * @param {String} [options.cwd=process.cwd()]
  * @returns {Object}
  */
 function parseOptions( options ) {
+	const defaultPackageJsonFieldsToRemove = [ 'devDependencies', 'depcheckIgnore', 'scripts', 'private' ];
+	const packageJsonFieldsToRemove = typeof options.packageJsonFieldsToRemove === 'function' ?
+		options.packageJsonFieldsToRemove( defaultPackageJsonFieldsToRemove ) :
+		options.packageJsonFieldsToRemove || defaultPackageJsonFieldsToRemove;
 	const {
 		packagesDirectory,
-		packageJsonFieldsToRemove = [ 'devDependencies', 'depcheckIgnore', 'scripts', 'private', 'engines' ],
 		preservePostInstallHook = false,
 		cwd = process.cwd()
 	} = options;
@@ -184,3 +188,13 @@ function sortPathsFromDeepestFirst( firstPath, secondPath ) {
 
 	return secondPathSegments - firstPathSegments;
 }
+
+/**
+ * @typedef {['devDependencies','depcheckIgnore','scripts','private']} DefaultFieldsToRemove
+ */
+
+/**
+ * @callback PackageJsonFieldsToRemoveCallback
+ * @param {DefaultFieldsToRemove} defaults
+ * @returns {Array.<String>}
+ */

--- a/packages/ckeditor5-dev-release-tools/tests/tasks/cleanuppackages.js
+++ b/packages/ckeditor5-dev-release-tools/tests/tasks/cleanuppackages.js
@@ -210,11 +210,7 @@ describe( 'dev-release-tools/tasks', () => {
 								types: 'src/index.d.ts',
 								files: [
 									'foo'
-								],
-								engines: {
-									'node': '>=16.0.0',
-									'npm': '>=5.7.1'
-								}
+								]
 							} ),
 							'README.md': '',
 							'LICENSE.md': '',
@@ -710,6 +706,56 @@ describe( 'dev-release-tools/tasks', () => {
 						'postinstall': 'node my-node-script.js',
 						'build': 'tsc -p ./tsconfig.json',
 						'dll:build': 'webpack'
+					}
+				} );
+			} );
+
+			it( 'should accept a callback for packageJsonFieldsToRemove', async () => {
+				mockFs( {
+					'release': {
+						'ckeditor5-foo': {
+							'package.json': JSON.stringify( {
+								name: 'ckeditor5-foo',
+								author: 'CKEditor 5 Devops Team',
+								version: '1.0.0',
+								description: 'Example package.',
+								dependencies: {
+									'ckeditor5': '^37.1.0'
+								},
+								devDependencies: {
+									'typescript': '^4.8.4'
+								},
+								main: 'src/index.ts',
+								depcheckIgnore: [
+									'eslint-plugin-ckeditor5-rules'
+								],
+								scripts: {
+									'postinstall': 'node my-node-script.js',
+									'build': 'tsc -p ./tsconfig.json',
+									'dll:build': 'webpack'
+								}
+							} )
+						}
+					}
+				} );
+
+				await cleanUpPackages( {
+					packagesDirectory: 'release',
+					packageJsonFieldsToRemove: defaults => [
+						...defaults,
+						'author'
+					]
+				} );
+
+				const call = stubs.fs.writeJson.getCall( 0 );
+
+				expect( call.args[ 1 ] ).to.deep.equal( {
+					description: 'Example package.',
+					main: 'src/index.ts',
+					name: 'ckeditor5-foo',
+					version: '1.0.0',
+					dependencies: {
+						'ckeditor5': '^37.1.0'
 					}
 				} );
 			} );

--- a/packages/ckeditor5-dev-release-tools/tests/tasks/cleanuppackages.js
+++ b/packages/ckeditor5-dev-release-tools/tests/tasks/cleanuppackages.js
@@ -210,7 +210,11 @@ describe( 'dev-release-tools/tasks', () => {
 								types: 'src/index.d.ts',
 								files: [
 									'foo'
-								]
+								],
+								engines: {
+									'node': '>=16.0.0',
+									'npm': '>=5.7.1'
+								}
 							} ),
 							'README.md': '',
 							'LICENSE.md': '',


### PR DESCRIPTION
…rocess.

### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other (release-tools): Added support in the `cleanUpPackages()` task to provide a callback in the optional `packageJsonFieldsToRemove` option that allows specifying which fields to remove from the `package.json`. Closes ckeditor/ckeditor5#14586.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
