### PR TITLE
Util for generating an internal release version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,40 @@
 Changelog
 =========
 
+## [44.2.0](https://github.com/ckeditor/ckeditor5-dev/compare/v44.1.1...v44.2.0) (2024-10-17)
+
+### Features
+
+* **[release-tools](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-release-tools)**: Created a new util exposed as `getNextInternal()` to generate an internal release version, e.g. `0.0.0-internal-20240102.0`. ([commit](https://github.com/ckeditor/ckeditor5-dev/commit/38346c679a8cb7ce328a9584a18529110f641325))
+
+### Released packages
+
+Check out the [Versioning policy](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/support/versioning-policy.html) guide for more information.
+
+<details>
+<summary>Released packages (summary)</summary>
+
+Releases containing new features:
+
+* [@ckeditor/ckeditor5-dev-release-tools](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-release-tools/v/44.2.0): v44.1.1 => v44.2.0
+
+Other releases:
+
+* [@ckeditor/ckeditor5-dev-build-tools](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-build-tools/v/44.2.0): v44.1.1 => v44.2.0
+* [@ckeditor/ckeditor5-dev-bump-year](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-bump-year/v/44.2.0): v44.1.1 => v44.2.0
+* [@ckeditor/ckeditor5-dev-ci](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-ci/v/44.2.0): v44.1.1 => v44.2.0
+* [@ckeditor/ckeditor5-dev-dependency-checker](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-dependency-checker/v/44.2.0): v44.1.1 => v44.2.0
+* [@ckeditor/ckeditor5-dev-docs](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-docs/v/44.2.0): v44.1.1 => v44.2.0
+* [@ckeditor/ckeditor5-dev-stale-bot](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-stale-bot/v/44.2.0): v44.1.1 => v44.2.0
+* [@ckeditor/ckeditor5-dev-tests](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-tests/v/44.2.0): v44.1.1 => v44.2.0
+* [@ckeditor/ckeditor5-dev-transifex](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-transifex/v/44.2.0): v44.1.1 => v44.2.0
+* [@ckeditor/ckeditor5-dev-translations](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-translations/v/44.2.0): v44.1.1 => v44.2.0
+* [@ckeditor/ckeditor5-dev-utils](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-utils/v/44.2.0): v44.1.1 => v44.2.0
+* [@ckeditor/ckeditor5-dev-web-crawler](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-web-crawler/v/44.2.0): v44.1.1 => v44.2.0
+* [@ckeditor/typedoc-plugins](https://www.npmjs.com/package/@ckeditor/typedoc-plugins/v/44.2.0): v44.1.1 => v44.2.0
+</details>
+
+
 ## [44.1.1](https://github.com/ckeditor/ckeditor5-dev/compare/v44.1.0...v44.1.1) (2024-10-16)
 
 > [!NOTE]
@@ -173,38 +207,6 @@ Other releases:
 * [@ckeditor/ckeditor5-dev-utils](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-utils/v/44.0.0-alpha.5): v44.0.0-alpha.4 => v44.0.0-alpha.5
 * [@ckeditor/ckeditor5-dev-web-crawler](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-web-crawler/v/44.0.0-alpha.5): v44.0.0-alpha.4 => v44.0.0-alpha.5
 * [@ckeditor/typedoc-plugins](https://www.npmjs.com/package/@ckeditor/typedoc-plugins/v/44.0.0-alpha.5): v44.0.0-alpha.4 => v44.0.0-alpha.5
-</details>
-
-
-## [44.0.0-alpha.4](https://github.com/ckeditor/ckeditor5-dev/compare/v44.0.0-alpha.3...v44.0.0-alpha.4) (2024-09-24)
-
-### Bug fixes
-
-* **[tests](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-tests)**: Prevent crashing the manual test server when reading a non-existing file due to an "ERR_HTTP_HEADERS_SENT" Node.js error. ([commit](https://github.com/ckeditor/ckeditor5-dev/commit/15a8f79e15a69ad4cec8365cb5d86cd731ba1953))
-* **[web-crawler](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-web-crawler)**: Use `jsonValue()` method to get the serialized arguments instead of calling `evaluate()` method, which may cause unhandled rejection due to destroyed context. ([commit](https://github.com/ckeditor/ckeditor5-dev/commit/c89444e9598bffbd7b3d1070df607ac05d54c2d9))
-
-### Released packages
-
-Check out the [Versioning policy](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/support/versioning-policy.html) guide for more information.
-
-<details>
-<summary>Released packages (summary)</summary>
-
-Other releases:
-
-* [@ckeditor/ckeditor5-dev-build-tools](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-build-tools/v/44.0.0-alpha.4): v44.0.0-alpha.3 => v44.0.0-alpha.4
-* [@ckeditor/ckeditor5-dev-bump-year](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-bump-year/v/44.0.0-alpha.4): v44.0.0-alpha.3 => v44.0.0-alpha.4
-* [@ckeditor/ckeditor5-dev-ci](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-ci/v/44.0.0-alpha.4): v44.0.0-alpha.3 => v44.0.0-alpha.4
-* [@ckeditor/ckeditor5-dev-dependency-checker](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-dependency-checker/v/44.0.0-alpha.4): v44.0.0-alpha.3 => v44.0.0-alpha.4
-* [@ckeditor/ckeditor5-dev-docs](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-docs/v/44.0.0-alpha.4): v44.0.0-alpha.3 => v44.0.0-alpha.4
-* [@ckeditor/ckeditor5-dev-release-tools](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-release-tools/v/44.0.0-alpha.4): v44.0.0-alpha.3 => v44.0.0-alpha.4
-* [@ckeditor/ckeditor5-dev-stale-bot](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-stale-bot/v/44.0.0-alpha.4): v44.0.0-alpha.3 => v44.0.0-alpha.4
-* [@ckeditor/ckeditor5-dev-tests](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-tests/v/44.0.0-alpha.4): v44.0.0-alpha.3 => v44.0.0-alpha.4
-* [@ckeditor/ckeditor5-dev-transifex](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-transifex/v/44.0.0-alpha.4): v44.0.0-alpha.3 => v44.0.0-alpha.4
-* [@ckeditor/ckeditor5-dev-translations](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-translations/v/44.0.0-alpha.4): v44.0.0-alpha.3 => v44.0.0-alpha.4
-* [@ckeditor/ckeditor5-dev-utils](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-utils/v/44.0.0-alpha.4): v44.0.0-alpha.3 => v44.0.0-alpha.4
-* [@ckeditor/ckeditor5-dev-web-crawler](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-web-crawler/v/44.0.0-alpha.4): v44.0.0-alpha.3 => v44.0.0-alpha.4
-* [@ckeditor/typedoc-plugins](https://www.npmjs.com/package/@ckeditor/typedoc-plugins/v/44.0.0-alpha.4): v44.0.0-alpha.3 => v44.0.0-alpha.4
 </details>
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Changelog
 
 ## [44.2.0](https://github.com/ckeditor/ckeditor5-dev/compare/v44.1.1...v44.2.0) (2024-10-17)
 
+> [!NOTE]
+> The release channel for this release is `next`.
+
 ### Features
 
 * **[release-tools](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-release-tools)**: Created a new util exposed as `getNextInternal()` to generate an internal release version, e.g. `0.0.0-internal-20240102.0`. ([commit](https://github.com/ckeditor/ckeditor5-dev/commit/38346c679a8cb7ce328a9584a18529110f641325))

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@inquirer/prompts": "^6.0.0",
     "@listr2/prompt-adapter-inquirer": "^2.0.16",
     "eslint": "^8.21.0",
-    "eslint-config-ckeditor5": "^7.0.0",
+    "eslint-config-ckeditor5": "^8.0.0",
     "fs-extra": "^11.0.0",
     "glob": "^10.0.0",
     "husky": "^8.0.2",

--- a/packages/ckeditor5-dev-release-tools/lib/index.js
+++ b/packages/ckeditor5-dev-release-tools/lib/index.js
@@ -20,6 +20,7 @@ export {
 	getNextPreRelease,
 	getLastNightly,
 	getNextNightly,
+	getNextInternal,
 	getCurrent,
 	getLastTagFromGit
 } from './utils/versions.js';

--- a/packages/ckeditor5-dev-release-tools/lib/utils/versions.js
+++ b/packages/ckeditor5-dev-release-tools/lib/utils/versions.js
@@ -93,14 +93,22 @@ export async function getNextPreRelease( releaseIdentifier, cwd = process.cwd() 
  * @returns {Promise<string>}
  */
 export async function getNextNightly( cwd = process.cwd() ) {
-	const today = new Date();
-	const year = today.getFullYear().toString();
-	const month = ( today.getMonth() + 1 ).toString().padStart( 2, '0' );
-	const day = today.getDate().toString().padStart( 2, '0' );
-
-	const nextNightlyReleaseIdentifier = `0.0.0-nightly-${ year }${ month }${ day }`;
+	const nextNightlyReleaseIdentifier = `0.0.0-nightly-${ getDateIdentifier() }`;
 
 	return getNextPreRelease( nextNightlyReleaseIdentifier, cwd );
+}
+
+/**
+ * Returns the next available internal version in the format of "0.0.0-internal-YYYYMMDD.X", where the "YYYYMMDD" is the current date for
+ * the internal release and the "X" is the sequential number starting from 0.
+ *
+ * @param {string} [cwd=process.cwd()]
+ * @returns {Promise<string>}
+ */
+export async function getNextInternal( cwd = process.cwd() ) {
+	const nextInternalReleaseIdentifier = `0.0.0-internal-${ getDateIdentifier() }`;
+
+	return getNextPreRelease( nextInternalReleaseIdentifier, cwd );
 }
 
 /**
@@ -127,6 +135,18 @@ export function getLastTagFromGit() {
  */
 export function getCurrent( cwd = process.cwd() ) {
 	return getPackageJson( cwd ).version;
+}
+
+/**
+ * @returns {string}
+ */
+function getDateIdentifier() {
+	const today = new Date();
+	const year = today.getFullYear().toString();
+	const month = ( today.getMonth() + 1 ).toString().padStart( 2, '0' );
+	const day = today.getDate().toString().padStart( 2, '0' );
+
+	return `${ year }${ month }${ day }`;
 }
 
 /**

--- a/packages/ckeditor5-dev-release-tools/tests/index.js
+++ b/packages/ckeditor5-dev-release-tools/tests/index.js
@@ -24,6 +24,7 @@ import {
 	getNextPreRelease,
 	getLastNightly,
 	getNextNightly,
+	getNextInternal,
 	getCurrent,
 	getLastTagFromGit
 } from '../lib/utils/versions.js';
@@ -176,6 +177,13 @@ describe( 'dev-release-tools/index', () => {
 		it( 'should be a function', () => {
 			expect( getNextNightly ).to.be.a( 'function' );
 			expect( index.getNextNightly ).to.equal( getNextNightly );
+		} );
+	} );
+
+	describe( 'getNextInternal()', () => {
+		it( 'should be a function', () => {
+			expect( getNextInternal ).to.be.a( 'function' );
+			expect( index.getNextInternal ).to.equal( getNextInternal );
 		} );
 	} );
 

--- a/packages/ckeditor5-dev-release-tools/tests/utils/versions.js
+++ b/packages/ckeditor5-dev-release-tools/tests/utils/versions.js
@@ -15,6 +15,7 @@ import {
 	getLastNightly,
 	getNextPreRelease,
 	getNextNightly,
+	getNextInternal,
 	getLastTagFromGit,
 	getCurrent
 } from '../../lib/utils/versions.js';
@@ -351,6 +352,35 @@ describe( 'versions', () => {
 			return getNextNightly()
 				.then( result => {
 					expect( result ).to.equal( '0.0.0-nightly-20230615.1' );
+				} );
+		} );
+	} );
+
+	describe( 'getNextInternal()', () => {
+		beforeEach( () => {
+			vi.mocked( getPackageJson ).mockReturnValue( { name: 'ckeditor5' } );
+
+			vi.useFakeTimers();
+			vi.setSystemTime( new Date( '2023-06-15 12:00:00' ) );
+		} );
+
+		afterEach( () => {
+			vi.useRealTimers();
+		} );
+
+		it( 'asks for a last internal pre-release version', () => {
+			vi.mocked( pacote ).packument.mockResolvedValue( {
+				name: 'ckeditor5',
+				versions: {
+					'0.0.0-internal-20230615.0': {},
+					'37.0.0-alpha.0': {},
+					'42.0.0': {}
+				}
+			} );
+
+			return getNextInternal()
+				.then( result => {
+					expect( result ).to.equal( '0.0.0-internal-20230615.1' );
 				} );
 		} );
 	} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature (release-tools): Created a new util exposed as `getNextInternal()` to generate an internal release version, e.g. `0.0.0-internal-20240102.0`.

Internal: Changelog for v44.2.0.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
