### PR TITLE
Prevent from for guessing the `globals` names for `ckeditor5' and `ckeditor5-premium-features` during UMD build.

### DIFF
--- a/packages/ckeditor5-dev-build-tools/src/build.ts
+++ b/packages/ckeditor5-dev-build-tools/src/build.ts
@@ -88,7 +88,11 @@ async function generateUmdBuild( args: BuildOptions, bundle: RollupOutput ): Pro
 		file: path.join( dir, `${ name }.umd.js` ),
 		assetFileNames: '[name][extname]',
 		sourcemap: args.sourceMap,
-		name: args.name
+		name: args.name,
+		globals: {
+			ckeditor5: 'ckeditor5',
+			'ckeditor5-premium-features': 'ckeditor5-premium-features'
+		}
 	} );
 
 	return {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix (build-tools): Prevent from for guessing the `globals` names for `ckeditor5' and `ckeditor5-premium-features` during UMD build.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
