### PR TITLE
Bumped Puppeteer to the latest version and switched to the new headless mode

### DIFF
--- a/packages/ckeditor5-dev-web-crawler/lib/runcrawler.js
+++ b/packages/ckeditor5-dev-web-crawler/lib/runcrawler.js
@@ -116,8 +116,8 @@ module.exports = async function runCrawler( options ) {
  */
 async function createBrowser( options ) {
 	const browserOptions = {
-		args: [ '--single-process' ],
-		headless: 'new'
+		args: [],
+		headless: true
 	};
 
 	if ( options.disableBrowserSandbox ) {

--- a/packages/ckeditor5-dev-web-crawler/lib/runcrawler.js
+++ b/packages/ckeditor5-dev-web-crawler/lib/runcrawler.js
@@ -129,18 +129,18 @@ async function createBrowser( options ) {
 
 	const browser = await puppeteer.launch( browserOptions );
 
-	console.log( await browser.version() );
-	console.log( await browser.pages() );
+	console.log( 'browser.version() = ', await browser.version() );
+	console.log( 'browser.pages() = ', await browser.pages() );
 
 	// For unknown reasons, in order to be able to visit pages in Puppeteer on CI, we must close the default page that is opened when the
 	// browser starts.
-	if ( process.env.CI ) {
-		const [ defaultBlankPage ] = await browser.pages();
+	// if ( process.env.CI ) {
+	// 	const [ defaultBlankPage ] = await browser.pages();
 
-		if ( defaultBlankPage ) {
-			await defaultBlankPage.close();
-		}
-	}
+	// 	if ( defaultBlankPage ) {
+	// 		await defaultBlankPage.close();
+	// 	}
+	// }
 
 	return browser;
 }

--- a/packages/ckeditor5-dev-web-crawler/lib/runcrawler.js
+++ b/packages/ckeditor5-dev-web-crawler/lib/runcrawler.js
@@ -114,7 +114,7 @@ module.exports = async function runCrawler( options ) {
  */
 async function createBrowser( options ) {
 	const browserOptions = {
-		args: [],
+		args: [ '--single-process' ],
 		headless: 'new'
 	};
 
@@ -134,13 +134,13 @@ async function createBrowser( options ) {
 
 	// For unknown reasons, in order to be able to visit pages in Puppeteer on CI, we must close the default page that is opened when the
 	// browser starts.
-	// if ( process.env.CI ) {
-	// 	const [ defaultBlankPage ] = await browser.pages();
+	if ( process.env.CI ) {
+		const [ defaultBlankPage ] = await browser.pages();
 
-	// 	if ( defaultBlankPage ) {
-	// 		await defaultBlankPage.close();
-	// 	}
-	// }
+		if ( defaultBlankPage ) {
+			await defaultBlankPage.close();
+		}
+	}
 
 	return browser;
 }

--- a/packages/ckeditor5-dev-web-crawler/lib/runcrawler.js
+++ b/packages/ckeditor5-dev-web-crawler/lib/runcrawler.js
@@ -89,7 +89,9 @@ module.exports = async function runCrawler( options ) {
 		quit,
 		onError: getErrorHandler( errors ),
 		onProgress: getProgressHandler( spinner, { verbose: noSpinner } )
-	} ).catch( () => {
+	} ).catch( error => {
+		console.log( 'Received error for openLinks() = ', error );
+
 		status = 'Terminated on first error';
 	} );
 

--- a/packages/ckeditor5-dev-web-crawler/lib/runcrawler.js
+++ b/packages/ckeditor5-dev-web-crawler/lib/runcrawler.js
@@ -115,7 +115,7 @@ module.exports = async function runCrawler( options ) {
 async function createBrowser( options ) {
 	const browserOptions = {
 		args: [],
-		headless: 'old'
+		headless: 'new'
 	};
 
 	if ( options.disableBrowserSandbox ) {
@@ -129,10 +129,14 @@ async function createBrowser( options ) {
 
 	const browser = await puppeteer.launch( browserOptions );
 
-	const [ defaultBlankPage ] = await browser.pages();
+	// For unknown reasons, in order to be able to visit pages in Puppeteer on CI, we must close the default page that is opened when the
+	// browser starts.
+	if ( process.env.CI ) {
+		const [ defaultBlankPage ] = await browser.pages();
 
-	if ( defaultBlankPage ) {
-		await defaultBlankPage.close();
+		if ( defaultBlankPage ) {
+			await defaultBlankPage.close();
+		}
 	}
 
 	return browser;

--- a/packages/ckeditor5-dev-web-crawler/lib/runcrawler.js
+++ b/packages/ckeditor5-dev-web-crawler/lib/runcrawler.js
@@ -130,16 +130,17 @@ async function createBrowser( options ) {
 	const browser = await puppeteer.launch( browserOptions );
 
 	console.log( await browser.version() );
+	console.log( await browser.pages() );
 
 	// For unknown reasons, in order to be able to visit pages in Puppeteer on CI, we must close the default page that is opened when the
 	// browser starts.
-	// if ( process.env.CI ) {
-	// 	const [ defaultBlankPage ] = await browser.pages();
+	if ( process.env.CI ) {
+		const [ defaultBlankPage ] = await browser.pages();
 
-	// 	if ( defaultBlankPage ) {
-	// 		await defaultBlankPage.close();
-	// 	}
-	// }
+		if ( defaultBlankPage ) {
+			await defaultBlankPage.close();
+		}
+	}
 
 	return browser;
 }
@@ -269,6 +270,8 @@ async function openLink( browser, { baseUrl, link, foundLinks, exclusions } ) {
 
 	const onError = error => errors.push( error );
 
+	console.log( 'Opening ', link );
+
 	// Create dedicated page for current link.
 	const page = await createPage( browser, { link, onError } );
 
@@ -276,6 +279,8 @@ async function openLink( browser, { baseUrl, link, foundLinks, exclusions } ) {
 		// Consider navigation to be finished when the `load` event is fired and there are no network connections for at least 500 ms.
 		await page.goto( link.url, { waitUntil: [ 'load', 'networkidle0' ] } );
 	} catch ( error ) {
+		console.log( error );
+
 		const errorMessage = error.message || '(empty message)';
 
 		// All navigation errors starting with the `net::` prefix are already covered by the "request" error handler, so it should

--- a/packages/ckeditor5-dev-web-crawler/lib/runcrawler.js
+++ b/packages/ckeditor5-dev-web-crawler/lib/runcrawler.js
@@ -89,9 +89,7 @@ module.exports = async function runCrawler( options ) {
 		quit,
 		onError: getErrorHandler( errors ),
 		onProgress: getProgressHandler( spinner, { verbose: noSpinner } )
-	} ).catch( error => {
-		console.log( 'Received error for openLinks() = ', error );
-
+	} ).catch( () => {
 		status = 'Terminated on first error';
 	} );
 
@@ -117,7 +115,7 @@ module.exports = async function runCrawler( options ) {
 async function createBrowser( options ) {
 	const browserOptions = {
 		args: [],
-		headless: true
+		headless: 'old'
 	};
 
 	if ( options.disableBrowserSandbox ) {
@@ -130,9 +128,6 @@ async function createBrowser( options ) {
 	}
 
 	const browser = await puppeteer.launch( browserOptions );
-
-	console.log( 'browser.version() = ', await browser.version() );
-	console.log( 'browser.pages() = ', await browser.pages() );
 
 	// For unknown reasons, in order to be able to visit pages in Puppeteer on CI, we must close the default page that is opened when the
 	// browser starts.
@@ -272,8 +267,6 @@ async function openLink( browser, { baseUrl, link, foundLinks, exclusions } ) {
 
 	const onError = error => errors.push( error );
 
-	console.log( 'Opening ', link );
-
 	// Create dedicated page for current link.
 	const page = await createPage( browser, { link, onError } );
 
@@ -281,8 +274,6 @@ async function openLink( browser, { baseUrl, link, foundLinks, exclusions } ) {
 		// Consider navigation to be finished when the `load` event is fired and there are no network connections for at least 500 ms.
 		await page.goto( link.url, { waitUntil: [ 'load', 'networkidle0' ] } );
 	} catch ( error ) {
-		console.log( error );
-
 		const errorMessage = error.message || '(empty message)';
 
 		// All navigation errors starting with the `net::` prefix are already covered by the "request" error handler, so it should

--- a/packages/ckeditor5-dev-web-crawler/lib/runcrawler.js
+++ b/packages/ckeditor5-dev-web-crawler/lib/runcrawler.js
@@ -129,15 +129,17 @@ async function createBrowser( options ) {
 
 	const browser = await puppeteer.launch( browserOptions );
 
+	console.log( await browser.version() );
+
 	// For unknown reasons, in order to be able to visit pages in Puppeteer on CI, we must close the default page that is opened when the
 	// browser starts.
-	if ( process.env.CI ) {
-		const [ defaultBlankPage ] = await browser.pages();
+	// if ( process.env.CI ) {
+	// 	const [ defaultBlankPage ] = await browser.pages();
 
-		if ( defaultBlankPage ) {
-			await defaultBlankPage.close();
-		}
-	}
+	// 	if ( defaultBlankPage ) {
+	// 		await defaultBlankPage.close();
+	// 	}
+	// }
 
 	return browser;
 }

--- a/packages/ckeditor5-dev-web-crawler/package.json
+++ b/packages/ckeditor5-dev-web-crawler/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "chalk": "^4.1.0",
     "ora": "^5.2.0",
-    "puppeteer": "^21.1.1",
+    "puppeteer": "^21.2.0",
     "strip-ansi": "^6.0.0"
   },
   "engines": {

--- a/packages/ckeditor5-dev-web-crawler/package.json
+++ b/packages/ckeditor5-dev-web-crawler/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "chalk": "^4.1.0",
     "ora": "^5.2.0",
-    "puppeteer": "^19.7.5",
+    "puppeteer": "^21.1.1",
     "strip-ansi": "^6.0.0"
   },
   "engines": {

--- a/packages/ckeditor5-dev-web-crawler/package.json
+++ b/packages/ckeditor5-dev-web-crawler/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "chalk": "^4.1.0",
     "ora": "^5.2.0",
-    "puppeteer": "^21.2.0",
+    "puppeteer": "^21.3.6",
     "strip-ansi": "^6.0.0"
   },
   "engines": {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Bumped Puppeteer to the latest version and switched to the new headless mode. New Puppeteer includes a fix for handling `<iframe>` in manual tests that no longer throws connection timeout. Closes ckeditor/ckeditor5#14906.

---

### Additional information

To do list before merging this PR:

- [x] Wait for new Puppeteer, probably v21.2.0: https://github.com/puppeteer/puppeteer/releases.
- [x] Use new version in this PR.
- [ ] Check if issue in ckeditor/ckeditor5#14906 is fixed.