### PR TITLE
Fixed release tooling to be compatible with npm 10.

### DIFF
--- a/packages/ckeditor5-dev-release-tools/lib/utils/checkversionavailability.js
+++ b/packages/ckeditor5-dev-release-tools/lib/utils/checkversionavailability.js
@@ -31,7 +31,7 @@ module.exports = async function checkVersionAvailability( version, packageName )
 		} )
 		.catch( error => {
 			// All errors except the "E404" are re-thrown.
-			if ( !error.toString().includes( 'npm ERR! code E404' ) ) {
+			if ( !error.toString().includes( 'code E404' ) ) {
 				throw error;
 			}
 

--- a/packages/ckeditor5-dev-release-tools/tests/utils/checkversionavailability.js
+++ b/packages/ckeditor5-dev-release-tools/tests/utils/checkversionavailability.js
@@ -33,8 +33,22 @@ describe( 'dev-release-tools/utils', () => {
 			sandbox.restore();
 		} );
 
-		it( 'should resolve to true if version does not exist (npm >= 8.13.0)', () => {
-			stubs.shExec.rejects( new Error( 'code E404' ) );
+		it( 'should resolve to true if version does not exist (npm >= 8.13.0 && npm < 10.0.0)', () => {
+			stubs.shExec.rejects( new Error( 'npm ERR! code E404' ) );
+
+			return checkVersionAvailability( '1.0.1', 'stub-package' )
+				.then( result => {
+					expect( stubs.shExec.callCount ).to.equal( 1 );
+					expect( stubs.shExec.firstCall.args[ 0 ] ).to.equal( 'npm show stub-package@1.0.1 version' );
+					expect( result ).to.be.true;
+				} )
+				.catch( () => {
+					throw new Error( 'Expected to be resolved.' );
+				} );
+		} );
+
+		it( 'should resolve to true if version does not exist (npm >= 10.0.0)', () => {
+			stubs.shExec.rejects( new Error( 'npm error code E404' ) );
 
 			return checkVersionAvailability( '1.0.1', 'stub-package' )
 				.then( result => {

--- a/packages/ckeditor5-dev-release-tools/tests/utils/checkversionavailability.js
+++ b/packages/ckeditor5-dev-release-tools/tests/utils/checkversionavailability.js
@@ -34,7 +34,7 @@ describe( 'dev-release-tools/utils', () => {
 		} );
 
 		it( 'should resolve to true if version does not exist (npm >= 8.13.0)', () => {
-			stubs.shExec.rejects( new Error( 'npm ERR! code E404' ) );
+			stubs.shExec.rejects( new Error( 'code E404' ) );
 
 			return checkVersionAvailability( '1.0.1', 'stub-package' )
 				.then( result => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix (release-tools): The release tools is now compatible with npm 10. Closes ckeditor/ckeditor5#16610.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
