### PR TITLE
Fixed missing translations in manual tests.

### DIFF
--- a/packages/ckeditor5-dev-tests/lib/utils/manual-tests/getwebpackconfig.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/manual-tests/getwebpackconfig.js
@@ -51,7 +51,8 @@ module.exports = function getWebpackConfigForManualTests( options ) {
 				// See https://ckeditor.com/docs/ckeditor5/latest/features/ui-language.html
 				language: options.language,
 				additionalLanguages: options.additionalLanguages,
-				addMainLanguageTranslationsToAllAssets: true
+				addMainLanguageTranslationsToAllAssets: true,
+				packageNamesPattern: /packages[/\\]ckeditor5-[^/\\]+[/\\]/
 			} ),
 			new webpack.DefinePlugin( definitions ),
 			new webpack.ProvidePlugin( {

--- a/packages/ckeditor5-dev-tests/tests/utils/manual-tests/getwebpackconfig.js
+++ b/packages/ckeditor5-dev-tests/tests/utils/manual-tests/getwebpackconfig.js
@@ -35,10 +35,19 @@ describe( 'getWebpackConfigForManualTests()', () => {
 				DefinePlugin: sinon.stub(),
 				ProvidePlugin: sinon.stub(),
 				SourceMapDevToolPlugin: sinon.stub()
+			},
+			devTranslations: {
+				CKEditorTranslationsPlugin: class {
+					constructor( args ) {
+						this.args = args;
+					}
+				}
 			}
 		};
 
 		mockery.registerMock( 'webpack', stubs.webpack );
+
+		mockery.registerMock( '@ckeditor/ckeditor5-dev-translations', stubs.devTranslations );
 
 		mockery.registerMock( '@ckeditor/ckeditor5-dev-utils', {
 			loaders: stubs.loaders,
@@ -114,5 +123,26 @@ describe( 'getWebpackConfigForManualTests()', () => {
 		expect( webpackConfig ).to.be.an( 'object' );
 		expect( webpackConfig ).to.not.have.property( 'devtool' );
 		expect( webpackConfig ).to.not.have.property( 'watch' );
+	} );
+
+	it( 'should pass correct options to CKEditorTranslationsPlugin', () => {
+		const webpackConfig = getWebpackConfigForManualTests( {
+			disableWatch: true,
+			language: 'pl',
+			additionalLanguages: [ 'fr', 'de' ]
+		} );
+
+		expect( webpackConfig ).to.have.property( 'plugins' );
+		expect( webpackConfig.plugins ).to.be.an( 'Array' );
+
+		const CKEditorTranslationsPlugin = webpackConfig.plugins.find( plugin => plugin.constructor.name === 'CKEditorTranslationsPlugin' );
+
+		expect( CKEditorTranslationsPlugin ).to.have.property( 'args' );
+		expect( CKEditorTranslationsPlugin.args ).to.deep.equal( {
+			language: 'pl',
+			additionalLanguages: [ 'fr', 'de' ],
+			addMainLanguageTranslationsToAllAssets: true,
+			packageNamesPattern: /packages[/\\]ckeditor5-[^/\\]+[/\\]/
+		} );
 	} );
 } );

--- a/packages/ckeditor5-dev-tests/tests/utils/manual-tests/getwebpackconfig.js
+++ b/packages/ckeditor5-dev-tests/tests/utils/manual-tests/getwebpackconfig.js
@@ -125,24 +125,29 @@ describe( 'getWebpackConfigForManualTests()', () => {
 		expect( webpackConfig ).to.not.have.property( 'watch' );
 	} );
 
-	it( 'should pass correct options to CKEditorTranslationsPlugin', () => {
-		const webpackConfig = getWebpackConfigForManualTests( {
-			disableWatch: true,
-			language: 'pl',
-			additionalLanguages: [ 'fr', 'de' ]
-		} );
+	it( 'pattern passed to CKEditorTranslationsPlugin should match paths to ckeditor5 packages', () => {
+		const webpackConfig = getWebpackConfigForManualTests( { disableWatch: true } );
 
 		expect( webpackConfig ).to.have.property( 'plugins' );
 		expect( webpackConfig.plugins ).to.be.an( 'Array' );
 
 		const CKEditorTranslationsPlugin = webpackConfig.plugins.find( plugin => plugin.constructor.name === 'CKEditorTranslationsPlugin' );
 
-		expect( CKEditorTranslationsPlugin ).to.have.property( 'args' );
-		expect( CKEditorTranslationsPlugin.args ).to.deep.equal( {
-			language: 'pl',
-			additionalLanguages: [ 'fr', 'de' ],
-			addMainLanguageTranslationsToAllAssets: true,
-			packageNamesPattern: /packages[/\\]ckeditor5-[^/\\]+[/\\]/
-		} );
+		const pattern = CKEditorTranslationsPlugin.args.packageNamesPattern;
+
+		expect( 'packages/ckeditor5-foo/bar'.match( pattern )[ 0 ] ).to.equal( 'packages/ckeditor5-foo/' );
+	} );
+
+	it( 'pattern passed to CKEditorTranslationsPlugin should match paths to external repositories named like ckeditor5 package', () => {
+		const webpackConfig = getWebpackConfigForManualTests( { disableWatch: true } );
+
+		expect( webpackConfig ).to.have.property( 'plugins' );
+		expect( webpackConfig.plugins ).to.be.an( 'Array' );
+
+		const CKEditorTranslationsPlugin = webpackConfig.plugins.find( plugin => plugin.constructor.name === 'CKEditorTranslationsPlugin' );
+
+		const pattern = CKEditorTranslationsPlugin.args.packageNamesPattern;
+
+		expect( 'external/ckeditor5-foo/packages/ckeditor5-bar/baz'.match( pattern )[ 0 ] ).to.equal( 'packages/ckeditor5-bar/' );
 	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix (tests): UI in manual tests will now be fully translated in cases in which some translations come from external packages.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
