### PR TITLE
Improved error handling for `triggerCircleBuild()`.

### DIFF
--- a/packages/ckeditor5-dev-ci/lib/trigger-circle-build.js
+++ b/packages/ckeditor5-dev-ci/lib/trigger-circle-build.js
@@ -57,5 +57,9 @@ module.exports = async function triggerCircleBuild( options ) {
 			if ( response.error_message ) {
 				throw new Error( `CI trigger failed: "${ response.error_message }".` );
 			}
+
+			if ( response.message ) {
+				throw new Error( `CI trigger failed: "${ response.message }".` );
+			}
 		} );
 };

--- a/packages/ckeditor5-dev-ci/tests/trigger-circle-build.js
+++ b/packages/ckeditor5-dev-ci/tests/trigger-circle-build.js
@@ -140,7 +140,7 @@ describe( 'lib/triggerCircleBuild', () => {
 		expect( body.parameters ).to.have.property( 'triggerRepositorySlug', 'ckeditor/ckeditor5' );
 	} );
 
-	it( 'should reject a promise when CircleCI responds with an error', async () => {
+	it( 'should reject a promise when CircleCI responds with an error containing error_message property', async () => {
 		stubs.fetch.resolves( {
 			json: () => Promise.resolve( {
 				error_message: 'HTTP 404'
@@ -155,6 +155,32 @@ describe( 'lib/triggerCircleBuild', () => {
 		};
 
 		return triggerCircleBuild( data )
+			.then( () => {
+				throw new Error( 'This error should not be thrown!' );
+			} )
+			.catch( err => {
+				expect( err.message ).to.equal( 'CI trigger failed: "HTTP 404".' );
+			} );
+	} );
+
+	it( 'should reject a promise when CircleCI responds with an error containing message property', async () => {
+		stubs.fetch.resolves( {
+			json: () => Promise.resolve( {
+				message: 'HTTP 404'
+			} )
+		} );
+
+		const data = {
+			circleToken: 'circle-token',
+			commit: 'abcd1234',
+			branch: 'master',
+			repositorySlug: 'ckeditor/ckeditor5-dev'
+		};
+
+		return triggerCircleBuild( data )
+			.then( () => {
+				throw new Error( 'This error should not be thrown!' );
+			} )
 			.catch( err => {
 				expect( err.message ).to.equal( 'CI trigger failed: "HTTP 404".' );
 			} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix (dev-ci): Improved error handling by checking both error properties for the `triggerCircleBuild()` util. Closes ckeditor/ckeditor5#16746.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
