### PR TITLE
Synchronizing translations should take care of "Plural-Forms"

### DIFF
--- a/packages/ckeditor5-dev-translations/lib/utils/createmissingpackagetranslations.js
+++ b/packages/ckeditor5-dev-translations/lib/utils/createmissingpackagetranslations.js
@@ -7,7 +7,6 @@ import upath from 'upath';
 import fs from 'fs-extra';
 import PO from 'pofile';
 import { fileURLToPath } from 'url';
-import { getNPlurals, getFormula } from 'plural-forms';
 import getLanguages from './getlanguages.js';
 import { TRANSLATION_FILES_PATH } from './constants.js';
 import cleanTranslationFileContent from './cleantranslationfilecontent.js';
@@ -35,12 +34,6 @@ export default function createMissingPackageTranslations( { packagePath, skipLic
 
 		const translations = PO.parse( translationsTemplate );
 		translations.headers = getHeaders( languageCode, localeCode );
-
-		// translations.headers.Language = localeCode;
-		// translations.headers[ 'Plural-Forms' ] = [
-		// 	`nplurals=${ getNPlurals( languageCode ) };`,
-		// 	`plural=${ getFormula( languageCode ) };`
-		// ].join( ' ' );
 
 		fs.outputFileSync( translationFilePath, cleanTranslationFileContent( translations ).toString(), 'utf-8' );
 	}

--- a/packages/ckeditor5-dev-translations/lib/utils/createmissingpackagetranslations.js
+++ b/packages/ckeditor5-dev-translations/lib/utils/createmissingpackagetranslations.js
@@ -11,6 +11,7 @@ import { getNPlurals, getFormula } from 'plural-forms';
 import getLanguages from './getlanguages.js';
 import { TRANSLATION_FILES_PATH } from './constants.js';
 import cleanTranslationFileContent from './cleantranslationfilecontent.js';
+import getHeaders from './getheaders.js';
 
 const __filename = fileURLToPath( import.meta.url );
 const __dirname = upath.dirname( __filename );
@@ -33,12 +34,13 @@ export default function createMissingPackageTranslations( { packagePath, skipLic
 		}
 
 		const translations = PO.parse( translationsTemplate );
+		translations.headers = getHeaders( languageCode, localeCode );
 
-		translations.headers.Language = localeCode;
-		translations.headers[ 'Plural-Forms' ] = [
-			`nplurals=${ getNPlurals( languageCode ) };`,
-			`plural=${ getFormula( languageCode ) };`
-		].join( ' ' );
+		// translations.headers.Language = localeCode;
+		// translations.headers[ 'Plural-Forms' ] = [
+		// 	`nplurals=${ getNPlurals( languageCode ) };`,
+		// 	`plural=${ getFormula( languageCode ) };`
+		// ].join( ' ' );
 
 		fs.outputFileSync( translationFilePath, cleanTranslationFileContent( translations ).toString(), 'utf-8' );
 	}

--- a/packages/ckeditor5-dev-translations/lib/utils/getheaders.js
+++ b/packages/ckeditor5-dev-translations/lib/utils/getheaders.js
@@ -1,0 +1,22 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+import { getNPlurals, getFormula } from 'plural-forms';
+
+/**
+ * @param {string} languageCode
+ * @param {string} localeCode
+ * @returns {object}
+ */
+export default function getHeaders( languageCode, localeCode ) {
+	return {
+		Language: localeCode,
+		'Plural-Forms': [
+			`nplurals=${ getNPlurals( languageCode ) };`,
+			`plural=${ getFormula( languageCode ) };`
+		].join( ' ' ),
+		'Content-Type': 'text/plain; charset=UTF-8'
+	};
+}

--- a/packages/ckeditor5-dev-translations/lib/utils/synchronizetranslationsbasedoncontext.js
+++ b/packages/ckeditor5-dev-translations/lib/utils/synchronizetranslationsbasedoncontext.js
@@ -10,6 +10,8 @@ import { glob } from 'glob';
 import createMissingPackageTranslations from './createmissingpackagetranslations.js';
 import { TRANSLATION_FILES_PATH } from './constants.js';
 import cleanTranslationFileContent from './cleantranslationfilecontent.js';
+import getHeaders from './getheaders.js';
+import getLanguages from './getlanguages.js';
 
 /**
  * @param {object} options
@@ -18,6 +20,8 @@ import cleanTranslationFileContent from './cleantranslationfilecontent.js';
  * @param {boolean} options.skipLicenseHeader Whether to skip adding the license header to newly created translation files.
  */
 export default function synchronizeTranslationsBasedOnContext( { packageContexts, sourceMessages, skipLicenseHeader } ) {
+	const allLanguages = getLanguages();
+
 	// For each package:
 	for ( const { packagePath, contextContent } of packageContexts ) {
 		// (1) Skip packages that do not contain language context.
@@ -66,6 +70,9 @@ export default function synchronizeTranslationsBasedOnContext( { packageContexts
 						return item;
 					} )
 			);
+
+			const languageCode = getLanguages.find();
+			translations.headers = getHeaders( languageCode, translations.headers.Language );
 
 			const translationFileUpdated = cleanTranslationFileContent( translations ).toString();
 

--- a/packages/ckeditor5-dev-translations/tests/utils/getheaders.js
+++ b/packages/ckeditor5-dev-translations/tests/utils/getheaders.js
@@ -1,0 +1,48 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import { getNPlurals, getFormula } from 'plural-forms';
+import getHeaders from '../../lib/utils/getheaders.js';
+
+vi.mock( 'plural-forms' );
+
+describe( 'getHeaders()', () => {
+	beforeEach( () => {
+		vi.mocked( getNPlurals ).mockReturnValue( 4 );
+		vi.mocked( getFormula ).mockReturnValue( 'example plural formula' );
+	} );
+
+	it( 'should be a function', () => {
+		expect( getHeaders ).toBeInstanceOf( Function );
+	} );
+
+	it( 'should return "Language" header', () => {
+		const headers = getHeaders( 'en', 'en_GB' );
+
+		expect( headers ).toEqual( expect.objectContaining( {
+			Language: 'en_GB'
+		} ) );
+	} );
+
+	it( 'should return "Plural-Forms" header', () => {
+		const headers = getHeaders( 'en', 'en_GB' );
+
+		expect( headers ).toEqual( expect.objectContaining( {
+			'Plural-Forms': 'nplurals=4; plural=example plural formula;'
+		} ) );
+
+		expect( getNPlurals ).toHaveBeenCalledWith( 'en' );
+		expect( getFormula ).toHaveBeenCalledWith( 'en' );
+	} );
+
+	it( 'should return "Content-Type" header', () => {
+		const headers = getHeaders( 'en', 'en_GB' );
+
+		expect( headers ).toEqual( expect.objectContaining( {
+			'Content-Type': 'text/plain; charset=UTF-8'
+		} ) );
+	} );
+} );

--- a/packages/ckeditor5-dev-translations/tests/utils/synchronizetranslationsbasedoncontext.js
+++ b/packages/ckeditor5-dev-translations/tests/utils/synchronizetranslationsbasedoncontext.js
@@ -205,6 +205,76 @@ describe( 'synchronizeTranslationsBasedOnContext()', () => {
 		] );
 	} );
 
+	it( 'should remove existing plural forms if a source file contains more than a language defines', () => {
+		translations.items = [
+			{
+				msgid: 'id1',
+				msgctxt: 'Context for example message 1',
+				msgid_plural: '',
+				msgstr: [ '' ]
+			},
+			{
+				msgid: 'id2',
+				msgctxt: 'Context for example message 2',
+				msgid_plural: 'Example message 2 - plural form',
+				msgstr: [ '1', '2', '3', '4', '5', '6' ]
+			}
+		];
+
+		synchronizeTranslationsBasedOnContext( defaultOptions );
+
+		expect( translations.items ).toEqual( [
+			// `id1` is not updated as it does not offer plural forms.
+			{
+				msgid: 'id1',
+				msgctxt: 'Context for example message 1',
+				msgid_plural: '',
+				msgstr: [ '' ]
+			},
+			{
+				msgid: 'id2',
+				msgctxt: 'Context for example message 2',
+				msgid_plural: 'Example message 2 - plural form',
+				msgstr: [ '1', '2', '3', '4' ]
+			}
+		] );
+	} );
+
+	it( 'should remove existing plural forms if a source file contains less than a language defines', () => {
+		translations.items = [
+			{
+				msgid: 'id1',
+				msgctxt: 'Context for example message 1',
+				msgid_plural: '',
+				msgstr: [ '' ]
+			},
+			{
+				msgid: 'id2',
+				msgctxt: 'Context for example message 2',
+				msgid_plural: 'Example message 2 - plural form',
+				msgstr: [ '1', '2' ]
+			}
+		];
+
+		synchronizeTranslationsBasedOnContext( defaultOptions );
+
+		expect( translations.items ).toEqual( [
+			// `id1` is not updated as it does not offer plural forms.
+			{
+				msgid: 'id1',
+				msgctxt: 'Context for example message 1',
+				msgid_plural: '',
+				msgstr: [ '' ]
+			},
+			{
+				msgid: 'id2',
+				msgctxt: 'Context for example message 2',
+				msgid_plural: 'Example message 2 - plural form',
+				msgstr: [ '1', '2', '', '' ]
+			}
+		] );
+	} );
+
 	it( 'should save updated translation files on filesystem after cleaning the content', () => {
 		synchronizeTranslationsBasedOnContext( defaultOptions );
 

--- a/packages/ckeditor5-dev-translations/tests/utils/synchronizetranslationsbasedoncontext.js
+++ b/packages/ckeditor5-dev-translations/tests/utils/synchronizetranslationsbasedoncontext.js
@@ -240,7 +240,7 @@ describe( 'synchronizeTranslationsBasedOnContext()', () => {
 		] );
 	} );
 
-	it( 'should remove existing plural forms if a source file contains less than a language defines', () => {
+	it( 'should add empty plural forms if a source file contains less than a language defines', () => {
 		translations.items = [
 			{
 				msgid: 'id1',

--- a/packages/ckeditor5-dev-translations/tests/utils/synchronizetranslationsbasedoncontext.js
+++ b/packages/ckeditor5-dev-translations/tests/utils/synchronizetranslationsbasedoncontext.js
@@ -9,6 +9,8 @@ import PO from 'pofile';
 import { glob } from 'glob';
 import cleanTranslationFileContent from '../../lib/utils/cleantranslationfilecontent.js';
 import createMissingPackageTranslations from '../../lib/utils/createmissingpackagetranslations.js';
+import getLanguages from '../../lib/utils/getlanguages.js';
+import getHeaders from '../../lib/utils/getheaders.js';
 import synchronizeTranslationsBasedOnContext from '../../lib/utils/synchronizetranslationsbasedoncontext.js';
 
 vi.mock( 'fs-extra' );
@@ -16,6 +18,8 @@ vi.mock( 'pofile' );
 vi.mock( 'glob' );
 vi.mock( '../../lib/utils/createmissingpackagetranslations.js' );
 vi.mock( '../../lib/utils/cleantranslationfilecontent.js' );
+vi.mock( '../../lib/utils/getlanguages.js' );
+vi.mock( '../../lib/utils/getheaders.js' );
 
 describe( 'synchronizeTranslationsBasedOnContext()', () => {
 	let defaultOptions, translations, stubs;
@@ -46,7 +50,9 @@ describe( 'synchronizeTranslationsBasedOnContext()', () => {
 		};
 
 		translations = {
-			headers: {},
+			headers: {
+				Language: 'en'
+			},
 			items: [
 				{ msgid: 'id1' },
 				{ msgid: 'id2' }
@@ -57,6 +63,19 @@ describe( 'synchronizeTranslationsBasedOnContext()', () => {
 		stubs = {
 			poItemConstructor: vi.fn()
 		};
+
+		vi.mocked( getLanguages ).mockReturnValue( [
+			{ localeCode: 'en', languageCode: 'en', languageFileName: 'en' },
+			{ localeCode: 'zh_TW', languageCode: 'zh', languageFileName: 'zh-tw' }
+		] );
+
+		vi.mocked( getHeaders ).mockImplementation( ( languageCode, localeCode ) => {
+			return {
+				Language: localeCode,
+				'Plural-Forms': 'nplurals=4; plural=example plural formula;',
+				'Content-Type': 'text/plain; charset=UTF-8'
+			};
+		} );
 
 		vi.mocked( PO.parse ).mockReturnValue( translations );
 
@@ -131,14 +150,24 @@ describe( 'synchronizeTranslationsBasedOnContext()', () => {
 
 	it( 'should parse each translation file', () => {
 		vi.mocked( glob.sync ).mockImplementation( pattern => {
-			return [ 'en', 'pl' ].map( language => pattern.replace( '*', language ) );
+			return [ 'en', 'zh-tw' ].map( language => pattern.replace( '*', language ) );
 		} );
 
 		synchronizeTranslationsBasedOnContext( defaultOptions );
 
 		expect( fs.readFileSync ).toHaveBeenCalledTimes( 2 );
 		expect( fs.readFileSync ).toHaveBeenCalledWith( 'packages/ckeditor5-foo/lang/translations/en.po', 'utf-8' );
-		expect( fs.readFileSync ).toHaveBeenCalledWith( 'packages/ckeditor5-foo/lang/translations/pl.po', 'utf-8' );
+		expect( fs.readFileSync ).toHaveBeenCalledWith( 'packages/ckeditor5-foo/lang/translations/zh-tw.po', 'utf-8' );
+	} );
+
+	it( 'should update file header', () => {
+		synchronizeTranslationsBasedOnContext( defaultOptions );
+
+		expect( translations.headers ).toEqual( {
+			Language: 'en',
+			'Plural-Forms': 'nplurals=4; plural=example plural formula;',
+			'Content-Type': 'text/plain; charset=UTF-8'
+		} );
 	} );
 
 	it( 'should remove unused translations', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix (translations): Align the number of plural forms to plural forms defined by a language in the `synchronizeTranslations()` function.

---

### Additional information

Closes cksource/ckeditor5-internal#3846
