### PR TITLE
Do not crash when creating inherited events when an interface extends a type

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
     "mocha": "^7.1.2",
     "nyc": "^15.1.0"
   },
+  "resolutions": {
+    "get-func-name": "2.0.0"
+  },
   "engines": {
     "node": ">=18.0.0"
   },

--- a/packages/typedoc-plugins/lib/event-inheritance-fixer/index.js
+++ b/packages/typedoc-plugins/lib/event-inheritance-fixer/index.js
@@ -38,9 +38,13 @@ function onEventEnd( context ) {
 		// Collect all events from. The goal is to insert them into a reflection.
 		// When using the mixins concept, Typedoc loses the inheritance tree.
 		// Hence, we need to look for parent classes manually to determine their events.
-		const eventReflections = parentReflections.flatMap( parentRef => {
-			return parentRef.children.filter( reflection => reflection.kindString === 'Event' );
-		} );
+		const eventReflections = parentReflections
+			// Filter out parents without children which can happen when an interface extends a type.
+			// The extended type (parent) does not have any children.
+			.filter( parentRef => parentRef.children )
+			.flatMap( parentRef => {
+				return parentRef.children.filter( reflection => reflection.kindString === 'Event' );
+			} );
 
 		// If class or interface does not fire events, skip it.
 		if ( !eventReflections.length ) {

--- a/packages/typedoc-plugins/tests/event-inheritance-fixer/fixtures/interface-extends-type.ts
+++ b/packages/typedoc-plugins/tests/event-inheritance-fixer/fixtures/interface-extends-type.ts
@@ -1,0 +1,23 @@
+/**
+ * @license Copyright (c) 2003-2023, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/**
+ * @module fixtures/interface-e
+ */
+
+export interface InterfaceE extends TFoo {
+	foo(): void;
+}
+
+export type TFoo = {
+	bar(): void;
+};
+
+/**
+ * @eventName ~InterfaceE#event-1-interface-e
+ */
+export type Event1InterfaceE = {
+	name: string;
+};

--- a/packages/typedoc-plugins/tests/event-inheritance-fixer/index.js
+++ b/packages/typedoc-plugins/tests/event-inheritance-fixer/index.js
@@ -44,10 +44,10 @@ describe( 'typedoc-plugins/event-inheritance-fixer', function() {
 			.getReflectionsByKind( TypeDoc.ReflectionKind.All )
 			.filter( child => child.kindString === 'Event' );
 
-		// There are 8 events from classes and 8 events from interfaces.
-		// There are also 3 events from "MixedClass", which implements the "InterfaceC".
+		// There are 8 events from classes and 9 events from interfaces.
+		// There are also 3 events from `MixedClass`, which implements the `InterfaceC`.
 		// Also, 3 events come from the `ClassFoo` and its descendant classes.
-		expect( events ).to.lengthOf( 22 );
+		expect( events ).to.lengthOf( 23 );
 	} );
 
 	// ---------------
@@ -72,6 +72,7 @@ describe( 'typedoc-plugins/event-inheritance-fixer', function() {
 	//     ⤷ InterfaceC
 	//        ⤷ MixedClass
 	// InterfaceD
+	// InterfaceE
 
 	// ------
 	// EVENTS
@@ -101,6 +102,7 @@ describe( 'typedoc-plugins/event-inheritance-fixer', function() {
 	//        ⤷ MixedClass ⟶ "event:event-1-interface-a" (inherited from InterfaceC)
 	//        ⤷ MixedClass ⟶ "event:event-2-interface-a" (inherited from InterfaceC)
 	//        ⤷ MixedClass ⟶ "event:event-3-interface-b" (inherited from InterfaceC)
+	// InterfaceE ⟶ "event:event-1-interface-e"
 
 	// The "MixedClass" implements the "InterfaceC", so all events from the "InterfaceC" will be cloned.
 
@@ -124,6 +126,7 @@ describe( 'typedoc-plugins/event-inheritance-fixer', function() {
 		expect( findEvent( 'InterfaceC', 'event:event-1-interface-a' ) ).to.not.be.undefined;
 		expect( findEvent( 'InterfaceC', 'event:event-2-interface-a' ) ).to.not.be.undefined;
 		expect( findEvent( 'InterfaceC', 'event:event-3-interface-b' ) ).to.not.be.undefined;
+		expect( findEvent( 'InterfaceE', 'event:event-1-interface-e' ) ).to.not.be.undefined;
 	} );
 
 	it( 'should find all events within the project (verifying a class that implements all interfaces)', () => {
@@ -347,7 +350,7 @@ describe( 'typedoc-plugins/event-inheritance-fixer', function() {
 				.getReflectionsByKind( TypeDoc.ReflectionKind.All )
 				.filter( child => child.kindString === 'Event' );
 
-			expect( events ).to.lengthOf( 19 );
+			expect( events ).to.lengthOf( 20 );
 		} );
 
 		it( 'should find all events within the project (verifying classes A-C)', () => {
@@ -367,6 +370,7 @@ describe( 'typedoc-plugins/event-inheritance-fixer', function() {
 			expect( findEvent( 'InterfaceC', 'event:event-1-interface-a' ) ).to.not.be.undefined;
 			expect( findEvent( 'InterfaceC', 'event:event-2-interface-a' ) ).to.not.be.undefined;
 			expect( findEvent( 'InterfaceC', 'event:event-3-interface-b' ) ).to.not.be.undefined;
+			expect( findEvent( 'InterfaceE', 'event:event-1-interface-e' ) ).to.not.be.undefined;
 		} );
 
 		it( 'should find all events within the project (verifying a class that implements all interfaces)', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix (typedoc-plugins): Fixed `typedoc-plugin-event-inheritance-fixer` plugin to not crash when creating inherited events if an interface extends a type. Closes ckeditor/ckeditor5#15063.
