### PR TITLE
Add assetNamesFilter option

### DIFF
--- a/packages/ckeditor5-dev-translations/README.md
+++ b/packages/ckeditor5-dev-translations/README.md
@@ -78,7 +78,7 @@ When set to `true`, the `getPluralForm()` function (if exists for the specified 
 
 ### `assetNamesFilter`
 
-A function to filter assets probably importing CKEditor modules. Potential performance boost for applications with many webpack entrypoints. Defaults to `name => name.endsWith( '.js' )`.
+A function to filter assets importing CKEditor 5 modules. Potential performance boost for applications with many webpack entry points. It allows disabling the `CKEditorTranslationsPlugin` plugin for an entry point not containing imports CKEditor 5 modules. Defaults to `name => name.endsWith( '.js' )`.
 
 ### `corePackagePattern`
 

--- a/packages/ckeditor5-dev-translations/README.md
+++ b/packages/ckeditor5-dev-translations/README.md
@@ -76,6 +76,10 @@ When set to `true`, all translations from the `ckeditor5-core` package will be a
 
 When set to `true`, the `getPluralForm()` function (if exists for the specified language) will not be added into the bundle file. Defaults to `false`.
 
+### `assetNamesFilter`
+
+A function to filter assets probably importing CKEditor modules. Potential performance boost for applications with many webpack entrypoints. Defaults to `name => name.endsWith( '.js' )`.
+
 ### `corePackagePattern`
 
 (internal)

--- a/packages/ckeditor5-dev-translations/lib/ckeditortranslationsplugin.js
+++ b/packages/ckeditor5-dev-translations/lib/ckeditortranslationsplugin.js
@@ -106,7 +106,7 @@ module.exports = class CKEditorTranslationsPlugin {
 
 /**
  * @callback assetNamesFilter
- * @param {String} name Webpack asset name/path 
+ * @param {String} name Webpack asset name/path
  * @returns {Boolean}
  */
 

--- a/packages/ckeditor5-dev-translations/lib/ckeditortranslationsplugin.js
+++ b/packages/ckeditor5-dev-translations/lib/ckeditortranslationsplugin.js
@@ -53,7 +53,8 @@ module.exports = class CKEditorTranslationsPlugin {
 			corePackageContextsResourcePath: options.corePackageContextsResourcePath || '@ckeditor/ckeditor5-core/lang/contexts.json',
 			translationsOutputFile: options.translationsOutputFile,
 			includeCorePackageTranslations: !!options.includeCorePackageTranslations,
-			skipPluralFormFunction: !!options.skipPluralFormFunction
+			skipPluralFormFunction: !!options.skipPluralFormFunction,
+			assetNamesFilter: options.assetNamesFilter || ( name => name.endsWith( '.js' ) )
 		};
 	}
 

--- a/packages/ckeditor5-dev-translations/lib/ckeditortranslationsplugin.js
+++ b/packages/ckeditor5-dev-translations/lib/ckeditortranslationsplugin.js
@@ -105,7 +105,7 @@ module.exports = class CKEditorTranslationsPlugin {
 };
 
 /**
- * @callback assetNamesFilter
+ * @callback AssetNamesFilter
  * @param {String} name Webpack asset name/path
  * @returns {Boolean}
  */
@@ -138,5 +138,5 @@ module.exports = class CKEditorTranslationsPlugin {
  * should be added to the output bundle file. If set to true, translations from the core package will be saved even if are not
  * used in the source code (*.js files).
  * @property {Boolean} [skipPluralFormFunction=false] Whether the `getPluralForm()` function should be added in the output bundle file.
- * @property {assetNamesFilter} [assetNamesFilter] A function to filter assets probably importing CKEditor modules.
+ * @property {AssetNamesFilter} [assetNamesFilter] A function to filter assets probably importing CKEditor 5 modules.
  */

--- a/packages/ckeditor5-dev-translations/lib/ckeditortranslationsplugin.js
+++ b/packages/ckeditor5-dev-translations/lib/ckeditortranslationsplugin.js
@@ -105,6 +105,12 @@ module.exports = class CKEditorTranslationsPlugin {
 };
 
 /**
+ * @callback assetNamesFilter
+ * @param {String} name Webpack asset name/path 
+ * @returns {Boolean}
+ */
+
+/**
  * @typedef {Object} CKEditorTranslationsPluginOptions CKEditorTranslationsPluginOptions options.
  *
  * @property {String} language The main language for internationalization - translations for that language
@@ -132,4 +138,5 @@ module.exports = class CKEditorTranslationsPlugin {
  * should be added to the output bundle file. If set to true, translations from the core package will be saved even if are not
  * used in the source code (*.js files).
  * @property {Boolean} [skipPluralFormFunction=false] Whether the `getPluralForm()` function should be added in the output bundle file.
+ * @property {assetNamesFilter} [assetNamesFilter] A function to filter assets probably importing CKEditor modules.
  */

--- a/packages/ckeditor5-dev-translations/lib/servetranslations.js
+++ b/packages/ckeditor5-dev-translations/lib/servetranslations.js
@@ -25,6 +25,7 @@ const { RawSource, ConcatSource } = require( 'webpack-sources' );
  * @param {String} [options.sourceFilesPattern] The source files pattern
  * @param {String} [options.packageNamesPattern] The package names pattern.
  * @param {String} [options.corePackagePattern] The core package pattern.
+ * @param {Function} [options.assetNamesFilter] A function to filter assets probably importing ckeditor modules.
  * @param {TranslationService} translationService Translation service that will load PO files, replace translation keys and generate assets.
  * ckeditor5 - independent without hard-to-test logic.
  */
@@ -114,10 +115,16 @@ module.exports = function serveTranslations( compiler, options, translationServi
 		// At the end of the compilation add assets generated from the PO files.
 		// Use `optimize-chunk-assets` instead of `emit` to emit assets before the `webpack.BannerPlugin`.
 		getChunkAssets( compilation ).tap( 'CKEditor5Plugin', chunks => {
+			const compilationAssetNamesFiltered = Object.keys( compilation.assets )
+				.filter( options.assetNamesFilter );
+
+			if ( !compilationAssetNamesFiltered.length ) {
+				return;
+			}
+
 			const generatedAssets = translationService.getAssets( {
 				outputDirectory: options.outputDirectory,
-				compilationAssetNames: Object.keys( compilation.assets )
-					.filter( name => name.endsWith( '.js' ) )
+				compilationAssetNames: compilationAssetNamesFiltered
 			} );
 
 			const allFiles = getFilesFromChunks( chunks );

--- a/packages/ckeditor5-dev-translations/lib/servetranslations.js
+++ b/packages/ckeditor5-dev-translations/lib/servetranslations.js
@@ -25,7 +25,7 @@ const { RawSource, ConcatSource } = require( 'webpack-sources' );
  * @param {String} [options.sourceFilesPattern] The source files pattern
  * @param {String} [options.packageNamesPattern] The package names pattern.
  * @param {String} [options.corePackagePattern] The core package pattern.
- * @param {Function} [options.assetNamesFilter] A function to filter assets probably importing ckeditor modules.
+ * @param {AssetNamesFilter} [options.assetNamesFilter] A function to filter assets probably importing CKEditor 5 modules.
  * @param {TranslationService} translationService Translation service that will load PO files, replace translation keys and generate assets.
  * ckeditor5 - independent without hard-to-test logic.
  */


### PR DESCRIPTION
Feature (translations): Compilation asset callback is now an optional field called `assetNamesFilter` in the object passed to the `CKEditorTranslationsPlugin` class. Thanks to that, it improves webpack compilation performance by filtering unrelated assets to reduce `TranslationService.getAssets()` calls. It only affects apps with many webpack entries and/or chunks.

---

### Additional information

#### Example:
```js
// webpack.config.js
module.exports = {
    //...
    plugins: [
        new CKEditorTranslationsPlugin({
            language: 'en',
            additionalLanguages: 'all',
            buildAllTranslationsToSeparateFiles: true,
            assetNamesFilter: name => name === 'app.js'
        })
    ]
    //...
}
```

#### Positive Side Effect:
Fixed an error related to a service worker generated by [workbox-webpack-plugin](https://github.com/googlechrome/workbox) when the service worker asset got filtered out by the `assetNamesFilter` function.

```
[CKEditorTranslationsPlugin] Error: No translation has been found for the en language.
<project>\app\node_modules\webpack\lib\cache\getLazyHashedEtag.js:77
        innerMap.set(obj, newHash);
                 ^

TypeError: Invalid value used as weak map key
    at WeakMap.set (<anonymous>)
    at getter (<project>\app\node_modules\webpack\lib\cache\getLazyHashedEtag.js:77:11)
    at CacheFacade.getLazyHashedEtag (<project>\app\node_modules\webpack\lib\CacheFacade.js:233:10)
    at <project>\app\node_modules\webpack\lib\SourceMapDevToolPlugin.js:237:16
    at arrayEach (<project>\app\node_modules\neo-async\async.js:2405:9)
    at Object.each (<project>\app\node_modules\neo-async\async.js:2846:9)
    at <project>\app\node_modules\webpack\lib\SourceMapDevToolPlugin.js:226:15
    at fn (<project>\app\node_modules\webpack\lib\Compilation.js:509:9)
    at _next2 (eval at create (<project>\app\node_modules\tapable\lib\HookCodeFactory.js:33:10), <anonymous>:35:1)
    at eval (eval at create (<project>\app\node_modules\tapable\lib\HookCodeFactory.js:33:10), <anonymous>:49:1)

Node.js v20.9.0
```
