### PR TITLE
The `synchronizeTranslations()` function does not fill "en.po"

### DIFF
--- a/packages/ckeditor5-dev-translations/lib/utils/addtranslation.js
+++ b/packages/ckeditor5-dev-translations/lib/utils/addtranslation.js
@@ -1,0 +1,33 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/**
+ * @param {object} options
+ * @param {string} options.languageCode
+ * @param {number} options.numberOfPluralForms
+ * @param {TranslatableEntry} options.message
+ * @returns {Array.<string>}
+ */
+export default function addTranslation( { languageCode, numberOfPluralForms, message } ) {
+	// English is the source (base) language, so set the translation value to the text collected from source code.
+	if ( languageCode === 'en' ) {
+		const msgstr = [ message.string ];
+
+		if ( message.plural ) {
+			msgstr.push( message.plural );
+		}
+
+		return msgstr;
+	}
+
+	// For other languages, pre-fill the translation value with an empty string which means that it requires translation.
+	const msgstr = [ '' ];
+
+	if ( message.plural ) {
+		msgstr.push( ...Array( numberOfPluralForms - 1 ).fill( '' ) );
+	}
+
+	return msgstr;
+}

--- a/packages/ckeditor5-dev-translations/lib/utils/synchronizetranslationsbasedoncontext.js
+++ b/packages/ckeditor5-dev-translations/lib/utils/synchronizetranslationsbasedoncontext.js
@@ -12,6 +12,7 @@ import { TRANSLATION_FILES_PATH } from './constants.js';
 import cleanTranslationFileContent from './cleantranslationfilecontent.js';
 import getHeaders from './getheaders.js';
 import getLanguages from './getlanguages.js';
+import addTranslation from './addtranslation.js';
 
 /**
  * @param {object} options
@@ -66,12 +67,12 @@ export default function synchronizeTranslationsBasedOnContext( { packageContexts
 
 						item.msgctxt = contextContent[ message.id ];
 						item.msgid = message.id;
-						item.msgstr.push( '' );
 
 						if ( message.plural ) {
 							item.msgid_plural = message.plural;
-							item.msgstr.push( ...Array( numberOfPluralForms - 1 ).fill( '' ) );
 						}
+
+						item.msgstr = addTranslation( { languageCode, numberOfPluralForms, message } );
 
 						return item;
 					} )

--- a/packages/ckeditor5-dev-translations/tests/utils/addtranslation.js
+++ b/packages/ckeditor5-dev-translations/tests/utils/addtranslation.js
@@ -1,0 +1,50 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import addTranslation from '../../lib/utils/addtranslation.js';
+
+describe( 'addTranslation()', () => {
+	let singularMessage, pluralMessage;
+
+	beforeEach( () => {
+		singularMessage = {
+			string: 'Example message 1'
+		};
+
+		pluralMessage = {
+			string: 'Example message 2',
+			plural: 'Example message 2 - plural form'
+		};
+	} );
+
+	it( 'should be a function', () => {
+		expect( addTranslation ).toBeInstanceOf( Function );
+	} );
+
+	it( 'should return translation (English, non-plural message)', () => {
+		const result = addTranslation( { languageCode: 'en', numberOfPluralForms: 2, message: singularMessage } );
+
+		expect( result ).toEqual( [ 'Example message 1' ] );
+	} );
+
+	it( 'should return translation (English, plural message)', () => {
+		const result = addTranslation( { languageCode: 'en', numberOfPluralForms: 2, message: pluralMessage } );
+
+		expect( result ).toEqual( [ 'Example message 2', 'Example message 2 - plural form' ] );
+	} );
+
+	it( 'should return translation (non-English, non-plural message)', () => {
+		const result = addTranslation( { languageCode: 'pl', numberOfPluralForms: 4, message: singularMessage } );
+
+		expect( result ).toEqual( [ '' ] );
+	} );
+
+	it( 'should return translation (non-English, plural message)', () => {
+		const result = addTranslation( { languageCode: 'pl', numberOfPluralForms: 4, message: pluralMessage } );
+
+		expect( result ).toEqual( [ '', '', '', '' ] );
+	} );
+} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix (translations): Fixed `synchronizeTranslations()` function to fill new translation entries for English in `en.po` with texts collected from the source code.

---

### Additional information

Closes cksource/ckeditor5-internal#3852.
