### PR TITLE
Do not remove a package after publishing it "successfully"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,43 @@
 Changelog
 =========
 
+## [45.0.2](https://github.com/ckeditor/ckeditor5-dev/compare/v45.0.1...v45.0.2) (2024-10-25)
+
+> [!NOTE]
+> The release channel for this release is `next`.
+
+### Bug fixes
+
+* **[translations](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-translations)**: Fixed the `synchronizeTranslations()` function to fill new translation entries for English in `en.po` with texts collected from the source code. ([commit](https://github.com/ckeditor/ckeditor5-dev/commit/6188a508fcab74d458419ee60aeb788140cd6bd0))
+
+### Other changes
+
+* **[release-tools](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-release-tools)**: The `publishPackageOnNpmCallback()` util does not remove a package directory even if npm says it was published. Closes [ckeditor/ckeditor5#17322](https://github.com/ckeditor/ckeditor5/issues/17322). ([commit](https://github.com/ckeditor/ckeditor5-dev/commit/a1b37c79347a7f74f88f6d945526e90b8ea96a67))
+
+### Released packages
+
+Check out the [Versioning policy](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/support/versioning-policy.html) guide for more information.
+
+<details>
+<summary>Released packages (summary)</summary>
+
+Other releases:
+
+* [@ckeditor/ckeditor5-dev-build-tools](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-build-tools/v/45.0.2): v45.0.1 => v45.0.2
+* [@ckeditor/ckeditor5-dev-bump-year](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-bump-year/v/45.0.2): v45.0.1 => v45.0.2
+* [@ckeditor/ckeditor5-dev-ci](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-ci/v/45.0.2): v45.0.1 => v45.0.2
+* [@ckeditor/ckeditor5-dev-dependency-checker](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-dependency-checker/v/45.0.2): v45.0.1 => v45.0.2
+* [@ckeditor/ckeditor5-dev-docs](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-docs/v/45.0.2): v45.0.1 => v45.0.2
+* [@ckeditor/ckeditor5-dev-release-tools](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-release-tools/v/45.0.2): v45.0.1 => v45.0.2
+* [@ckeditor/ckeditor5-dev-stale-bot](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-stale-bot/v/45.0.2): v45.0.1 => v45.0.2
+* [@ckeditor/ckeditor5-dev-tests](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-tests/v/45.0.2): v45.0.1 => v45.0.2
+* [@ckeditor/ckeditor5-dev-translations](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-translations/v/45.0.2): v45.0.1 => v45.0.2
+* [@ckeditor/ckeditor5-dev-utils](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-utils/v/45.0.2): v45.0.1 => v45.0.2
+* [@ckeditor/ckeditor5-dev-web-crawler](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-web-crawler/v/45.0.2): v45.0.1 => v45.0.2
+* [@ckeditor/typedoc-plugins](https://www.npmjs.com/package/@ckeditor/typedoc-plugins/v/45.0.2): v45.0.1 => v45.0.2
+</details>
+
+
 ## [45.0.1](https://github.com/ckeditor/ckeditor5-dev/compare/v45.0.0...v45.0.1) (2024-10-23)
 
 > [!NOTE]
@@ -150,40 +187,6 @@ Other releases:
 * [@ckeditor/ckeditor5-dev-utils](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-utils/v/44.2.0): v44.1.1 => v44.2.0
 * [@ckeditor/ckeditor5-dev-web-crawler](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-web-crawler/v/44.2.0): v44.1.1 => v44.2.0
 * [@ckeditor/typedoc-plugins](https://www.npmjs.com/package/@ckeditor/typedoc-plugins/v/44.2.0): v44.1.1 => v44.2.0
-</details>
-
-
-## [44.1.1](https://github.com/ckeditor/ckeditor5-dev/compare/v44.1.0...v44.1.1) (2024-10-16)
-
-> [!NOTE]
-> The release channel for this release is `next`.
-
-### Bug fixes
-
-* **[release-tools](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-release-tools)**: Added a missing dependency (simple-git). ([commit](https://github.com/ckeditor/ckeditor5-dev/commit/914436ff2d14b8e44a767a8c66a3d36fe832158b))
-
-### Released packages
-
-Check out the [Versioning policy](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/support/versioning-policy.html) guide for more information.
-
-<details>
-<summary>Released packages (summary)</summary>
-
-Other releases:
-
-* [@ckeditor/ckeditor5-dev-build-tools](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-build-tools/v/44.1.1): v44.1.0 => v44.1.1
-* [@ckeditor/ckeditor5-dev-bump-year](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-bump-year/v/44.1.1): v44.1.0 => v44.1.1
-* [@ckeditor/ckeditor5-dev-ci](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-ci/v/44.1.1): v44.1.0 => v44.1.1
-* [@ckeditor/ckeditor5-dev-dependency-checker](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-dependency-checker/v/44.1.1): v44.1.0 => v44.1.1
-* [@ckeditor/ckeditor5-dev-docs](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-docs/v/44.1.1): v44.1.0 => v44.1.1
-* [@ckeditor/ckeditor5-dev-release-tools](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-release-tools/v/44.1.1): v44.1.0 => v44.1.1
-* [@ckeditor/ckeditor5-dev-stale-bot](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-stale-bot/v/44.1.1): v44.1.0 => v44.1.1
-* [@ckeditor/ckeditor5-dev-tests](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-tests/v/44.1.1): v44.1.0 => v44.1.1
-* [@ckeditor/ckeditor5-dev-transifex](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-transifex/v/44.1.1): v44.1.0 => v44.1.1
-* [@ckeditor/ckeditor5-dev-translations](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-translations/v/44.1.1): v44.1.0 => v44.1.1
-* [@ckeditor/ckeditor5-dev-utils](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-utils/v/44.1.1): v44.1.0 => v44.1.1
-* [@ckeditor/ckeditor5-dev-web-crawler](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-web-crawler/v/44.1.1): v44.1.0 => v44.1.1
-* [@ckeditor/typedoc-plugins](https://www.npmjs.com/package/@ckeditor/typedoc-plugins/v/44.1.1): v44.1.0 => v44.1.1
 </details>
 
 ---

--- a/packages/ckeditor5-dev-release-tools/lib/utils/publishpackageonnpmcallback.js
+++ b/packages/ckeditor5-dev-release-tools/lib/utils/publishpackageonnpmcallback.js
@@ -13,7 +13,6 @@
  */
 export default async function publishPackageOnNpmCallback( packagePath, taskOptions ) {
 	const { tools } = await import( '@ckeditor/ckeditor5-dev-utils' );
-	const { default: fs } = await import( 'fs-extra' );
 
 	try {
 		await tools.shExec( `npm publish --access=public --tag ${ taskOptions.npmTag }`, {
@@ -22,7 +21,7 @@ export default async function publishPackageOnNpmCallback( packagePath, taskOpti
 			verbosity: 'error'
 		} );
 
-		await fs.remove( packagePath );
+		// Do nothing if `npm publish` says "OK". We cannot trust anything npm says.
 	} catch {
 		// Do nothing if an error occurs. A parent task will handle it.
 	}

--- a/packages/ckeditor5-dev-release-tools/tests/utils/publishpackageonnpmcallback.js
+++ b/packages/ckeditor5-dev-release-tools/tests/utils/publishpackageonnpmcallback.js
@@ -62,18 +62,18 @@ describe( 'publishPackageOnNpmCallback()', () => {
 			} );
 	} );
 
-	it( 'should remove package directory after publishing on npm', () => {
+	// See: https://github.com/ckeditor/ckeditor5/issues/17322.
+	it( 'should not remove package directory after publishing on npm', async () => {
 		const packagePath = '/workspace/ckeditor5/packages/ckeditor5-foo';
 
-		return publishPackageOnNpmCallback( packagePath, { npmTag: 'nightly' } )
-			.then( () => {
-				expect( fs.remove ).toHaveBeenCalledTimes( 1 );
-				expect( fs.remove ).toHaveBeenCalledWith( packagePath );
-			} );
+		await publishPackageOnNpmCallback( packagePath, { npmTag: 'nightly' } );
+
+		expect( fs.remove ).not.toHaveBeenCalled();
 	} );
 
-	it( 'should not remove a package directory and not throw error when publishing on npm failed with code 409', async () => {
-		vi.mocked( tools.shExec ).mockRejectedValue( new Error( 'code E409' ) );
+	// See: https://github.com/ckeditor/ckeditor5/issues/17120
+	it( 'should not remove a package directory and not throw error when publishing on npm failed', async () => {
+		vi.mocked( tools.shExec ).mockRejectedValue( new Error( 'I failed because I can' ) );
 
 		const packagePath = '/workspace/ckeditor5/packages/ckeditor5-foo';
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Changelog for v45.0.2.

Internal: The `publishPackageOnNpmCallback()` util does not remove a package directory even if npm says it was published. Closes ckeditor/ckeditor5#17322.

---

### Additional information

I used _Internal_ messages as changelog contains the entry, so I would like to avoid duplications in the future releases.
