### PR TITLE
Treat dependencies in the `dist` folder as production dependencies.

### DIFF
--- a/packages/ckeditor5-dev-build-tools/src/plugins/translations.ts
+++ b/packages/ckeditor5-dev-build-tools/src/plugins/translations.ts
@@ -14,7 +14,7 @@ import type { Plugin } from 'rollup';
 import { removeWhitespace } from '../utils';
 
 const TYPINGS = removeWhitespace( `
-	import type { Translations } from 'ckeditor5';
+	import type { Translations } from '@ckeditor/ckeditor5-utils';
 
 	declare const translations: Translations;
 	export default translations;

--- a/packages/ckeditor5-dev-build-tools/tests/plugins/translations/translations.test.ts
+++ b/packages/ckeditor5-dev-build-tools/tests/plugins/translations/translations.test.ts
@@ -77,3 +77,14 @@ test( 'destination', async () => {
 	verifyChunk( output, 'languages/de.js', GERMAN_TRANSLATIONS_FROM_ROOT );
 	verifyChunk( output, 'languages/en.js', ENGLISH_TRANSLATIONS_FROM_ROOT );
 } );
+
+/**
+ * Ensure that the typings are generated and that the `Translations` type is imported from `@ckeditor/ckeditor5-utils`.
+ */
+test( 'typings', async () => {
+	const output = await generateBundle( {
+		destination: 'languages'
+	} );
+
+	verifyChunk( output, 'languages/en.d.ts', 'import type { Translations } from \'@ckeditor/ckeditor5-utils\'' );
+} );

--- a/packages/ckeditor5-dev-dependency-checker/lib/checkdependencies.js
+++ b/packages/ckeditor5-dev-dependency-checker/lib/checkdependencies.js
@@ -69,7 +69,7 @@ async function checkDependenciesInPackage( packagePath, options ) {
 			'**/*.ts': depCheck.parser.typescript,
 			'**/*.vue': depCheck.parser.vue
 		},
-		ignorePatterns: [ 'docs', 'build', 'dist' ],
+		ignorePatterns: [ 'docs', 'build' ],
 		ignoreMatches: [ 'eslint*', 'webpack*', 'husky', 'lint-staged' ]
 	};
 
@@ -383,7 +383,7 @@ async function isDevDependency( packageName, absolutePaths ) {
 
 	for ( const absolutePath of absolutePaths ) {
 		// Only imports in files in src/ or theme/ could be non dev dependency.
-		if ( !absolutePath.match( /[/\\](src|theme)[/\\]/ ) ) {
+		if ( !absolutePath.match( /[/\\](src|theme|dist)[/\\]/ ) ) {
 			continue;
 		}
 

--- a/packages/ckeditor5-dev-dependency-checker/lib/checkdependencies.js
+++ b/packages/ckeditor5-dev-dependency-checker/lib/checkdependencies.js
@@ -381,9 +381,30 @@ async function isDevDependency( packageName, absolutePaths ) {
 		return true;
 	}
 
+	/**
+	 * These folders contain code that will be shipped to npm and run in the final projects.
+	 * This means that all dependencies used in these folders are production dependencies.
+	 */
+	const foldersContainingProductionCode = [
+		/**
+		 * These folders contain the source code of the packages.
+		 */
+		/[/\\]src[/\\]/,
+		/[/\\]theme[/\\]/,
+
+		/**
+		 * This folder contains the compiled code of the packages. Most of this code is the same
+		 * as the source, but during the build process some of the imports are replaced with those
+		 * compatible with the "new installation methods", which may use different dependencies.
+		 *
+		 * For example, the `ckeditor5/src/core.js` import is replaced with `@ckeditor/ckeditor5-core/dist/index.js`.
+		 *                   ^^^^^^^^^                                       ^^^^^^^^^^^^^^^^^^^^^^^^
+		 */
+		/[/\\]dist[/\\]/
+	];
+
 	for ( const absolutePath of absolutePaths ) {
-		// Only imports in files in src/ or theme/ could be non dev dependency.
-		if ( !absolutePath.match( /[/\\](src|theme|dist)[/\\]/ ) ) {
+		if ( !foldersContainingProductionCode.some( folder => absolutePath.match( folder ) ) ) {
 			continue;
 		}
 

--- a/packages/ckeditor5-dev-dependency-checker/lib/checkdependencies.js
+++ b/packages/ckeditor5-dev-dependency-checker/lib/checkdependencies.js
@@ -69,7 +69,7 @@ async function checkDependenciesInPackage( packagePath, options ) {
 			'**/*.ts': depCheck.parser.typescript,
 			'**/*.vue': depCheck.parser.vue
 		},
-		ignorePatterns: [ 'docs', 'build' ],
+		ignorePatterns: [ 'docs', 'build', 'dist/browser' ],
 		ignoreMatches: [ 'eslint*', 'webpack*', 'husky', 'lint-staged' ]
 	};
 

--- a/packages/ckeditor5-dev-dependency-checker/lib/checkdependencies.js
+++ b/packages/ckeditor5-dev-dependency-checker/lib/checkdependencies.js
@@ -370,7 +370,8 @@ async function findMisplacedDependencies( options ) {
 }
 
 /**
- * Checks if a package is a development dependency: a package not used in the source and theme.
+ * Checks if a given package is a development-only dependency. Package is considered a dev dependency
+ * if it is used only in files that are not used in the final build, such as tests, demos or typings.
  *
  * @param {String} packageName
  * @param {Array.<String>} absolutePaths Files where a given package has been imported.


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix (dependency-checker): Treat dependencies in the `dist` folder as production dependencies. See ckeditor/ckeditor5#16646.

Other (build-tools): The `.d.ts` files for translations should import directly from `@ckeditor/ckeditor5-utils` instead of `ckeditor5`. See ckeditor/ckeditor5#16646.

MINOR BREAKING CHANGE: Treat dependencies in the `dist` folder as production `dependencies`.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
