### PR TITLE
Remove `cssnano` warning and set `splitCss` code coverage to 100%.

### DIFF
--- a/packages/ckeditor5-dev-build-tools/src/plugins/splitCss.ts
+++ b/packages/ckeditor5-dev-build-tools/src/plugins/splitCss.ts
@@ -75,7 +75,7 @@ function getCssStylesheet( bundle: OutputBundle ) {
 		return '';
 	}
 
-	return ( cssStylesheetChunk as EmittedAsset ).source?.toString() || '';
+	return ( cssStylesheetChunk as EmittedAsset ).source?.toString()!;
 }
 
 /**
@@ -252,7 +252,7 @@ async function unifyFileContentOutput( content: string = '', minimize: boolean )
 	}
 
 	const minifier = cssnano() as Processor;
-	const minifiedResult = await minifier.process( content );
+	const minifiedResult = await minifier.process( content, { from: undefined } );
 
 	return minifiedResult.css;
 }

--- a/packages/ckeditor5-dev-build-tools/src/plugins/splitCss.ts
+++ b/packages/ckeditor5-dev-build-tools/src/plugins/splitCss.ts
@@ -75,7 +75,7 @@ function getCssStylesheet( bundle: OutputBundle ) {
 		return '';
 	}
 
-	return ( cssStylesheetChunk as EmittedAsset ).source?.toString()!;
+	return ( cssStylesheetChunk as EmittedAsset ).source!.toString();
 }
 
 /**


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Type: Message. Closes #000.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
