### PR TITLE
Fix (build-tools): Keep nested CSS variables when splitting stylesheets into editor- or content-only stylesheets.

### DIFF
--- a/packages/ckeditor5-dev-build-tools/tests/plugins/splitCss/fixtures/nested-css-variables/file1.css
+++ b/packages/ckeditor5-dev-build-tools/tests/plugins/splitCss/fixtures/nested-css-variables/file1.css
@@ -1,10 +1,14 @@
 :root {
+	/* Test CSS variables use by other CSS variables, including fallback values. */
 	--ck-spacing-unit: var(--ck-variable-1);
 	--ck-variable-1: var(--ck-variable-2);
-	--ck-variable-2: var(--ck-variable-3);
-	--ck-variable-3: var(--ck-variable-4);
-	--ck-variable-4: var(--ck-variable-5);
-	--ck-variable-5: 0.6em;
+	--ck-variable-2: var(--ck-nonexistent-variable, var(--ck-variable-3));
+	--ck-variable-3: 0.6em;
+
+	/* Test whether the unused variables are removed. */
+	--ck-unused-primary: green;
+	--ck-unused-secondary: red;
+	--ck-unused-variable-2: var(--ck-unused-primary, var(--ck-unused-secondary));
 }
 
 .ck {

--- a/packages/ckeditor5-dev-build-tools/tests/plugins/splitCss/fixtures/nested-css-variables/file1.css
+++ b/packages/ckeditor5-dev-build-tools/tests/plugins/splitCss/fixtures/nested-css-variables/file1.css
@@ -1,0 +1,12 @@
+:root {
+	--ck-spacing-unit: var(--ck-variable-1);
+	--ck-variable-1: var(--ck-variable-2);
+	--ck-variable-2: var(--ck-variable-3);
+	--ck-variable-3: var(--ck-variable-4);
+	--ck-variable-4: var(--ck-variable-5);
+	--ck-variable-5: 0.6em;
+}
+
+.ck {
+	margin: var(--ck-spacing-unit);
+}

--- a/packages/ckeditor5-dev-build-tools/tests/plugins/splitCss/fixtures/nested-css-variables/input.ts
+++ b/packages/ckeditor5-dev-build-tools/tests/plugins/splitCss/fixtures/nested-css-variables/input.ts
@@ -1,0 +1,8 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+import './file1.css';
+
+export const test = 123;

--- a/packages/ckeditor5-dev-build-tools/tests/plugins/splitCss/splitCss.test.ts
+++ b/packages/ckeditor5-dev-build-tools/tests/plugins/splitCss/splitCss.test.ts
@@ -276,10 +276,8 @@ test( 'should keep CSS variables used by other CSS variables', async () => {
 		`:root {
 			--ck-spacing-unit: var(--ck-variable-1);
 			--ck-variable-1: var(--ck-variable-2);
-			--ck-variable-2: var(--ck-variable-3);
-			--ck-variable-3: var(--ck-variable-4);
-			--ck-variable-4: var(--ck-variable-5);
-			--ck-variable-5: 0.6em;
+			--ck-variable-2: var(--ck-nonexistent-variable, var(--ck-variable-3));
+			--ck-variable-3: 0.6em;
 		}
 		.ck {
 			margin: var(--ck-spacing-unit);

--- a/packages/ckeditor5-dev-build-tools/tests/plugins/splitCss/splitCss.test.ts
+++ b/packages/ckeditor5-dev-build-tools/tests/plugins/splitCss/splitCss.test.ts
@@ -260,8 +260,31 @@ test( 'should correctly parse the `data:image` style definition (should do not a
 			'stroke-width=\'13\' dominant-baseline=\'middle\' fill=\'black\' x=\'100%\' text-anchor=\'end\' y=\'7\' font-size=\'9px\' ' +
 			'font-family=\'Consolas, %22Lucida Console%22, %22Lucida Sans Typewriter%22, %22DejaVu Sans Mono%22, ' +
 			'%22Bitstream Vera Sans Mono%22, %22Liberation Mono%22, Monaco, %22Courier New%22, Courier, monospace\'>' +
-			'FIGCAPTION</text></svg>");background-position: calc(100% - 1px) 1px;}\n' );
+			'FIGCAPTION</text></svg>");background-position: calc(100% - 1px) 1px;\n}\n' );
 
 	verifyDividedStyleSheet( output, 'styles-editor.css', expectedResult );
 	verifyDividedStyleSheet( output, 'styles-content.css', '' );
+} );
+
+test( 'should keep CSS variables used by other CSS variables', async () => {
+	const output = await generateBundle(
+		'./fixtures/nested-css-variables/input.ts',
+		{ baseFileName: 'styles' }
+	);
+
+	const expectedResult = removeWhitespace(
+		`:root {
+			--ck-spacing-unit: var(--ck-variable-1);
+			--ck-variable-1: var(--ck-variable-2);
+			--ck-variable-2: var(--ck-variable-3);
+			--ck-variable-3: var(--ck-variable-4);
+			--ck-variable-4: var(--ck-variable-5);
+			--ck-variable-5: 0.6em;
+		}
+		.ck {
+			margin: var(--ck-spacing-unit);
+		}
+	` );
+
+	verifyDividedStyleSheet( output, 'styles-editor.css', expectedResult );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix (build-tools): Preserve CSS variables used by other CSS variables when splitting styles into editor- or content-only stylesheets. Fixes [ckeditor/ckeditor5#16689](https://github.com/ckeditor/ckeditor5/issues/16689).

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
