### PR TITLE
Fix (build-tools): Don't fail when `ckeditor5-premium-features` is in `external`, but not installed.

### DIFF
--- a/packages/ckeditor5-dev-build-tools/src/config.ts
+++ b/packages/ckeditor5-dev-build-tools/src/config.ts
@@ -65,13 +65,8 @@ export async function getRollupConfig( options: BuildOptions ) {
 	 *
 	 * This mapping can be removed when old installation methods are deprecated.
 	 */
-	const coreRewrites = external.includes( 'ckeditor5' ) ?
-		getPackageDependencies( 'ckeditor5' ) :
-		[];
-
-	const commercialRewrites = external.includes( 'ckeditor5-premium-features' ) ?
-		getPackageDependencies( 'ckeditor5-premium-features' ) :
-		[];
+	const coreRewrites = getPackageDependencies( 'ckeditor5' );
+	const commercialRewrites = getPackageDependencies( 'ckeditor5-premium-features' );
 
 	external.push( ...coreRewrites, ...commercialRewrites );
 
@@ -283,9 +278,13 @@ function getOptionalPlugin<T extends InputPluginOption>( condition: unknown, plu
  * Returns a list of keys in `package.json` file of a given dependency.
  */
 function getPackageDependencies( packageName: string ): Array<string> {
-	const pkg: PackageJson = getUserDependency( `${ packageName }/package.json` );
+	try {
+		const pkg: PackageJson = getUserDependency( `${ packageName }/package.json` );
 
-	return Object.keys( pkg.dependencies! );
+		return Object.keys( pkg.dependencies! );
+	} catch {
+		return [];
+	}
 }
 
 /**

--- a/packages/ckeditor5-dev-build-tools/tests/config/config.test.ts
+++ b/packages/ckeditor5-dev-build-tools/tests/config/config.test.ts
@@ -127,6 +127,21 @@ test( '--external automatically adds packages that make up the "ckeditor5-premiu
 	expect( config.external( '@ckeditor/ckeditor5-real-time-collaboration/theme/usermarkers.css' ) ).toBe( false );
 } );
 
+test( '--external doesn\'t fail when "ckeditor5-premium-features" is not installed', async () => {
+	await mockGetUserDependency(
+		'ckeditor5-premium-features/package.json',
+		() => {
+			throw new Error( 'Cannot find module' );
+		}
+	);
+
+	const config = await getConfig( {
+		external: [ 'ckeditor5-premium-features' ]
+	} );
+
+	expect( config.external( 'ckeditor5-premium-features' ) ).toBe( true );
+} );
+
 test( '--translations', async () => {
 	const withoutTranslations = await getConfig();
 	const withTranslations = await getConfig( {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix (build-tools): Don't fail when `ckeditor5-premium-features` is in `external`, but not installed.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
