### PR TITLE
Update esbuild-loader to ^4.1.0

### DIFF
--- a/packages/ckeditor5-dev-utils/lib/loaders/index.js
+++ b/packages/ckeditor5-dev-utils/lib/loaders/index.js
@@ -31,7 +31,10 @@ module.exports = {
 			use: [
 				{
 					loader: 'esbuild-loader',
-					options: { tsconfig: configFile }
+					options: {
+						target: 'es2022',
+						tsconfig: configFile
+					}
 				},
 				includeDebugLoader ? getDebugLoader( debugFlags ) : null
 			].filter( Boolean )

--- a/packages/ckeditor5-dev-utils/package.json
+++ b/packages/ckeditor5-dev-utils/package.json
@@ -12,7 +12,7 @@
     "css-loader": "^5.2.7",
     "cssnano": "^6.0.3",
     "del": "^5.0.0",
-    "esbuild-loader": "~3.0.1",
+    "esbuild-loader": "^4.1.0",
     "fs-extra": "^9.1.0",
     "is-interactive": "^1.0.0",
     "javascript-stringify": "^1.6.0",


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature (dev-utils): Update `esbuild-loader` to ^4.1.0.

Feature (dev-utils): Set `target: es2022` in `esbuild-loader`.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
