### PR TITLE
Preserve all selectors in CSS files during split into editor and content stylesheets.

### DIFF
--- a/packages/ckeditor5-dev-build-tools/src/plugins/splitCss.ts
+++ b/packages/ckeditor5-dev-build-tools/src/plugins/splitCss.ts
@@ -394,14 +394,7 @@ function getSplittedStyleKeyframes( keyframesRules: Array<KeyFrames>, allRulesCo
 	keyframesRules.forEach( keyframeRule => {
 		const animationName = keyframeRule.name;
 
-		if ( !animationName ) {
-			return;
-		}
-
 		allRulesContainingAnimations.forEach( rule => {
-			if ( rule.type !== 'rule' ) {
-				return;
-			}
 			const declarations = rule.declarations as Array<Declaration>;
 			const selectorStartsWithCkContent = isSelectorStartsWithCkContent( rule );
 			const selectorStartsWithoutCkContent = isSelectorStartsWithoutCkContent( rule );
@@ -411,7 +404,7 @@ function getSplittedStyleKeyframes( keyframesRules: Array<KeyFrames>, allRulesCo
 					return;
 				}
 
-				if ( declaration.value!.includes( animationName ) ) {
+				if ( declaration.value!.includes( animationName! ) ) {
 					const selector = `@keyframes ${ animationName }`;
 					const keyframeEntries = getKeyframesEntries( keyframeRule );
 					const ruleDeclarationsWithSelector = wrapDefinitionsIntoSelector( selector, keyframeEntries );

--- a/packages/ckeditor5-dev-build-tools/src/plugins/splitCss.ts
+++ b/packages/ckeditor5-dev-build-tools/src/plugins/splitCss.ts
@@ -237,7 +237,7 @@ function createRootDeclarationOfUsedVariables(
  * Decides to which stylesheet should passed `rule` be placed or it should be in `:root` definition.
  */
 function divideRuleStylesBetweenStylesheets( rule: Rule ) {
-	const selector = rule.selectors![ 0 ]!;
+	const selector = rule.selectors!.join( ',\n' );
 	const rootDefinitions = [];
 
 	let editorStyles = '';

--- a/packages/ckeditor5-dev-build-tools/src/plugins/splitCss.ts
+++ b/packages/ckeditor5-dev-build-tools/src/plugins/splitCss.ts
@@ -277,8 +277,8 @@ function divideRuleStylesBetweenStylesheets( rule: Rule | Media | KeyFrames ) {
 			editorStyles: '',
 			editingViewStyles: '',
 			keyframesRules: ''
-		}
-	};
+		};
+	}
 }
 
 /**

--- a/packages/ckeditor5-dev-build-tools/src/plugins/splitCss.ts
+++ b/packages/ckeditor5-dev-build-tools/src/plugins/splitCss.ts
@@ -4,7 +4,15 @@
  */
 
 import { createFilter } from '@rollup/pluginutils';
-import { parse, type Rule, type Declaration, type Stylesheet, type KeyFrames, type KeyFrame, type Media } from 'css';
+import {
+	parse,
+	type Rule,
+	type Declaration,
+	type Stylesheet,
+	type KeyFrames,
+	type KeyFrame,
+	type Media
+} from 'css';
 import type { Plugin, OutputBundle, NormalizedOutputOptions, EmittedAsset } from 'rollup';
 import type { Processor } from 'postcss';
 import cssnano from 'cssnano';
@@ -415,7 +423,6 @@ function getSplittedStyleKeyframes( keyframesRules: Array<KeyFrames>, allRulesCo
 					if ( selectorStartsWithoutCkContent ) {
 						editorStyles += ruleDeclarationsWithSelector;
 					}
-
 				}
 			} );
 		} );
@@ -519,10 +526,15 @@ function getKeyframesEntries( rule: KeyFrames ) {
 	let keyframeEntries = '';
 
 	rule.keyframes!.forEach( keyframe => {
-		keyframeEntries += ` ${ ( keyframe as KeyFrame ) .values!.join(',\n') } { ${ getRuleDeclarations( ( keyframe as KeyFrame ).declarations! ) } }`;
+		if ( 'comment' in keyframe ) {
+			return;
+		}
+		const keyFrameSelector = ( keyframe as KeyFrame ).values!.join( ',\n' );
+		const keyFrameDeclarations = getRuleDeclarations( ( keyframe as KeyFrame ).declarations! );
+		keyframeEntries += ` ${ keyFrameSelector } { ${ keyFrameDeclarations } }`;
 	} );
 
-	return keyframeEntries
+	return keyframeEntries;
 }
 
 function isSelectorStartsWithCkContent( rule: Rule ) {

--- a/packages/ckeditor5-dev-build-tools/tests/plugins/splitCss/fixtures/keyframes/file1.css
+++ b/packages/ckeditor5-dev-build-tools/tests/plugins/splitCss/fixtures/keyframes/file1.css
@@ -1,0 +1,12 @@
+.animation {
+	/* This is a comment */
+	animation: fadeIn 1s;
+}
+@keyframes fadeIn {
+	from {
+		/* This is a comment */
+		opacity: 0;
+	}
+	/* This is a comment */
+	to { opacity: 1; }
+}

--- a/packages/ckeditor5-dev-build-tools/tests/plugins/splitCss/fixtures/keyframes/file2.css
+++ b/packages/ckeditor5-dev-build-tools/tests/plugins/splitCss/fixtures/keyframes/file2.css
@@ -1,0 +1,17 @@
+@media (forced-colors: none) {
+	/* This is a comment */
+	.ck-content.animation-in-media-query {
+		/* This is a comment */
+		animation: ck-animation 1s ease-out;
+	}
+}
+
+@keyframes ck-animation {
+	0% {
+		background-color: white;
+	}
+
+	100% {
+		background-color: black;
+	}
+}

--- a/packages/ckeditor5-dev-build-tools/tests/plugins/splitCss/fixtures/keyframes/input.ts
+++ b/packages/ckeditor5-dev-build-tools/tests/plugins/splitCss/fixtures/keyframes/input.ts
@@ -1,0 +1,9 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+import './file1.css';
+import './file2.css';
+
+export const test = 123;

--- a/packages/ckeditor5-dev-build-tools/tests/plugins/splitCss/fixtures/media-query/file1.css
+++ b/packages/ckeditor5-dev-build-tools/tests/plugins/splitCss/fixtures/media-query/file1.css
@@ -1,0 +1,5 @@
+@media (prefers-reduced-motion: reduce) {
+	.ck-image-upload-complete-icon {
+		animation-duration: 0ms;
+	}
+}

--- a/packages/ckeditor5-dev-build-tools/tests/plugins/splitCss/fixtures/media-query/file2.css
+++ b/packages/ckeditor5-dev-build-tools/tests/plugins/splitCss/fixtures/media-query/file2.css
@@ -1,0 +1,12 @@
+@media print {
+	.ck-content .page-break {
+		padding: 0;
+	}
+}
+
+@media screen and (max-width: 600px) {
+	/* This is a comment */
+	.ck-content {
+		width: 100%;
+	}
+}

--- a/packages/ckeditor5-dev-build-tools/tests/plugins/splitCss/fixtures/media-query/input.ts
+++ b/packages/ckeditor5-dev-build-tools/tests/plugins/splitCss/fixtures/media-query/input.ts
@@ -1,0 +1,9 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+import './file1.css';
+import './file2.css';
+
+export const test = 123;

--- a/packages/ckeditor5-dev-build-tools/tests/plugins/splitCss/fixtures/more-than-one-selector/file1.css
+++ b/packages/ckeditor5-dev-build-tools/tests/plugins/splitCss/fixtures/more-than-one-selector/file1.css
@@ -1,0 +1,5 @@
+.ck,
+.second-selector,
+.third-selector p {
+	color: red;
+}

--- a/packages/ckeditor5-dev-build-tools/tests/plugins/splitCss/fixtures/more-than-one-selector/input.ts
+++ b/packages/ckeditor5-dev-build-tools/tests/plugins/splitCss/fixtures/more-than-one-selector/input.ts
@@ -1,0 +1,8 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+import './file1.css';
+
+export const test = 123;

--- a/packages/ckeditor5-dev-build-tools/tests/plugins/splitCss/splitCss.test.ts
+++ b/packages/ckeditor5-dev-build-tools/tests/plugins/splitCss/splitCss.test.ts
@@ -303,3 +303,68 @@ test( 'should preserve all selectors', async () => {
 
 	verifyDividedStyleSheet( output, 'styles-editor.css', expectedResult );
 } );
+
+test( 'should preserve all `@media` queries and split it correctly', async () => {
+	const output = await generateBundle(
+		'./fixtures/media-query/input.ts',
+		{ baseFileName: 'styles' }
+	);
+
+	const expectedEditorResult = removeWhitespace(
+		`@media (prefers-reduced-motion: reduce) {
+			.ck-image-upload-complete-icon {
+				animation-duration: 0ms;
+			}
+		}
+	` );
+
+	const expectedContentResult = removeWhitespace(
+		`@media print {
+			.ck-content .page-break {
+				padding: 0;
+			}
+		}
+		@media screen and (max-width: 600px) {
+			.ck-content {
+				width: 100%;
+			}
+		}
+	` );
+
+	verifyDividedStyleSheet( output, 'styles-editor.css', expectedEditorResult );
+	verifyDividedStyleSheet( output, 'styles-content.css', expectedContentResult );
+} );
+
+test( 'should preserve all `@keyframes` queries and split it correctly', async () => {
+	const output = await generateBundle(
+		'./fixtures/keyframes/input.ts',
+		{ baseFileName: 'styles' }
+	);
+
+	const expectedEditorResult = removeWhitespace(
+		`.animation {
+			animation: fadeIn 1s;
+		}
+		@keyframes fadeIn {
+			from { opacity: 0;
+			} to { opacity: 1;
+			}
+		}
+	` );
+
+	const expectedContentResult = removeWhitespace(
+		`@media (forced-colors: none) {
+			.ck-content.animation-in-media-query {
+				animation: ck-animation 1s ease-out;
+			}
+		}
+		@keyframes ck-animation {
+			0% { background-color: white;
+			} 100% { background-color: black;
+		}
+	}
+	` );
+
+	verifyDividedStyleSheet( output, 'styles-editor.css', expectedEditorResult );
+	verifyDividedStyleSheet( output, 'styles-content.css', expectedContentResult );
+} );

--- a/packages/ckeditor5-dev-build-tools/tests/plugins/splitCss/splitCss.test.ts
+++ b/packages/ckeditor5-dev-build-tools/tests/plugins/splitCss/splitCss.test.ts
@@ -286,3 +286,20 @@ test( 'should keep CSS variables used by other CSS variables', async () => {
 
 	verifyDividedStyleSheet( output, 'styles-editor.css', expectedResult );
 } );
+
+test( 'should preserve all selectors', async () => {
+	const output = await generateBundle(
+		'./fixtures/more-than-one-selector/input.ts',
+		{ baseFileName: 'styles' }
+	);
+
+	const expectedResult = removeWhitespace(
+		`.ck,
+		.second-selector,
+		.third-selector p {
+			color: red;
+		}
+	` );
+
+	verifyDividedStyleSheet( output, 'styles-editor.css', expectedResult );
+} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix (build-tools): Should preserve all selectors and at-rules in CSS files during split into `editor` and `content` stylesheets. Closes https://github.com/ckeditor/ckeditor5/issues/16703.

---

### Additional information

The main problem was when we were splitting main css file into `editor` and `content`. Mainly it was done using `.ck-content` CSS class as a main target what should be put into `content` file and all the rest should land into `editor`. But this condition didn't include neither `@media` queries or  animations with `@keyframes` that class contains.

Currently all `@media` queries are splitted by class name mention above.

The `@keyframes` are gathered from whole main css file; also all selectors that are containing `animation` or `animation-name` are gathered and compared in against selector that are used into. By this they can be correctly divided and added to desired css stylesheets.

Also some CSS classes were omitted when there were more than one selector in definition. It's also fixed in this PR.
