### PR TITLE
Typedoc linker does not emit a warning when linking to type's children

### DIFF
--- a/packages/ckeditor5-dev-docs/tests/validators/link-validator/fixtures/links.ts
+++ b/packages/ckeditor5-dev-docs/tests/validators/link-validator/fixtures/links.ts
@@ -94,6 +94,9 @@ export class ClassWithLinks {
  * - valid one: {@link module:fixtures/links~ClassWithLinks#property link to a doclet},
  * - invalid one: {@link module:non-existing/module~Foo#bar link to a doclet}.
  *
+ * Valid link added at the end fo avoid modifying indexes.
+ * - {@link module:fixtures/types~MentionFeedObjectItem#id}
+ *
  * @eventName ~ClassWithLinks#event-example
  */
 export type EventExample = {

--- a/packages/ckeditor5-dev-docs/tests/validators/link-validator/fixtures/types.ts
+++ b/packages/ckeditor5-dev-docs/tests/validators/link-validator/fixtures/types.ts
@@ -1,0 +1,21 @@
+/**
+ * @license Copyright (c) 2003-2023, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/**
+ * @module fixtures/types
+ */
+
+export type MentionFeedObjectItem = {
+
+	/**
+	 * A unique ID of the mention. It must start with the marker character.
+	 */
+	id: string;
+
+	/**
+	 * Text inserted into the editor when creating a mention.
+	 */
+	text?: string;
+};

--- a/packages/ckeditor5-dev-docs/tests/validators/link-validator/index.js
+++ b/packages/ckeditor5-dev-docs/tests/validators/link-validator/index.js
@@ -104,11 +104,11 @@ describe( 'dev-docs/validators/link-validator', function() {
 			},
 			{
 				identifier: 'module:non-existing/module~Foo#bar',
-				source: 'links.ts:99'
+				source: 'links.ts:102'
 			},
 			{
 				identifier: 'module:non-existing/module~Foo#bar',
-				source: 'links.ts:99'
+				source: 'links.ts:102'
 			}
 		];
 

--- a/packages/typedoc-plugins/package.json
+++ b/packages/typedoc-plugins/package.json
@@ -6,7 +6,8 @@
   "main": "lib/index.js",
   "devDependencies": {
     "chai": "^4.2.0",
-    "fast-glob": "^3.2.4"
+    "fast-glob": "^3.2.4",
+    "typedoc": "^0.23.15"
   },
   "peerDependencies": {
     "typedoc": "^0.23.15"


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix (docs): Typedoc linker validator should not emit a warning when a link points to a property defined as children of the `type` declaration. Closes ckeditor/ckeditor5#15321.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
