### PR TITLE
Added skip ci to the `commitAndTag()` function.

### DIFF
--- a/packages/ckeditor5-dev-release-tools/lib/tasks/commitandtag.js
+++ b/packages/ckeditor5-dev-release-tools/lib/tasks/commitandtag.js
@@ -16,9 +16,10 @@ const { toUnix } = upath;
  * @param {string} options.version The commit will contain this param in its message and the tag will have a `v` prefix.
  * @param {Array.<string>} options.files Array of glob patterns for files to be added to the release commit.
  * @param {string} [options.cwd=process.cwd()] Current working directory from which all paths will be resolved.
+ * @param {boolean} [options.skipCi=true] Whether to add [skip ci] to the commit.
  * @returns {Promise}
  */
-export default async function commitAndTag( { version, files, cwd = process.cwd() } ) {
+export default async function commitAndTag( { version, files, cwd = process.cwd(), skipCi = true } ) {
 	const normalizedCwd = toUnix( cwd );
 	const filePathsToAdd = await glob( files, { cwd: normalizedCwd, absolute: true, nodir: true } );
 
@@ -38,6 +39,6 @@ export default async function commitAndTag( { version, files, cwd = process.cwd(
 		return;
 	}
 
-	await git.commit( `Release: v${ version }.`, filePathsToAdd );
+	await git.commit( `Release: v${ version }.${ skipCi ? ' [skip ci]' : '' }`, filePathsToAdd );
 	await git.addTag( `v${ version }` );
 }

--- a/packages/ckeditor5-dev-release-tools/lib/tasks/commitandtag.js
+++ b/packages/ckeditor5-dev-release-tools/lib/tasks/commitandtag.js
@@ -16,7 +16,7 @@ const { toUnix } = upath;
  * @param {string} options.version The commit will contain this param in its message and the tag will have a `v` prefix.
  * @param {Array.<string>} options.files Array of glob patterns for files to be added to the release commit.
  * @param {string} [options.cwd=process.cwd()] Current working directory from which all paths will be resolved.
- * @param {boolean} [options.skipCi=true] Whether to add [skip ci] to the commit.
+ * @param {boolean} [options.skipCi=true] Whether to add the "[skip ci]" suffix to the commit message.
  * @returns {Promise}
  */
 export default async function commitAndTag( { version, files, cwd = process.cwd(), skipCi = true } ) {

--- a/packages/ckeditor5-dev-release-tools/tests/tasks/commitandtag.js
+++ b/packages/ckeditor5-dev-release-tools/tests/tasks/commitandtag.js
@@ -92,11 +92,27 @@ describe( 'commitAndTag()', () => {
 		} ) );
 
 		expect( stubs.git.commit ).toHaveBeenCalledExactlyOnceWith(
-			'Release: v1.0.0.',
+			'Release: v1.0.0. [skip ci]',
 			[
 				'package.json',
 				'packages/ckeditor5-foo/package.json'
 			]
+		);
+	} );
+
+	it( 'should not add skip ci to the commit when skipCi is set as false', async () => {
+		vi.mocked( glob ).mockResolvedValue( [ 'package.json', 'packages/ckeditor5-foo/package.json' ] );
+
+		await commitAndTag( { version: '1.0.0', packagesDirectory: 'packages', files: [ '**/package.json' ], skipCi: false } );
+
+		expect( vi.mocked( glob ) ).toHaveBeenCalledExactlyOnceWith( expect.anything(), expect.objectContaining( {
+			absolute: true,
+			nodir: true
+		} ) );
+
+		expect( stubs.git.commit ).toHaveBeenCalledExactlyOnceWith(
+			'Release: v1.0.0.',
+			expect.anything()
 		);
 	} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other (release-tools): The `commitAndTag()` function understands a new parameter called `skipCi`. By default, release commits will not trigger a new workflow on CI. This behavior can be disabled when passing the `false` value.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
