### PR TITLE
Stale bot - find and close `pending:feedback` issues

### DIFF
--- a/packages/ckeditor5-dev-stale-bot/README.md
+++ b/packages/ckeditor5-dev-stale-bot/README.md
@@ -27,9 +27,9 @@ The following configuration options are supported by the stale bot:
 
 * `GITHUB_TOKEN` &ndash; Required. A GitHub token with the `repo:*` scope needed for managing repositories and issues.
 * `REPOSITORY_SLUG` &ndash; Required. The repository name in the format of `owner/name`, where stale bot will check for stale issues and pull requests.
-* `STALE_LABELS` &ndash; Required. List of labels to add on staled issues and pull requests.
-* `CLOSE_ISSUE_LABELS` &ndash; Required. List of labels to add after closing a stale issue.
-* `CLOSE_PR_LABELS` &ndash; Required. List of labels to add after closing a stale pull request.
+* `STALE_LABELS` &ndash; Required. A list of labels to add on staled issues and pull requests.
+* `CLOSE_ISSUE_LABELS` &ndash; Required. A list of labels to add after closing a stale issue.
+* `CLOSE_PR_LABELS` &ndash; Required. A list of labels to add after closing a stale pull request.
 * `STALE_ISSUE_MESSAGE` &ndash; Required. A comment that is added on the staled issues.
 * `STALE_PR_MESSAGE` &ndash; Required. A comment that is added on the staled pull requests.
 * `CLOSE_ISSUE_MESSAGE` &ndash; Required. A comment that is added on the closed issues.
@@ -40,6 +40,8 @@ The following configuration options are supported by the stale bot:
   * the last date of adding a reaction to the body of issue or pull request,
   * the last date of adding or editing a comment,
   * the last date of changing a label.
+* `DAYS_BEFORE_STALE_PENDING_ISSUE` &ndash; Optional, 14 by default. The number of days without a comment on pending issue from a non-team member that qualifies the issue to be marked as stale.
+* `PENDING_ISSUE_LABELS` &ndash; Optional, an empty array by default. A list of labels that identify a pending issue. If empty, then pending issues are not processed.
 * `DAYS_BEFORE_CLOSE` &ndash; Optional, 30 by default. The number of days before closing the stale issues or the stale pull requests.
 * `IGNORE_VIEWER_ACTIVITY` &ndash; Optional, `true` by default. If set, the activity from the currently authenticated user is ignored.
 * `IGNORED_ISSUE_LABELS` &ndash; Optional, an empty array by default. A list of labels, whose assignment to an issue causes the issue to be ignored, even if it fits the stale criteria.

--- a/packages/ckeditor5-dev-stale-bot/bin/utils/parseconfig.js
+++ b/packages/ckeditor5-dev-stale-bot/bin/utils/parseconfig.js
@@ -24,7 +24,9 @@ module.exports = function parseConfig( viewerLogin, config ) {
 		CLOSE_ISSUE_MESSAGE,
 		CLOSE_PR_LABELS,
 		CLOSE_PR_MESSAGE,
+		PENDING_ISSUE_LABELS = [],
 		DAYS_BEFORE_STALE = 365,
+		DAYS_BEFORE_STALE_PENDING_ISSUE = 14,
 		DAYS_BEFORE_CLOSE = 30,
 		IGNORE_VIEWER_ACTIVITY = true,
 		IGNORED_ISSUE_LABELS = [],
@@ -35,14 +37,17 @@ module.exports = function parseConfig( viewerLogin, config ) {
 
 	const now = new Date();
 	const staleDate = formatISO( subDays( now, DAYS_BEFORE_STALE ) );
+	const staleDatePendingIssue = formatISO( subDays( now, DAYS_BEFORE_STALE_PENDING_ISSUE ) );
 	const closeDate = formatISO( subDays( now, DAYS_BEFORE_CLOSE ) );
 
 	return {
 		repositorySlug: REPOSITORY_SLUG,
 		staleDate,
+		staleDatePendingIssue,
 		closeDate,
-		searchDate: staleDate,
 		staleLabels: STALE_LABELS,
+		shouldProcessPendingIssues: PENDING_ISSUE_LABELS.length > 0,
+		pendingIssueLabels: PENDING_ISSUE_LABELS,
 		staleIssueMessage: STALE_ISSUE_MESSAGE,
 		stalePullRequestMessage: STALE_PR_MESSAGE,
 		closeIssueLabels: CLOSE_ISSUE_LABELS,
@@ -69,7 +74,9 @@ module.exports = function parseConfig( viewerLogin, config ) {
  * @property {String} CLOSE_ISSUE_MESSAGE
  * @property {Array.<String>} CLOSE_PR_LABELS
  * @property {String} CLOSE_PR_MESSAGE
+ * @property {Array.<String>} [PENDING_ISSUE_LABELS=[]]
  * @property {Number} [DAYS_BEFORE_STALE=365]
+ * @property {Number} [DAYS_BEFORE_STALE_PENDING_ISSUE=14]
  * @property {Number} [DAYS_BEFORE_CLOSE=30]
  * @property {Boolean} [IGNORE_VIEWER_ACTIVITY=true]
  * @property {Array.<String>} [IGNORED_ISSUE_LABELS=[]]
@@ -82,9 +89,11 @@ module.exports = function parseConfig( viewerLogin, config ) {
  * @typedef {Object} Options
  * @property {String} repositorySlug
  * @property {String} staleDate
+ * @property {String} staleDatePendingIssue
  * @property {String} closeDate
- * @property {String} searchDate
  * @property {Array.<String>} staleLabels
+ * @property {Boolean} shouldProcessPendingIssues
+ * @property {Array.<String>} pendingIssueLabels
  * @property {String} staleIssueMessage
  * @property {String} stalePullRequestMessage
  * @property {Array.<String>} closeIssueLabels

--- a/packages/ckeditor5-dev-stale-bot/lib/graphql/searchpendingissues.graphql
+++ b/packages/ckeditor5-dev-stale-bot/lib/graphql/searchpendingissues.graphql
@@ -1,0 +1,28 @@
+query SearchPendingIssues( $query: String!, $cursor: String ) {
+	search( type: ISSUE, query: $query, first: 100, after: $cursor ) {
+		issueCount
+		nodes {
+			... on Issue {
+				id
+				type: __typename
+				title
+				url
+				comments( last: 1 ) {
+					nodes {
+						createdAt
+						authorAssociation
+					}
+				}
+				labels( first: 100 ) {
+					nodes {
+						name
+					}
+				}
+			}
+		}
+		pageInfo {
+			cursor: endCursor
+			hasNextPage
+		}
+	}
+}

--- a/packages/ckeditor5-dev-stale-bot/lib/utils/ispendingissuestale.js
+++ b/packages/ckeditor5-dev-stale-bot/lib/utils/ispendingissuestale.js
@@ -1,0 +1,17 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+'use strict';
+
+/**
+ * Checks whether pending issue is already stale.
+ *
+ * @param {PendingIssue} pendingIssue Pending issue to check.
+ * @param {Options} options Configuration options.
+ * @returns {Boolean}
+ */
+module.exports = function isPendingIssueStale( pendingIssue, options ) {
+	return options.staleLabels.every( staleLabel => pendingIssue.labels.includes( staleLabel ) );
+};

--- a/packages/ckeditor5-dev-stale-bot/lib/utils/ispendingissuetostale.js
+++ b/packages/ckeditor5-dev-stale-bot/lib/utils/ispendingissuetostale.js
@@ -1,0 +1,35 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+'use strict';
+
+const { isBefore, parseISO } = require( 'date-fns' );
+const isPendingIssueStale = require( './ispendingissuestale' );
+
+/**
+ * Checks whether pending issue should be staled, because it was not answered by a community member since the defined moment of time.
+ *
+ * @param {PendingIssue} pendingIssue Pending issue to check.
+ * @param {Options} options Configuration options.
+ * @returns {Boolean}
+ */
+module.exports = function isPendingIssueToStale( pendingIssue, options ) {
+	const { lastComment } = pendingIssue;
+	const { staleDatePendingIssue } = options;
+
+	if ( isPendingIssueStale( pendingIssue, options ) ) {
+		return false;
+	}
+
+	if ( !lastComment ) {
+		return false;
+	}
+
+	if ( lastComment.isExternal ) {
+		return false;
+	}
+
+	return isBefore( parseISO( lastComment.createdAt ), parseISO( staleDatePendingIssue ) );
+};

--- a/packages/ckeditor5-dev-stale-bot/lib/utils/ispendingissuetounlabel.js
+++ b/packages/ckeditor5-dev-stale-bot/lib/utils/ispendingissuetounlabel.js
@@ -1,0 +1,20 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+'use strict';
+
+/**
+ * Checks whether pending issue should be unlabeled, because it was answered by a community member.
+ *
+ * @param {PendingIssue} pendingIssue Pending issue to check.
+ * @returns {Boolean}
+ */
+module.exports = function isPendingIssueToUnlabel( pendingIssue ) {
+	if ( !pendingIssue.lastComment ) {
+		return false;
+	}
+
+	return pendingIssue.lastComment.isExternal;
+};

--- a/packages/ckeditor5-dev-stale-bot/lib/utils/preparesearchquery.js
+++ b/packages/ckeditor5-dev-stale-bot/lib/utils/preparesearchquery.js
@@ -10,7 +10,7 @@
  *
  * @param {Object} options
  * @param {String} options.repositorySlug
- * @param {String} options.searchDate
+ * @param {String} [options.searchDate]
  * @param {'Issue'|'PullRequest'} [options.type]
  * @param {Array.<String>} [options.labels=[]]
  * @param {Array.<String>} [options.ignoredLabels=[]]
@@ -29,7 +29,7 @@ module.exports = function prepareSearchQuery( options ) {
 
 	return [
 		`repo:${ repositorySlug }`,
-		`created:<${ searchDate }`,
+		searchDate ? `created:<${ searchDate }` : '',
 		resourceType ? `type:${ resourceType }` : '',
 		'state:open',
 		'sort:created-desc',

--- a/packages/ckeditor5-dev-stale-bot/tests/githubrepository.js
+++ b/packages/ckeditor5-dev-stale-bot/tests/githubrepository.js
@@ -41,7 +41,9 @@ describe( 'dev-stale-bot/lib', () => {
 				prepareSearchQuery: sinon.stub().returns( 'search query' ),
 				isIssueOrPullRequestToStale: sinon.stub().returns( true ),
 				isIssueOrPullRequestToUnstale: sinon.stub().returns( true ),
-				isIssueOrPullRequestToClose: sinon.stub().returns( true )
+				isIssueOrPullRequestToClose: sinon.stub().returns( true ),
+				isPendingIssueToStale: sinon.stub().returns( true ),
+				isPendingIssueToUnlabel: sinon.stub().returns( true )
 			};
 
 			pageInfoWithNextPage = {
@@ -57,6 +59,7 @@ describe( 'dev-stale-bot/lib', () => {
 			const queries = {
 				getviewerlogin: 'query GetViewerLogin',
 				searchissuesorpullrequests: 'query SearchIssuesOrPullRequests',
+				searchpendingissues: 'query SearchPendingIssues',
 				getissueorpullrequesttimelineitems: 'query GetIssueOrPullRequestTimelineItems',
 				addcomment: 'mutation AddComment',
 				getlabels: 'query GetLabels',
@@ -85,7 +88,9 @@ describe( 'dev-stale-bot/lib', () => {
 				'./utils/preparesearchquery': stubs.prepareSearchQuery,
 				'./utils/isissueorpullrequesttostale': stubs.isIssueOrPullRequestToStale,
 				'./utils/isissueorpullrequesttounstale': stubs.isIssueOrPullRequestToUnstale,
-				'./utils/isissueorpullrequesttoclose': stubs.isIssueOrPullRequestToClose
+				'./utils/isissueorpullrequesttoclose': stubs.isIssueOrPullRequestToClose,
+				'./utils/ispendingissuetostale': stubs.isPendingIssueToStale,
+				'./utils/ispendingissuetounlabel': stubs.isPendingIssueToUnlabel
 			} );
 
 			githubRepository = new GitHubRepository( 'authorization-token' );
@@ -398,7 +403,7 @@ describe( 'dev-stale-bot/lib', () => {
 			} );
 		} );
 
-		describe( '#searchIssuesOrPullRequestsToStale()', () => {
+		describe( 'searching', () => {
 			let onProgress, optionsBase, issueBase;
 
 			beforeEach( () => {
@@ -406,9 +411,9 @@ describe( 'dev-stale-bot/lib', () => {
 
 				optionsBase = {
 					repositorySlug: 'ckeditor/ckeditor5',
-					searchDate: '2022-12-01',
 					staleDate: '2022-12-01',
-					staleLabels: [],
+					staleLabels: [ 'status:stale' ],
+					pendingIssueLabels: [ 'pending:feedback' ],
 					ignoredIssueLabels: [],
 					ignoredPullRequestLabels: [],
 					ignoredActivityLogins: [],
@@ -430,919 +435,1391 @@ describe( 'dev-stale-bot/lib', () => {
 					timelineItems: {
 						nodes: [],
 						pageInfo: pageInfoNoNextPage
+					},
+					comments: {
+						nodes: []
+					},
+					labels: {
+						nodes: []
 					}
 				};
 			} );
 
-			it( 'should be a function', () => {
-				expect( githubRepository.searchIssuesOrPullRequestsToStale ).to.be.a( 'function' );
-			} );
-
-			it( 'should ask for issue search query', () => {
-				const issues = [
-					{ ...issueBase, number: 1 },
-					{ ...issueBase, number: 2 },
-					{ ...issueBase, number: 3 }
-				];
-
-				const options = {
-					...optionsBase,
-					staleLabels: [ 'status:stale' ],
-					ignoredIssueLabels: [ 'support:1', 'support:2', 'support:3' ]
-				};
-
-				stubs.GraphQLClient.request.resolves( {
-					search: {
-						issueCount: issues.length,
-						nodes: issues,
-						pageInfo: pageInfoNoNextPage
-					}
+			describe( '#searchIssuesOrPullRequestsToStale()', () => {
+				it( 'should be a function', () => {
+					expect( githubRepository.searchIssuesOrPullRequestsToStale ).to.be.a( 'function' );
 				} );
 
-				return githubRepository.searchIssuesOrPullRequestsToStale( 'Issue', options, onProgress ).then( () => {
-					expect( stubs.prepareSearchQuery.calledOnce ).to.equal( true );
-					expect( stubs.prepareSearchQuery.getCall( 0 ).args[ 0 ] ).to.deep.equal( {
-						type: 'Issue',
-						searchDate: '2022-12-01',
-						repositorySlug: 'ckeditor/ckeditor5',
-						ignoredLabels: [ 'status:stale', 'support:1', 'support:2', 'support:3' ]
-					} );
-				} );
-			} );
+				it( 'should ask for issue search query', () => {
+					const issues = [
+						{ ...issueBase, number: 1 },
+						{ ...issueBase, number: 2 },
+						{ ...issueBase, number: 3 }
+					];
 
-			it( 'should ask for pull request search query', () => {
-				const issues = [
-					{ ...issueBase, number: 1 },
-					{ ...issueBase, number: 2 },
-					{ ...issueBase, number: 3 }
-				];
-
-				const options = {
-					...optionsBase,
-					staleLabels: [ 'status:stale' ],
-					ignoredPullRequestLabels: [ 'support:1', 'support:2', 'support:3' ]
-				};
-
-				stubs.GraphQLClient.request.resolves( {
-					search: {
-						issueCount: issues.length,
-						nodes: issues,
-						pageInfo: pageInfoNoNextPage
-					}
-				} );
-
-				return githubRepository.searchIssuesOrPullRequestsToStale( 'PullRequest', options, onProgress ).then( () => {
-					expect( stubs.prepareSearchQuery.calledOnce ).to.equal( true );
-					expect( stubs.prepareSearchQuery.getCall( 0 ).args[ 0 ] ).to.deep.equal( {
-						type: 'PullRequest',
-						searchDate: '2022-12-01',
-						repositorySlug: 'ckeditor/ckeditor5',
-						ignoredLabels: [ 'status:stale', 'support:1', 'support:2', 'support:3' ]
-					} );
-				} );
-			} );
-
-			it( 'should return all issues to stale if they are not paginated', () => {
-				const issues = [
-					{ ...issueBase, number: 1 },
-					{ ...issueBase, number: 2 },
-					{ ...issueBase, number: 3 }
-				];
-
-				stubs.GraphQLClient.request.resolves( {
-					search: {
-						issueCount: issues.length,
-						nodes: issues,
-						pageInfo: pageInfoNoNextPage
-					}
-				} );
-
-				return githubRepository.searchIssuesOrPullRequestsToStale( 'Issue', optionsBase, onProgress ).then( result => {
-					expect( result ).to.be.an( 'array' );
-					expect( result ).to.have.length( 3 );
-					expect( result[ 0 ] ).to.deep.equal(
-						{ id: 'IssueId', title: 'IssueTitle', type: 'Issue', url: 'https://github.com/' }
-					);
-					expect( result[ 1 ] ).to.deep.equal(
-						{ id: 'IssueId', title: 'IssueTitle', type: 'Issue', url: 'https://github.com/' }
-					);
-					expect( result[ 2 ] ).to.deep.equal(
-						{ id: 'IssueId', title: 'IssueTitle', type: 'Issue', url: 'https://github.com/' }
-					);
-				} );
-			} );
-
-			it( 'should return all issues to stale if they are paginated', () => {
-				const issues = [
-					{ ...issueBase, number: 1 },
-					{ ...issueBase, number: 2 },
-					{ ...issueBase, number: 3 }
-				];
-
-				paginateRequest( issues, ( { nodes, pageInfo } ) => {
-					return {
-						search: {
-							issueCount: issues.length,
-							nodes,
-							pageInfo
-						}
+					const options = {
+						...optionsBase,
+						ignoredIssueLabels: [ 'support:1', 'support:2', 'support:3' ]
 					};
-				} );
 
-				return githubRepository.searchIssuesOrPullRequestsToStale( 'Issue', optionsBase, onProgress ).then( result => {
-					expect( result ).to.be.an( 'array' );
-					expect( result ).to.have.length( 3 );
-					expect( result[ 0 ] ).to.deep.equal(
-						{ id: 'IssueId', title: 'IssueTitle', type: 'Issue', url: 'https://github.com/' }
-					);
-					expect( result[ 1 ] ).to.deep.equal(
-						{ id: 'IssueId', title: 'IssueTitle', type: 'Issue', url: 'https://github.com/' }
-					);
-					expect( result[ 2 ] ).to.deep.equal(
-						{ id: 'IssueId', title: 'IssueTitle', type: 'Issue', url: 'https://github.com/' }
-					);
-				} );
-			} );
-
-			it( 'should send one request for all issues to stale if they are not paginated', () => {
-				const issues = [
-					{ ...issueBase, number: 1 },
-					{ ...issueBase, number: 2 },
-					{ ...issueBase, number: 3 }
-				];
-
-				stubs.GraphQLClient.request.resolves( {
-					search: {
-						issueCount: issues.length,
-						nodes: issues,
-						pageInfo: pageInfoNoNextPage
-					}
-				} );
-
-				return githubRepository.searchIssuesOrPullRequestsToStale( 'Issue', optionsBase, onProgress ).then( () => {
-					expect( stubs.GraphQLClient.request.calledOnce ).to.equal( true );
-					expect( stubs.GraphQLClient.request.getCall( 0 ).args[ 0 ] ).to.equal( 'query SearchIssuesOrPullRequests' );
-					expect( stubs.GraphQLClient.request.getCall( 0 ).args[ 1 ] ).to.deep.equal( { query: 'search query', cursor: null } );
-				} );
-			} );
-
-			it( 'should send multiple requests for all issues to stale if they are paginated', () => {
-				const issues = [
-					{ ...issueBase, number: 1 },
-					{ ...issueBase, number: 2 },
-					{ ...issueBase, number: 3 }
-				];
-
-				paginateRequest( issues, ( { nodes, pageInfo } ) => {
-					return {
+					stubs.GraphQLClient.request.resolves( {
 						search: {
 							issueCount: issues.length,
-							nodes,
-							pageInfo
-						}
-					};
-				} );
-
-				return githubRepository.searchIssuesOrPullRequestsToStale( 'Issue', optionsBase, onProgress ).then( () => {
-					expect( stubs.GraphQLClient.request.callCount ).to.equal( 3 );
-
-					expect( stubs.GraphQLClient.request.getCall( 0 ).args[ 0 ] ).to.equal( 'query SearchIssuesOrPullRequests' );
-					expect( stubs.GraphQLClient.request.getCall( 0 ).args[ 1 ] ).to.deep.equal(
-						{ query: 'search query', cursor: null }
-					);
-
-					expect( stubs.GraphQLClient.request.getCall( 1 ).args[ 0 ] ).to.equal( 'query SearchIssuesOrPullRequests' );
-					expect( stubs.GraphQLClient.request.getCall( 1 ).args[ 1 ] ).to.deep.equal(
-						{ query: 'search query', cursor: 'cursor' }
-					);
-
-					expect( stubs.GraphQLClient.request.getCall( 2 ).args[ 0 ] ).to.equal( 'query SearchIssuesOrPullRequests' );
-					expect( stubs.GraphQLClient.request.getCall( 2 ).args[ 1 ] ).to.deep.equal(
-						{ query: 'search query', cursor: 'cursor' }
-					);
-				} );
-			} );
-
-			it( 'should fetch all timeline events for any issue if they are paginated', () => {
-				const issues = [
-					{ ...issueBase, number: 1, timelineItems: {
-						nodes: [],
-						pageInfo: pageInfoWithNextPage
-					} }
-				];
-
-				sinon.stub( githubRepository, 'getIssueOrPullRequestTimelineItems' ).resolves( [] );
-
-				stubs.GraphQLClient.request.resolves( {
-					search: {
-						issueCount: issues.length,
-						nodes: issues,
-						pageInfo: pageInfoNoNextPage
-					}
-				} );
-
-				return githubRepository.searchIssuesOrPullRequestsToStale( 'Issue', optionsBase, onProgress ).then( () => {
-					expect( githubRepository.getIssueOrPullRequestTimelineItems.callCount ).to.equal( 1 );
-
-					expect( githubRepository.getIssueOrPullRequestTimelineItems.getCall( 0 ).args[ 0 ] ).to.equal( 'IssueId' );
-					expect( githubRepository.getIssueOrPullRequestTimelineItems.getCall( 0 ).args[ 1 ] ).to.deep.equal( {
-						hasNextPage: true,
-						cursor: 'cursor'
-					} );
-				} );
-			} );
-
-			it( 'should ask for a new search query with new offset if GitHub prevents going to the next page', () => {
-				const issues = [
-					{ ...issueBase, number: 1, createdAt: '2022-11-01T09:00:00Z' },
-					{ ...issueBase, number: 2, createdAt: '2022-10-01T09:00:00Z' },
-					{ ...issueBase, number: 3, createdAt: '2022-09-01T09:00:00Z' }
-				];
-
-				paginateRequest( issues, ( { nodes } ) => {
-					return {
-						search: {
-							issueCount: issues.length,
-							nodes,
+							nodes: issues,
 							pageInfo: pageInfoNoNextPage
 						}
+					} );
+
+					return githubRepository.searchIssuesOrPullRequestsToStale( 'Issue', options, onProgress ).then( () => {
+						expect( stubs.prepareSearchQuery.calledOnce ).to.equal( true );
+						expect( stubs.prepareSearchQuery.getCall( 0 ).args[ 0 ] ).to.deep.equal( {
+							type: 'Issue',
+							searchDate: '2022-12-01',
+							repositorySlug: 'ckeditor/ckeditor5',
+							ignoredLabels: [ 'status:stale', 'support:1', 'support:2', 'support:3' ]
+						} );
+					} );
+				} );
+
+				it( 'should ask for pull request search query', () => {
+					const issues = [
+						{ ...issueBase, number: 1 },
+						{ ...issueBase, number: 2 },
+						{ ...issueBase, number: 3 }
+					];
+
+					const options = {
+						...optionsBase,
+						ignoredPullRequestLabels: [ 'support:1', 'support:2', 'support:3' ]
 					};
-				} );
 
-				return githubRepository.searchIssuesOrPullRequestsToStale( 'Issue', optionsBase, onProgress ).then( () => {
-					expect( stubs.prepareSearchQuery.callCount ).to.equal( 3 );
-					expect( stubs.prepareSearchQuery.getCall( 0 ).args[ 0 ] ).to.have.property( 'searchDate', '2022-12-01' );
-					expect( stubs.prepareSearchQuery.getCall( 1 ).args[ 0 ] ).to.have.property( 'searchDate', '2022-11-01T09:00:00Z' );
-					expect( stubs.prepareSearchQuery.getCall( 2 ).args[ 0 ] ).to.have.property( 'searchDate', '2022-10-01T09:00:00Z' );
-				} );
-			} );
-
-			it( 'should return all issues to stale if GitHub prevents going to the next page', () => {
-				const issues = [
-					{ ...issueBase, number: 1 },
-					{ ...issueBase, number: 2 },
-					{ ...issueBase, number: 3 }
-				];
-
-				paginateRequest( issues, ( { nodes } ) => {
-					return {
+					stubs.GraphQLClient.request.resolves( {
 						search: {
 							issueCount: issues.length,
-							nodes,
+							nodes: issues,
 							pageInfo: pageInfoNoNextPage
 						}
-					};
+					} );
+
+					return githubRepository.searchIssuesOrPullRequestsToStale( 'PullRequest', options, onProgress ).then( () => {
+						expect( stubs.prepareSearchQuery.calledOnce ).to.equal( true );
+						expect( stubs.prepareSearchQuery.getCall( 0 ).args[ 0 ] ).to.deep.equal( {
+							type: 'PullRequest',
+							searchDate: '2022-12-01',
+							repositorySlug: 'ckeditor/ckeditor5',
+							ignoredLabels: [ 'status:stale', 'support:1', 'support:2', 'support:3' ]
+						} );
+					} );
 				} );
 
-				return githubRepository.searchIssuesOrPullRequestsToStale( 'Issue', optionsBase, onProgress ).then( result => {
-					expect( result ).to.be.an( 'array' );
-					expect( result ).to.have.length( 3 );
-					expect( result[ 0 ] ).to.deep.equal(
-						{ id: 'IssueId', title: 'IssueTitle', type: 'Issue', url: 'https://github.com/' }
-					);
-					expect( result[ 1 ] ).to.deep.equal(
-						{ id: 'IssueId', title: 'IssueTitle', type: 'Issue', url: 'https://github.com/' }
-					);
-					expect( result[ 2 ] ).to.deep.equal(
-						{ id: 'IssueId', title: 'IssueTitle', type: 'Issue', url: 'https://github.com/' }
-					);
-				} );
-			} );
-
-			it( 'should check each issue if it is stale', () => {
-				const issues = [
-					{ ...issueBase, number: 1 },
-					{ ...issueBase, number: 2 },
-					{ ...issueBase, number: 3 }
-				];
-
-				stubs.GraphQLClient.request.resolves( {
-					search: {
-						issueCount: issues.length,
-						nodes: issues,
-						pageInfo: pageInfoNoNextPage
-					}
-				} );
-
-				stubs.isIssueOrPullRequestToStale.onCall( 1 ).returns( false );
-
-				return githubRepository.searchIssuesOrPullRequestsToStale( 'Issue', optionsBase, onProgress ).then( result => {
-					const expectedIssue = {
-						...issueBase,
-						lastReactedAt: null,
-						timelineItems: []
+				it( 'should start the search from stale date if search date is not set', () => {
+					const options = {
+						...optionsBase,
+						searchDate: undefined,
+						staleDate: '2023-01-01'
 					};
 
-					expect( stubs.isIssueOrPullRequestToStale.callCount ).to.equal( 3 );
+					stubs.GraphQLClient.request.resolves( {
+						search: {
+							issueCount: 0,
+							nodes: [],
+							pageInfo: pageInfoNoNextPage
+						}
+					} );
 
-					expect( stubs.isIssueOrPullRequestToStale.getCall( 0 ).args[ 0 ] ).to.deep.equal( { ...expectedIssue, number: 1 } );
-					expect( stubs.isIssueOrPullRequestToStale.getCall( 0 ).args[ 1 ] ).to.deep.equal( optionsBase );
-
-					expect( stubs.isIssueOrPullRequestToStale.getCall( 1 ).args[ 0 ] ).to.deep.equal( { ...expectedIssue, number: 2 } );
-					expect( stubs.isIssueOrPullRequestToStale.getCall( 1 ).args[ 1 ] ).to.deep.equal( optionsBase );
-
-					expect( stubs.isIssueOrPullRequestToStale.getCall( 2 ).args[ 0 ] ).to.deep.equal( { ...expectedIssue, number: 3 } );
-					expect( stubs.isIssueOrPullRequestToStale.getCall( 2 ).args[ 1 ] ).to.deep.equal( optionsBase );
-
-					expect( result ).to.be.an( 'array' );
-					expect( result ).to.have.length( 2 );
+					return githubRepository.searchIssuesOrPullRequestsToStale( 'Issue', options, onProgress ).then( () => {
+						expect( stubs.prepareSearchQuery.calledOnce ).to.equal( true );
+						expect( stubs.prepareSearchQuery.getCall( 0 ).args[ 0 ] ).to.have.property( 'searchDate', '2023-01-01' );
+					} );
 				} );
-			} );
 
-			it( 'should call on progress callback', () => {
-				const issues = [
-					{ ...issueBase, number: 1 },
-					{ ...issueBase, number: 2 },
-					{ ...issueBase, number: 3 }
-				];
+				it( 'should return all issues to stale if they are not paginated', () => {
+					const issues = [
+						{ ...issueBase, number: 1 },
+						{ ...issueBase, number: 2 },
+						{ ...issueBase, number: 3 }
+					];
 
-				paginateRequest( issues, ( { nodes, pageInfo } ) => {
-					return {
+					stubs.GraphQLClient.request.resolves( {
 						search: {
 							issueCount: issues.length,
-							nodes,
-							pageInfo
+							nodes: issues,
+							pageInfo: pageInfoNoNextPage
 						}
-					};
-				} );
+					} );
 
-				return githubRepository.searchIssuesOrPullRequestsToStale( 'Issue', optionsBase, onProgress ).then( () => {
-					expect( onProgress.callCount ).to.equal( 3 );
-
-					expect( onProgress.getCall( 0 ).args[ 0 ] ).to.deep.equal( { done: 1, total: 3 } );
-					expect( onProgress.getCall( 1 ).args[ 0 ] ).to.deep.equal( { done: 2, total: 3 } );
-					expect( onProgress.getCall( 2 ).args[ 0 ] ).to.deep.equal( { done: 3, total: 3 } );
-				} );
-			} );
-
-			it( 'should count total hits only once using the value from first response', () => {
-				const issues = [
-					{ ...issueBase, number: 1 },
-					{ ...issueBase, number: 2 },
-					{ ...issueBase, number: 3 }
-				];
-
-				paginateRequest( issues, ( { nodes, pageInfo, entryIndex } ) => {
-					return {
-						search: {
-							issueCount: issues.length - entryIndex,
-							nodes,
-							pageInfo
-						}
-					};
-				} );
-
-				return githubRepository.searchIssuesOrPullRequestsToStale( 'Issue', optionsBase, onProgress ).then( () => {
-					expect( onProgress.callCount ).to.equal( 3 );
-
-					expect( onProgress.getCall( 0 ).args[ 0 ] ).to.deep.equal( { done: 1, total: 3 } );
-					expect( onProgress.getCall( 1 ).args[ 0 ] ).to.deep.equal( { done: 2, total: 3 } );
-					expect( onProgress.getCall( 2 ).args[ 0 ] ).to.deep.equal( { done: 3, total: 3 } );
-				} );
-			} );
-
-			it( 'should reject if request failed', () => {
-				stubs.GraphQLClient.request.rejects( new Error( '500 Internal Server Error' ) );
-
-				return githubRepository.searchIssuesOrPullRequestsToStale( 'Issue', optionsBase, onProgress ).then(
-					() => {
-						throw new Error( 'Expected to be rejected.' );
-					},
-					() => {
-						return Promise.resolve();
-					}
-				);
-			} );
-
-			it( 'should reject if subsequent request failed', () => {
-				const issues = [
-					{ ...issueBase, number: 1 },
-					{ ...issueBase, number: 2 },
-					{ ...issueBase, number: 3 }
-				];
-
-				paginateRequest( issues, ( { nodes, pageInfo } ) => {
-					return {
-						search: {
-							issueCount: issues.length,
-							nodes,
-							pageInfo
-						}
-					};
-				} );
-
-				stubs.GraphQLClient.request.onCall( 2 ).rejects( new Error( '500 Internal Server Error' ) );
-
-				return githubRepository.searchIssuesOrPullRequestsToStale( 'Issue', optionsBase, onProgress ).then(
-					() => {
-						throw new Error( 'Expected to be rejected.' );
-					},
-					() => {
-						return Promise.resolve();
-					}
-				);
-			} );
-
-			it( 'should log an error if request failed', () => {
-				const error = new Error( '500 Internal Server Error' );
-
-				stubs.GraphQLClient.request.rejects( error );
-
-				return githubRepository.searchIssuesOrPullRequestsToStale( 'Issue', optionsBase, onProgress ).then(
-					() => {
-						throw new Error( 'Expected to be rejected.' );
-					},
-					() => {
-						expect( stubs.logger.error.callCount ).to.equal( 1 );
-						expect( stubs.logger.error.getCall( 0 ).args[ 0 ] ).to.equal(
-							'Unexpected error when executing "#searchIssuesOrPullRequestsToStale()".'
+					return githubRepository.searchIssuesOrPullRequestsToStale( 'Issue', optionsBase, onProgress ).then( result => {
+						expect( result ).to.be.an( 'array' );
+						expect( result ).to.have.length( 3 );
+						expect( result[ 0 ] ).to.deep.equal(
+							{ id: 'IssueId', title: 'IssueTitle', type: 'Issue', url: 'https://github.com/' }
 						);
-						expect( stubs.logger.error.getCall( 0 ).args[ 1 ] ).to.equal( error );
-					}
-				);
-			} );
-		} );
-
-		describe( '#searchStaleIssuesOrPullRequests()', () => {
-			let onProgress, optionsBase, issueBase;
-
-			beforeEach( () => {
-				onProgress = sinon.stub();
-
-				optionsBase = {
-					repositorySlug: 'ckeditor/ckeditor5',
-					searchDate: '2022-12-01',
-					staleDate: '2022-12-01',
-					staleLabels: [ 'status:stale' ],
-					ignoredActivityLogins: [],
-					ignoredActivityLabels: []
-				};
-
-				issueBase = {
-					type: 'Issue',
-					id: 'IssueId',
-					url: 'https://github.com/',
-					title: 'IssueTitle',
-					number: 1,
-					createdAt: '2022-11-30T23:59:59Z',
-					lastEditedAt: null,
-					reactions: {
-						nodes: [],
-						pageInfo: pageInfoNoNextPage
-					},
-					timelineItems: {
-						nodes: [],
-						pageInfo: pageInfoNoNextPage
-					}
-				};
-			} );
-
-			it( 'should be a function', () => {
-				expect( githubRepository.searchStaleIssuesOrPullRequests ).to.be.a( 'function' );
-			} );
-
-			it( 'should ask for search query', () => {
-				const issues = [
-					{ ...issueBase, number: 1 },
-					{ ...issueBase, number: 2 },
-					{ ...issueBase, number: 3 }
-				];
-
-				stubs.GraphQLClient.request.resolves( {
-					search: {
-						issueCount: issues.length,
-						nodes: issues,
-						pageInfo: pageInfoNoNextPage
-					}
-				} );
-
-				return githubRepository.searchStaleIssuesOrPullRequests( optionsBase, onProgress ).then( () => {
-					expect( stubs.prepareSearchQuery.calledOnce ).to.equal( true );
-					expect( stubs.prepareSearchQuery.getCall( 0 ).args[ 0 ] ).to.deep.equal( {
-						searchDate: '2022-12-01',
-						repositorySlug: 'ckeditor/ckeditor5',
-						labels: [ 'status:stale' ]
-					} );
-				} );
-			} );
-
-			it( 'should return all stale issues if they are not paginated', () => {
-				const issues = [
-					{ ...issueBase, number: 1 },
-					{ ...issueBase, number: 2 },
-					{ ...issueBase, number: 3 }
-				];
-
-				stubs.GraphQLClient.request.resolves( {
-					search: {
-						issueCount: issues.length,
-						nodes: issues,
-						pageInfo: pageInfoNoNextPage
-					}
-				} );
-
-				return githubRepository.searchStaleIssuesOrPullRequests( optionsBase, onProgress ).then( result => {
-					expect( result ).to.have.property( 'issuesOrPullRequestsToClose' );
-					expect( result ).to.have.property( 'issuesOrPullRequestsToUnstale' );
-
-					expect( result.issuesOrPullRequestsToClose ).to.be.an( 'array' );
-					expect( result.issuesOrPullRequestsToClose ).to.have.length( 3 );
-					expect( result.issuesOrPullRequestsToClose[ 0 ] ).to.deep.equal(
-						{ id: 'IssueId', type: 'Issue', title: 'IssueTitle', url: 'https://github.com/' }
-					);
-					expect( result.issuesOrPullRequestsToClose[ 1 ] ).to.deep.equal(
-						{ id: 'IssueId', type: 'Issue', title: 'IssueTitle', url: 'https://github.com/' }
-					);
-					expect( result.issuesOrPullRequestsToClose[ 2 ] ).to.deep.equal(
-						{ id: 'IssueId', type: 'Issue', title: 'IssueTitle', url: 'https://github.com/' }
-					);
-
-					expect( result.issuesOrPullRequestsToUnstale ).to.be.an( 'array' );
-					expect( result.issuesOrPullRequestsToUnstale ).to.have.length( 3 );
-					expect( result.issuesOrPullRequestsToUnstale[ 0 ] ).to.deep.equal(
-						{ id: 'IssueId', type: 'Issue', title: 'IssueTitle', url: 'https://github.com/' }
-					);
-					expect( result.issuesOrPullRequestsToUnstale[ 1 ] ).to.deep.equal(
-						{ id: 'IssueId', type: 'Issue', title: 'IssueTitle', url: 'https://github.com/' }
-					);
-					expect( result.issuesOrPullRequestsToUnstale[ 2 ] ).to.deep.equal(
-						{ id: 'IssueId', type: 'Issue', title: 'IssueTitle', url: 'https://github.com/' }
-					);
-				} );
-			} );
-
-			it( 'should return all stale issues if they are paginated', () => {
-				const issues = [
-					{ ...issueBase, number: 1 },
-					{ ...issueBase, number: 2 },
-					{ ...issueBase, number: 3 }
-				];
-
-				paginateRequest( issues, ( { nodes, pageInfo } ) => {
-					return {
-						search: {
-							issueCount: issues.length,
-							nodes,
-							pageInfo
-						}
-					};
-				} );
-
-				return githubRepository.searchStaleIssuesOrPullRequests( optionsBase, onProgress ).then( result => {
-					expect( result ).to.have.property( 'issuesOrPullRequestsToClose' );
-					expect( result ).to.have.property( 'issuesOrPullRequestsToUnstale' );
-
-					expect( result.issuesOrPullRequestsToClose ).to.be.an( 'array' );
-					expect( result.issuesOrPullRequestsToClose ).to.have.length( 3 );
-					expect( result.issuesOrPullRequestsToClose[ 0 ] ).to.deep.equal(
-						{ id: 'IssueId', type: 'Issue', title: 'IssueTitle', url: 'https://github.com/' }
-					);
-					expect( result.issuesOrPullRequestsToClose[ 1 ] ).to.deep.equal(
-						{ id: 'IssueId', type: 'Issue', title: 'IssueTitle', url: 'https://github.com/' }
-					);
-					expect( result.issuesOrPullRequestsToClose[ 2 ] ).to.deep.equal(
-						{ id: 'IssueId', type: 'Issue', title: 'IssueTitle', url: 'https://github.com/' }
-					);
-
-					expect( result.issuesOrPullRequestsToUnstale ).to.be.an( 'array' );
-					expect( result.issuesOrPullRequestsToUnstale ).to.have.length( 3 );
-					expect( result.issuesOrPullRequestsToUnstale[ 0 ] ).to.deep.equal(
-						{ id: 'IssueId', type: 'Issue', title: 'IssueTitle', url: 'https://github.com/' }
-					);
-					expect( result.issuesOrPullRequestsToUnstale[ 1 ] ).to.deep.equal(
-						{ id: 'IssueId', type: 'Issue', title: 'IssueTitle', url: 'https://github.com/' }
-					);
-					expect( result.issuesOrPullRequestsToUnstale[ 2 ] ).to.deep.equal(
-						{ id: 'IssueId', type: 'Issue', title: 'IssueTitle', url: 'https://github.com/' }
-					);
-				} );
-			} );
-
-			it( 'should send one request for all stale issues if they are not paginated', () => {
-				const issues = [
-					{ ...issueBase, number: 1 },
-					{ ...issueBase, number: 2 },
-					{ ...issueBase, number: 3 }
-				];
-
-				stubs.GraphQLClient.request.resolves( {
-					search: {
-						issueCount: issues.length,
-						nodes: issues,
-						pageInfo: pageInfoNoNextPage
-					}
-				} );
-
-				return githubRepository.searchStaleIssuesOrPullRequests( optionsBase, onProgress ).then( () => {
-					expect( stubs.GraphQLClient.request.calledOnce ).to.equal( true );
-					expect( stubs.GraphQLClient.request.getCall( 0 ).args[ 0 ] ).to.equal( 'query SearchIssuesOrPullRequests' );
-					expect( stubs.GraphQLClient.request.getCall( 0 ).args[ 1 ] ).to.deep.equal( { query: 'search query', cursor: null } );
-				} );
-			} );
-
-			it( 'should send multiple requests for all stale issues if they are paginated', () => {
-				const issues = [
-					{ ...issueBase, number: 1 },
-					{ ...issueBase, number: 2 },
-					{ ...issueBase, number: 3 }
-				];
-
-				paginateRequest( issues, ( { nodes, pageInfo } ) => {
-					return {
-						search: {
-							issueCount: issues.length,
-							nodes,
-							pageInfo
-						}
-					};
-				} );
-
-				return githubRepository.searchStaleIssuesOrPullRequests( optionsBase, onProgress ).then( () => {
-					expect( stubs.GraphQLClient.request.callCount ).to.equal( 3 );
-
-					expect( stubs.GraphQLClient.request.getCall( 0 ).args[ 0 ] ).to.equal( 'query SearchIssuesOrPullRequests' );
-					expect( stubs.GraphQLClient.request.getCall( 0 ).args[ 1 ] ).to.deep.equal(
-						{ query: 'search query', cursor: null }
-					);
-
-					expect( stubs.GraphQLClient.request.getCall( 1 ).args[ 0 ] ).to.equal( 'query SearchIssuesOrPullRequests' );
-					expect( stubs.GraphQLClient.request.getCall( 1 ).args[ 1 ] ).to.deep.equal(
-						{ query: 'search query', cursor: 'cursor' }
-					);
-
-					expect( stubs.GraphQLClient.request.getCall( 2 ).args[ 0 ] ).to.equal( 'query SearchIssuesOrPullRequests' );
-					expect( stubs.GraphQLClient.request.getCall( 2 ).args[ 1 ] ).to.deep.equal(
-						{ query: 'search query', cursor: 'cursor' }
-					);
-				} );
-			} );
-
-			it( 'should fetch all timeline events for any issue if they are paginated', () => {
-				const issues = [
-					{ ...issueBase, number: 1, timelineItems: {
-						nodes: [],
-						pageInfo: pageInfoWithNextPage
-					} }
-				];
-
-				sinon.stub( githubRepository, 'getIssueOrPullRequestTimelineItems' ).resolves( [] );
-
-				stubs.GraphQLClient.request.resolves( {
-					search: {
-						issueCount: issues.length,
-						nodes: issues,
-						pageInfo: pageInfoNoNextPage
-					}
-				} );
-
-				return githubRepository.searchStaleIssuesOrPullRequests( optionsBase, onProgress ).then( () => {
-					expect( githubRepository.getIssueOrPullRequestTimelineItems.callCount ).to.equal( 1 );
-
-					expect( githubRepository.getIssueOrPullRequestTimelineItems.getCall( 0 ).args[ 0 ] ).to.equal( 'IssueId' );
-					expect( githubRepository.getIssueOrPullRequestTimelineItems.getCall( 0 ).args[ 1 ] ).to.deep.equal( {
-						hasNextPage: true,
-						cursor: 'cursor'
-					} );
-				} );
-			} );
-
-			it( 'should ask for a new search query with new offset if GitHub prevents going to the next page', () => {
-				const issues = [
-					{ ...issueBase, number: 1, createdAt: '2022-11-01T09:00:00Z' },
-					{ ...issueBase, number: 2, createdAt: '2022-10-01T09:00:00Z' },
-					{ ...issueBase, number: 3, createdAt: '2022-09-01T09:00:00Z' }
-				];
-
-				paginateRequest( issues, ( { nodes } ) => {
-					return {
-						search: {
-							issueCount: issues.length,
-							nodes,
-							pageInfo: pageInfoNoNextPage
-						}
-					};
-				} );
-
-				return githubRepository.searchStaleIssuesOrPullRequests( optionsBase, onProgress ).then( () => {
-					expect( stubs.prepareSearchQuery.callCount ).to.equal( 3 );
-					expect( stubs.prepareSearchQuery.getCall( 0 ).args[ 0 ] ).to.have.property( 'searchDate', '2022-12-01' );
-					expect( stubs.prepareSearchQuery.getCall( 1 ).args[ 0 ] ).to.have.property( 'searchDate', '2022-11-01T09:00:00Z' );
-					expect( stubs.prepareSearchQuery.getCall( 2 ).args[ 0 ] ).to.have.property( 'searchDate', '2022-10-01T09:00:00Z' );
-				} );
-			} );
-
-			it( 'should return all stale issues if GitHub prevents going to the next page', () => {
-				const issues = [
-					{ ...issueBase, number: 1 },
-					{ ...issueBase, number: 2 },
-					{ ...issueBase, number: 3 }
-				];
-
-				paginateRequest( issues, ( { nodes } ) => {
-					return {
-						search: {
-							issueCount: issues.length,
-							nodes,
-							pageInfo: pageInfoNoNextPage
-						}
-					};
-				} );
-
-				return githubRepository.searchStaleIssuesOrPullRequests( optionsBase, onProgress ).then( result => {
-					expect( result ).to.have.property( 'issuesOrPullRequestsToClose' );
-					expect( result ).to.have.property( 'issuesOrPullRequestsToUnstale' );
-
-					expect( result.issuesOrPullRequestsToClose ).to.be.an( 'array' );
-					expect( result.issuesOrPullRequestsToClose ).to.have.length( 3 );
-					expect( result.issuesOrPullRequestsToClose[ 0 ] ).to.deep.equal(
-						{ id: 'IssueId', type: 'Issue', title: 'IssueTitle', url: 'https://github.com/' }
-					);
-					expect( result.issuesOrPullRequestsToClose[ 1 ] ).to.deep.equal(
-						{ id: 'IssueId', type: 'Issue', title: 'IssueTitle', url: 'https://github.com/' }
-					);
-					expect( result.issuesOrPullRequestsToClose[ 2 ] ).to.deep.equal(
-						{ id: 'IssueId', type: 'Issue', title: 'IssueTitle', url: 'https://github.com/' }
-					);
-
-					expect( result.issuesOrPullRequestsToUnstale ).to.be.an( 'array' );
-					expect( result.issuesOrPullRequestsToUnstale ).to.have.length( 3 );
-					expect( result.issuesOrPullRequestsToUnstale[ 0 ] ).to.deep.equal(
-						{ id: 'IssueId', type: 'Issue', title: 'IssueTitle', url: 'https://github.com/' }
-					);
-					expect( result.issuesOrPullRequestsToUnstale[ 1 ] ).to.deep.equal(
-						{ id: 'IssueId', type: 'Issue', title: 'IssueTitle', url: 'https://github.com/' }
-					);
-					expect( result.issuesOrPullRequestsToUnstale[ 2 ] ).to.deep.equal(
-						{ id: 'IssueId', type: 'Issue', title: 'IssueTitle', url: 'https://github.com/' }
-					);
-				} );
-			} );
-
-			it( 'should check each issue if it should be unstaled or closed', () => {
-				const issues = [
-					{ ...issueBase, number: 1 },
-					{ ...issueBase, number: 2 },
-					{ ...issueBase, number: 3 }
-				];
-
-				stubs.GraphQLClient.request.resolves( {
-					search: {
-						issueCount: issues.length,
-						nodes: issues,
-						pageInfo: pageInfoNoNextPage
-					}
-				} );
-
-				stubs.isIssueOrPullRequestToUnstale.onCall( 1 ).returns( false );
-				stubs.isIssueOrPullRequestToClose.onCall( 1 ).returns( false );
-
-				return githubRepository.searchStaleIssuesOrPullRequests( optionsBase, onProgress ).then( result => {
-					const expectedIssue = {
-						...issueBase,
-						lastReactedAt: null,
-						timelineItems: []
-					};
-
-					expect( stubs.isIssueOrPullRequestToUnstale.callCount ).to.equal( 3 );
-
-					expect( stubs.isIssueOrPullRequestToUnstale.getCall( 0 ).args[ 0 ] ).to.deep.equal( { ...expectedIssue, number: 1 } );
-					expect( stubs.isIssueOrPullRequestToUnstale.getCall( 0 ).args[ 1 ] ).to.deep.equal( optionsBase );
-
-					expect( stubs.isIssueOrPullRequestToUnstale.getCall( 1 ).args[ 0 ] ).to.deep.equal( { ...expectedIssue, number: 2 } );
-					expect( stubs.isIssueOrPullRequestToUnstale.getCall( 1 ).args[ 1 ] ).to.deep.equal( optionsBase );
-
-					expect( stubs.isIssueOrPullRequestToUnstale.getCall( 2 ).args[ 0 ] ).to.deep.equal( { ...expectedIssue, number: 3 } );
-					expect( stubs.isIssueOrPullRequestToUnstale.getCall( 2 ).args[ 1 ] ).to.deep.equal( optionsBase );
-
-					expect( stubs.isIssueOrPullRequestToClose.callCount ).to.equal( 3 );
-
-					expect( stubs.isIssueOrPullRequestToClose.getCall( 0 ).args[ 0 ] ).to.deep.equal( { ...expectedIssue, number: 1 } );
-					expect( stubs.isIssueOrPullRequestToClose.getCall( 0 ).args[ 1 ] ).to.deep.equal( optionsBase );
-
-					expect( stubs.isIssueOrPullRequestToClose.getCall( 1 ).args[ 0 ] ).to.deep.equal( { ...expectedIssue, number: 2 } );
-					expect( stubs.isIssueOrPullRequestToClose.getCall( 1 ).args[ 1 ] ).to.deep.equal( optionsBase );
-
-					expect( stubs.isIssueOrPullRequestToClose.getCall( 2 ).args[ 0 ] ).to.deep.equal( { ...expectedIssue, number: 3 } );
-					expect( stubs.isIssueOrPullRequestToClose.getCall( 2 ).args[ 1 ] ).to.deep.equal( optionsBase );
-
-					expect( result.issuesOrPullRequestsToUnstale ).to.be.an( 'array' );
-					expect( result.issuesOrPullRequestsToUnstale ).to.have.length( 2 );
-					expect( result.issuesOrPullRequestsToClose ).to.be.an( 'array' );
-					expect( result.issuesOrPullRequestsToClose ).to.have.length( 2 );
-				} );
-			} );
-
-			it( 'should call on progress callback', () => {
-				const issues = [
-					{ ...issueBase, number: 1 },
-					{ ...issueBase, number: 2 },
-					{ ...issueBase, number: 3 }
-				];
-
-				paginateRequest( issues, ( { nodes, pageInfo } ) => {
-					return {
-						search: {
-							issueCount: issues.length,
-							nodes,
-							pageInfo
-						}
-					};
-				} );
-
-				return githubRepository.searchStaleIssuesOrPullRequests( optionsBase, onProgress ).then( () => {
-					expect( onProgress.callCount ).to.equal( 3 );
-
-					expect( onProgress.getCall( 0 ).args[ 0 ] ).to.deep.equal( { done: 1, total: 3 } );
-					expect( onProgress.getCall( 1 ).args[ 0 ] ).to.deep.equal( { done: 2, total: 3 } );
-					expect( onProgress.getCall( 2 ).args[ 0 ] ).to.deep.equal( { done: 3, total: 3 } );
-				} );
-			} );
-
-			it( 'should count total hits only once using the value from first response', () => {
-				const issues = [
-					{ ...issueBase, number: 1 },
-					{ ...issueBase, number: 2 },
-					{ ...issueBase, number: 3 }
-				];
-
-				paginateRequest( issues, ( { nodes, pageInfo, entryIndex } ) => {
-					return {
-						search: {
-							issueCount: issues.length - entryIndex,
-							nodes,
-							pageInfo
-						}
-					};
-				} );
-
-				return githubRepository.searchStaleIssuesOrPullRequests( optionsBase, onProgress ).then( () => {
-					expect( onProgress.callCount ).to.equal( 3 );
-
-					expect( onProgress.getCall( 0 ).args[ 0 ] ).to.deep.equal( { done: 1, total: 3 } );
-					expect( onProgress.getCall( 1 ).args[ 0 ] ).to.deep.equal( { done: 2, total: 3 } );
-					expect( onProgress.getCall( 2 ).args[ 0 ] ).to.deep.equal( { done: 3, total: 3 } );
-				} );
-			} );
-
-			it( 'should reject if request failed', () => {
-				stubs.GraphQLClient.request.rejects( new Error( '500 Internal Server Error' ) );
-
-				return githubRepository.searchStaleIssuesOrPullRequests( optionsBase, onProgress ).then(
-					() => {
-						throw new Error( 'Expected to be rejected.' );
-					},
-					() => {
-						return Promise.resolve();
-					}
-				);
-			} );
-
-			it( 'should reject if subsequent request failed', () => {
-				const issues = [
-					{ ...issueBase, number: 1 },
-					{ ...issueBase, number: 2 },
-					{ ...issueBase, number: 3 }
-				];
-
-				paginateRequest( issues, ( { nodes, pageInfo } ) => {
-					return {
-						search: {
-							issueCount: issues.length,
-							nodes,
-							pageInfo
-						}
-					};
-				} );
-
-				stubs.GraphQLClient.request.onCall( 2 ).rejects( new Error( '500 Internal Server Error' ) );
-
-				return githubRepository.searchStaleIssuesOrPullRequests( optionsBase, onProgress ).then(
-					() => {
-						throw new Error( 'Expected to be rejected.' );
-					},
-					() => {
-						return Promise.resolve();
-					}
-				);
-			} );
-
-			it( 'should log an error if request failed', () => {
-				const error = new Error( '500 Internal Server Error' );
-
-				stubs.GraphQLClient.request.rejects( error );
-
-				return githubRepository.searchStaleIssuesOrPullRequests( optionsBase, onProgress ).then(
-					() => {
-						throw new Error( 'Expected to be rejected.' );
-					},
-					() => {
-						expect( stubs.logger.error.callCount ).to.equal( 1 );
-						expect( stubs.logger.error.getCall( 0 ).args[ 0 ] ).to.equal(
-							'Unexpected error when executing "#searchStaleIssuesOrPullRequests()".'
+						expect( result[ 1 ] ).to.deep.equal(
+							{ id: 'IssueId', title: 'IssueTitle', type: 'Issue', url: 'https://github.com/' }
 						);
-						expect( stubs.logger.error.getCall( 0 ).args[ 1 ] ).to.equal( error );
-					}
-				);
+						expect( result[ 2 ] ).to.deep.equal(
+							{ id: 'IssueId', title: 'IssueTitle', type: 'Issue', url: 'https://github.com/' }
+						);
+					} );
+				} );
+
+				it( 'should return all issues to stale if they are paginated', () => {
+					const issues = [
+						{ ...issueBase, number: 1 },
+						{ ...issueBase, number: 2 },
+						{ ...issueBase, number: 3 }
+					];
+
+					paginateRequest( issues, ( { nodes, pageInfo } ) => {
+						return {
+							search: {
+								issueCount: issues.length,
+								nodes,
+								pageInfo
+							}
+						};
+					} );
+
+					return githubRepository.searchIssuesOrPullRequestsToStale( 'Issue', optionsBase, onProgress ).then( result => {
+						expect( result ).to.be.an( 'array' );
+						expect( result ).to.have.length( 3 );
+						expect( result[ 0 ] ).to.deep.equal(
+							{ id: 'IssueId', title: 'IssueTitle', type: 'Issue', url: 'https://github.com/' }
+						);
+						expect( result[ 1 ] ).to.deep.equal(
+							{ id: 'IssueId', title: 'IssueTitle', type: 'Issue', url: 'https://github.com/' }
+						);
+						expect( result[ 2 ] ).to.deep.equal(
+							{ id: 'IssueId', title: 'IssueTitle', type: 'Issue', url: 'https://github.com/' }
+						);
+					} );
+				} );
+
+				it( 'should send one request for all issues to stale if they are not paginated', () => {
+					const issues = [
+						{ ...issueBase, number: 1 },
+						{ ...issueBase, number: 2 },
+						{ ...issueBase, number: 3 }
+					];
+
+					stubs.GraphQLClient.request.resolves( {
+						search: {
+							issueCount: issues.length,
+							nodes: issues,
+							pageInfo: pageInfoNoNextPage
+						}
+					} );
+
+					return githubRepository.searchIssuesOrPullRequestsToStale( 'Issue', optionsBase, onProgress ).then( () => {
+						expect( stubs.GraphQLClient.request.calledOnce ).to.equal( true );
+						expect( stubs.GraphQLClient.request.getCall( 0 ).args[ 0 ] ).to.equal( 'query SearchIssuesOrPullRequests' );
+						expect( stubs.GraphQLClient.request.getCall( 0 ).args[ 1 ] ).to.deep.equal(
+							{ query: 'search query', cursor: null }
+						);
+					} );
+				} );
+
+				it( 'should send multiple requests for all issues to stale if they are paginated', () => {
+					const issues = [
+						{ ...issueBase, number: 1 },
+						{ ...issueBase, number: 2 },
+						{ ...issueBase, number: 3 }
+					];
+
+					paginateRequest( issues, ( { nodes, pageInfo } ) => {
+						return {
+							search: {
+								issueCount: issues.length,
+								nodes,
+								pageInfo
+							}
+						};
+					} );
+
+					return githubRepository.searchIssuesOrPullRequestsToStale( 'Issue', optionsBase, onProgress ).then( () => {
+						expect( stubs.GraphQLClient.request.callCount ).to.equal( 3 );
+
+						expect( stubs.GraphQLClient.request.getCall( 0 ).args[ 0 ] ).to.equal( 'query SearchIssuesOrPullRequests' );
+						expect( stubs.GraphQLClient.request.getCall( 0 ).args[ 1 ] ).to.deep.equal(
+							{ query: 'search query', cursor: null }
+						);
+
+						expect( stubs.GraphQLClient.request.getCall( 1 ).args[ 0 ] ).to.equal( 'query SearchIssuesOrPullRequests' );
+						expect( stubs.GraphQLClient.request.getCall( 1 ).args[ 1 ] ).to.deep.equal(
+							{ query: 'search query', cursor: 'cursor' }
+						);
+
+						expect( stubs.GraphQLClient.request.getCall( 2 ).args[ 0 ] ).to.equal( 'query SearchIssuesOrPullRequests' );
+						expect( stubs.GraphQLClient.request.getCall( 2 ).args[ 1 ] ).to.deep.equal(
+							{ query: 'search query', cursor: 'cursor' }
+						);
+					} );
+				} );
+
+				it( 'should fetch all timeline events for any issue if they are paginated', () => {
+					const issues = [
+						{ ...issueBase, number: 1, timelineItems: {
+							nodes: [],
+							pageInfo: pageInfoWithNextPage
+						} }
+					];
+
+					sinon.stub( githubRepository, 'getIssueOrPullRequestTimelineItems' ).resolves( [] );
+
+					stubs.GraphQLClient.request.resolves( {
+						search: {
+							issueCount: issues.length,
+							nodes: issues,
+							pageInfo: pageInfoNoNextPage
+						}
+					} );
+
+					return githubRepository.searchIssuesOrPullRequestsToStale( 'Issue', optionsBase, onProgress ).then( () => {
+						expect( githubRepository.getIssueOrPullRequestTimelineItems.callCount ).to.equal( 1 );
+
+						expect( githubRepository.getIssueOrPullRequestTimelineItems.getCall( 0 ).args[ 0 ] ).to.equal( 'IssueId' );
+						expect( githubRepository.getIssueOrPullRequestTimelineItems.getCall( 0 ).args[ 1 ] ).to.deep.equal( {
+							hasNextPage: true,
+							cursor: 'cursor'
+						} );
+					} );
+				} );
+
+				it( 'should ask for a new search query with new offset if GitHub prevents going to the next page', () => {
+					const issues = [
+						{ ...issueBase, number: 1, createdAt: '2022-11-01T09:00:00Z' },
+						{ ...issueBase, number: 2, createdAt: '2022-10-01T09:00:00Z' },
+						{ ...issueBase, number: 3, createdAt: '2022-09-01T09:00:00Z' }
+					];
+
+					paginateRequest( issues, ( { nodes } ) => {
+						return {
+							search: {
+								issueCount: issues.length,
+								nodes,
+								pageInfo: pageInfoNoNextPage
+							}
+						};
+					} );
+
+					return githubRepository.searchIssuesOrPullRequestsToStale( 'Issue', optionsBase, onProgress ).then( () => {
+						expect( stubs.prepareSearchQuery.callCount ).to.equal( 3 );
+						expect( stubs.prepareSearchQuery.getCall( 0 ).args[ 0 ] ).to.have.property( 'searchDate', '2022-12-01' );
+						expect( stubs.prepareSearchQuery.getCall( 1 ).args[ 0 ] ).to.have.property( 'searchDate', '2022-11-01T09:00:00Z' );
+						expect( stubs.prepareSearchQuery.getCall( 2 ).args[ 0 ] ).to.have.property( 'searchDate', '2022-10-01T09:00:00Z' );
+					} );
+				} );
+
+				it( 'should return all issues to stale if GitHub prevents going to the next page', () => {
+					const issues = [
+						{ ...issueBase, number: 1 },
+						{ ...issueBase, number: 2 },
+						{ ...issueBase, number: 3 }
+					];
+
+					paginateRequest( issues, ( { nodes } ) => {
+						return {
+							search: {
+								issueCount: issues.length,
+								nodes,
+								pageInfo: pageInfoNoNextPage
+							}
+						};
+					} );
+
+					return githubRepository.searchIssuesOrPullRequestsToStale( 'Issue', optionsBase, onProgress ).then( result => {
+						expect( result ).to.be.an( 'array' );
+						expect( result ).to.have.length( 3 );
+						expect( result[ 0 ] ).to.deep.equal(
+							{ id: 'IssueId', title: 'IssueTitle', type: 'Issue', url: 'https://github.com/' }
+						);
+						expect( result[ 1 ] ).to.deep.equal(
+							{ id: 'IssueId', title: 'IssueTitle', type: 'Issue', url: 'https://github.com/' }
+						);
+						expect( result[ 2 ] ).to.deep.equal(
+							{ id: 'IssueId', title: 'IssueTitle', type: 'Issue', url: 'https://github.com/' }
+						);
+					} );
+				} );
+
+				it( 'should check each issue if it is stale', () => {
+					const issues = [
+						{ ...issueBase, number: 1 },
+						{ ...issueBase, number: 2 },
+						{ ...issueBase, number: 3 }
+					];
+
+					stubs.GraphQLClient.request.resolves( {
+						search: {
+							issueCount: issues.length,
+							nodes: issues,
+							pageInfo: pageInfoNoNextPage
+						}
+					} );
+
+					stubs.isIssueOrPullRequestToStale.onCall( 1 ).returns( false );
+
+					return githubRepository.searchIssuesOrPullRequestsToStale( 'Issue', optionsBase, onProgress ).then( result => {
+						const expectedIssue = {
+							...issueBase,
+							lastReactedAt: null,
+							timelineItems: []
+						};
+
+						expect( stubs.isIssueOrPullRequestToStale.callCount ).to.equal( 3 );
+
+						expect( stubs.isIssueOrPullRequestToStale.getCall( 0 ).args[ 0 ] ).to.deep.equal( { ...expectedIssue, number: 1 } );
+						expect( stubs.isIssueOrPullRequestToStale.getCall( 0 ).args[ 1 ] ).to.deep.equal( optionsBase );
+
+						expect( stubs.isIssueOrPullRequestToStale.getCall( 1 ).args[ 0 ] ).to.deep.equal( { ...expectedIssue, number: 2 } );
+						expect( stubs.isIssueOrPullRequestToStale.getCall( 1 ).args[ 1 ] ).to.deep.equal( optionsBase );
+
+						expect( stubs.isIssueOrPullRequestToStale.getCall( 2 ).args[ 0 ] ).to.deep.equal( { ...expectedIssue, number: 3 } );
+						expect( stubs.isIssueOrPullRequestToStale.getCall( 2 ).args[ 1 ] ).to.deep.equal( optionsBase );
+
+						expect( result ).to.be.an( 'array' );
+						expect( result ).to.have.length( 2 );
+					} );
+				} );
+
+				it( 'should call on progress callback', () => {
+					const issues = [
+						{ ...issueBase, number: 1 },
+						{ ...issueBase, number: 2 },
+						{ ...issueBase, number: 3 }
+					];
+
+					paginateRequest( issues, ( { nodes, pageInfo } ) => {
+						return {
+							search: {
+								issueCount: issues.length,
+								nodes,
+								pageInfo
+							}
+						};
+					} );
+
+					return githubRepository.searchIssuesOrPullRequestsToStale( 'Issue', optionsBase, onProgress ).then( () => {
+						expect( onProgress.callCount ).to.equal( 3 );
+
+						expect( onProgress.getCall( 0 ).args[ 0 ] ).to.deep.equal( { done: 1, total: 3 } );
+						expect( onProgress.getCall( 1 ).args[ 0 ] ).to.deep.equal( { done: 2, total: 3 } );
+						expect( onProgress.getCall( 2 ).args[ 0 ] ).to.deep.equal( { done: 3, total: 3 } );
+					} );
+				} );
+
+				it( 'should count total hits only once using the value from first response', () => {
+					const issues = [
+						{ ...issueBase, number: 1 },
+						{ ...issueBase, number: 2 },
+						{ ...issueBase, number: 3 }
+					];
+
+					paginateRequest( issues, ( { nodes, pageInfo, entryIndex } ) => {
+						return {
+							search: {
+								issueCount: issues.length - entryIndex,
+								nodes,
+								pageInfo
+							}
+						};
+					} );
+
+					return githubRepository.searchIssuesOrPullRequestsToStale( 'Issue', optionsBase, onProgress ).then( () => {
+						expect( onProgress.callCount ).to.equal( 3 );
+
+						expect( onProgress.getCall( 0 ).args[ 0 ] ).to.deep.equal( { done: 1, total: 3 } );
+						expect( onProgress.getCall( 1 ).args[ 0 ] ).to.deep.equal( { done: 2, total: 3 } );
+						expect( onProgress.getCall( 2 ).args[ 0 ] ).to.deep.equal( { done: 3, total: 3 } );
+					} );
+				} );
+
+				it( 'should reject if request failed', () => {
+					stubs.GraphQLClient.request.rejects( new Error( '500 Internal Server Error' ) );
+
+					return githubRepository.searchIssuesOrPullRequestsToStale( 'Issue', optionsBase, onProgress ).then(
+						() => {
+							throw new Error( 'Expected to be rejected.' );
+						},
+						() => {
+							return Promise.resolve();
+						}
+					);
+				} );
+
+				it( 'should reject if subsequent request failed', () => {
+					const issues = [
+						{ ...issueBase, number: 1 },
+						{ ...issueBase, number: 2 },
+						{ ...issueBase, number: 3 }
+					];
+
+					paginateRequest( issues, ( { nodes, pageInfo } ) => {
+						return {
+							search: {
+								issueCount: issues.length,
+								nodes,
+								pageInfo
+							}
+						};
+					} );
+
+					stubs.GraphQLClient.request.onCall( 2 ).rejects( new Error( '500 Internal Server Error' ) );
+
+					return githubRepository.searchIssuesOrPullRequestsToStale( 'Issue', optionsBase, onProgress ).then(
+						() => {
+							throw new Error( 'Expected to be rejected.' );
+						},
+						() => {
+							return Promise.resolve();
+						}
+					);
+				} );
+
+				it( 'should log an error if request failed', () => {
+					const error = new Error( '500 Internal Server Error' );
+
+					stubs.GraphQLClient.request.rejects( error );
+
+					return githubRepository.searchIssuesOrPullRequestsToStale( 'Issue', optionsBase, onProgress ).then(
+						() => {
+							throw new Error( 'Expected to be rejected.' );
+						},
+						() => {
+							expect( stubs.logger.error.callCount ).to.equal( 1 );
+							expect( stubs.logger.error.getCall( 0 ).args[ 0 ] ).to.equal(
+								'Unexpected error when executing "#searchIssuesOrPullRequestsToStale()".'
+							);
+							expect( stubs.logger.error.getCall( 0 ).args[ 1 ] ).to.equal( error );
+						}
+					);
+				} );
+			} );
+
+			describe( '#searchStaleIssuesOrPullRequests()', () => {
+				it( 'should be a function', () => {
+					expect( githubRepository.searchStaleIssuesOrPullRequests ).to.be.a( 'function' );
+				} );
+
+				it( 'should ask for search query', () => {
+					const issues = [
+						{ ...issueBase, number: 1 },
+						{ ...issueBase, number: 2 },
+						{ ...issueBase, number: 3 }
+					];
+
+					stubs.GraphQLClient.request.resolves( {
+						search: {
+							issueCount: issues.length,
+							nodes: issues,
+							pageInfo: pageInfoNoNextPage
+						}
+					} );
+
+					return githubRepository.searchStaleIssuesOrPullRequests( optionsBase, onProgress ).then( () => {
+						expect( stubs.prepareSearchQuery.calledOnce ).to.equal( true );
+						expect( stubs.prepareSearchQuery.getCall( 0 ).args[ 0 ] ).to.deep.equal( {
+							searchDate: '2022-12-01',
+							repositorySlug: 'ckeditor/ckeditor5',
+							labels: [ 'status:stale' ]
+						} );
+					} );
+				} );
+
+				it( 'should start the search from stale date if search date is not set', () => {
+					const options = {
+						...optionsBase,
+						searchDate: undefined,
+						staleDate: '2023-01-01'
+					};
+
+					stubs.GraphQLClient.request.resolves( {
+						search: {
+							issueCount: 0,
+							nodes: [],
+							pageInfo: pageInfoNoNextPage
+						}
+					} );
+
+					return githubRepository.searchStaleIssuesOrPullRequests( options, onProgress ).then( () => {
+						expect( stubs.prepareSearchQuery.calledOnce ).to.equal( true );
+						expect( stubs.prepareSearchQuery.getCall( 0 ).args[ 0 ] ).to.have.property( 'searchDate', '2023-01-01' );
+					} );
+				} );
+
+				it( 'should return all stale issues if they are not paginated', () => {
+					const issues = [
+						{ ...issueBase, number: 1 },
+						{ ...issueBase, number: 2 },
+						{ ...issueBase, number: 3 }
+					];
+
+					stubs.GraphQLClient.request.resolves( {
+						search: {
+							issueCount: issues.length,
+							nodes: issues,
+							pageInfo: pageInfoNoNextPage
+						}
+					} );
+
+					return githubRepository.searchStaleIssuesOrPullRequests( optionsBase, onProgress ).then( result => {
+						expect( result ).to.have.property( 'issuesOrPullRequestsToClose' );
+						expect( result ).to.have.property( 'issuesOrPullRequestsToUnstale' );
+
+						expect( result.issuesOrPullRequestsToClose ).to.be.an( 'array' );
+						expect( result.issuesOrPullRequestsToClose ).to.have.length( 3 );
+						expect( result.issuesOrPullRequestsToClose[ 0 ] ).to.deep.equal(
+							{ id: 'IssueId', type: 'Issue', title: 'IssueTitle', url: 'https://github.com/' }
+						);
+						expect( result.issuesOrPullRequestsToClose[ 1 ] ).to.deep.equal(
+							{ id: 'IssueId', type: 'Issue', title: 'IssueTitle', url: 'https://github.com/' }
+						);
+						expect( result.issuesOrPullRequestsToClose[ 2 ] ).to.deep.equal(
+							{ id: 'IssueId', type: 'Issue', title: 'IssueTitle', url: 'https://github.com/' }
+						);
+
+						expect( result.issuesOrPullRequestsToUnstale ).to.be.an( 'array' );
+						expect( result.issuesOrPullRequestsToUnstale ).to.have.length( 3 );
+						expect( result.issuesOrPullRequestsToUnstale[ 0 ] ).to.deep.equal(
+							{ id: 'IssueId', type: 'Issue', title: 'IssueTitle', url: 'https://github.com/' }
+						);
+						expect( result.issuesOrPullRequestsToUnstale[ 1 ] ).to.deep.equal(
+							{ id: 'IssueId', type: 'Issue', title: 'IssueTitle', url: 'https://github.com/' }
+						);
+						expect( result.issuesOrPullRequestsToUnstale[ 2 ] ).to.deep.equal(
+							{ id: 'IssueId', type: 'Issue', title: 'IssueTitle', url: 'https://github.com/' }
+						);
+					} );
+				} );
+
+				it( 'should return all stale issues if they are paginated', () => {
+					const issues = [
+						{ ...issueBase, number: 1 },
+						{ ...issueBase, number: 2 },
+						{ ...issueBase, number: 3 }
+					];
+
+					paginateRequest( issues, ( { nodes, pageInfo } ) => {
+						return {
+							search: {
+								issueCount: issues.length,
+								nodes,
+								pageInfo
+							}
+						};
+					} );
+
+					return githubRepository.searchStaleIssuesOrPullRequests( optionsBase, onProgress ).then( result => {
+						expect( result ).to.have.property( 'issuesOrPullRequestsToClose' );
+						expect( result ).to.have.property( 'issuesOrPullRequestsToUnstale' );
+
+						expect( result.issuesOrPullRequestsToClose ).to.be.an( 'array' );
+						expect( result.issuesOrPullRequestsToClose ).to.have.length( 3 );
+						expect( result.issuesOrPullRequestsToClose[ 0 ] ).to.deep.equal(
+							{ id: 'IssueId', type: 'Issue', title: 'IssueTitle', url: 'https://github.com/' }
+						);
+						expect( result.issuesOrPullRequestsToClose[ 1 ] ).to.deep.equal(
+							{ id: 'IssueId', type: 'Issue', title: 'IssueTitle', url: 'https://github.com/' }
+						);
+						expect( result.issuesOrPullRequestsToClose[ 2 ] ).to.deep.equal(
+							{ id: 'IssueId', type: 'Issue', title: 'IssueTitle', url: 'https://github.com/' }
+						);
+
+						expect( result.issuesOrPullRequestsToUnstale ).to.be.an( 'array' );
+						expect( result.issuesOrPullRequestsToUnstale ).to.have.length( 3 );
+						expect( result.issuesOrPullRequestsToUnstale[ 0 ] ).to.deep.equal(
+							{ id: 'IssueId', type: 'Issue', title: 'IssueTitle', url: 'https://github.com/' }
+						);
+						expect( result.issuesOrPullRequestsToUnstale[ 1 ] ).to.deep.equal(
+							{ id: 'IssueId', type: 'Issue', title: 'IssueTitle', url: 'https://github.com/' }
+						);
+						expect( result.issuesOrPullRequestsToUnstale[ 2 ] ).to.deep.equal(
+							{ id: 'IssueId', type: 'Issue', title: 'IssueTitle', url: 'https://github.com/' }
+						);
+					} );
+				} );
+
+				it( 'should send one request for all stale issues if they are not paginated', () => {
+					const issues = [
+						{ ...issueBase, number: 1 },
+						{ ...issueBase, number: 2 },
+						{ ...issueBase, number: 3 }
+					];
+
+					stubs.GraphQLClient.request.resolves( {
+						search: {
+							issueCount: issues.length,
+							nodes: issues,
+							pageInfo: pageInfoNoNextPage
+						}
+					} );
+
+					return githubRepository.searchStaleIssuesOrPullRequests( optionsBase, onProgress ).then( () => {
+						expect( stubs.GraphQLClient.request.calledOnce ).to.equal( true );
+						expect( stubs.GraphQLClient.request.getCall( 0 ).args[ 0 ] ).to.equal( 'query SearchIssuesOrPullRequests' );
+						expect( stubs.GraphQLClient.request.getCall( 0 ).args[ 1 ] ).to.deep.equal(
+							{ query: 'search query', cursor: null }
+						);
+					} );
+				} );
+
+				it( 'should send multiple requests for all stale issues if they are paginated', () => {
+					const issues = [
+						{ ...issueBase, number: 1 },
+						{ ...issueBase, number: 2 },
+						{ ...issueBase, number: 3 }
+					];
+
+					paginateRequest( issues, ( { nodes, pageInfo } ) => {
+						return {
+							search: {
+								issueCount: issues.length,
+								nodes,
+								pageInfo
+							}
+						};
+					} );
+
+					return githubRepository.searchStaleIssuesOrPullRequests( optionsBase, onProgress ).then( () => {
+						expect( stubs.GraphQLClient.request.callCount ).to.equal( 3 );
+
+						expect( stubs.GraphQLClient.request.getCall( 0 ).args[ 0 ] ).to.equal( 'query SearchIssuesOrPullRequests' );
+						expect( stubs.GraphQLClient.request.getCall( 0 ).args[ 1 ] ).to.deep.equal(
+							{ query: 'search query', cursor: null }
+						);
+
+						expect( stubs.GraphQLClient.request.getCall( 1 ).args[ 0 ] ).to.equal( 'query SearchIssuesOrPullRequests' );
+						expect( stubs.GraphQLClient.request.getCall( 1 ).args[ 1 ] ).to.deep.equal(
+							{ query: 'search query', cursor: 'cursor' }
+						);
+
+						expect( stubs.GraphQLClient.request.getCall( 2 ).args[ 0 ] ).to.equal( 'query SearchIssuesOrPullRequests' );
+						expect( stubs.GraphQLClient.request.getCall( 2 ).args[ 1 ] ).to.deep.equal(
+							{ query: 'search query', cursor: 'cursor' }
+						);
+					} );
+				} );
+
+				it( 'should fetch all timeline events for any issue if they are paginated', () => {
+					const issues = [
+						{ ...issueBase, number: 1, timelineItems: {
+							nodes: [],
+							pageInfo: pageInfoWithNextPage
+						} }
+					];
+
+					sinon.stub( githubRepository, 'getIssueOrPullRequestTimelineItems' ).resolves( [] );
+
+					stubs.GraphQLClient.request.resolves( {
+						search: {
+							issueCount: issues.length,
+							nodes: issues,
+							pageInfo: pageInfoNoNextPage
+						}
+					} );
+
+					return githubRepository.searchStaleIssuesOrPullRequests( optionsBase, onProgress ).then( () => {
+						expect( githubRepository.getIssueOrPullRequestTimelineItems.callCount ).to.equal( 1 );
+
+						expect( githubRepository.getIssueOrPullRequestTimelineItems.getCall( 0 ).args[ 0 ] ).to.equal( 'IssueId' );
+						expect( githubRepository.getIssueOrPullRequestTimelineItems.getCall( 0 ).args[ 1 ] ).to.deep.equal( {
+							hasNextPage: true,
+							cursor: 'cursor'
+						} );
+					} );
+				} );
+
+				it( 'should ask for a new search query with new offset if GitHub prevents going to the next page', () => {
+					const issues = [
+						{ ...issueBase, number: 1, createdAt: '2022-11-01T09:00:00Z' },
+						{ ...issueBase, number: 2, createdAt: '2022-10-01T09:00:00Z' },
+						{ ...issueBase, number: 3, createdAt: '2022-09-01T09:00:00Z' }
+					];
+
+					paginateRequest( issues, ( { nodes } ) => {
+						return {
+							search: {
+								issueCount: issues.length,
+								nodes,
+								pageInfo: pageInfoNoNextPage
+							}
+						};
+					} );
+
+					return githubRepository.searchStaleIssuesOrPullRequests( optionsBase, onProgress ).then( () => {
+						expect( stubs.prepareSearchQuery.callCount ).to.equal( 3 );
+						expect( stubs.prepareSearchQuery.getCall( 0 ).args[ 0 ] ).to.have.property( 'searchDate', '2022-12-01' );
+						expect( stubs.prepareSearchQuery.getCall( 1 ).args[ 0 ] ).to.have.property( 'searchDate', '2022-11-01T09:00:00Z' );
+						expect( stubs.prepareSearchQuery.getCall( 2 ).args[ 0 ] ).to.have.property( 'searchDate', '2022-10-01T09:00:00Z' );
+					} );
+				} );
+
+				it( 'should return all stale issues if GitHub prevents going to the next page', () => {
+					const issues = [
+						{ ...issueBase, number: 1 },
+						{ ...issueBase, number: 2 },
+						{ ...issueBase, number: 3 }
+					];
+
+					paginateRequest( issues, ( { nodes } ) => {
+						return {
+							search: {
+								issueCount: issues.length,
+								nodes,
+								pageInfo: pageInfoNoNextPage
+							}
+						};
+					} );
+
+					return githubRepository.searchStaleIssuesOrPullRequests( optionsBase, onProgress ).then( result => {
+						expect( result ).to.have.property( 'issuesOrPullRequestsToClose' );
+						expect( result ).to.have.property( 'issuesOrPullRequestsToUnstale' );
+
+						expect( result.issuesOrPullRequestsToClose ).to.be.an( 'array' );
+						expect( result.issuesOrPullRequestsToClose ).to.have.length( 3 );
+						expect( result.issuesOrPullRequestsToClose[ 0 ] ).to.deep.equal(
+							{ id: 'IssueId', type: 'Issue', title: 'IssueTitle', url: 'https://github.com/' }
+						);
+						expect( result.issuesOrPullRequestsToClose[ 1 ] ).to.deep.equal(
+							{ id: 'IssueId', type: 'Issue', title: 'IssueTitle', url: 'https://github.com/' }
+						);
+						expect( result.issuesOrPullRequestsToClose[ 2 ] ).to.deep.equal(
+							{ id: 'IssueId', type: 'Issue', title: 'IssueTitle', url: 'https://github.com/' }
+						);
+
+						expect( result.issuesOrPullRequestsToUnstale ).to.be.an( 'array' );
+						expect( result.issuesOrPullRequestsToUnstale ).to.have.length( 3 );
+						expect( result.issuesOrPullRequestsToUnstale[ 0 ] ).to.deep.equal(
+							{ id: 'IssueId', type: 'Issue', title: 'IssueTitle', url: 'https://github.com/' }
+						);
+						expect( result.issuesOrPullRequestsToUnstale[ 1 ] ).to.deep.equal(
+							{ id: 'IssueId', type: 'Issue', title: 'IssueTitle', url: 'https://github.com/' }
+						);
+						expect( result.issuesOrPullRequestsToUnstale[ 2 ] ).to.deep.equal(
+							{ id: 'IssueId', type: 'Issue', title: 'IssueTitle', url: 'https://github.com/' }
+						);
+					} );
+				} );
+
+				it( 'should check each issue if it should be unstaled or closed', () => {
+					const issues = [
+						{ ...issueBase, number: 1 },
+						{ ...issueBase, number: 2 },
+						{ ...issueBase, number: 3 }
+					];
+
+					stubs.GraphQLClient.request.resolves( {
+						search: {
+							issueCount: issues.length,
+							nodes: issues,
+							pageInfo: pageInfoNoNextPage
+						}
+					} );
+
+					stubs.isIssueOrPullRequestToUnstale.onCall( 1 ).returns( false );
+					stubs.isIssueOrPullRequestToClose.onCall( 1 ).returns( false );
+
+					return githubRepository.searchStaleIssuesOrPullRequests( optionsBase, onProgress ).then( result => {
+						const expectedIssue = {
+							...issueBase,
+							lastReactedAt: null,
+							timelineItems: []
+						};
+
+						expect( stubs.isIssueOrPullRequestToUnstale.callCount ).to.equal( 3 );
+
+						expect( stubs.isIssueOrPullRequestToUnstale.getCall( 0 ).args[ 0 ] ).to.deep.equal(
+							{ ...expectedIssue, number: 1 }
+						);
+						expect( stubs.isIssueOrPullRequestToUnstale.getCall( 0 ).args[ 1 ] ).to.deep.equal( optionsBase );
+
+						expect( stubs.isIssueOrPullRequestToUnstale.getCall( 1 ).args[ 0 ] ).to.deep.equal(
+							{ ...expectedIssue, number: 2 }
+						);
+						expect( stubs.isIssueOrPullRequestToUnstale.getCall( 1 ).args[ 1 ] ).to.deep.equal( optionsBase );
+
+						expect( stubs.isIssueOrPullRequestToUnstale.getCall( 2 ).args[ 0 ] ).to.deep.equal(
+							{ ...expectedIssue, number: 3 }
+						);
+						expect( stubs.isIssueOrPullRequestToUnstale.getCall( 2 ).args[ 1 ] ).to.deep.equal( optionsBase );
+
+						expect( stubs.isIssueOrPullRequestToClose.callCount ).to.equal( 3 );
+
+						expect( stubs.isIssueOrPullRequestToClose.getCall( 0 ).args[ 0 ] ).to.deep.equal( { ...expectedIssue, number: 1 } );
+						expect( stubs.isIssueOrPullRequestToClose.getCall( 0 ).args[ 1 ] ).to.deep.equal( optionsBase );
+
+						expect( stubs.isIssueOrPullRequestToClose.getCall( 1 ).args[ 0 ] ).to.deep.equal( { ...expectedIssue, number: 2 } );
+						expect( stubs.isIssueOrPullRequestToClose.getCall( 1 ).args[ 1 ] ).to.deep.equal( optionsBase );
+
+						expect( stubs.isIssueOrPullRequestToClose.getCall( 2 ).args[ 0 ] ).to.deep.equal( { ...expectedIssue, number: 3 } );
+						expect( stubs.isIssueOrPullRequestToClose.getCall( 2 ).args[ 1 ] ).to.deep.equal( optionsBase );
+
+						expect( result.issuesOrPullRequestsToUnstale ).to.be.an( 'array' );
+						expect( result.issuesOrPullRequestsToUnstale ).to.have.length( 2 );
+						expect( result.issuesOrPullRequestsToClose ).to.be.an( 'array' );
+						expect( result.issuesOrPullRequestsToClose ).to.have.length( 2 );
+					} );
+				} );
+
+				it( 'should call on progress callback', () => {
+					const issues = [
+						{ ...issueBase, number: 1 },
+						{ ...issueBase, number: 2 },
+						{ ...issueBase, number: 3 }
+					];
+
+					paginateRequest( issues, ( { nodes, pageInfo } ) => {
+						return {
+							search: {
+								issueCount: issues.length,
+								nodes,
+								pageInfo
+							}
+						};
+					} );
+
+					return githubRepository.searchStaleIssuesOrPullRequests( optionsBase, onProgress ).then( () => {
+						expect( onProgress.callCount ).to.equal( 3 );
+
+						expect( onProgress.getCall( 0 ).args[ 0 ] ).to.deep.equal( { done: 1, total: 3 } );
+						expect( onProgress.getCall( 1 ).args[ 0 ] ).to.deep.equal( { done: 2, total: 3 } );
+						expect( onProgress.getCall( 2 ).args[ 0 ] ).to.deep.equal( { done: 3, total: 3 } );
+					} );
+				} );
+
+				it( 'should count total hits only once using the value from first response', () => {
+					const issues = [
+						{ ...issueBase, number: 1 },
+						{ ...issueBase, number: 2 },
+						{ ...issueBase, number: 3 }
+					];
+
+					paginateRequest( issues, ( { nodes, pageInfo, entryIndex } ) => {
+						return {
+							search: {
+								issueCount: issues.length - entryIndex,
+								nodes,
+								pageInfo
+							}
+						};
+					} );
+
+					return githubRepository.searchStaleIssuesOrPullRequests( optionsBase, onProgress ).then( () => {
+						expect( onProgress.callCount ).to.equal( 3 );
+
+						expect( onProgress.getCall( 0 ).args[ 0 ] ).to.deep.equal( { done: 1, total: 3 } );
+						expect( onProgress.getCall( 1 ).args[ 0 ] ).to.deep.equal( { done: 2, total: 3 } );
+						expect( onProgress.getCall( 2 ).args[ 0 ] ).to.deep.equal( { done: 3, total: 3 } );
+					} );
+				} );
+
+				it( 'should reject if request failed', () => {
+					stubs.GraphQLClient.request.rejects( new Error( '500 Internal Server Error' ) );
+
+					return githubRepository.searchStaleIssuesOrPullRequests( optionsBase, onProgress ).then(
+						() => {
+							throw new Error( 'Expected to be rejected.' );
+						},
+						() => {
+							return Promise.resolve();
+						}
+					);
+				} );
+
+				it( 'should reject if subsequent request failed', () => {
+					const issues = [
+						{ ...issueBase, number: 1 },
+						{ ...issueBase, number: 2 },
+						{ ...issueBase, number: 3 }
+					];
+
+					paginateRequest( issues, ( { nodes, pageInfo } ) => {
+						return {
+							search: {
+								issueCount: issues.length,
+								nodes,
+								pageInfo
+							}
+						};
+					} );
+
+					stubs.GraphQLClient.request.onCall( 2 ).rejects( new Error( '500 Internal Server Error' ) );
+
+					return githubRepository.searchStaleIssuesOrPullRequests( optionsBase, onProgress ).then(
+						() => {
+							throw new Error( 'Expected to be rejected.' );
+						},
+						() => {
+							return Promise.resolve();
+						}
+					);
+				} );
+
+				it( 'should log an error if request failed', () => {
+					const error = new Error( '500 Internal Server Error' );
+
+					stubs.GraphQLClient.request.rejects( error );
+
+					return githubRepository.searchStaleIssuesOrPullRequests( optionsBase, onProgress ).then(
+						() => {
+							throw new Error( 'Expected to be rejected.' );
+						},
+						() => {
+							expect( stubs.logger.error.callCount ).to.equal( 1 );
+							expect( stubs.logger.error.getCall( 0 ).args[ 0 ] ).to.equal(
+								'Unexpected error when executing "#searchStaleIssuesOrPullRequests()".'
+							);
+							expect( stubs.logger.error.getCall( 0 ).args[ 1 ] ).to.equal( error );
+						}
+					);
+				} );
+			} );
+
+			describe( '#searchPendingIssues()', () => {
+				beforeEach( () => {
+					issueBase.labels.nodes = [
+						...optionsBase.pendingIssueLabels
+					];
+				} );
+
+				it( 'should be a function', () => {
+					expect( githubRepository.searchPendingIssues ).to.be.a( 'function' );
+				} );
+
+				it( 'should ask for search query', () => {
+					const issues = [
+						{ ...issueBase, number: 1 },
+						{ ...issueBase, number: 2 },
+						{ ...issueBase, number: 3 }
+					];
+
+					const options = {
+						...optionsBase,
+						ignoredIssueLabels: [ 'support:1', 'support:2', 'support:3' ]
+					};
+
+					stubs.GraphQLClient.request.resolves( {
+						search: {
+							issueCount: issues.length,
+							nodes: issues,
+							pageInfo: pageInfoNoNextPage
+						}
+					} );
+
+					return githubRepository.searchPendingIssues( options, onProgress ).then( () => {
+						expect( stubs.prepareSearchQuery.calledOnce ).to.equal( true );
+						expect( stubs.prepareSearchQuery.getCall( 0 ).args[ 0 ] ).to.deep.equal( {
+							type: 'Issue',
+							searchDate: undefined,
+							repositorySlug: 'ckeditor/ckeditor5',
+							labels: [ 'pending:feedback' ],
+							ignoredLabels: [ 'support:1', 'support:2', 'support:3' ]
+						} );
+					} );
+				} );
+
+				it( 'should return all pending issues if they are not paginated', () => {
+					const issues = [
+						{ ...issueBase, number: 1 },
+						{ ...issueBase, number: 2 },
+						{ ...issueBase, number: 3 }
+					];
+
+					stubs.GraphQLClient.request.resolves( {
+						search: {
+							issueCount: issues.length,
+							nodes: issues,
+							pageInfo: pageInfoNoNextPage
+						}
+					} );
+
+					return githubRepository.searchPendingIssues( optionsBase, onProgress ).then( result => {
+						expect( result ).to.have.property( 'pendingIssuesToStale' );
+						expect( result ).to.have.property( 'pendingIssuesToUnlabel' );
+
+						expect( result.pendingIssuesToStale ).to.be.an( 'array' );
+						expect( result.pendingIssuesToStale ).to.have.length( 3 );
+						expect( result.pendingIssuesToStale[ 0 ] ).to.deep.equal(
+							{ id: 'IssueId', type: 'Issue', title: 'IssueTitle', url: 'https://github.com/' }
+						);
+						expect( result.pendingIssuesToStale[ 1 ] ).to.deep.equal(
+							{ id: 'IssueId', type: 'Issue', title: 'IssueTitle', url: 'https://github.com/' }
+						);
+						expect( result.pendingIssuesToStale[ 2 ] ).to.deep.equal(
+							{ id: 'IssueId', type: 'Issue', title: 'IssueTitle', url: 'https://github.com/' }
+						);
+
+						expect( result.pendingIssuesToUnlabel ).to.be.an( 'array' );
+						expect( result.pendingIssuesToUnlabel ).to.have.length( 3 );
+						expect( result.pendingIssuesToUnlabel[ 0 ] ).to.deep.equal(
+							{ id: 'IssueId', type: 'Issue', title: 'IssueTitle', url: 'https://github.com/' }
+						);
+						expect( result.pendingIssuesToUnlabel[ 1 ] ).to.deep.equal(
+							{ id: 'IssueId', type: 'Issue', title: 'IssueTitle', url: 'https://github.com/' }
+						);
+						expect( result.pendingIssuesToUnlabel[ 2 ] ).to.deep.equal(
+							{ id: 'IssueId', type: 'Issue', title: 'IssueTitle', url: 'https://github.com/' }
+						);
+					} );
+				} );
+
+				it( 'should return all pending issues if they are paginated', () => {
+					const issues = [
+						{ ...issueBase, number: 1 },
+						{ ...issueBase, number: 2 },
+						{ ...issueBase, number: 3 }
+					];
+
+					paginateRequest( issues, ( { nodes, pageInfo } ) => {
+						return {
+							search: {
+								issueCount: issues.length,
+								nodes,
+								pageInfo
+							}
+						};
+					} );
+
+					return githubRepository.searchPendingIssues( optionsBase, onProgress ).then( result => {
+						expect( result ).to.have.property( 'pendingIssuesToStale' );
+						expect( result ).to.have.property( 'pendingIssuesToUnlabel' );
+
+						expect( result.pendingIssuesToStale ).to.be.an( 'array' );
+						expect( result.pendingIssuesToStale ).to.have.length( 3 );
+						expect( result.pendingIssuesToStale[ 0 ] ).to.deep.equal(
+							{ id: 'IssueId', type: 'Issue', title: 'IssueTitle', url: 'https://github.com/' }
+						);
+						expect( result.pendingIssuesToStale[ 1 ] ).to.deep.equal(
+							{ id: 'IssueId', type: 'Issue', title: 'IssueTitle', url: 'https://github.com/' }
+						);
+						expect( result.pendingIssuesToStale[ 2 ] ).to.deep.equal(
+							{ id: 'IssueId', type: 'Issue', title: 'IssueTitle', url: 'https://github.com/' }
+						);
+
+						expect( result.pendingIssuesToUnlabel ).to.be.an( 'array' );
+						expect( result.pendingIssuesToUnlabel ).to.have.length( 3 );
+						expect( result.pendingIssuesToUnlabel[ 0 ] ).to.deep.equal(
+							{ id: 'IssueId', type: 'Issue', title: 'IssueTitle', url: 'https://github.com/' }
+						);
+						expect( result.pendingIssuesToUnlabel[ 1 ] ).to.deep.equal(
+							{ id: 'IssueId', type: 'Issue', title: 'IssueTitle', url: 'https://github.com/' }
+						);
+						expect( result.pendingIssuesToUnlabel[ 2 ] ).to.deep.equal(
+							{ id: 'IssueId', type: 'Issue', title: 'IssueTitle', url: 'https://github.com/' }
+						);
+					} );
+				} );
+
+				it( 'should send one request for all pending issues if they are not paginated', () => {
+					const issues = [
+						{ ...issueBase, number: 1 },
+						{ ...issueBase, number: 2 },
+						{ ...issueBase, number: 3 }
+					];
+
+					stubs.GraphQLClient.request.resolves( {
+						search: {
+							issueCount: issues.length,
+							nodes: issues,
+							pageInfo: pageInfoNoNextPage
+						}
+					} );
+
+					return githubRepository.searchPendingIssues( optionsBase, onProgress ).then( () => {
+						expect( stubs.GraphQLClient.request.calledOnce ).to.equal( true );
+						expect( stubs.GraphQLClient.request.getCall( 0 ).args[ 0 ] ).to.equal( 'query SearchPendingIssues' );
+						expect( stubs.GraphQLClient.request.getCall( 0 ).args[ 1 ] ).to.deep.equal(
+							{ query: 'search query', cursor: null }
+						);
+					} );
+				} );
+
+				it( 'should send multiple requests for all pending issues if they are paginated', () => {
+					const issues = [
+						{ ...issueBase, number: 1 },
+						{ ...issueBase, number: 2 },
+						{ ...issueBase, number: 3 }
+					];
+
+					paginateRequest( issues, ( { nodes, pageInfo } ) => {
+						return {
+							search: {
+								issueCount: issues.length,
+								nodes,
+								pageInfo
+							}
+						};
+					} );
+
+					return githubRepository.searchPendingIssues( optionsBase, onProgress ).then( () => {
+						expect( stubs.GraphQLClient.request.callCount ).to.equal( 3 );
+
+						expect( stubs.GraphQLClient.request.getCall( 0 ).args[ 0 ] ).to.equal( 'query SearchPendingIssues' );
+						expect( stubs.GraphQLClient.request.getCall( 0 ).args[ 1 ] ).to.deep.equal(
+							{ query: 'search query', cursor: null }
+						);
+
+						expect( stubs.GraphQLClient.request.getCall( 1 ).args[ 0 ] ).to.equal( 'query SearchPendingIssues' );
+						expect( stubs.GraphQLClient.request.getCall( 1 ).args[ 1 ] ).to.deep.equal(
+							{ query: 'search query', cursor: 'cursor' }
+						);
+
+						expect( stubs.GraphQLClient.request.getCall( 2 ).args[ 0 ] ).to.equal( 'query SearchPendingIssues' );
+						expect( stubs.GraphQLClient.request.getCall( 2 ).args[ 1 ] ).to.deep.equal(
+							{ query: 'search query', cursor: 'cursor' }
+						);
+					} );
+				} );
+
+				it( 'should ask for a new search query with new offset if GitHub prevents going to the next page', () => {
+					const issues = [
+						{ ...issueBase, number: 1, createdAt: '2022-11-01T09:00:00Z' },
+						{ ...issueBase, number: 2, createdAt: '2022-10-01T09:00:00Z' },
+						{ ...issueBase, number: 3, createdAt: '2022-09-01T09:00:00Z' }
+					];
+
+					paginateRequest( issues, ( { nodes } ) => {
+						return {
+							search: {
+								issueCount: issues.length,
+								nodes,
+								pageInfo: pageInfoNoNextPage
+							}
+						};
+					} );
+
+					return githubRepository.searchPendingIssues( optionsBase, onProgress ).then( () => {
+						expect( stubs.prepareSearchQuery.callCount ).to.equal( 3 );
+						expect( stubs.prepareSearchQuery.getCall( 0 ).args[ 0 ] ).to.have.property( 'searchDate', undefined );
+						expect( stubs.prepareSearchQuery.getCall( 1 ).args[ 0 ] ).to.have.property( 'searchDate', '2022-11-01T09:00:00Z' );
+						expect( stubs.prepareSearchQuery.getCall( 2 ).args[ 0 ] ).to.have.property( 'searchDate', '2022-10-01T09:00:00Z' );
+					} );
+				} );
+
+				it( 'should return all pending issues if GitHub prevents going to the next page', () => {
+					const issues = [
+						{ ...issueBase, number: 1 },
+						{ ...issueBase, number: 2 },
+						{ ...issueBase, number: 3 }
+					];
+
+					paginateRequest( issues, ( { nodes } ) => {
+						return {
+							search: {
+								issueCount: issues.length,
+								nodes,
+								pageInfo: pageInfoNoNextPage
+							}
+						};
+					} );
+
+					return githubRepository.searchPendingIssues( optionsBase, onProgress ).then( result => {
+						expect( result ).to.have.property( 'pendingIssuesToStale' );
+						expect( result ).to.have.property( 'pendingIssuesToUnlabel' );
+
+						expect( result.pendingIssuesToStale ).to.be.an( 'array' );
+						expect( result.pendingIssuesToStale ).to.have.length( 3 );
+						expect( result.pendingIssuesToStale[ 0 ] ).to.deep.equal(
+							{ id: 'IssueId', type: 'Issue', title: 'IssueTitle', url: 'https://github.com/' }
+						);
+						expect( result.pendingIssuesToStale[ 1 ] ).to.deep.equal(
+							{ id: 'IssueId', type: 'Issue', title: 'IssueTitle', url: 'https://github.com/' }
+						);
+						expect( result.pendingIssuesToStale[ 2 ] ).to.deep.equal(
+							{ id: 'IssueId', type: 'Issue', title: 'IssueTitle', url: 'https://github.com/' }
+						);
+
+						expect( result.pendingIssuesToUnlabel ).to.be.an( 'array' );
+						expect( result.pendingIssuesToUnlabel ).to.have.length( 3 );
+						expect( result.pendingIssuesToUnlabel[ 0 ] ).to.deep.equal(
+							{ id: 'IssueId', type: 'Issue', title: 'IssueTitle', url: 'https://github.com/' }
+						);
+						expect( result.pendingIssuesToUnlabel[ 1 ] ).to.deep.equal(
+							{ id: 'IssueId', type: 'Issue', title: 'IssueTitle', url: 'https://github.com/' }
+						);
+						expect( result.pendingIssuesToUnlabel[ 2 ] ).to.deep.equal(
+							{ id: 'IssueId', type: 'Issue', title: 'IssueTitle', url: 'https://github.com/' }
+						);
+					} );
+				} );
+
+				it( 'should check each issue if it should be staled or unlabeled', () => {
+					const commentMember = {
+						createdAt: '2022-11-30T23:59:59Z',
+						authorAssociation: 'MEMBER'
+					};
+
+					const commentNonMember = {
+						createdAt: '2022-11-30T23:59:59Z',
+						authorAssociation: 'CONTRIBUTOR'
+					};
+
+					const issues = [
+						{ ...issueBase, number: 1, comments: { nodes: [ commentMember ] } },
+						{ ...issueBase, number: 2, comments: { nodes: [ commentMember ] } },
+						{ ...issueBase, number: 3, comments: { nodes: [ commentNonMember ] } }
+					];
+
+					stubs.GraphQLClient.request.resolves( {
+						search: {
+							issueCount: issues.length,
+							nodes: issues,
+							pageInfo: pageInfoNoNextPage
+						}
+					} );
+
+					stubs.isPendingIssueToStale.onCall( 1 ).returns( false );
+					stubs.isPendingIssueToUnlabel.onCall( 1 ).returns( false );
+
+					return githubRepository.searchPendingIssues( optionsBase, onProgress ).then( result => {
+						expect( stubs.isPendingIssueToStale.callCount ).to.equal( 3 );
+
+						expect( stubs.isPendingIssueToStale.getCall( 0 ).args[ 0 ] ).to.have.deep.property( 'lastComment', {
+							createdAt: '2022-11-30T23:59:59Z', isExternal: false
+						} );
+						expect( stubs.isPendingIssueToStale.getCall( 0 ).args[ 1 ] ).to.deep.equal( optionsBase );
+
+						expect( stubs.isPendingIssueToStale.getCall( 1 ).args[ 0 ] ).to.have.deep.property( 'lastComment', {
+							createdAt: '2022-11-30T23:59:59Z', isExternal: false
+						} );
+						expect( stubs.isPendingIssueToStale.getCall( 1 ).args[ 1 ] ).to.deep.equal( optionsBase );
+
+						expect( stubs.isPendingIssueToStale.getCall( 2 ).args[ 0 ] ).to.have.deep.property( 'lastComment', {
+							createdAt: '2022-11-30T23:59:59Z', isExternal: true
+						} );
+						expect( stubs.isPendingIssueToStale.getCall( 2 ).args[ 1 ] ).to.deep.equal( optionsBase );
+
+						expect( stubs.isPendingIssueToUnlabel.callCount ).to.equal( 3 );
+
+						expect( stubs.isPendingIssueToUnlabel.getCall( 0 ).args[ 0 ] ).to.have.deep.property( 'lastComment', {
+							createdAt: '2022-11-30T23:59:59Z', isExternal: false
+						} );
+						expect( stubs.isPendingIssueToUnlabel.getCall( 1 ).args[ 0 ] ).to.have.deep.property( 'lastComment', {
+							createdAt: '2022-11-30T23:59:59Z', isExternal: false
+						} );
+						expect( stubs.isPendingIssueToUnlabel.getCall( 2 ).args[ 0 ] ).to.have.deep.property( 'lastComment', {
+							createdAt: '2022-11-30T23:59:59Z', isExternal: true
+						} );
+
+						expect( result.pendingIssuesToStale ).to.be.an( 'array' );
+						expect( result.pendingIssuesToStale ).to.have.length( 2 );
+						expect( result.pendingIssuesToUnlabel ).to.be.an( 'array' );
+						expect( result.pendingIssuesToUnlabel ).to.have.length( 2 );
+					} );
+				} );
+
+				it( 'should call on progress callback', () => {
+					const issues = [
+						{ ...issueBase, number: 1 },
+						{ ...issueBase, number: 2 },
+						{ ...issueBase, number: 3 }
+					];
+
+					paginateRequest( issues, ( { nodes, pageInfo } ) => {
+						return {
+							search: {
+								issueCount: issues.length,
+								nodes,
+								pageInfo
+							}
+						};
+					} );
+
+					return githubRepository.searchPendingIssues( optionsBase, onProgress ).then( () => {
+						expect( onProgress.callCount ).to.equal( 3 );
+
+						expect( onProgress.getCall( 0 ).args[ 0 ] ).to.deep.equal( { done: 1, total: 3 } );
+						expect( onProgress.getCall( 1 ).args[ 0 ] ).to.deep.equal( { done: 2, total: 3 } );
+						expect( onProgress.getCall( 2 ).args[ 0 ] ).to.deep.equal( { done: 3, total: 3 } );
+					} );
+				} );
+
+				it( 'should count total hits only once using the value from first response', () => {
+					const issues = [
+						{ ...issueBase, number: 1 },
+						{ ...issueBase, number: 2 },
+						{ ...issueBase, number: 3 }
+					];
+
+					paginateRequest( issues, ( { nodes, pageInfo, entryIndex } ) => {
+						return {
+							search: {
+								issueCount: issues.length - entryIndex,
+								nodes,
+								pageInfo
+							}
+						};
+					} );
+
+					return githubRepository.searchPendingIssues( optionsBase, onProgress ).then( () => {
+						expect( onProgress.callCount ).to.equal( 3 );
+
+						expect( onProgress.getCall( 0 ).args[ 0 ] ).to.deep.equal( { done: 1, total: 3 } );
+						expect( onProgress.getCall( 1 ).args[ 0 ] ).to.deep.equal( { done: 2, total: 3 } );
+						expect( onProgress.getCall( 2 ).args[ 0 ] ).to.deep.equal( { done: 3, total: 3 } );
+					} );
+				} );
+
+				it( 'should reject if request failed', () => {
+					stubs.GraphQLClient.request.rejects( new Error( '500 Internal Server Error' ) );
+
+					return githubRepository.searchPendingIssues( optionsBase, onProgress ).then(
+						() => {
+							throw new Error( 'Expected to be rejected.' );
+						},
+						() => {
+							return Promise.resolve();
+						}
+					);
+				} );
+
+				it( 'should reject if subsequent request failed', () => {
+					const issues = [
+						{ ...issueBase, number: 1 },
+						{ ...issueBase, number: 2 },
+						{ ...issueBase, number: 3 }
+					];
+
+					paginateRequest( issues, ( { nodes, pageInfo } ) => {
+						return {
+							search: {
+								issueCount: issues.length,
+								nodes,
+								pageInfo
+							}
+						};
+					} );
+
+					stubs.GraphQLClient.request.onCall( 2 ).rejects( new Error( '500 Internal Server Error' ) );
+
+					return githubRepository.searchPendingIssues( optionsBase, onProgress ).then(
+						() => {
+							throw new Error( 'Expected to be rejected.' );
+						},
+						() => {
+							return Promise.resolve();
+						}
+					);
+				} );
+
+				it( 'should log an error if request failed', () => {
+					const error = new Error( '500 Internal Server Error' );
+
+					stubs.GraphQLClient.request.rejects( error );
+
+					return githubRepository.searchPendingIssues( optionsBase, onProgress ).then(
+						() => {
+							throw new Error( 'Expected to be rejected.' );
+						},
+						() => {
+							expect( stubs.logger.error.callCount ).to.equal( 1 );
+							expect( stubs.logger.error.getCall( 0 ).args[ 0 ] ).to.equal(
+								'Unexpected error when executing "#searchPendingIssues()".'
+							);
+							expect( stubs.logger.error.getCall( 0 ).args[ 1 ] ).to.equal( error );
+						}
+					);
+				} );
 			} );
 		} );
 
@@ -1397,6 +1874,13 @@ describe( 'dev-stale-bot/lib', () => {
 		describe( '#getLabels()', () => {
 			it( 'should be a function', () => {
 				expect( githubRepository.getLabels ).to.be.a( 'function' );
+			} );
+
+			it( 'should return an empty array if no labels are provided', () => {
+				return githubRepository.getLabels( 'ckeditor/ckeditor5', [] ).then( result => {
+					expect( result ).to.be.an( 'array' );
+					expect( result ).to.have.length( 0 );
+				} );
 			} );
 
 			it( 'should return labels', () => {

--- a/packages/ckeditor5-dev-stale-bot/tests/utils/ispendingissuestale.js
+++ b/packages/ckeditor5-dev-stale-bot/tests/utils/ispendingissuestale.js
@@ -1,0 +1,70 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+const expect = require( 'chai' ).expect;
+const isPendingIssueStale = require( '../../lib/utils/ispendingissuestale' );
+
+describe( 'dev-stale-bot/lib/utils', () => {
+	describe( 'isPendingIssueStale', () => {
+		it( 'should be a function', () => {
+			expect( isPendingIssueStale ).to.be.a( 'function' );
+		} );
+
+		it( 'should return false if issue does not have any label', () => {
+			const issue = {
+				labels: []
+			};
+			const options = {
+				staleLabels: [ 'pending:feedback' ]
+			};
+
+			expect( isPendingIssueStale( issue, options ) ).to.be.false;
+		} );
+
+		it( 'should return false if issue does not have a pending label', () => {
+			const issue = {
+				labels: [ 'type:bug' ]
+			};
+			const options = {
+				staleLabels: [ 'pending:feedback' ]
+			};
+
+			expect( isPendingIssueStale( issue, options ) ).to.be.false;
+		} );
+
+		it( 'should return false if issue does not have all pending labels', () => {
+			const issue = {
+				labels: [ 'type:bug', 'pending:feedback' ]
+			};
+			const options = {
+				staleLabels: [ 'pending:feedback', 'pending:even-more-feedback' ]
+			};
+
+			expect( isPendingIssueStale( issue, options ) ).to.be.false;
+		} );
+
+		it( 'should return true if issue have all pending labels - single label', () => {
+			const issue = {
+				labels: [ 'type:bug', 'pending:feedback' ]
+			};
+			const options = {
+				staleLabels: [ 'pending:feedback' ]
+			};
+
+			expect( isPendingIssueStale( issue, options ) ).to.be.true;
+		} );
+
+		it( 'should return true if issue have all pending labels - multiple labels', () => {
+			const issue = {
+				labels: [ 'type:bug', 'pending:feedback', 'pending:even-more-feedback' ]
+			};
+			const options = {
+				staleLabels: [ 'pending:feedback', 'pending:even-more-feedback' ]
+			};
+
+			expect( isPendingIssueStale( issue, options ) ).to.be.true;
+		} );
+	} );
+} );

--- a/packages/ckeditor5-dev-stale-bot/tests/utils/ispendingissuetostale.js
+++ b/packages/ckeditor5-dev-stale-bot/tests/utils/ispendingissuetostale.js
@@ -1,0 +1,90 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+const expect = require( 'chai' ).expect;
+const sinon = require( 'sinon' );
+const proxyquire = require( 'proxyquire' );
+
+describe( 'dev-stale-bot/lib/utils', () => {
+	describe( 'isPendingIssueToStale', () => {
+		let isPendingIssueToStale, issueBase, optionsBase, stubs;
+		let staleDatePendingIssue, afterStaleDatePendingIssue, beforeStaleDatePendingIssue;
+
+		beforeEach( () => {
+			staleDatePendingIssue = '2022-12-01T00:00:00Z';
+			afterStaleDatePendingIssue = '2022-12-01T00:00:01Z';
+			beforeStaleDatePendingIssue = '2022-11-30T23:59:59Z';
+
+			issueBase = {
+				lastComment: null
+			};
+
+			optionsBase = {
+				staleDatePendingIssue
+			};
+
+			stubs = {
+				isPendingIssueStale: sinon.stub()
+			};
+
+			isPendingIssueToStale = proxyquire( '../../lib/utils/ispendingissuetostale', {
+				'./ispendingissuestale': stubs.isPendingIssueStale
+			} );
+		} );
+
+		it( 'should be a function', () => {
+			expect( isPendingIssueToStale ).to.be.a( 'function' );
+		} );
+
+		it( 'should check if issue is stale', () => {
+			isPendingIssueToStale( issueBase, optionsBase );
+
+			expect( stubs.isPendingIssueStale.calledOnce ).to.equal( true );
+			expect( stubs.isPendingIssueStale.getCall( 0 ).args[ 0 ] ).to.equal( issueBase );
+			expect( stubs.isPendingIssueStale.getCall( 0 ).args[ 1 ] ).to.equal( optionsBase );
+		} );
+
+		it( 'should return false if issue is already stale', () => {
+			stubs.isPendingIssueStale.returns( true );
+
+			expect( isPendingIssueToStale( issueBase, optionsBase ) ).to.be.false;
+		} );
+
+		it( 'should return false if issue does not have any comment', () => {
+			stubs.isPendingIssueStale.returns( false );
+
+			expect( isPendingIssueToStale( issueBase, optionsBase ) ).to.be.false;
+		} );
+
+		it( 'should return false if last comment was created by a community member', () => {
+			stubs.isPendingIssueStale.returns( false );
+			issueBase.lastComment = {
+				isExternal: true
+			};
+
+			expect( isPendingIssueToStale( issueBase, optionsBase ) ).to.be.false;
+		} );
+
+		it( 'should return false if last comment was created by a team member and time to stale has not passed', () => {
+			stubs.isPendingIssueStale.returns( false );
+			issueBase.lastComment = {
+				isExternal: false,
+				createdAt: afterStaleDatePendingIssue
+			};
+
+			expect( isPendingIssueToStale( issueBase, optionsBase ) ).to.be.false;
+		} );
+
+		it( 'should return true if last comment was created by a team member and time to stale has passed', () => {
+			stubs.isPendingIssueStale.returns( false );
+			issueBase.lastComment = {
+				isExternal: false,
+				createdAt: beforeStaleDatePendingIssue
+			};
+
+			expect( isPendingIssueToStale( issueBase, optionsBase ) ).to.be.true;
+		} );
+	} );
+} );

--- a/packages/ckeditor5-dev-stale-bot/tests/utils/ispendingissuetounlabel.js
+++ b/packages/ckeditor5-dev-stale-bot/tests/utils/ispendingissuetounlabel.js
@@ -1,0 +1,43 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+const expect = require( 'chai' ).expect;
+const isPendingIssueToUnlabel = require( '../../lib/utils/ispendingissuetounlabel' );
+
+describe( 'dev-stale-bot/lib/utils', () => {
+	describe( 'isPendingIssueToUnlabel', () => {
+		it( 'should be a function', () => {
+			expect( isPendingIssueToUnlabel ).to.be.a( 'function' );
+		} );
+
+		it( 'should return false if issue does not have any comment', () => {
+			const issue = {
+				lastComment: null
+			};
+
+			expect( isPendingIssueToUnlabel( issue ) ).to.be.false;
+		} );
+
+		it( 'should return false if last comment was created by a team member', () => {
+			const issue = {
+				lastComment: {
+					isExternal: false
+				}
+			};
+
+			expect( isPendingIssueToUnlabel( issue ) ).to.be.false;
+		} );
+
+		it( 'should return true if last comment was created by a community member', () => {
+			const issue = {
+				lastComment: {
+					isExternal: true
+				}
+			};
+
+			expect( isPendingIssueToUnlabel( issue ) ).to.be.true;
+		} );
+	} );
+} );

--- a/packages/ckeditor5-dev-stale-bot/tests/utils/preparesearchquery.js
+++ b/packages/ckeditor5-dev-stale-bot/tests/utils/preparesearchquery.js
@@ -32,6 +32,10 @@ describe( 'dev-stale-bot/lib/utils', () => {
 			expect( prepareSearchQuery( { searchDate: '2022-12-01' } ) ).to.include( 'created:<2022-12-01' );
 		} );
 
+		it( 'should prepare a query without specifying a start date', () => {
+			expect( prepareSearchQuery( {} ) ).to.not.include( 'created:' );
+		} );
+
 		it( 'should prepare a query for open items', () => {
 			expect( prepareSearchQuery( {} ) ).to.include( 'state:open' );
 		} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature (stale-bot): Added support for pending issues so that they can be flagged sooner as stale ones. Closes ckeditor/ckeditor5#15697.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
