### PR TITLE
Added nextVersion and skipFileSave options

### DIFF
--- a/packages/ckeditor5-dev-release-tools/lib/tasks/generatechangelogformonorepository.js
+++ b/packages/ckeditor5-dev-release-tools/lib/tasks/generatechangelogformonorepository.js
@@ -211,6 +211,7 @@ module.exports = async function generateChangelogForMonoRepository( options ) {
 	 * @returns {Promise.<Array.<Commit>>}
 	 */
 	function gatherAllCommits( options ) {
+		process.chdir( options.cwd );
 		logInfo( `Processing "${ options.cwd }"...`, { indentLevel: 1 } );
 
 		const transformCommit = transformCommitFactory( {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature (release-tools): Added the `skipFileSave` option to the `generateChangelogForMonoRepository()` function that allows returning the changelog entries instead of saving them into the changelog file. See ckeditor/ckeditor5#14601.

Feature (release-tools): Added  the `nextVersion` option to the `generateChangelogForMonoRepository()` function to pass a predefined version to the function. When using this option, the function no longer interacts with a user. See ckeditor/ckeditor5#14601.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
