### PR TITLE
Allowed different dash type in bump year script

### DIFF
--- a/packages/ckeditor5-dev-bump-year/lib/bumpyear.js
+++ b/packages/ckeditor5-dev-bump-year/lib/bumpyear.js
@@ -55,7 +55,7 @@ module.exports = function bumpYear( params ) {
 
 	filesToUpdate.forEach( fileName => {
 		const fileContent = fs.readFileSync( fileName, 'utf-8' );
-		const yearRegexp = new RegExp( `(?<=Copyright (?:\\(c\\)|©) ${ params.initialYear }-)\\d{4}`, 'g' );
+		const yearRegexp = new RegExp( `(?<=Copyright (?:\\(c\\)|©) ${ params.initialYear }[-–])\\d{4}`, 'g' );
 
 		const updatedFileContent = fileContent.replace( yearRegexp, currentYear );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other (bump-year): The bump year script supports both _hyphen_ and _en dash_ symbols in the year range. Closes ckeditor/ckeditor5#15286.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
