### PR TITLE
Sort package versions in natural way where multi-digit numbers are treated atomically

### DIFF
--- a/packages/ckeditor5-dev-release-tools/lib/utils/versions.js
+++ b/packages/ckeditor5-dev-release-tools/lib/utils/versions.js
@@ -44,7 +44,7 @@ const versions = {
 			.then( result => {
 				const lastVersion = JSON.parse( result )
 					.filter( version => version.startsWith( releaseIdentifier ) )
-					.sort()
+					.sort( ( a, b ) => a.localeCompare( b, undefined, { numeric: true } ) )
 					.pop();
 
 				return lastVersion || null;

--- a/packages/ckeditor5-dev-release-tools/tests/utils/versions.js
+++ b/packages/ckeditor5-dev-release-tools/tests/utils/versions.js
@@ -182,6 +182,23 @@ describe( 'dev-release-tools/utils', () => {
 					} );
 			} );
 
+			it( 'returns last pre-release version matching the release identifier (sequence numbers greater than 10)', () => {
+				shExecStub.resolves( JSON.stringify( [
+					'0.0.0-nightly-20230615.0',
+					'37.0.0-alpha.1',
+					'37.0.0-alpha.2',
+					'37.0.0-alpha.3',
+					'41.0.0',
+					'37.0.0-alpha.10',
+					'37.0.0-alpha.11'
+				] ) );
+
+				return version.getLastPreRelease( '37.0.0-alpha' )
+					.then( result => {
+						expect( result ).to.equal( '37.0.0-alpha.11' );
+					} );
+			} );
+
 			it( 'returns last nightly version', () => {
 				shExecStub.resolves( JSON.stringify( [
 					'0.0.0-nightly-20230614.0',


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix (release-tools): Fixed the `getLastPreRelease()` function to handle pre-release versions with a multi-digit sequence number correctly. Closes ckeditor/ckeditor5#16576.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
