### PR TITLE
Release tools - an entry point validator

### DIFF
--- a/packages/ckeditor5-dev-release-tools/lib/tasks/publishpackages.js
+++ b/packages/ckeditor5-dev-release-tools/lib/tasks/publishpackages.js
@@ -38,6 +38,10 @@ const publishPackageOnNpmCallback = require( '../utils/publishpackageonnpmcallba
  * packages that do not have own definition.
  * @param {String} [options.confirmationCallback=null] An callback whose response decides to continue the publishing packages. Synchronous
  * and asynchronous callbacks are supported.
+ * @param {Boolean} [options.requireEntryPoint=false] Whether to verify if packages to publish define an entry point. In other words,
+ * whether their `package.json` define the `main` field.
+ * @param {Array.<String>} [options.optionalEntryPointPackages=[]] If the entry point validator is enabled (`requireEntryPoint=true`),
+ * this array contains a list of packages that will not be checked. In other words, they do not have to define the entry point.
  * @param {String} [options.cwd=process.cwd()] Current working directory from which all paths will be resolved.
  * @param {Number} [options.concurrency=4] Number of CPUs that will execute the task.
  * @returns {Promise}
@@ -51,6 +55,8 @@ module.exports = async function publishPackages( options ) {
 		npmTag = 'staging',
 		optionalEntries = null,
 		confirmationCallback = null,
+		requireEntryPoint = false,
+		optionalEntryPointPackages = [],
 		cwd = process.cwd(),
 		concurrency = 4
 	} = options;
@@ -62,7 +68,7 @@ module.exports = async function publishPackages( options ) {
 		absolute: true
 	} );
 
-	await assertPackages( packagePaths );
+	await assertPackages( packagePaths, { requireEntryPoint, optionalEntryPointPackages } );
 	await assertFilesToPublish( packagePaths, optionalEntries );
 	await assertNpmTag( packagePaths, npmTag );
 

--- a/packages/ckeditor5-dev-release-tools/lib/utils/assertpackages.js
+++ b/packages/ckeditor5-dev-release-tools/lib/utils/assertpackages.js
@@ -12,20 +12,38 @@ const upath = require( 'upath' );
  * Checks if all packages in the provided directories contain the `package.json` file.
  *
  * @param {Array.<String>} packagePaths
+ * @param {Object} options
+ * @param {Boolean} options.requireEntryPoint Whether to verify if packages to publish define an entry point. In other words,
+ * whether their `package.json` define the `main` field.
+ * @param {Array.<String>} options.optionalEntryPointPackages If the entry point validator is enabled (`requireEntryPoint=true`),
+ * this array contains a list of packages that will not be checked. In other words, they do not have to define the entry point.
  * @returns {Promise}
  */
-module.exports = async function assertPackages( packagePaths ) {
+module.exports = async function assertPackages( packagePaths, options ) {
 	const errors = [];
+	const { requireEntryPoint, optionalEntryPointPackages } = options;
 
 	for ( const packagePath of packagePaths ) {
 		const packageName = upath.basename( packagePath );
 		const packageJsonPath = upath.join( packagePath, 'package.json' );
 
 		if ( await fs.pathExists( packageJsonPath ) ) {
-			continue;
-		}
+			if ( !requireEntryPoint ) {
+				continue;
+			}
 
-		errors.push( `The "package.json" file is missing in the "${ packageName }" package.` );
+			const { name: packageName, main: entryPoint } = await fs.readJson( packageJsonPath );
+
+			if ( optionalEntryPointPackages.includes( packageName ) ) {
+				continue;
+			}
+
+			if ( !entryPoint ) {
+				errors.push( `The "${ packageName }" package misses the entry point ("main") definition in its "package.json".` );
+			}
+		} else {
+			errors.push( `The "package.json" file is missing in the "${ packageName }" package.` );
+		}
 	}
 
 	if ( errors.length ) {

--- a/packages/ckeditor5-dev-release-tools/tests/tasks/publishpackages.js
+++ b/packages/ckeditor5-dev-release-tools/tests/tasks/publishpackages.js
@@ -128,6 +128,39 @@ describe( 'dev-release-tools/tasks', () => {
 					'/work/project/packages/ckeditor5-foo',
 					'/work/project/packages/ckeditor5-bar'
 				] );
+				expect( stubs.assertPackages.firstCall.args[ 1 ] ).to.deep.equal( {
+					requireEntryPoint: false,
+					optionalEntryPointPackages: []
+				} );
+			} );
+		} );
+
+		// See: https://github.com/ckeditor/ckeditor5/issues/15127.
+		it( 'should allow enabling the "package entry point" validator', () => {
+			stubs.glob.glob.resolves( [
+				'/work/project/packages/ckeditor5-foo',
+				'/work/project/packages/ckeditor5-bar'
+			] );
+
+			return publishPackages( {
+				packagesDirectory: 'packages',
+				npmOwner: 'pepe',
+				requireEntryPoint: true,
+				optionalEntryPointPackages: [
+					'ckeditor5-foo'
+				]
+			} ).then( () => {
+				expect( stubs.assertPackages.callCount ).to.equal( 1 );
+				expect( stubs.assertPackages.firstCall.args[ 0 ] ).to.deep.equal( [
+					'/work/project/packages/ckeditor5-foo',
+					'/work/project/packages/ckeditor5-bar'
+				] );
+				expect( stubs.assertPackages.firstCall.args[ 1 ] ).to.deep.equal( {
+					requireEntryPoint: true,
+					optionalEntryPointPackages: [
+						'ckeditor5-foo'
+					]
+				} );
 			} );
 		} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature (release-tools): The `publishPackages()` task accepts new options to ensure that packages define an entry point before publishing a new release. Closes ckeditor/ckeditor5#15127.

By default, the validator is disabled, but it can be changed by passing the `requireEntryPoint: true` value in the options object. Additionally, if any package does not define an entry point, the validator can skip such package by specifying its full name in the `optionalEntryPointPackages` array.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
