### PR TITLE
Use process.env.CI when defining browsers available on CI

### DIFF
--- a/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getkarmaconfig.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getkarmaconfig.js
@@ -102,9 +102,9 @@ module.exports = function getKarmaConfig( options ) {
 		browsers: getBrowsers( options ),
 
 		customLaunchers: {
-			CHROME_TRAVIS_CI: {
+			CHROME_CI: {
 				base: 'Chrome',
-				flags: getFlagsForBrowser( 'CHROME_TRAVIS_CI' )
+				flags: getFlagsForBrowser( 'CHROME_CI' )
 			},
 			CHROME_LOCAL: {
 				base: 'Chrome',
@@ -213,7 +213,7 @@ function getBrowsers( options ) {
 			return browser;
 		}
 
-		return process.env.TRAVIS ? 'CHROME_TRAVIS_CI' : 'CHROME_LOCAL';
+		return process.env.CI ? 'CHROME_CI' : 'CHROME_LOCAL';
 	} );
 }
 
@@ -229,7 +229,7 @@ function getFlagsForBrowser( browser ) {
 		'--disable-backgrounding-occluded-windows'
 	];
 
-	if ( browser === 'CHROME_TRAVIS_CI' ) {
+	if ( browser === 'CHROME_CI' ) {
 		return [
 			...commonFlags,
 			'--no-sandbox'

--- a/packages/ckeditor5-dev-tests/tests/utils/automated-tests/getkarmaconfig.js
+++ b/packages/ckeditor5-dev-tests/tests/utils/automated-tests/getkarmaconfig.js
@@ -23,7 +23,7 @@ describe( 'getKarmaConfig()', () => {
 		sandbox.stub( path, 'join' ).callsFake( ( ...chunks ) => chunks.join( '/' ) );
 
 		// Sinon cannot stub non-existing props.
-		process.env = Object.assign( {}, originalEnv, { TRAVIS: false } );
+		process.env = Object.assign( {}, originalEnv, { CI: false } );
 
 		mockery.enable( {
 			useCleanCache: true,
@@ -194,12 +194,12 @@ describe( 'getKarmaConfig()', () => {
 		const karmaConfig = getKarmaConfig( options );
 
 		expect( karmaConfig ).to.have.own.property( 'customLaunchers' );
-		expect( karmaConfig.customLaunchers ).to.have.own.property( 'CHROME_TRAVIS_CI' );
+		expect( karmaConfig.customLaunchers ).to.have.own.property( 'CHROME_CI' );
 		expect( karmaConfig.customLaunchers ).to.have.own.property( 'CHROME_LOCAL' );
 
-		expect( karmaConfig.customLaunchers.CHROME_TRAVIS_CI ).to.have.own.property( 'base', 'Chrome' );
-		expect( karmaConfig.customLaunchers.CHROME_TRAVIS_CI ).to.have.own.property( 'flags' );
-		expect( karmaConfig.customLaunchers.CHROME_TRAVIS_CI.flags ).to.deep.equal( [
+		expect( karmaConfig.customLaunchers.CHROME_CI ).to.have.own.property( 'base', 'Chrome' );
+		expect( karmaConfig.customLaunchers.CHROME_CI ).to.have.own.property( 'flags' );
+		expect( karmaConfig.customLaunchers.CHROME_CI.flags ).to.deep.equal( [
 			'--disable-background-timer-throttling',
 			'--js-flags="--expose-gc"',
 			'--disable-renderer-backgrounding',


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Use `process.env.CI` to determine if a process is executed on CI when preparing a list of available browsers.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
