### PR TITLE
Support for ignoring some packages in the release process

### DIFF
--- a/packages/ckeditor5-dev-release-tools/lib/tasks/updatedependencies.js
+++ b/packages/ckeditor5-dev-release-tools/lib/tasks/updatedependencies.js
@@ -22,8 +22,10 @@ const upath = require( 'upath' );
  * @param {Object} options
  * @param {String} options.version Target version or a range version to which all eligible dependencies will be updated.
  * Examples: `1.0.0`, `^1.0.0`, etc.
- * @param {Function} options.shouldUpdateVersionCallback Callback function that decides whether to update a version for a dependency.
- * It receives a package name as an argument and should return a boolean value.
+ * @param {UpdateVersionCallback} options.shouldUpdateVersionCallback Callback function that decides whether to update a version
+ * for a dependency. It receives a package name as an argument and should return a boolean value.
+ * @param {UpdateDependenciesPackagesDirectoryFilter|null} [options.packagesDirectoryFilter=null] An optional callback allowing
+ * filtering out directories/packages that should not be touched by the task.
  * @param {String} [options.packagesDirectory] Relative path to a location of packages to update their dependencies. If not specified,
  * only the root package is checked.
  * @param {String} [options.cwd=process.cwd()] Current working directory from which all paths will be resolved.
@@ -34,14 +36,9 @@ module.exports = async function updateDependencies( options ) {
 		version,
 		packagesDirectory,
 		shouldUpdateVersionCallback,
+		packagesDirectoryFilter = null,
 		cwd = process.cwd()
 	} = options;
-
-	const globOptions = {
-		cwd,
-		nodir: true,
-		absolute: true
-	};
 
 	const globPatterns = [ 'package.json' ];
 
@@ -51,7 +48,7 @@ module.exports = async function updateDependencies( options ) {
 		globPatterns.push( packagesDirectoryPattern );
 	}
 
-	const pkgJsonPaths = await glob( globPatterns, globOptions );
+	const pkgJsonPaths = await getPackageJsonPaths( cwd, globPatterns, packagesDirectoryFilter );
 
 	for ( const pkgJsonPath of pkgJsonPaths ) {
 		const pkgJson = await fs.readJson( pkgJsonPath );
@@ -82,3 +79,41 @@ function updateVersion( version, callback, dependencies ) {
 		}
 	}
 }
+
+/**
+ * @param {String} cwd
+ * @param {Array.<String>} globPatterns
+ * @param {UpdateDependenciesPackagesDirectoryFilter|null} packagesDirectoryFilter
+ * @returns {Promise.<Array.<String>>}
+ */
+async function getPackageJsonPaths( cwd, globPatterns, packagesDirectoryFilter ) {
+	const globOptions = {
+		cwd,
+		nodir: true,
+		absolute: true
+	};
+
+	const pkgJsonPaths = await glob( globPatterns, globOptions );
+
+	if ( !packagesDirectoryFilter ) {
+		return pkgJsonPaths;
+	}
+
+	return pkgJsonPaths.filter( packagesDirectoryFilter );
+}
+
+/**
+ * @callback UpdateVersionCallback
+ *
+ * @param {String} packageName A package name.
+ *
+ * @returns {Boolean} Whether to update (`true`) or ignore (`false`) bumping the package version.
+ */
+
+/**
+ * @callback UpdateDependenciesPackagesDirectoryFilter
+ *
+ * @param {String} packageJsonPath An absolute path to a `package.json` file.
+ *
+ * @returns {Boolean} Whether to include (`true`) or skip (`false`) processing the given directory/package.
+ */

--- a/packages/ckeditor5-dev-release-tools/lib/tasks/updateversions.js
+++ b/packages/ckeditor5-dev-release-tools/lib/tasks/updateversions.js
@@ -87,7 +87,7 @@ async function getPackageJsonPaths( cwd, globPatterns, packagesDirectoryFilter )
 
 /**
  * @param {String} packagesDirectory
- * @returns {Object}
+ * @returns {Promise.<Object>}
  */
 function readPackageJson( packagesDirectory ) {
 	const packageJsonPath = join( packagesDirectory, 'package.json' );

--- a/packages/ckeditor5-dev-release-tools/lib/utils/executeinparallel.js
+++ b/packages/ckeditor5-dev-release-tools/lib/utils/executeinparallel.js
@@ -31,9 +31,8 @@ const WORKER_SCRIPT = upath.join( __dirname, 'parallelworker.js' );
  * @param {ListrTaskObject} [options.listrTask={}] An instance of `ListrTask`.
  * @param {AbortSignal|null} [options.signal=null] Signal to abort the asynchronous process. If not set, default AbortController is created.
  * @param {Object} [options.taskOptions=null] Optional data required by the task.
- * @param {Function} [options.packagesDirectoryFilter=null] A function that is executed for each found package directory to filter out those
- * that do not require executing a task. It should return a truthy value to keep the package and a falsy value to skip the package from
- * processing.
+ * @param {ExecuteInParallelPackagesDirectoryFilter|null} [options.packagesDirectoryFilter=null] An optional callback allowing filtering out
+ * directories/packages that should not be touched by the task.
  * @param {String} [options.cwd=process.cwd()] Current working directory from which all paths will be resolved.
  * @param {Number} [options.concurrency=require( 'os' ).cpus().length / 2] Number of CPUs that will execute the task.
  * @returns {Promise}
@@ -177,4 +176,12 @@ function getPackagesGroupedByThreads( packages, concurrency ) {
  * @property {String} title Title of the task.
  *
  * @property {String} output Update the current output of the task.
+ */
+
+/**
+ * @callback ExecuteInParallelPackagesDirectoryFilter
+ *
+ * @param {String} directoryPath An absolute path to a directory.
+ *
+ * @returns {Boolean} Whether to include (`true`) or skip (`false`) processing the given directory.
  */


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature (release-tools): The `updateVersions` and `updateDependencies` tasks accept a new option called `packagesDirectoryFilter`. It is a callback allowing filtering out directories/packages that the task should not touch. It receives an absolute path to a `package.json` and should return a boolean value.

---

### Additional information

See cksource/ckeditor5-commercial#5501.
