### PR TITLE
Fixed `executeInParallel()` function throwing error when the number o…

### DIFF
--- a/packages/ckeditor5-dev-release-tools/lib/utils/executeinparallel.js
+++ b/packages/ckeditor5-dev-release-tools/lib/utils/executeinparallel.js
@@ -48,6 +48,7 @@ export default async function executeInParallel( options ) {
 		concurrency = os.cpus().length / 2
 	} = options;
 
+	const concurrencyAsInteger = Math.floor( concurrency ) || 1;
 	const normalizedCwd = upath.toUnix( cwd );
 	const packages = ( await glob( `${ packagesDirectory }/*/`, {
 		cwd: normalizedCwd,
@@ -58,7 +59,7 @@ export default async function executeInParallel( options ) {
 		packages.filter( packagesDirectoryFilter ) :
 		packages;
 
-	const packagesInThreads = getPackagesGroupedByThreads( packagesToProcess, concurrency );
+	const packagesInThreads = getPackagesGroupedByThreads( packagesToProcess, concurrencyAsInteger );
 
 	const callbackModule = upath.join( cwd, crypto.randomUUID() + '.mjs' );
 	await fs.writeFile( callbackModule, `export default ${ taskToExecute };`, 'utf-8' );

--- a/packages/ckeditor5-dev-release-tools/tests/utils/executeinparallel.js
+++ b/packages/ckeditor5-dev-release-tools/tests/utils/executeinparallel.js
@@ -334,6 +334,56 @@ describe( 'executeInParallel()', () => {
 		await promise;
 	} );
 
+	it( 'should use number of cores divided by two as default (`concurrency`)', async () => {
+		const promise = executeInParallel( defaultOptions );
+		await delay( 0 );
+
+		expect( stubs.WorkerMock.instances ).toHaveLength( 2 );
+
+		// Workers did not emit an error.
+		for ( const worker of stubs.WorkerMock.instances ) {
+			getExitCallback( worker )( 0 );
+		}
+
+		await promise;
+	} );
+
+	it( 'should round down to the closest integer (`concurrency`)', async () => {
+		const options = Object.assign( {}, defaultOptions, {
+			concurrency: 3.5
+		} );
+
+		const promise = executeInParallel( options );
+		await delay( 0 );
+
+		expect( stubs.WorkerMock.instances ).toHaveLength( 3 );
+
+		// Workers did not emit an error.
+		for ( const worker of stubs.WorkerMock.instances ) {
+			getExitCallback( worker )( 0 );
+		}
+
+		await promise;
+	} );
+
+	it( 'should assign at least one thread even if concurrency is 0 (`concurrency`)', async () => {
+		const options = Object.assign( {}, defaultOptions, {
+			concurrency: 0
+		} );
+
+		const promise = executeInParallel( options );
+		await delay( 0 );
+
+		expect( stubs.WorkerMock.instances ).toHaveLength( 1 );
+
+		// Workers did not emit an error.
+		for ( const worker of stubs.WorkerMock.instances ) {
+			getExitCallback( worker )( 0 );
+		}
+
+		await promise;
+	} );
+
 	it( 'should resolve the promise if a worker finished (aborted) with a non-zero exit code (first worker)', async () => {
 		const promise = executeInParallel( defaultOptions );
 		await delay( 0 );

--- a/packages/ckeditor5-dev-release-tools/tests/utils/executeinparallel.js
+++ b/packages/ckeditor5-dev-release-tools/tests/utils/executeinparallel.js
@@ -8,6 +8,7 @@ import { glob } from 'glob';
 import fs from 'fs/promises';
 import { registerAbortController, deregisterAbortController } from '../../lib/utils/abortcontroller.js';
 import executeInParallel from '../../lib/utils/executeinparallel.js';
+import os from 'os';
 
 const stubs = vi.hoisted( () => ( {
 	WorkerMock: class {
@@ -335,10 +336,12 @@ describe( 'executeInParallel()', () => {
 	} );
 
 	it( 'should use number of cores divided by two as default (`concurrency`)', async () => {
+		vi.mocked( os.cpus ).mockReturnValue( new Array( 7 ) );
+
 		const promise = executeInParallel( defaultOptions );
 		await delay( 0 );
 
-		expect( stubs.WorkerMock.instances ).toHaveLength( 2 );
+		expect( stubs.WorkerMock.instances ).toHaveLength( 3 );
 
 		// Workers did not emit an error.
 		for ( const worker of stubs.WorkerMock.instances ) {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix (release-tools): Passing an odd number as a value of the `concurrency` option will not crash the `executeInParallel()` function. Closes ckeditor/ckeditor5#17025.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
