### PR TITLE
Converted `ckeditor5-dev-bump-year` to ESM.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -36,6 +36,7 @@ module.exports = {
 		{
 			files: [
 				// TODO: add packages as they are migrated to ESM.
+				'./packages/ckeditor5-dev-bump-year/**/*',
 				'./packages/ckeditor5-dev-stale-bot/**/*',
 				'./packages/ckeditor5-dev-ci/**/*',
 				'./packages/ckeditor5-dev-docs/**/*'

--- a/packages/ckeditor5-dev-bump-year/lib/bumpyear.js
+++ b/packages/ckeditor5-dev-bump-year/lib/bumpyear.js
@@ -3,8 +3,6 @@
  * For licensing, see LICENSE.md.
  */
 
-'use strict';
-
 import chalk from 'chalk';
 import fs from 'fs';
 import { globSync } from 'glob';

--- a/packages/ckeditor5-dev-bump-year/lib/bumpyear.js
+++ b/packages/ckeditor5-dev-bump-year/lib/bumpyear.js
@@ -5,9 +5,9 @@
 
 'use strict';
 
-const chalk = require( 'chalk' );
-const fs = require( 'fs' );
-const { globSync } = require( 'glob' );
+import chalk from 'chalk';
+import fs from 'fs';
+import { globSync } from 'glob';
 
 /**
  * Updates year in all licenses in the provided directory, based on provided glob patterns.
@@ -24,7 +24,7 @@ const { globSync } = require( 'glob' );
  * and optionally `options` property for this `glob` pattern.
  * @param {String} [params.initialYear='2003'] Year from which the licenses should begin.
  */
-module.exports = function bumpYear( params ) {
+export default function bumpYear( params ) {
 	if ( !params.initialYear ) {
 		params.initialYear = '2003';
 	}
@@ -92,7 +92,7 @@ module.exports = function bumpYear( params ) {
 			console.log( file );
 		}
 	}
-};
+}
 
 /**
  * License headers are only required in JS and TS files.

--- a/packages/ckeditor5-dev-bump-year/lib/index.js
+++ b/packages/ckeditor5-dev-bump-year/lib/index.js
@@ -5,8 +5,8 @@
 
 'use strict';
 
-const bumpYear = require( './bumpyear' );
+import bumpYear from './bumpyear.js';
 
-module.exports = {
+export default {
 	bumpYear
 };

--- a/packages/ckeditor5-dev-bump-year/lib/index.js
+++ b/packages/ckeditor5-dev-bump-year/lib/index.js
@@ -3,8 +3,6 @@
  * For licensing, see LICENSE.md.
  */
 
-'use strict';
-
 import bumpYear from './bumpyear.js';
 
 export default {

--- a/packages/ckeditor5-dev-bump-year/package.json
+++ b/packages/ckeditor5-dev-bump-year/package.json
@@ -17,6 +17,7 @@
     "npm": ">=5.7.1"
   },
   "main": "lib/index.js",
+  "type": "module",
   "files": [
     "lib"
   ],


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal (bump-year): Converted `ckeditor5-dev-bump-year` to ESM. 

Closes cksource/ckeditor5-internal#3763.


---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
