### PR TITLE
Build tools extended with the ability to pass the globals parameter.

### DIFF
--- a/packages/ckeditor5-dev-build-tools/README.md
+++ b/packages/ckeditor5-dev-build-tools/README.md
@@ -148,9 +148,9 @@ This option is required if the `browser' option is enabled.
 
 **Default value:** `{}`
 
-A list of pairs necessary for external imports in `umd` bundles.
+Pairs of external package names and associated global variables used in the `umd` build.
 
-The list of `globals` already contains `ckeditor5` and `ckeditor5-premium-features` which are mapped to `CKEDITOR` and `CKEDITOR_PREMIUM_FEATURES`.
+The list already contains `ckeditor5` and `ckeditor5-premium-features` which are mapped to `CKEDITOR` and `CKEDITOR_PREMIUM_FEATURES`.
 
 When using the CLI, this option can be used multiple times.
 

--- a/packages/ckeditor5-dev-build-tools/README.md
+++ b/packages/ckeditor5-dev-build-tools/README.md
@@ -142,6 +142,30 @@ The name of the UMD bundle. This name will be used as the global variable name w
 
 This option is required if the `browser' option is enabled.
 
+#### `globals` / `--globals=[moduleID:Global]`
+
+**Type:** `{ [ name: string ]: string } | ( ( name: string ) => string )` | `string[]`
+
+**Default value:** `{}`
+
+A list of pairs necessary for external imports in `umd` bundles.
+
+The list of `globals` already contains `ckeditor5` and `ckeditor5-premium-features` which are mapped to `CKEDITOR` and `CKEDITOR_PREMIUM_FEATURES`.
+
+When using the CLI, this option can be used multiple times.
+
+**Example value:** `--globals=external-id:variableName --globals=another-external-id:anotherVariableName`
+
+When using the JavaScript API, the option must be an object.
+
+**Example value:**
+```js
+globals: {
+	'external-id': 'variableName',
+	'another-external-id': 'anotherVariableName'
+}
+```
+
 #### `external` / `--external=[path]`
 
 **Type:** `string[]` | `string`

--- a/packages/ckeditor5-dev-build-tools/src/build.ts
+++ b/packages/ckeditor5-dev-build-tools/src/build.ts
@@ -10,7 +10,7 @@ import chalk from 'chalk';
 import path from 'upath';
 import { rollup, type RollupOutput, type GlobalsOption } from 'rollup';
 import { getRollupConfig } from './config.js';
-import { getCwdPath, camelizeObjectKeys, removeWhitespace, CKEDITOR_GLOBALS } from './utils.js';
+import { getCwdPath, camelizeObjectKeys, removeWhitespace } from './utils.js';
 
 export interface BuildOptions {
 	input: string;
@@ -44,6 +44,14 @@ export const defaultOptions: BuildOptions = {
 	minify: false,
 	clean: false,
 	browser: false
+};
+
+/**
+ * `ckeditor5` and `ckeditor5-premium-features` globals.
+ */
+const CKEDITOR_GLOBALS: GlobalsOption = {
+	ckeditor5: 'CKEDITOR',
+	'ckeditor5-premium-features': 'CKEDITOR_PREMIUM_FEATURES'
 };
 
 /**

--- a/packages/ckeditor5-dev-build-tools/src/build.ts
+++ b/packages/ckeditor5-dev-build-tools/src/build.ts
@@ -10,7 +10,7 @@ import chalk from 'chalk';
 import path from 'upath';
 import { rollup, type RollupOutput, type GlobalsOption } from 'rollup';
 import { getRollupConfig } from './config.js';
-import { getCwdPath, camelizeObjectKeys, removeWhitespace } from './utils.js';
+import { getCwdPath, camelizeObjectKeys, removeWhitespace, CKEDITOR_GLOBALS } from './utils.js';
 
 export interface BuildOptions {
 	input: string;
@@ -97,6 +97,10 @@ async function generateUmdBuild( args: BuildOptions, bundle: RollupOutput ): Pro
 	const { dir, name } = path.parse( args.output );
 	const { plugins, ...config } = await getRollupConfig( args );
 	const build = await rollup( config );
+	const globals = {
+		...CKEDITOR_GLOBALS,
+		...args.globals as GlobalsOption
+	};
 
 	const umdBundle = await build.write( {
 		format: 'umd',
@@ -104,7 +108,7 @@ async function generateUmdBuild( args: BuildOptions, bundle: RollupOutput ): Pro
 		assetFileNames: '[name][extname]',
 		sourcemap: args.sourceMap,
 		name: args.name,
-		globals: args.globals as GlobalsOption | undefined
+		globals
 	} );
 
 	return {

--- a/packages/ckeditor5-dev-build-tools/src/utils.ts
+++ b/packages/ckeditor5-dev-build-tools/src/utils.ts
@@ -6,6 +6,7 @@
 import { createRequire } from 'module';
 import path from 'upath';
 import type { CamelCase, CamelCasedProperties } from 'type-fest';
+import type { GlobalsOption } from 'rollup';
 
 const require = createRequire( import.meta.url );
 
@@ -60,3 +61,11 @@ export function getUserDependency( name: string ): any {
 
 	return require( path );
 }
+
+/**
+ * `ckeditor5` and `ckeditor5-premium-features` globals.
+ */
+export const CKEDITOR_GLOBALS: GlobalsOption = {
+	ckeditor5: 'CKEDITOR',
+	'ckeditor5-premium-features': 'CKEDITOR_PREMIUM_FEATURES'
+};

--- a/packages/ckeditor5-dev-build-tools/src/utils.ts
+++ b/packages/ckeditor5-dev-build-tools/src/utils.ts
@@ -6,7 +6,6 @@
 import { createRequire } from 'module';
 import path from 'upath';
 import type { CamelCase, CamelCasedProperties } from 'type-fest';
-import type { GlobalsOption } from 'rollup';
 
 const require = createRequire( import.meta.url );
 
@@ -61,11 +60,3 @@ export function getUserDependency( name: string ): any {
 
 	return require( path );
 }
-
-/**
- * `ckeditor5` and `ckeditor5-premium-features` globals.
- */
-export const CKEDITOR_GLOBALS: GlobalsOption = {
-	ckeditor5: 'CKEDITOR',
-	'ckeditor5-premium-features': 'CKEDITOR_PREMIUM_FEATURES'
-};

--- a/packages/ckeditor5-dev-build-tools/tests/build/arguments.test.ts
+++ b/packages/ckeditor5-dev-build-tools/tests/build/arguments.test.ts
@@ -122,6 +122,15 @@ test( '--external', async () => {
 	expect( spy ).toHaveBeenCalledWith( expect.objectContaining( { external: [ 'foo', 'bar' ] } ) );
 } );
 
+test( '--globals', async () => {
+	const spy = getConfigMock();
+
+	mockCliArgs( '--globals=foo:bar', '--globals=baz:faz' );
+	await build();
+
+	expect( spy ).toHaveBeenCalledWith( expect.objectContaining( { globals: { foo: 'bar', baz: 'faz' } } ) );
+} );
+
 test( '--declarations', async () => {
 	const spy = getConfigMock();
 
@@ -210,6 +219,22 @@ test( '.external', async () => {
 	await build( { external: [ 'foo', 'bar' ] } );
 
 	expect( spy ).toHaveBeenCalledWith( expect.objectContaining( { external: [ 'foo', 'bar' ] } ) );
+} );
+
+test( '.globals', async () => {
+	const spy = getConfigMock();
+
+	await build( { globals: { foo: 'bar' } } );
+
+	expect( spy ).toHaveBeenCalledWith( expect.objectContaining( { globals: { foo: 'bar' } } ) );
+} );
+
+test( '.globals (empty object)', async () => {
+	const spy = getConfigMock();
+
+	await build( { globals: {} } );
+
+	expect( spy ).toHaveBeenCalledWith( expect.objectContaining( { globals: {} } ) );
 } );
 
 test( '.rewrite', async () => {

--- a/packages/ckeditor5-dev-build-tools/tests/build/build.test.ts
+++ b/packages/ckeditor5-dev-build-tools/tests/build/build.test.ts
@@ -310,7 +310,7 @@ test( 'Minify', async () => {
 	expect( output[ 0 ].code ).toContain( 'export{' );
 } );
 
-test( 'Minification doesnt remove banner', async () => {
+test( 'Minification doesn\'t remove banner', async () => {
 	const { output } = await build( {
 		input: 'src/input.js',
 		banner: 'src/banner.js',

--- a/packages/ckeditor5-dev-build-tools/tests/config/config.test.ts
+++ b/packages/ckeditor5-dev-build-tools/tests/config/config.test.ts
@@ -16,6 +16,7 @@ const defaults: Options = {
 	banner: '',
 	external: [],
 	rewrite: [],
+	globals: [],
 	declarations: false,
 	translations: '',
 	sourceMap: false,


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix (build-tools): Ability to pass `globals` parameter if necessary for external imports in `umd` bundles. See https://github.com/ckeditor/ckeditor5/issues/16798.

BREAKING CHANGE: Ability to pass `globals` parameter if necessary for external imports in `umd` bundles.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
