### PR TITLE
Fix (build-tools): Fix banner path resolution on Windows.

### DIFF
--- a/packages/ckeditor5-dev-build-tools/src/build.ts
+++ b/packages/ckeditor5-dev-build-tools/src/build.ts
@@ -4,6 +4,7 @@
  */
 
 import fs from 'fs';
+import url from 'url';
 import util from 'util';
 import chalk from 'chalk';
 import path from 'upath';
@@ -130,7 +131,8 @@ async function normalizeOptions( options: Partial<BuildOptions> ): Promise<Build
 	 * Replace banner path with the actual banner contents.
 	 */
 	if ( normalized.banner ) {
-		const { banner } = await import( normalized.banner );
+		const { href } = url.pathToFileURL( normalized.banner );
+		const { banner } = await import( href );
 
 		normalized.banner = banner;
 	}


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix (build-tools): Fix banner path resolution that prevents the package from being built on Windows. Closes ckeditor/ckeditor5#16578.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
