### PR TITLE
Load TS files first when importing a file containing the ".js" extension

### DIFF
--- a/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getwebpackconfig.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getwebpackconfig.js
@@ -43,7 +43,7 @@ module.exports = function getWebpackConfigForAutomatedTests( options ) {
 				[ '.ts', '.js', '.json' ],
 
 			extensionAlias: {
-				'.js': [ '.js', '.ts' ]
+				'.js': [ '.ts', '.js' ]
 			}
 		},
 

--- a/packages/ckeditor5-dev-tests/lib/utils/manual-tests/getwebpackconfig.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/manual-tests/getwebpackconfig.js
@@ -67,7 +67,7 @@ module.exports = function getWebpackConfigForManualTests( options ) {
 			},
 			extensions: [ '.ts', '.js', '.json' ],
 			extensionAlias: {
-				'.js': [ '.js', '.ts' ]
+				'.js': [ '.ts', '.js' ]
 			}
 		},
 

--- a/packages/ckeditor5-dev-tests/tests/utils/automated-tests/getwebpackconfig.js
+++ b/packages/ckeditor5-dev-tests/tests/utils/automated-tests/getwebpackconfig.js
@@ -172,4 +172,17 @@ describe( 'getWebpackConfigForAutomatedTests()', () => {
 		expect( webpackConfig.plugins.filter( plugin => plugin instanceof stubs.TreatWarningsAsErrorsWebpackPlugin ) )
 			.to.have.lengthOf( 1 );
 	} );
+
+	it( 'should load TypeScript files first when importing JS files', () => {
+		const webpackConfig = getWebpackConfigForAutomatedTests( {
+			production: true
+		} );
+
+		expect( webpackConfig.resolve.extensionAlias ).to.be.an( 'object' );
+		expect( webpackConfig.resolve.extensionAlias[ '.js' ] ).to.be.an( 'array' );
+		expect( webpackConfig.resolve.extensionAlias[ '.js' ] ).to.deep.equal( [
+			'.ts',
+			'.js'
+		] );
+	} );
 } );

--- a/packages/ckeditor5-dev-tests/tests/utils/manual-tests/getwebpackconfig.js
+++ b/packages/ckeditor5-dev-tests/tests/utils/manual-tests/getwebpackconfig.js
@@ -147,4 +147,29 @@ describe( 'getWebpackConfigForManualTests()', () => {
 
 		expect( 'external/ckeditor5-foo/packages/ckeditor5-bar/baz'.match( pattern )[ 0 ] ).to.equal( 'packages/ckeditor5-bar/' );
 	} );
+
+	it( 'should load TypeScript files first when importing JS files', () => {
+		const entries = {
+			'ckeditor5/tests/manual/all-features': '/home/ckeditor/ckeditor5/tests/manual/all-features.js'
+		};
+
+		const buildDir = '/home/ckeditor/ckeditor5/build/.manual-tests';
+
+		const debug = [];
+
+		const webpackConfig = getWebpackConfigForManualTests( {
+			entries,
+			buildDir,
+			debug,
+			themePath: '/theme/path',
+			tsconfig: '/tsconfig/path'
+		} );
+
+		expect( webpackConfig.resolve.extensionAlias ).to.be.an( 'object' );
+		expect( webpackConfig.resolve.extensionAlias[ '.js' ] ).to.be.an( 'array' );
+		expect( webpackConfig.resolve.extensionAlias[ '.js' ] ).to.deep.equal( [
+			'.ts',
+			'.js'
+		] );
+	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix (tests): Force loading TypeScript files first when importing a file ending with the `.js` extension.

---

### Additional information

According to the error reported by the team member:

```
Module parse failed: Unexpected token (130:46)
File was processed with these loaders:
 * ./node_modules/@ckeditor/ckeditor5-dev-translations/lib/translatesourceloader.js
 * ./node_modules/@ckeditor/ckeditor5-dev-utils/lib/loaders/ck-debug-loader.js
You may need an additional loader to handle the result of these loaders.
|   */
|   _handleError(error, evt) {
>     /* @if CK_DEBUG */ const err = error as CKEditorError;
|     /* @if CK_DEBUG */ if ( err.is && err.is( 'CKEditorError' ) && err.context === undefined ) {
|     /* @if CK_DEBUG */ console.warn( 'The error is missing its context and Watchdog cannot restart the proper item.' );
```

It looks like something goes wrong with importing TS files imported via the `.js` extension. Perhaps the proposed changes could resolve the issue.
