### PR TITLE
Fixed logic in `verifyPackagesPublishedCorrectly` to use `checkVersionAvailability` correctly.

### DIFF
--- a/packages/ckeditor5-dev-release-tools/lib/tasks/verifypackagespublishedcorrectly.js
+++ b/packages/ckeditor5-dev-release-tools/lib/tasks/verifypackagespublishedcorrectly.js
@@ -35,8 +35,13 @@ module.exports = async function verifyPackagesPublishedCorrectly( options ) {
 		const packageJson = await fs.readJson( upath.join( packageToVerify, 'package.json' ) );
 
 		try {
-			await checkVersionAvailability( version, packageJson.name );
-			await fs.remove( packageToVerify );
+			const packageWasUploadedCorrectly = !await checkVersionAvailability( version, packageJson.name );
+
+			if ( packageWasUploadedCorrectly ) {
+				await fs.remove( packageToVerify );
+			} else {
+				errors.push( packageJson.name );
+			}
 		} catch {
 			errors.push( packageJson.name );
 		}


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Fixed logic in `verifyPackagesPublishedCorrectly` to use `checkVersionAvailability` correctly. See ckeditor/ckeditor5#16625.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
