### PR TITLE
Fixed `transformcommitutils.linkToGithubIssue()` incorrectly matching strings containing HEX colors

### DIFF
--- a/packages/ckeditor5-dev-release-tools/lib/utils/transformcommitutils.js
+++ b/packages/ckeditor5-dev-release-tools/lib/utils/transformcommitutils.js
@@ -79,7 +79,7 @@ const transformCommitUtils = {
 	 * @returns {String}
 	 */
 	linkToGithubIssue( comment ) {
-		return comment.replace( /(\/?[\w-]+\/[\w-]+)?#([\d]+)/ig, ( matchedText, maybeRepository, issueId ) => {
+		return comment.replace( /(\/?[\w-]+\/[\w-]+)?#([\d]+)(?=$|[\s,.)\]])/igm, ( matchedText, maybeRepository, issueId ) => {
 			if ( maybeRepository ) {
 				if ( maybeRepository.startsWith( '/' ) ) {
 					return matchedText;

--- a/packages/ckeditor5-dev-release-tools/tests/utils/transformcommitutils.js
+++ b/packages/ckeditor5-dev-release-tools/tests/utils/transformcommitutils.js
@@ -153,6 +153,26 @@ describe( 'dev-release-tools/utils', () => {
 				expect( transformCommitUtils.linkToGithubIssue( 'ckeditor/ckeditor5-dev#' ) )
 					.to.equal( 'ckeditor/ckeditor5-dev#' );
 			} );
+
+			it( 'does not make a link from a comment which contains color hex code with letters and numbers', () => {
+				stubs.getPackageJson.returns( {
+					name: 'test-package',
+					repository: 'https://github.com/ckeditor/ckeditor5-dev'
+				} );
+
+				expect( transformCommitUtils.linkToGithubIssue( 'Colors: first: `#8da47e`, second: `#f7ce76`.' ) )
+					.to.equal( 'Colors: first: `#8da47e`, second: `#f7ce76`.' );
+			} );
+
+			it( 'does not make a link from a comment which contains color hex code with letters or numbers only', () => {
+				stubs.getPackageJson.returns( {
+					name: 'test-package',
+					repository: 'https://github.com/ckeditor/ckeditor5-dev'
+				} );
+
+				expect( transformCommitUtils.linkToGithubIssue( 'Colors: first: `#000000`, second: `#ffffff`.' ) )
+					.to.equal( 'Colors: first: `#000000`, second: `#ffffff`.' );
+			} );
 		} );
 
 		describe( 'getCommitType()', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix (release-tools): Fixed the `transformCommitUtils.linkToGithubIssue()` function to correctly match GitHub issue references that could look similar to HEX colors. Closes ckeditor/ckeditor5#14941.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
