### PR TITLE
Set target to `es2022`

### DIFF
--- a/packages/ckeditor5-dev-build-tools/src/config.ts
+++ b/packages/ckeditor5-dev-build-tools/src/config.ts
@@ -175,7 +175,8 @@ export async function getRollupConfig( options: BuildOptions ) {
 				include: [ '**/*.[jt]s' ],
 				swc: {
 					jsc: {
-						target: 'es2019'
+						target: 'es2022',
+						loose: false
 					},
 					module: {
 						type: 'es6'
@@ -295,6 +296,7 @@ function getTypeScriptPlugin( {
 	}
 
 	return typescriptPlugin( {
+		noForceEmit: true,
 		tsconfig,
 		sourceMap,
 		noEmitOnError: true,


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature (build-tools): Set `target:es2022` and `loose:false` in swc plugin to avoid syntax lowering and unnecessary code transformation.

Fix (build-tools): Prevent TypeScript plugin from processing the source code (which is already done by the swc plugin).

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
