### PR TITLE
Add `emitCss` plugin

### DIFF
--- a/packages/ckeditor5-dev-build-tools/src/config.ts
+++ b/packages/ckeditor5-dev-build-tools/src/config.ts
@@ -21,6 +21,7 @@ import commonjs from '@rollup/plugin-commonjs';
 import typescriptPlugin from '@rollup/plugin-typescript';
 import { nodeResolve } from '@rollup/plugin-node-resolve';
 import { banner as bannerPlugin } from './plugins/banner.js';
+import { emitCss as emitCssPlugin } from './plugins/emitCss.js';
 import { replace as replacePlugin } from './plugins/replace.js';
 import { splitCss as splitCssPlugin } from './plugins/splitCss.js';
 import { translations as translationsPlugin } from './plugins/translations.js';
@@ -173,6 +174,13 @@ export async function getRollupConfig( options: Omit<BuildOptions, 'clean'> ) {
 			 */
 			splitCssPlugin( {
 				minimize: minify
+			} ),
+
+			/**
+			 * Ensures empty files are emitted if files of given names were not generated.
+			 */
+			emitCssPlugin( {
+				fileNames: [ minify ? 'styles.min.css' : 'styles.css' ]
 			} ),
 
 			/**

--- a/packages/ckeditor5-dev-build-tools/src/index.ts
+++ b/packages/ckeditor5-dev-build-tools/src/index.ts
@@ -5,6 +5,7 @@
 
 export { build } from './build.js';
 export { banner, type RollupBannerOptions } from './plugins/banner.js';
+export { emitCss, type RollupEmitCssOptions } from './plugins/emitCss.js';
 export { replace, type RollupReplaceOptions } from './plugins/replace.js';
-export { translations, type RollupTranslationsOptions } from './plugins/translations.js';
 export { splitCss, type RollupSplitCssOptions } from './plugins/splitCss.js';
+export { translations, type RollupTranslationsOptions } from './plugins/translations.js';

--- a/packages/ckeditor5-dev-build-tools/src/plugins/emitCss.ts
+++ b/packages/ckeditor5-dev-build-tools/src/plugins/emitCss.ts
@@ -1,0 +1,31 @@
+import type { Plugin } from 'rollup';
+
+export interface RollupEmitCssOptions {
+	/**
+	 * Name of the empty CSS files that will be emitted if
+	 * no other CSS files were emitted during the build process.
+	 */
+	fileNames: string[];
+}
+
+export function emitCss( pluginOptions: RollupEmitCssOptions ): Plugin {
+	return {
+		name: 'cke5-emit-css',
+
+		async generateBundle( outputOptions, bundle ) {
+			const emittedCss = Object.keys( bundle );
+
+			for ( const fileName of pluginOptions.fileNames ) {
+				if ( emittedCss.includes( fileName ) ) {
+					continue;
+				}
+
+				this.emitFile( {
+					type: 'asset',
+					fileName,
+					source: ''
+				} );
+			}
+		}
+	};
+}

--- a/packages/ckeditor5-dev-build-tools/src/plugins/emitCss.ts
+++ b/packages/ckeditor5-dev-build-tools/src/plugins/emitCss.ts
@@ -1,11 +1,17 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
 import type { Plugin } from 'rollup';
 
 export interface RollupEmitCssOptions {
+
 	/**
 	 * Name of the empty CSS files that will be emitted if
 	 * no other CSS files were emitted during the build process.
 	 */
-	fileNames: string[];
+	fileNames: Array<string>;
 }
 
 export function emitCss( pluginOptions: RollupEmitCssOptions ): Plugin {

--- a/packages/ckeditor5-dev-build-tools/src/plugins/splitCss.ts
+++ b/packages/ckeditor5-dev-build-tools/src/plugins/splitCss.ts
@@ -30,7 +30,7 @@ export function splitCss( pluginOptions?: RollupSplitCssOptions ): Plugin {
 	}, pluginOptions || {} );
 
 	return {
-		name: 'cke5-styles',
+		name: 'cke5-split-css',
 		transform( code, id ) {
 			if ( !filter( id ) ) {
 				return;

--- a/packages/ckeditor5-dev-build-tools/tests/build/build.test.ts
+++ b/packages/ckeditor5-dev-build-tools/tests/build/build.test.ts
@@ -58,7 +58,7 @@ test( 'TypeScript input', async () => {
 		'index.js',
 		'styles.css',
 		'editor-styles.css',
-		'content-styles.css',
+		'content-styles.css'
 	] );
 } );
 

--- a/packages/ckeditor5-dev-build-tools/tests/build/build.test.ts
+++ b/packages/ckeditor5-dev-build-tools/tests/build/build.test.ts
@@ -205,7 +205,7 @@ test( 'Minification doesnt remove banner', async () => {
  */
 test( 'Overriding', async () => {
 	const { output } = await build( {
-		input: 'src/overriding.ts'
+		input: 'src/overriding.js'
 	} );
 
 	expect( output[ 0 ].code ).toContain( '@ckeditor/ckeditor5-utils/dist/index.js' );

--- a/packages/ckeditor5-dev-build-tools/tests/build/build.test.ts
+++ b/packages/ckeditor5-dev-build-tools/tests/build/build.test.ts
@@ -56,7 +56,9 @@ test( 'TypeScript input', async () => {
 
 	expect( output.map( o => o.fileName ) ).toMatchObject( [
 		'index.js',
-		'styles.css'
+		'styles.css',
+		'editor-styles.css',
+		'content-styles.css',
 	] );
 } );
 
@@ -72,6 +74,8 @@ test( 'TypeScript declarations', async () => {
 	expect( output.map( o => o.fileName ) ).toMatchObject( [
 		'index.js',
 		'styles.css',
+		'editor-styles.css',
+		'content-styles.css',
 		'types/input.d.ts'
 	] );
 } );
@@ -118,7 +122,12 @@ test( 'No translations', async () => {
 		input: 'src/input.js'
 	} );
 
-	expect( output.map( o => o.fileName ) ).toMatchObject( [ 'index.js' ] );
+	expect( output.map( o => o.fileName ) ).toMatchObject( [
+		'index.js',
+		'editor-styles.css',
+		'content-styles.css',
+		'styles.css'
+	] );
 } );
 
 test( 'Translations', async () => {
@@ -132,7 +141,9 @@ test( 'Translations', async () => {
 	expect( output.map( o => o.fileName ) ).toMatchObject( [
 		'index.js',
 		'translations/en.js',
-		'styles.css'
+		'styles.css',
+		'editor-styles.css',
+		'content-styles.css'
 	] );
 } );
 
@@ -149,7 +160,9 @@ test( 'Source map', async () => {
 		'index.js',
 		'index.js.map',
 		'styles.css',
-		'styles.css.map'
+		'styles.css.map',
+		'editor-styles.css',
+		'content-styles.css'
 	] );
 } );
 
@@ -192,7 +205,7 @@ test( 'Minification doesnt remove banner', async () => {
  */
 test( 'Overriding', async () => {
 	const { output } = await build( {
-		input: 'src/overriding.js'
+		input: 'src/overriding.ts'
 	} );
 
 	expect( output[ 0 ].code ).toContain( '@ckeditor/ckeditor5-utils/dist/index.js' );

--- a/packages/ckeditor5-dev-build-tools/tests/plugins/emitCss/emitCss.test.ts
+++ b/packages/ckeditor5-dev-build-tools/tests/plugins/emitCss/emitCss.test.ts
@@ -52,7 +52,7 @@ test( 'Emits file if it wasnt already', async () => {
 	verifyAsset( output, 'styles.css', '' );
 } );
 
-test( 'Doesnt override file if it was emitted', async () => {
+test( 'Doesn\'t override file if it was emitted', async () => {
 	const output = await generateBundle( './fixtures/input-css.ts' );
 
 	verifyAsset( output, 'styles.css', 'div' );

--- a/packages/ckeditor5-dev-build-tools/tests/plugins/emitCss/emitCss.test.ts
+++ b/packages/ckeditor5-dev-build-tools/tests/plugins/emitCss/emitCss.test.ts
@@ -1,0 +1,60 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+import { join } from 'path';
+import { test } from 'vitest';
+import styles from 'rollup-plugin-styles';
+import typescript from '@rollup/plugin-typescript';
+import { rollup, type RollupOutput } from 'rollup';
+import { verifyAsset } from '../../_utils/utils.js';
+
+import { emitCss } from '../../../src/index.js';
+
+async function generateBundle( input: string ): Promise<RollupOutput['output']> {
+	const bundle = await rollup( {
+		input: join( import.meta.dirname, input ),
+		plugins: [
+			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+			// @ts-ignore
+			typescript( {
+				tsconfig: join( import.meta.dirname, './fixtures/tsconfig.json' )
+			} ),
+
+			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+			// @ts-ignore
+			styles( {
+				mode: [
+					'extract',
+					'styles.css'
+				]
+			} ),
+
+			emitCss( {
+				fileNames: [ 'styles.css' ]
+			} )
+		]
+	} );
+
+	const { output } = await bundle.generate( {
+		format: 'esm',
+		file: 'input.js',
+		assetFileNames: '[name][extname]',
+	} );
+
+	return output;
+}
+
+test( 'Emits file if it wasnt already', async () => {
+	const output = await generateBundle( './fixtures/input.ts' );
+
+	verifyAsset( output, 'styles.css', '' );
+} );
+
+
+test( 'Doesnt override file if it was emitted', async () => {
+	const output = await generateBundle( './fixtures/input-css.ts' );
+
+	verifyAsset( output, 'styles.css', 'div' );
+} );

--- a/packages/ckeditor5-dev-build-tools/tests/plugins/emitCss/emitCss.test.ts
+++ b/packages/ckeditor5-dev-build-tools/tests/plugins/emitCss/emitCss.test.ts
@@ -46,7 +46,7 @@ async function generateBundle( input: string ): Promise<RollupOutput['output']> 
 	return output;
 }
 
-test( 'Emits file if it wasnt already', async () => {
+test( 'Emits file if it wasn\'t already', async () => {
 	const output = await generateBundle( './fixtures/input.ts' );
 
 	verifyAsset( output, 'styles.css', '' );

--- a/packages/ckeditor5-dev-build-tools/tests/plugins/emitCss/emitCss.test.ts
+++ b/packages/ckeditor5-dev-build-tools/tests/plugins/emitCss/emitCss.test.ts
@@ -40,7 +40,7 @@ async function generateBundle( input: string ): Promise<RollupOutput['output']> 
 	const { output } = await bundle.generate( {
 		format: 'esm',
 		file: 'input.js',
-		assetFileNames: '[name][extname]',
+		assetFileNames: '[name][extname]'
 	} );
 
 	return output;
@@ -51,7 +51,6 @@ test( 'Emits file if it wasnt already', async () => {
 
 	verifyAsset( output, 'styles.css', '' );
 } );
-
 
 test( 'Doesnt override file if it was emitted', async () => {
 	const output = await generateBundle( './fixtures/input-css.ts' );

--- a/packages/ckeditor5-dev-build-tools/tests/plugins/emitCss/fixtures/input-css.ts
+++ b/packages/ckeditor5-dev-build-tools/tests/plugins/emitCss/fixtures/input-css.ts
@@ -1,0 +1,8 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+import './input.css';
+
+export const test = 123;

--- a/packages/ckeditor5-dev-build-tools/tests/plugins/emitCss/fixtures/input.css
+++ b/packages/ckeditor5-dev-build-tools/tests/plugins/emitCss/fixtures/input.css
@@ -1,0 +1,3 @@
+div {
+	border: 1px solid red;
+}

--- a/packages/ckeditor5-dev-build-tools/tests/plugins/emitCss/fixtures/input.ts
+++ b/packages/ckeditor5-dev-build-tools/tests/plugins/emitCss/fixtures/input.ts
@@ -1,0 +1,6 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+export const test = 123;

--- a/packages/ckeditor5-dev-build-tools/tests/plugins/emitCss/fixtures/tsconfig.json
+++ b/packages/ckeditor5-dev-build-tools/tests/plugins/emitCss/fixtures/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": [
+      "ES2022",
+      "DOM",
+      "DOM.Iterable"
+    ],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "skipLibCheck": true,
+    "resolveJsonModule": true
+  },
+  "include": [
+    "**/*"
+  ]
+}


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Add `emitCss` plugin to emit empty CSS file if no file of given name was already emitted.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
