### PR TITLE
Fix (build-tools): Properly detect "external" packages that contain dot in name.

### DIFF
--- a/packages/ckeditor5-dev-build-tools/src/config.ts
+++ b/packages/ckeditor5-dev-build-tools/src/config.ts
@@ -94,7 +94,7 @@ export async function getRollupConfig( options: BuildOptions ) {
 		 */
 		external: ( id: string ) => {
 			// Bundle relative and absolute imports.
-			if ( id.startsWith( '.' ) || id.startsWith( '/' ) ) {
+			if ( id.startsWith( '.' ) || path.isAbsolute( id ) ) {
 				return false;
 			}
 

--- a/packages/ckeditor5-dev-build-tools/src/config.ts
+++ b/packages/ckeditor5-dev-build-tools/src/config.ts
@@ -95,7 +95,7 @@ export async function getRollupConfig( options: BuildOptions ) {
 		external: ( id: string ) => {
 			// Bundle relative and absolute imports.
 			if ( id.startsWith( '.' ) || id.startsWith( '/' ) ) {
-				return false; 
+				return false;
 			}
 
 			// Don't bundle imports that exactly match the `external` list.

--- a/packages/ckeditor5-dev-build-tools/src/config.ts
+++ b/packages/ckeditor5-dev-build-tools/src/config.ts
@@ -93,8 +93,14 @@ export async function getRollupConfig( options: BuildOptions ) {
 		 * List of packages that will not be bundled, but their imports will be left as they are.
 		 */
 		external: ( id: string ) => {
+			// Bundle relative and absolute imports.
 			if ( id.startsWith( '.' ) || id.startsWith( '/' ) ) {
-				return false; // Relative or absolute import
+				return false; 
+			}
+
+			// Don't bundle imports that exactly match the `external` list.
+			if ( external.includes( id ) ) {
+				return true;
 			}
 
 			const packageName = id

--- a/packages/ckeditor5-dev-build-tools/tests/config/config.test.ts
+++ b/packages/ckeditor5-dev-build-tools/tests/config/config.test.ts
@@ -63,8 +63,22 @@ test( '--external', async () => {
 		]
 	} );
 
+	// Exclude simple package names.
 	expect( config.external( 'foo' ) ).toBe( true );
+
+	// Exclude package names that contain a dot (which might be treated as a file extension).
 	expect( config.external( 'socket.io-client' ) ).toBe( true );
+
+	// Exclude packages with a code file extension (.ts, .js, .json, etc.).
+	expect( config.external( 'socket.io-client/src/index.js' ) ).toBe( true );
+
+	// Don't exclude CSS files.
+	expect( config.external( 'socket.io-client/src/index.css' ) ).toBe( false );
+
+	// Don't exclude SVG files.
+	expect( config.external( 'socket.io-client/theme/icon.svg' ) ).toBe( false );
+
+	// Don't exclude packages not listed in the "external" option.
 	expect( config.external( 'bar' ) ).toBe( false );
 } );
 

--- a/packages/ckeditor5-dev-build-tools/tests/config/config.test.ts
+++ b/packages/ckeditor5-dev-build-tools/tests/config/config.test.ts
@@ -57,10 +57,14 @@ test( '--tsconfig', async () => {
 
 test( '--external', async () => {
 	const config = await getConfig( {
-		external: [ 'foo' ]
+		external: [
+			'foo',
+			'socket.io-client'
+		]
 	} );
 
 	expect( config.external( 'foo' ) ).toBe( true );
+	expect( config.external( 'socket.io-client' ) ).toBe( true );
 	expect( config.external( 'bar' ) ).toBe( false );
 } );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix (build-tools): Properly detect "external" packages that contain dot in name.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
