### PR TITLE
Spaces in "members.json"

### DIFF
--- a/packages/ckeditor5-dev-ci/lib/data/members.json
+++ b/packages/ckeditor5-dev-ci/lib/data/members.json
@@ -8,7 +8,7 @@
   "DawidKossowski": "U0401V31S9M",
   "dufipl": "U02SG0U25GS",
   "Dumluregn": "UGG2JE7JR",
-  "filipsobol ": "U04GZ96MKCN",
+  "filipsobol": "U04GZ96MKCN",
   "FilipTokarski": "URSK5KV9V",
   "godai78": "U017DJLU7NX",
   "gorzelinski": "U04DJ7BKSKU",

--- a/packages/ckeditor5-dev-ci/lib/data/members.json
+++ b/packages/ckeditor5-dev-ci/lib/data/members.json
@@ -30,5 +30,6 @@
   "pszczesniak": "U04167FKV88",
   "Reinmar": "U03UQRP0C",
   "scofalik": "U05611ZMM",
+  "Witoso": "U04S02SUZS5",
   "wwalc": "U03UQQ8PY"
 }

--- a/packages/ckeditor5-dev-ci/lib/format-message.js
+++ b/packages/ckeditor5-dev-ci/lib/format-message.js
@@ -75,12 +75,12 @@ module.exports = async function formatMessage( options ) {
  * @returns {String}
  */
 function getNotifierMessage( options ) {
-	const slackAccount = members[ options.githubAccount ] || null;
-	const botActionMessage = '_Automated stuff happened on one of the branches. Got time to have a look at it, anyone?_';
-
 	if ( options.shouldHideAuthor ) {
 		return '_The author of the commit was hidden. <https://github.com/ckeditor/ckeditor5/issues/9252|Read more about why.>_';
 	}
+
+	const slackAccount = findSlackAccount( options.githubAccount );
+	const botActionMessage = '_Automated stuff happened on one of the branches. Got time to have a look at it, anyone?_';
 
 	if ( bots.includes( options.githubAccount ) ) {
 		return botActionMessage;
@@ -96,6 +96,24 @@ function getNotifierMessage( options ) {
 	}
 
 	return `<@${ slackAccount }>, could you take a look?`;
+}
+
+/**
+ * @param {String|null} githubAccount
+ * @returns {String|null}
+ */
+function findSlackAccount( githubAccount ) {
+	if ( !githubAccount ) {
+		return null;
+	}
+
+	for ( const [ key, value ] of Object.entries( members ) ) {
+		if ( key.toLowerCase() === githubAccount.toLowerCase() ) {
+			return value;
+		}
+	}
+
+	return null;
 }
 
 /**

--- a/packages/ckeditor5-dev-ci/tests/data/members.js
+++ b/packages/ckeditor5-dev-ci/tests/data/members.js
@@ -1,0 +1,24 @@
+/**
+ * @license Copyright (c) 2003-2023, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/* eslint-env node */
+
+'use strict';
+
+const members = require( '../../lib/data/members.json' );
+const expect = require( 'chai' ).expect;
+
+describe( 'lib/data/members', () => {
+	it( 'should be a function', () => {
+		expect( members ).to.be.a( 'object' );
+	} );
+
+	// https://github.com/ckeditor/ckeditor5/issues/14876.
+	it( 'should not contain GitHub names with spaces', () => {
+		const spaceMembers = Object.keys( members ).filter( name => name.includes( ' ' ) );
+
+		expect( spaceMembers ).to.deep.equal( [] );
+	} );
+} );

--- a/packages/ckeditor5-dev-ci/tests/format-message.js
+++ b/packages/ckeditor5-dev-ci/tests/format-message.js
@@ -20,7 +20,10 @@ describe( 'lib/format-message', () => {
 		};
 
 		formatMessage = proxyquire( '../lib/format-message', {
-			'node-fetch': stubs.nodeFetch
+			'node-fetch': stubs.nodeFetch,
+			'./data/members.json': {
+				ExampleNick: 'slackId'
+			}
 		} );
 	} );
 
@@ -140,6 +143,45 @@ describe( 'lib/format-message', () => {
 			expect( message ).to.be.an( 'object' );
 			expect( message ).to.have.property( 'text' );
 			expect( message.text ).to.equal( '<!channel> (CKEditor5DevopsBot), could you take a look?' );
+		} );
+
+		it( 'should find a Slack account based on a GitHub account case-insensitive', async () => {
+			stubs.nodeFetch.resolves( {
+				json() {
+					return Promise.resolve( {
+						author: {
+							login: 'exampleNICK'
+						},
+						commit: {
+							author: {
+								name: 'Example Nick'
+							},
+							message: 'An example message.'
+						},
+						sha: '35cbea88dc0b5c00406c9a5f0c357ad2a7195a19'
+					} );
+				}
+			} );
+
+			const message = await formatMessage( {
+				slackMessageUsername: 'Test',
+				iconUrl: 'https://avatars.githubusercontent.com/u/26329082?v=4',
+				repositoryOwner: 'ckeditor',
+				repositoryName: 'ckeditor5-dev',
+				branch: 'master',
+				buildTitle: 'Workflow',
+				buildUrl: 'https://...',
+				buildId: 1,
+				githubToken: 'secret-token',
+				triggeringCommitUrl: 'https://github.com/ckeditor/ckeditor5-dev/commit/35cbea88dc0b5c00406c9a5f0c357ad2a7195a19',
+				startTime: 1,
+				endTime: 2,
+				shouldHideAuthor: false
+			} );
+
+			expect( message ).to.be.an( 'object' );
+			expect( message ).to.have.property( 'text' );
+			expect( message.text ).to.equal( '<@slackId>, could you take a look?' );
 		} );
 	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other (ci): The `formatMessage()` function should find a Slack account based on a GitHub name case-insensitive. Closes ckeditor/ckeditor5#14876.

Internal: GitHub members should not contain spaces.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
