### PR TITLE
Added a Chrome flag to prevent displaying the search engine choice screen

### DIFF
--- a/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getkarmaconfig.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getkarmaconfig.js
@@ -226,7 +226,8 @@ function getFlagsForBrowser( browser ) {
 		'--disable-background-timer-throttling',
 		'--js-flags="--expose-gc"',
 		'--disable-renderer-backgrounding',
-		'--disable-backgrounding-occluded-windows'
+		'--disable-backgrounding-occluded-windows',
+		'--disable-search-engine-choice-screen'
 	];
 
 	if ( browser === 'CHROME_CI' ) {

--- a/packages/ckeditor5-dev-tests/tests/utils/automated-tests/getkarmaconfig.js
+++ b/packages/ckeditor5-dev-tests/tests/utils/automated-tests/getkarmaconfig.js
@@ -204,6 +204,7 @@ describe( 'getKarmaConfig()', () => {
 			'--js-flags="--expose-gc"',
 			'--disable-renderer-backgrounding',
 			'--disable-backgrounding-occluded-windows',
+			'--disable-search-engine-choice-screen',
 			'--no-sandbox'
 		] );
 
@@ -214,6 +215,7 @@ describe( 'getKarmaConfig()', () => {
 			'--js-flags="--expose-gc"',
 			'--disable-renderer-backgrounding',
 			'--disable-backgrounding-occluded-windows',
+			'--disable-search-engine-choice-screen',
 			'--remote-debugging-port=9222'
 		] );
 	} );


### PR DESCRIPTION
Fix (dev-tests): Added a Chrome flag to prevent displaying the search engine choice screen that disrupts automated tests in windowed mode. Closes https://github.com/ckeditor/ckeditor5/issues/16825.
