### PR TITLE
Support for processing squash commits

### DIFF
--- a/packages/ckeditor5-dev-release-tools/lib/utils/transformcommitfactory.js
+++ b/packages/ckeditor5-dev-release-tools/lib/utils/transformcommitfactory.js
@@ -49,10 +49,11 @@ module.exports = function transformCommitFactory( options = {} ) {
 		// Also, let's update the "merge" field to display a merge commit on the screen,
 		// when passing the commits array through the `displayCommits()` function.
 		if ( isSquashMergeCommit( commit ) ) {
-			const squashCommit = commit.shift();
 			const firstCommit = commit.find( c => c.isPublicCommit );
 
 			if ( firstCommit ) {
+				const squashCommit = commit.shift();
+
 				firstCommit.notes = squashCommit.notes;
 				firstCommit.merge = squashCommit.header;
 

--- a/packages/ckeditor5-dev-release-tools/lib/utils/transformcommitfactory.js
+++ b/packages/ckeditor5-dev-release-tools/lib/utils/transformcommitfactory.js
@@ -10,7 +10,7 @@ const utils = require( './transformcommitutils' );
 const getChangedFilesForCommit = require( './getchangedfilesforcommit' );
 
 // Squash commit follows the pattern: "A pull request title (#{number})".
-const SQUASH_COMMIT_REGEXP = /[\W\w]+ \(#\d+\)/;
+const SQUASH_COMMIT_REGEXP = /^[\W\w]+ \(#\d+\)$/;
 
 /**
  * Factory function.

--- a/packages/ckeditor5-dev-release-tools/lib/utils/transformcommitfactory.js
+++ b/packages/ckeditor5-dev-release-tools/lib/utils/transformcommitfactory.js
@@ -478,6 +478,10 @@ module.exports = function transformCommitFactory( options = {} ) {
 	function isSquashMergeCommit( commits ) {
 		const [ squashCommit ] = commits;
 
+		if ( squashCommit.type ) {
+			return false;
+		}
+
 		return !!squashCommit.header.match( SQUASH_COMMIT_REGEXP );
 	}
 };
@@ -495,7 +499,7 @@ module.exports = function transformCommitFactory( options = {} ) {
  *
  * @property {String} rawType Type of the commit without any modifications.
  *
- * @property {String} type Type of the commit (it can be modified).
+ * @property {String|null} type Type of the commit (it can be modified).
  *
  * @property {String} header First line of the commit message.
  *

--- a/packages/ckeditor5-dev-release-tools/lib/utils/transformcommitfactory.js
+++ b/packages/ckeditor5-dev-release-tools/lib/utils/transformcommitfactory.js
@@ -50,11 +50,14 @@ module.exports = function transformCommitFactory( options = {} ) {
 		// when passing the commits array through the `displayCommits()` function.
 		if ( isSquashMergeCommit( commit ) ) {
 			const squashCommit = commit.shift();
-			const [ firstCommit ] = commit;
-			firstCommit.notes = squashCommit.notes;
-			firstCommit.merge = squashCommit.header;
+			const firstCommit = commit.find( c => c.isPublicCommit );
 
-			normalizeNotes( firstCommit );
+			if ( firstCommit ) {
+				firstCommit.notes = squashCommit.notes;
+				firstCommit.merge = squashCommit.header;
+
+				normalizeNotes( firstCommit );
+			}
 		}
 
 		return commit.flatMap( splitMultiScopeCommit );

--- a/packages/ckeditor5-dev-release-tools/tests/utils/transformcommitfactory.js
+++ b/packages/ckeditor5-dev-release-tools/tests/utils/transformcommitfactory.js
@@ -1469,6 +1469,46 @@ describe( 'dev-release-tools/utils', () => {
 						body: ''
 					} );
 				} );
+
+				it( 'processes a title including various non-letter symbols', () => {
+					const rawCommit = {
+						type: null,
+						subject: null,
+						merge: null,
+						header: 'A squash pull (#12) request change! (#111)',
+						body: 'Just details.',
+						footer: '',
+						notes: [],
+						references: [],
+						mentions: [],
+						revert: null,
+						hash: 'bb24d87e46a9f4675eabfa97e247ee7f58debeee'
+					};
+
+					const commits = transformCommit( rawCommit );
+
+					expect( commits ).to.be.an( 'Array' );
+					expect( commits ).to.lengthOf( 4 );
+
+					expect( commits[ 0 ] ).to.deep.equal( {
+						type: null,
+						subject: null,
+						merge: null,
+						header: 'A squash pull (#12) request change! (#111)',
+						body: '',
+						footer: '',
+						notes: [],
+						references: [],
+						mentions: [],
+						revert: null,
+						hash: 'bb24d87e46a9f4675eabfa97e247ee7f58debeee',
+						rawType: undefined,
+						files: [],
+						scope: undefined,
+						isPublicCommit: false,
+						repositoryUrl: 'https://github.com/ckeditor/ckeditor5-dev'
+					} );
+				} );
 			} );
 		} );
 	} );

--- a/packages/ckeditor5-dev-release-tools/tests/utils/transformcommitfactory.js
+++ b/packages/ckeditor5-dev-release-tools/tests/utils/transformcommitfactory.js
@@ -1207,9 +1207,8 @@ describe( 'dev-release-tools/utils', () => {
 			} );
 
 			describe( 'squash merge commit', () => {
-				// TODO: Verify results.
 				it( 'removes the squash commit part from results', () => {
-					const commit = {
+					const rawCommit = {
 						type: null,
 						subject: null,
 						merge: null,
@@ -1227,12 +1226,67 @@ describe( 'dev-release-tools/utils', () => {
 						hash: 'bb24d87e46a9f4675eabfa97e247ee7f58debeee'
 					};
 
-					/* const rawCommit = */transformCommit( commit );
+					const commits = transformCommit( rawCommit );
+
+					expect( commits ).to.be.an( 'Array' );
+					expect( commits ).to.lengthOf( 3 );
+
+					expect( commits[ 0 ] ).to.deep.equal( {
+						revert: null,
+						merge: 'A squash pull request change (#111)',
+						footer: null,
+						hash: 'bb24d87e46a9f4675eabfa97e247ee7f58debeee',
+						files: [],
+						repositoryUrl: 'https://github.com/ckeditor/ckeditor5-dev',
+						notes: [],
+						mentions: [],
+						rawType: 'Fix',
+						scope: [ 'scope-1' ],
+						isPublicCommit: true,
+						type: 'Bug fixes',
+						header: 'Fix (scope-1): Description 1.',
+						subject: 'Description 1.',
+						body: ''
+					} );
+
+					expect( commits[ 1 ] ).to.deep.equal( {
+						revert: null,
+						merge: null,
+						footer: null,
+						hash: 'bb24d87e46a9f4675eabfa97e247ee7f58debeee',
+						files: [],
+						repositoryUrl: 'https://github.com/ckeditor/ckeditor5-dev',
+						notes: [],
+						mentions: [],
+						rawType: 'Other',
+						scope: [ 'scope-2' ],
+						isPublicCommit: true,
+						type: 'Other changes',
+						header: 'Other (scope-2): Description 2.',
+						subject: 'Description 2.',
+						body: ''
+					} );
+
+					expect( commits[ 2 ] ).to.deep.equal( {
+						revert: null,
+						merge: null,
+						footer: null,
+						hash: 'bb24d87e46a9f4675eabfa97e247ee7f58debeee',
+						files: [],
+						repositoryUrl: 'https://github.com/ckeditor/ckeditor5-dev',
+						notes: [],
+						mentions: [],
+						rawType: 'Internal',
+						scope: [ 'scope-3' ],
+						isPublicCommit: false,
+						header: 'Internal (scope-3): Description 3.',
+						subject: 'Description 3.',
+						body: ''
+					} );
 				} );
 
-				// TODO: Verify results.
 				it( 'processes breaking change notes from the removed squash commit', () => {
-					const commit = {
+					const rawCommit = {
 						type: null,
 						subject: null,
 						merge: null,
@@ -1261,7 +1315,159 @@ describe( 'dev-release-tools/utils', () => {
 						hash: 'bb24d87e46a9f4675eabfa97e247ee7f58debeee'
 					};
 
-					/* const rawCommit = */transformCommit( commit );
+					const commits = transformCommit( rawCommit );
+
+					expect( commits ).to.be.an( 'Array' );
+					expect( commits ).to.lengthOf( 3 );
+
+					expect( commits[ 0 ] ).to.deep.equal( {
+						revert: null,
+						merge: 'A squash pull request change (#111)',
+						footer: null,
+						hash: 'bb24d87e46a9f4675eabfa97e247ee7f58debeee',
+						files: [],
+						repositoryUrl: 'https://github.com/ckeditor/ckeditor5-dev',
+						notes: [
+							{
+								scope: [
+									'scope-1'
+								],
+								text: 'BC 1.',
+								title: 'BREAKING CHANGES'
+							},
+							{
+								scope: [
+									'scope-2'
+								],
+								text: 'BC 2.',
+								title: 'BREAKING CHANGES'
+							}
+						],
+						mentions: [],
+						rawType: 'Fix',
+						scope: [ 'scope-1' ],
+						isPublicCommit: true,
+						type: 'Bug fixes',
+						header: 'Fix (scope-1): Description 1.',
+						subject: 'Description 1.',
+						body: ''
+					} );
+					expect( commits[ 1 ].notes ).to.deep.equal( [] );
+					expect( commits[ 2 ].notes ).to.deep.equal( [] );
+				} );
+
+				it( 'does not remove the squash commit if all changes are marked as internal', () => {
+					const rawCommit = {
+						type: null,
+						subject: null,
+						merge: null,
+						header: 'A squash pull request change (#111)',
+						body: 'Internal (scope-1): Description 1.\n' +
+							'\n' +
+							'Internal (scope-2): Description 2.\n' +
+							'\n' +
+							'Internal (scope-3): Description 3.',
+						footer: 'MINOR BREAKING CHANGE (scope-1): BC 1.\n' +
+							'\n' +
+							'MINOR BREAKING CHANGE (scope-2): BC 2.',
+						notes: [
+							{
+								title: 'MINOR BREAKING CHANGE',
+								text: '(scope-1): BC 1.'
+							},
+							{
+								title: 'MINOR BREAKING CHANGE',
+								text: '(scope-2): BC 2.'
+							}
+						],
+						references: [],
+						mentions: [],
+						revert: null,
+						hash: 'bb24d87e46a9f4675eabfa97e247ee7f58debeee'
+					};
+
+					const commits = transformCommit( rawCommit );
+
+					expect( commits ).to.be.an( 'Array' );
+					expect( commits ).to.lengthOf( 4 );
+
+					expect( commits[ 0 ] ).to.deep.equal( {
+						type: null,
+						subject: null,
+						merge: null,
+						header: 'A squash pull request change (#111)',
+						body: '',
+						footer: 'MINOR BREAKING CHANGE (scope-1): BC 1.\n' +
+							'\n' +
+							'MINOR BREAKING CHANGE (scope-2): BC 2.',
+						notes: [
+							{
+								text: '(scope-1): BC 1.',
+								title: 'MINOR BREAKING CHANGE'
+							},
+							{
+								text: '(scope-2): BC 2.',
+								title: 'MINOR BREAKING CHANGE'
+							}
+						],
+						references: [],
+						mentions: [],
+						revert: null,
+						hash: 'bb24d87e46a9f4675eabfa97e247ee7f58debeee',
+						rawType: undefined,
+						files: [],
+						scope: undefined,
+						isPublicCommit: false,
+						repositoryUrl: 'https://github.com/ckeditor/ckeditor5-dev'
+					} );
+					expect( commits[ 1 ] ).to.deep.equal( {
+						revert: null,
+						merge: null,
+						footer: null,
+						hash: 'bb24d87e46a9f4675eabfa97e247ee7f58debeee',
+						files: [],
+						repositoryUrl: 'https://github.com/ckeditor/ckeditor5-dev',
+						notes: [],
+						mentions: [],
+						rawType: 'Internal',
+						scope: [ 'scope-1' ],
+						isPublicCommit: false,
+						header: 'Internal (scope-1): Description 1.',
+						subject: 'Description 1.',
+						body: ''
+					} );
+					expect( commits[ 2 ] ).to.deep.equal( {
+						revert: null,
+						merge: null,
+						footer: null,
+						hash: 'bb24d87e46a9f4675eabfa97e247ee7f58debeee',
+						files: [],
+						repositoryUrl: 'https://github.com/ckeditor/ckeditor5-dev',
+						notes: [],
+						mentions: [],
+						rawType: 'Internal',
+						scope: [ 'scope-2' ],
+						isPublicCommit: false,
+						header: 'Internal (scope-2): Description 2.',
+						subject: 'Description 2.',
+						body: ''
+					} );
+					expect( commits[ 3 ] ).to.deep.equal( {
+						revert: null,
+						merge: null,
+						footer: null,
+						hash: 'bb24d87e46a9f4675eabfa97e247ee7f58debeee',
+						files: [],
+						repositoryUrl: 'https://github.com/ckeditor/ckeditor5-dev',
+						notes: [],
+						mentions: [],
+						rawType: 'Internal',
+						scope: [ 'scope-3' ],
+						isPublicCommit: false,
+						header: 'Internal (scope-3): Description 3.',
+						subject: 'Description 3.',
+						body: ''
+					} );
 				} );
 			} );
 		} );

--- a/packages/ckeditor5-dev-release-tools/tests/utils/transformcommitfactory.js
+++ b/packages/ckeditor5-dev-release-tools/tests/utils/transformcommitfactory.js
@@ -1540,17 +1540,15 @@ describe( 'dev-release-tools/utils', () => {
 						hash: 'bb24d87e46a9f4675eabfa97e247ee7f58debeee'
 					};
 
-					const commits = transformCommit( rawCommit );
+					const commit = transformCommit( rawCommit );
 
-					expect( commits ).to.be.an( 'Array' );
-					expect( commits ).to.lengthOf( 4 );
-
-					expect( commits[ 0 ] ).to.deep.equal( {
+					expect( commit ).to.be.an( 'Object' );
+					expect( commit ).to.deep.equal( {
 						type: null,
 						subject: null,
 						merge: null,
 						header: 'A squash pull (#12) request change! (#111)',
-						body: '',
+						body: 'Just details.',
 						footer: '',
 						notes: [],
 						references: [],

--- a/packages/ckeditor5-dev-release-tools/tests/utils/transformcommitfactory.js
+++ b/packages/ckeditor5-dev-release-tools/tests/utils/transformcommitfactory.js
@@ -1205,6 +1205,65 @@ describe( 'dev-release-tools/utils', () => {
 					} );
 				} );
 			} );
+
+			describe( 'squash merge commit', () => {
+				// TODO: Verify results.
+				it( 'removes the squash commit part from results', () => {
+					const commit = {
+						type: null,
+						subject: null,
+						merge: null,
+						header: 'A squash pull request change (#111)',
+						body: 'Fix (scope-1): Description 1.\n' +
+							'\n' +
+							'Other (scope-2): Description 2.\n' +
+							'\n' +
+							'Internal (scope-3): Description 3.',
+						footer: '',
+						notes: [],
+						references: [],
+						mentions: [],
+						revert: null,
+						hash: 'bb24d87e46a9f4675eabfa97e247ee7f58debeee'
+					};
+
+					/* const rawCommit = */transformCommit( commit );
+				} );
+
+				// TODO: Verify results.
+				it( 'processes breaking change notes from the removed squash commit', () => {
+					const commit = {
+						type: null,
+						subject: null,
+						merge: null,
+						header: 'A squash pull request change (#111)',
+						body: 'Fix (scope-1): Description 1.\n' +
+							'\n' +
+							'Other (scope-2): Description 2.\n' +
+							'\n' +
+							'Internal (scope-3): Description 3.',
+						footer: 'MINOR BREAKING CHANGE (scope-1): BC 1.\n' +
+							'\n' +
+							'MINOR BREAKING CHANGE (scope-2): BC 2.',
+						notes: [
+							{
+								title: 'MINOR BREAKING CHANGE',
+								text: '(scope-1): BC 1.'
+							},
+							{
+								title: 'MINOR BREAKING CHANGE',
+								text: '(scope-2): BC 2.'
+							}
+						],
+						references: [],
+						mentions: [],
+						revert: null,
+						hash: 'bb24d87e46a9f4675eabfa97e247ee7f58debeee'
+					};
+
+					/* const rawCommit = */transformCommit( commit );
+				} );
+			} );
 		} );
 	} );
 } );

--- a/packages/ckeditor5-dev-release-tools/tests/utils/transformcommitfactory.js
+++ b/packages/ckeditor5-dev-release-tools/tests/utils/transformcommitfactory.js
@@ -1470,6 +1470,61 @@ describe( 'dev-release-tools/utils', () => {
 					} );
 				} );
 
+				it( 'does not remove the squash commit if it is a valid message', () => {
+					const rawCommit = {
+						type: 'Fix',
+						subject: 'A squash pull request change (#111)',
+						merge: null,
+						header: 'Fix: A squash pull request change (#111)',
+						body: 'Internal (scope-1): Description 1.',
+						footer: '',
+						notes: [],
+						references: [],
+						mentions: [],
+						revert: null,
+						hash: 'bb24d87e46a9f4675eabfa97e247ee7f58debeee'
+					};
+
+					const commits = transformCommit( rawCommit );
+
+					expect( commits ).to.be.an( 'Array' );
+					expect( commits ).to.lengthOf( 2 );
+
+					expect( commits[ 0 ] ).to.deep.equal( {
+						type: 'Bug fixes',
+						rawType: 'Fix',
+						subject: 'A squash pull request change ([#111](https://github.com/ckeditor/ckeditor5-dev/issues/111)).',
+						merge: null,
+						header: 'Fix: A squash pull request change (#111)',
+						body: '',
+						footer: '',
+						notes: [],
+						mentions: [],
+						revert: null,
+						hash: 'bb24d87e46a9f4675eabfa97e247ee7f58debeee',
+						files: [],
+						scope: null,
+						isPublicCommit: true,
+						repositoryUrl: 'https://github.com/ckeditor/ckeditor5-dev'
+					} );
+					expect( commits[ 1 ] ).to.deep.equal( {
+						revert: null,
+						merge: null,
+						footer: null,
+						hash: 'bb24d87e46a9f4675eabfa97e247ee7f58debeee',
+						files: [],
+						repositoryUrl: 'https://github.com/ckeditor/ckeditor5-dev',
+						notes: [],
+						mentions: [],
+						rawType: 'Internal',
+						scope: [ 'scope-1' ],
+						isPublicCommit: false,
+						header: 'Internal (scope-1): Description 1.',
+						subject: 'Description 1.',
+						body: ''
+					} );
+				} );
+
 				it( 'processes a title including various non-letter symbols', () => {
 					const rawCommit = {
 						type: null,


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix (release-tools): The changelog generator will process a squash merge commit correctly. Before the change, the tool created an additional commit that didn't match a commit pattern. Hence, it's breaking changes notes were ignored. Closes ckeditor/ckeditor5#15056.
