### PR TITLE
Stale bot does not remove the stale label from pending issues

### DIFF
--- a/packages/ckeditor5-dev-stale-bot/README.md
+++ b/packages/ckeditor5-dev-stale-bot/README.md
@@ -42,6 +42,7 @@ The following configuration options are supported by the stale bot:
   * the last date of changing a label.
 * `DAYS_BEFORE_STALE_PENDING_ISSUE` &ndash; Optional, 14 by default. The number of days without a comment on pending issue from a non-team member that qualifies the issue to be marked as stale.
 * `PENDING_ISSUE_LABELS` &ndash; Optional, an empty array by default. A list of labels that identify a pending issue. If empty, then pending issues are not processed.
+* `STALE_PENDING_ISSUE_MESSAGE` &ndash; Optional, set to the value from `STALE_ISSUE_MESSAGE` by default. A comment that is added on the staled pending issues.
 * `DAYS_BEFORE_CLOSE` &ndash; Optional, 30 by default. The number of days before closing the stale issues or the stale pull requests.
 * `IGNORE_VIEWER_ACTIVITY` &ndash; Optional, `true` by default. If set, the activity from the currently authenticated user is ignored.
 * `IGNORED_ISSUE_LABELS` &ndash; Optional, an empty array by default. A list of labels, whose assignment to an issue causes the issue to be ignored, even if it fits the stale criteria.

--- a/packages/ckeditor5-dev-stale-bot/bin/utils/parseconfig.js
+++ b/packages/ckeditor5-dev-stale-bot/bin/utils/parseconfig.js
@@ -24,6 +24,7 @@ module.exports = function parseConfig( viewerLogin, config ) {
 		CLOSE_ISSUE_MESSAGE,
 		CLOSE_PR_LABELS,
 		CLOSE_PR_MESSAGE,
+		STALE_PENDING_ISSUE_MESSAGE = STALE_ISSUE_MESSAGE,
 		PENDING_ISSUE_LABELS = [],
 		DAYS_BEFORE_STALE = 365,
 		DAYS_BEFORE_STALE_PENDING_ISSUE = 14,
@@ -49,6 +50,7 @@ module.exports = function parseConfig( viewerLogin, config ) {
 		shouldProcessPendingIssues: PENDING_ISSUE_LABELS.length > 0,
 		pendingIssueLabels: PENDING_ISSUE_LABELS,
 		staleIssueMessage: STALE_ISSUE_MESSAGE,
+		stalePendingIssueMessage: STALE_PENDING_ISSUE_MESSAGE,
 		stalePullRequestMessage: STALE_PR_MESSAGE,
 		closeIssueLabels: CLOSE_ISSUE_LABELS,
 		closeIssueMessage: CLOSE_ISSUE_MESSAGE,
@@ -74,6 +76,7 @@ module.exports = function parseConfig( viewerLogin, config ) {
  * @property {String} CLOSE_ISSUE_MESSAGE
  * @property {Array.<String>} CLOSE_PR_LABELS
  * @property {String} CLOSE_PR_MESSAGE
+ * @property {String} [STALE_PENDING_ISSUE_MESSAGE=STALE_ISSUE_MESSAGE]
  * @property {Array.<String>} [PENDING_ISSUE_LABELS=[]]
  * @property {Number} [DAYS_BEFORE_STALE=365]
  * @property {Number} [DAYS_BEFORE_STALE_PENDING_ISSUE=14]
@@ -95,6 +98,7 @@ module.exports = function parseConfig( viewerLogin, config ) {
  * @property {Boolean} shouldProcessPendingIssues
  * @property {Array.<String>} pendingIssueLabels
  * @property {String} staleIssueMessage
+ * @property {String} stalePendingIssueMessage
  * @property {String} stalePullRequestMessage
  * @property {Array.<String>} closeIssueLabels
  * @property {String} closeIssueMessage

--- a/packages/ckeditor5-dev-stale-bot/lib/githubrepository.js
+++ b/packages/ckeditor5-dev-stale-bot/lib/githubrepository.js
@@ -141,7 +141,7 @@ module.exports = class GitHubRepository {
 	 */
 	async searchStaleIssuesOrPullRequests( options, onProgress, pageInfo = { done: 0, total: 0 } ) {
 		const query = prepareSearchQuery( {
-			searchDate: options.searchDate || options.staleDate,
+			searchDate: options.searchDate,
 			repositorySlug: options.repositorySlug,
 			labels: options.staleLabels
 		} );

--- a/packages/ckeditor5-dev-stale-bot/tests/githubrepository.js
+++ b/packages/ckeditor5-dev-stale-bot/tests/githubrepository.js
@@ -919,14 +919,14 @@ describe( 'dev-stale-bot/lib', () => {
 					return githubRepository.searchStaleIssuesOrPullRequests( optionsBase, onProgress ).then( () => {
 						expect( stubs.prepareSearchQuery.calledOnce ).to.equal( true );
 						expect( stubs.prepareSearchQuery.getCall( 0 ).args[ 0 ] ).to.deep.equal( {
-							searchDate: '2022-12-01',
+							searchDate: undefined,
 							repositorySlug: 'ckeditor/ckeditor5',
 							labels: [ 'status:stale' ]
 						} );
 					} );
 				} );
 
-				it( 'should start the search from stale date if search date is not set', () => {
+				it( 'should not set the initial start date', () => {
 					const options = {
 						...optionsBase,
 						searchDate: undefined,
@@ -943,7 +943,7 @@ describe( 'dev-stale-bot/lib', () => {
 
 					return githubRepository.searchStaleIssuesOrPullRequests( options, onProgress ).then( () => {
 						expect( stubs.prepareSearchQuery.calledOnce ).to.equal( true );
-						expect( stubs.prepareSearchQuery.getCall( 0 ).args[ 0 ] ).to.have.property( 'searchDate', '2023-01-01' );
+						expect( stubs.prepareSearchQuery.getCall( 0 ).args[ 0 ] ).to.have.property( 'searchDate', undefined );
 					} );
 				} );
 
@@ -1148,7 +1148,7 @@ describe( 'dev-stale-bot/lib', () => {
 
 					return githubRepository.searchStaleIssuesOrPullRequests( optionsBase, onProgress ).then( () => {
 						expect( stubs.prepareSearchQuery.callCount ).to.equal( 3 );
-						expect( stubs.prepareSearchQuery.getCall( 0 ).args[ 0 ] ).to.have.property( 'searchDate', '2022-12-01' );
+						expect( stubs.prepareSearchQuery.getCall( 0 ).args[ 0 ] ).to.have.property( 'searchDate', undefined );
 						expect( stubs.prepareSearchQuery.getCall( 1 ).args[ 0 ] ).to.have.property( 'searchDate', '2022-11-01T09:00:00Z' );
 						expect( stubs.prepareSearchQuery.getCall( 2 ).args[ 0 ] ).to.have.property( 'searchDate', '2022-10-01T09:00:00Z' );
 					} );
@@ -1415,6 +1415,27 @@ describe( 'dev-stale-bot/lib', () => {
 							labels: [ 'pending:feedback' ],
 							ignoredLabels: [ 'support:1', 'support:2', 'support:3' ]
 						} );
+					} );
+				} );
+
+				it( 'should not set the initial start date', () => {
+					const options = {
+						...optionsBase,
+						searchDate: undefined,
+						staleDate: '2023-01-01'
+					};
+
+					stubs.GraphQLClient.request.resolves( {
+						search: {
+							issueCount: 0,
+							nodes: [],
+							pageInfo: pageInfoNoNextPage
+						}
+					} );
+
+					return githubRepository.searchPendingIssues( options, onProgress ).then( () => {
+						expect( stubs.prepareSearchQuery.calledOnce ).to.equal( true );
+						expect( stubs.prepareSearchQuery.getCall( 0 ).args[ 0 ] ).to.have.property( 'searchDate', undefined );
 					} );
 				} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix (stale-bot): Start searching for stale issues without initial date set to allow removing stale labels from unlabeled pending issues. Closes ckeditor/ckeditor5#15812.

Other (stale-bot): Allow defining custom comment that is added to pending issues that are staled.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
