### PR TITLE
Aligned stale bot to recent changes in the GitHub GraphQL API

### DIFF
--- a/packages/ckeditor5-dev-stale-bot/lib/githubrepository.js
+++ b/packages/ckeditor5-dev-stale-bot/lib/githubrepository.js
@@ -323,7 +323,12 @@ module.exports = class GitHubRepository {
 		};
 
 		return this.sendRequest( await queries.getLabels, variables )
-			.then( data => data.repository.labels.nodes.map( label => label.id ) )
+			.then( data => {
+				return data.repository.labels.nodes
+					// Additional filtering is needed, because GitHub endpoint may return many more results than match the query.
+					.filter( label => labelNames.includes( label.name ) )
+					.map( label => label.id );
+			} )
 			.catch( error => {
 				this.logger.error( 'Unexpected error when executing "#getLabels()".', error );
 

--- a/packages/ckeditor5-dev-stale-bot/lib/graphql/getlabels.graphql
+++ b/packages/ckeditor5-dev-stale-bot/lib/graphql/getlabels.graphql
@@ -3,6 +3,7 @@ query GetLabels( $repositoryOwner: String!, $repositoryName: String!, $labelName
 		labels( query: $labelNames, first: 100 ) {
 			nodes {
 				id
+				name
 			}
 		}
 	}


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other (stale-bot): Aligned stale bot to recent changes in the GitHub GraphQL API in the `repository.labels` connection. GitHub recently started returning a lot of mismatched labels for the query and now stale bot ensures that only the required ones are used. Closes ckeditor/ckeditor5#16872.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
