### PR TITLE
Support for defining the date format while preparing the changelog file

### DIFF
--- a/packages/ckeditor5-dev-release-tools/lib/tasks/generatechangelogformonorepository.js
+++ b/packages/ckeditor5-dev-release-tools/lib/tasks/generatechangelogformonorepository.js
@@ -58,6 +58,9 @@ const noteInfo = `[ℹ️](${ VERSIONING_POLICY_URL }#major-and-minor-breaking-c
  *
  * @param {String|null} [options.nextVersion=null] Next version to use. If not provided, a user needs to provide via CLI.
  *
+ * @param {FormatDateCallback} [options.formatDate] A callback allowing defining a custom format of the date inserted into the changelog.
+ * If not specified, the default date matches the `YYYY-MM-DD` pattern.
+ *
  * @returns {Promise.<undefined|String>}
  */
 module.exports = async function generateChangelogForMonoRepository( options ) {
@@ -406,7 +409,8 @@ module.exports = async function generateChangelogForMonoRepository( options ) {
 			previousTag: options.from ? options.from : 'v' + rootPkgJson.version,
 			isPatch: semver.diff( version, rootPkgJson.version ) === 'patch',
 			skipCommitsLink: Boolean( options.skipLinks ),
-			skipCompareLink: Boolean( options.skipLinks )
+			skipCompareLink: Boolean( options.skipLinks ),
+			date: options.formatDate ? options.formatDate( new Date() ) : changelogUtils.getFormattedDate()
 		};
 
 		const writerOptions = getWriterOptions( {
@@ -747,4 +751,12 @@ module.exports = async function generateChangelogForMonoRepository( options ) {
  *
  * @param {String} [releaseBranch] A name of the branch that should be used for releasing packages. If not specified, the branch
  * used for the main repository will be used.
+ */
+
+/**
+ * @callback FormatDateCallback
+ *
+ * @param {Date} now The current date.
+ *
+ * @returns {String} The formatted date inserted into the changelog.
  */

--- a/packages/ckeditor5-dev-release-tools/lib/tasks/generatechangelogforsinglepackage.js
+++ b/packages/ckeditor5-dev-release-tools/lib/tasks/generatechangelogforsinglepackage.js
@@ -35,6 +35,9 @@ const SKIP_GENERATE_CHANGELOG = 'Typed "skip" as a new version. Aborting.';
  *
  * @param {String} [options.releaseBranch='master'] A name of the branch that should be used for releasing packages.
  *
+ * @param {FormatDateCallback} [options.formatDate] A callback allowing defining a custom format of the date inserted into the changelog.
+ * If not specified, the default date matches the `YYYY-MM-DD` pattern.
+ *
  * @returns {Promise}
  */
 module.exports = async function generateChangelogForSinglePackage( options = {} ) {
@@ -102,7 +105,8 @@ module.exports = async function generateChangelogForSinglePackage( options = {} 
 				isPatch: semver.diff( version, pkgJson.version ) === 'patch',
 				isInternalRelease,
 				skipCommitsLink: Boolean( options.skipLinks ),
-				skipCompareLink: Boolean( options.skipLinks )
+				skipCompareLink: Boolean( options.skipLinks ),
+				date: options.formatDate ? options.formatDate( new Date() ) : changelogUtils.getFormattedDate()
 			};
 
 			const writerOptions = getWriterOptions( {
@@ -192,3 +196,11 @@ module.exports = async function generateChangelogForSinglePackage( options = {} 
 		log[ method ]( `${ startWithNewLine ? '\n' : '' }${ ' '.repeat( indentLevel * cli.INDENT_SIZE ) }` + message );
 	}
 };
+
+/**
+ * @callback FormatDateCallback
+ *
+ * @param {Date} now The current date.
+ *
+ * @returns {String} The formatted date inserted into the changelog.
+ */

--- a/packages/ckeditor5-dev-release-tools/lib/utils/changelog.js
+++ b/packages/ckeditor5-dev-release-tools/lib/utils/changelog.js
@@ -7,6 +7,7 @@
 
 const fs = require( 'fs' );
 const path = require( 'path' );
+const { format } = require( 'date-fns' );
 const { getRepositoryUrl } = require( './transformcommitutils' );
 
 const utils = {
@@ -95,6 +96,13 @@ const utils = {
 		const truncatedChangelog = utils.changelogHeader + truncatedEntries.join( '\n' ).trim() + changelogFooter;
 
 		utils.saveChangelog( truncatedChangelog, cwd );
+	},
+
+	/**
+	 * @returns {String}
+	 */
+	getFormattedDate() {
+		return format( new Date(), 'yyyy-MM-dd' );
 	}
 };
 

--- a/packages/ckeditor5-dev-release-tools/package.json
+++ b/packages/ckeditor5-dev-release-tools/package.json
@@ -15,6 +15,7 @@
     "conventional-changelog-writer": "^6.0.0",
     "conventional-commits-filter": "^3.0.0",
     "conventional-commits-parser": "^4.0.0",
+    "date-fns": "^2.30.0",
     "diff": "^5.0.0",
     "fs-extra": "^9.1.0",
     "git-raw-commits": "^3.0.0",

--- a/packages/ckeditor5-dev-release-tools/tests/utils/changelog.js
+++ b/packages/ckeditor5-dev-release-tools/tests/utils/changelog.js
@@ -415,5 +415,23 @@ describe( 'dev-release-tools/utils', () => {
 				);
 			} );
 		} );
+
+		describe( 'getFormattedDate()', () => {
+			let clock;
+
+			beforeEach( () => {
+				clock = sinon.useFakeTimers( {
+					now: new Date( '2023-06-15 12:00:00' )
+				} );
+			} );
+
+			afterEach( () => {
+				clock.restore();
+			} );
+
+			it( 'returns a date following the format "year-month-day" with the leading zeros', () => {
+				expect( utils.getFormattedDate() ).to.equal( '2023-06-15' );
+			} );
+		} );
 	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature (release-tools): Allow defining the date format while preparing the changelog file. See ckeditor/ckeditor5#15429.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
