### PR TITLE
Extend CLI with `browser` and `outputName` parameters.

### DIFF
--- a/packages/ckeditor5-dev-build-tools/.gitignore
+++ b/packages/ckeditor5-dev-build-tools/.gitignore
@@ -1,3 +1,3 @@
 coverage
-dist
+./dist
 node_modules

--- a/packages/ckeditor5-dev-build-tools/src/build.ts
+++ b/packages/ckeditor5-dev-build-tools/src/build.ts
@@ -137,7 +137,7 @@ export async function build(
 			file: args.output,
 			assetFileNames: '[name][extname]',
 			sourcemap: args.sourceMap,
-			...( args.format === 'umd' && { name: 'CKEDITOR5' } ),
+			...( args.format === 'umd' && { name: 'CKEDITOR5' } )
 		} );
 	} catch ( error: any ) {
 		let message: string;

--- a/packages/ckeditor5-dev-build-tools/src/build.ts
+++ b/packages/ckeditor5-dev-build-tools/src/build.ts
@@ -150,7 +150,7 @@ export async function build(
 			const { plugins, ...configWithoutPlugins } = configUmd;
 			const umdBuild = await rollup( configWithoutPlugins );
 
-			const umdBndle = await umdBuild.write( {
+			const umdBundle = await umdBuild.write( {
 				format: 'umd',
 				file: upath.join( upath.dirname( args.output ), 'index.umd.js' ),
 				assetFileNames: '[name][extname]',
@@ -159,10 +159,9 @@ export async function build(
 			} );
 
 			return { output: [
-					...bundle.output,
-					...umdBndle.output,
-				]
-			};
+				...bundle.output,
+				...umdBundle.output
+			] };
 		}
 
 		return bundle;

--- a/packages/ckeditor5-dev-build-tools/src/build.ts
+++ b/packages/ckeditor5-dev-build-tools/src/build.ts
@@ -6,7 +6,7 @@
 import fs from 'fs';
 import util from 'util';
 import chalk from 'chalk';
-import { rollup, type RollupOutput } from 'rollup';
+import { rollup, type RollupOutput, type ModuleFormat } from 'rollup';
 import { getRollupConfig } from './config.js';
 import { getCwdPath, camelizeObjectKeys, removeWhitespace } from './utils.js';
 
@@ -14,6 +14,7 @@ export interface BuildOptions {
 	input: string;
 	output: string;
 	tsconfig: string;
+	format: string;
 	banner: string;
 	external: Array<string>;
 	declarations: boolean;
@@ -27,6 +28,7 @@ export const defaultOptions: BuildOptions = {
 	input: 'src/index.ts',
 	output: 'dist/index.js',
 	tsconfig: 'tsconfig.json',
+	format: 'esm',
 	banner: '',
 	external: [],
 	declarations: false,
@@ -45,6 +47,7 @@ function getCliArguments(): Partial<BuildOptions> {
 			'input': { type: 'string' },
 			'output': { type: 'string' },
 			'tsconfig': { type: 'string' },
+			'format': { type: 'string' },
 			'banner': { type: 'string' },
 			'external': { type: 'string', multiple: true },
 			'declarations': { type: 'boolean' },
@@ -130,10 +133,11 @@ export async function build(
 		 * Write bundles to the filesystem.
 		 */
 		return await build.write( {
-			format: 'esm',
+			format: args.format as ModuleFormat,
 			file: args.output,
 			assetFileNames: '[name][extname]',
-			sourcemap: args.sourceMap
+			sourcemap: args.sourceMap,
+			...( args.format === 'umd' && { name: 'CKEDITOR5' } ),
 		} );
 	} catch ( error: any ) {
 		let message: string;

--- a/packages/ckeditor5-dev-build-tools/src/build.ts
+++ b/packages/ckeditor5-dev-build-tools/src/build.ts
@@ -145,7 +145,6 @@ export async function build(
 
 		if ( args.browser ) {
 			args.input = args.output;
-			args.sourceMap = false;
 
 			const configUmd = await getRollupConfig( args );
 			const { plugins, ...configWithoutPlugins } = configUmd;

--- a/packages/ckeditor5-dev-build-tools/src/build.ts
+++ b/packages/ckeditor5-dev-build-tools/src/build.ts
@@ -15,6 +15,7 @@ export interface BuildOptions {
 	output: string;
 	tsconfig: string;
 	format: string;
+	outputName: string,
 	banner: string;
 	external: Array<string>;
 	declarations: boolean;
@@ -29,6 +30,7 @@ export const defaultOptions: BuildOptions = {
 	output: 'dist/index.js',
 	tsconfig: 'tsconfig.json',
 	format: 'esm',
+	outputName: '',
 	banner: '',
 	external: [],
 	declarations: false,
@@ -137,7 +139,7 @@ export async function build(
 			file: args.output,
 			assetFileNames: '[name][extname]',
 			sourcemap: args.sourceMap,
-			...( args.format === 'umd' && { name: 'CKEDITOR5' } )
+			name: args.outputName
 		} );
 	} catch ( error: any ) {
 		let message: string;

--- a/packages/ckeditor5-dev-build-tools/src/build.ts
+++ b/packages/ckeditor5-dev-build-tools/src/build.ts
@@ -148,15 +148,21 @@ export async function build(
 
 			const configUmd = await getRollupConfig( args );
 			const { plugins, ...configWithoutPlugins } = configUmd;
-			const umdBundle = await rollup( configWithoutPlugins );
+			const umdBuild = await rollup( configWithoutPlugins );
 
-			return await umdBundle.write( {
+			const umdBndle = await umdBuild.write( {
 				format: 'umd',
 				file: upath.join( upath.dirname( args.output ), 'index.umd.js' ),
 				assetFileNames: '[name][extname]',
 				sourcemap: args.sourceMap,
 				name: args.outputName
 			} );
+
+			return { output: [
+					...bundle.output,
+					...umdBndle.output,
+				]
+			};
 		}
 
 		return bundle;

--- a/packages/ckeditor5-dev-build-tools/src/build.ts
+++ b/packages/ckeditor5-dev-build-tools/src/build.ts
@@ -7,7 +7,7 @@ import fs from 'fs';
 import util from 'util';
 import chalk from 'chalk';
 import upath from 'upath';
-import { rollup, type RollupOutput, type ModuleFormat } from 'rollup';
+import { rollup, type RollupOutput } from 'rollup';
 import { getRollupConfig } from './config.js';
 import { getCwdPath, camelizeObjectKeys, removeWhitespace } from './utils.js';
 
@@ -15,8 +15,7 @@ export interface BuildOptions {
 	input: string;
 	output: string;
 	tsconfig: string;
-	format: string;
-	outputName: string,
+	outputName: string;
 	banner: string;
 	external: Array<string>;
 	declarations: boolean;
@@ -24,14 +23,13 @@ export interface BuildOptions {
 	sourceMap: boolean;
 	minify: boolean;
 	clean: boolean;
-	browser: boolean
+	browser: boolean;
 }
 
 export const defaultOptions: BuildOptions = {
 	input: 'src/index.ts',
 	output: 'dist/index.js',
 	tsconfig: 'tsconfig.json',
-	format: 'esm',
 	outputName: '',
 	banner: '',
 	external: [],
@@ -52,7 +50,6 @@ function getCliArguments(): Partial<BuildOptions> {
 			'input': { type: 'string' },
 			'output': { type: 'string' },
 			'tsconfig': { type: 'string' },
-			'format': { type: 'string' },
 			'banner': { type: 'string' },
 			'external': { type: 'string', multiple: true },
 			'declarations': { type: 'boolean' },
@@ -139,7 +136,7 @@ export async function build(
 		 * Write bundles to the filesystem.
 		 */
 		const bundle = await build.write( {
-			format: args.format as ModuleFormat,
+			format: 'esm',
 			file: args.output,
 			assetFileNames: '[name][extname]',
 			sourcemap: args.sourceMap,
@@ -148,7 +145,6 @@ export async function build(
 
 		if ( args.browser ) {
 			args.input = args.output;
-			args.format = 'umd';
 			args.sourceMap = false;
 
 			const configUmd = await getRollupConfig( args );
@@ -156,7 +152,7 @@ export async function build(
 			const umdBundle = await rollup( configWithoutPlugins );
 
 			return await umdBundle.write( {
-				format: args.format as ModuleFormat,
+				format: 'umd',
 				file: upath.join( upath.dirname( args.output ), 'index.umd.js' ),
 				assetFileNames: '[name][extname]',
 				sourcemap: args.sourceMap,

--- a/packages/ckeditor5-dev-build-tools/tests/build/build.test.ts
+++ b/packages/ckeditor5-dev-build-tools/tests/build/build.test.ts
@@ -83,7 +83,22 @@ test( 'TypeScript declarations', async () => {
 /**
  * Format
  */
-test( 'Format', async () => {
+test( 'Format esm', async () => {
+	const { output } = await build( {
+		input: 'src/input.ts',
+		tsconfig: 'tsconfig.json',
+		format: 'esm'
+	} );
+
+	expect( output.map( o => o.fileName ) ).toMatchObject( [
+		'index.js',
+		'index.css',
+		'editor-index.css',
+		'content-index.css'
+	] );
+} );
+
+test( 'Format umd', async () => {
 	const { output } = await build( {
 		input: 'src/input.ts',
 		tsconfig: 'tsconfig.json',

--- a/packages/ckeditor5-dev-build-tools/tests/build/build.test.ts
+++ b/packages/ckeditor5-dev-build-tools/tests/build/build.test.ts
@@ -81,9 +81,48 @@ test( 'TypeScript declarations', async () => {
 } );
 
 /**
+ * Format
+ */
+test( 'Format', async () => {
+	const { output } = await build( {
+		input: 'src/input.ts',
+		tsconfig: 'tsconfig.json',
+		format: 'umd',
+		outputName: 'EXAMPLE_OUTPUT_NAME'
+	} );
+
+	expect( output.map( o => o.fileName ) ).toMatchObject( [
+		'index.js',
+		'index.css',
+		'editor-index.css',
+		'content-index.css'
+	] );
+} );
+
+/**
+ * Output Name
+ */
+test( 'Output name', async () => {
+	const { output } = await build( {
+		input: 'src/input.ts',
+		tsconfig: 'tsconfig.json',
+		format: 'umd',
+		outputName: 'EXAMPLE_OUTPUT_NAME'
+	} );
+
+	expect( output[ 0 ].code ).toContain( 'EXAMPLE_OUTPUT_NAME' );
+
+	expect( output.map( o => o.fileName ) ).toMatchObject( [
+		'index.js',
+		'index.css',
+		'editor-index.css',
+		'content-index.css'
+	] );
+} );
+
+/**
  * Banner
  */
-
 test( 'Banner', async () => {
 	const { output } = await build( {
 		input: 'src/input.js',

--- a/packages/ckeditor5-dev-build-tools/tests/build/build.test.ts
+++ b/packages/ckeditor5-dev-build-tools/tests/build/build.test.ts
@@ -81,13 +81,13 @@ test( 'TypeScript declarations', async () => {
 } );
 
 /**
- * Format
+ * Browser
  */
-test( 'Format esm', async () => {
+test( 'Browser parameter set to `false`', async () => {
 	const { output } = await build( {
 		input: 'src/input.ts',
 		tsconfig: 'tsconfig.json',
-		format: 'esm'
+		browser: false
 	} );
 
 	expect( output.map( o => o.fileName ) ).toMatchObject( [
@@ -98,11 +98,11 @@ test( 'Format esm', async () => {
 	] );
 } );
 
-test( 'Format umd', async () => {
+test( 'Browser parameter set to `true`', async () => {
 	const { output } = await build( {
 		input: 'src/input.ts',
 		tsconfig: 'tsconfig.json',
-		format: 'umd',
+		browser: true,
 		outputName: 'EXAMPLE_OUTPUT_NAME'
 	} );
 
@@ -110,7 +110,8 @@ test( 'Format umd', async () => {
 		'index.js',
 		'index.css',
 		'editor-index.css',
-		'content-index.css'
+		'content-index.css',
+		'index.umd.js'
 	] );
 } );
 
@@ -121,17 +122,28 @@ test( 'Output name', async () => {
 	const { output } = await build( {
 		input: 'src/input.ts',
 		tsconfig: 'tsconfig.json',
-		format: 'umd',
+		browser: true,
 		outputName: 'EXAMPLE_OUTPUT_NAME'
 	} );
 
-	expect( output[ 0 ].code ).toContain( 'EXAMPLE_OUTPUT_NAME' );
+	let code;
+
+	output.forEach( item => {
+		if ( item.type === 'chunk' && item.fileName === 'index.umd.js' ) {
+			code = item.code;
+		}
+	})
+
+	if ( code ) {
+		expect( code ).toContain( 'EXAMPLE_OUTPUT_NAME' );
+	}
 
 	expect( output.map( o => o.fileName ) ).toMatchObject( [
 		'index.js',
 		'index.css',
 		'editor-index.css',
-		'content-index.css'
+		'content-index.css',
+		'index.umd.js'
 	] );
 } );
 

--- a/packages/ckeditor5-dev-build-tools/tests/build/build.test.ts
+++ b/packages/ckeditor5-dev-build-tools/tests/build/build.test.ts
@@ -132,7 +132,7 @@ test( 'Output name', async () => {
 		if ( item.type === 'chunk' && item.fileName === 'index.umd.js' ) {
 			code = item.code;
 		}
-	})
+	} );
 
 	if ( code ) {
 		expect( code ).toContain( 'EXAMPLE_OUTPUT_NAME' );

--- a/packages/ckeditor5-dev-build-tools/tests/build/fixtures/dist/index.js
+++ b/packages/ckeditor5-dev-build-tools/tests/build/fixtures/dist/index.js
@@ -1,0 +1,8 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+// It's a mock file, for testing the `UMD` build.
+
+export const foo = 'bar';


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature (build-tools): Ability to set parameters `browser` and `outputName` for a build.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
