### PR TITLE
Migrated `ckeditor5-dev-dependency-checker` to ESM

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -36,6 +36,7 @@ module.exports = {
 		{
 			files: [
 				// TODO: add packages as they are migrated to ESM.
+				'./packages/ckeditor5-dev-dependency-checker/**/*',
 				'./packages/ckeditor5-dev-stale-bot/**/*',
 				'./packages/ckeditor5-dev-ci/**/*',
 				'./packages/ckeditor5-dev-docs/**/*'

--- a/packages/ckeditor5-dev-dependency-checker/bin/dependencychecker.js
+++ b/packages/ckeditor5-dev-dependency-checker/bin/dependencychecker.js
@@ -5,12 +5,10 @@
  * For licensing, see LICENSE.md.
  */
 
-'use strict';
-
-const path = require( 'path' );
-const minimist = require( 'minimist' );
-const { tools } = require( '@ckeditor/ckeditor5-dev-utils' );
-const checkDependencies = require( '../lib/checkdependencies' );
+import path from 'path';
+import minimist from 'minimist';
+import { tools } from '@ckeditor/ckeditor5-dev-utils';
+import checkDependencies from '../lib/checkdependencies.js';
 
 const { packagePaths, options } = parseArguments( process.argv.slice( 2 ) );
 

--- a/packages/ckeditor5-dev-dependency-checker/lib/checkdependencies.js
+++ b/packages/ckeditor5-dev-dependency-checker/lib/checkdependencies.js
@@ -3,13 +3,11 @@
  * For licensing, see LICENSE.md.
  */
 
-'use strict';
-
-const fs = require( 'fs' );
-const upath = require( 'upath' );
-const { globSync } = require( 'glob' );
-const depCheck = require( 'depcheck' );
-const chalk = require( 'chalk' );
+import fs from 'fs';
+import upath from 'upath';
+import { globSync } from 'glob';
+import depCheck from 'depcheck';
+import chalk from 'chalk';
 
 /**
  * Checks dependencies sequentially in all provided packages.
@@ -19,7 +17,7 @@ const chalk = require( 'chalk' );
  * @param {Boolean} [options.quiet=false] Whether to inform about the progress.
  * @returns {Promise.<Boolean>} Resolves a promise with a flag informing whether detected an error.
  */
-module.exports = async function checkDependencies( packagePaths, options ) {
+export default async function checkDependencies( packagePaths, options ) {
 	let foundError = false;
 
 	for ( const packagePath of packagePaths ) {
@@ -34,7 +32,7 @@ module.exports = async function checkDependencies( packagePaths, options ) {
 	}
 
 	return Promise.resolve( foundError );
-};
+}
 
 /**
  * Checks dependencies in provided package. If the folder does not contain a package.json file the function quits with success.

--- a/packages/ckeditor5-dev-dependency-checker/lib/index.js
+++ b/packages/ckeditor5-dev-dependency-checker/lib/index.js
@@ -3,10 +3,8 @@
  * For licensing, see LICENSE.md.
  */
 
-'use strict';
+import checkDependencies from './checkdependencies.js';
 
-const checkDependencies = require( './checkdependencies' );
-
-module.exports = {
+export default {
 	checkDependencies
 };

--- a/packages/ckeditor5-dev-dependency-checker/package.json
+++ b/packages/ckeditor5-dev-dependency-checker/package.json
@@ -16,6 +16,7 @@
     "node": ">=18.0.0",
     "npm": ">=5.7.1"
   },
+  "type": "module",
   "files": [
     "bin",
     "lib"


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal (dependency-checker): Converted the package to ESM.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
