### PR TITLE
Disable cache when talking with the npm registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,39 @@
 Changelog
 =========
 
+## [45.0.3](https://github.com/ckeditor/ckeditor5-dev/compare/v45.0.2...v45.0.3) (2024-10-25)
+
+> [!NOTE]
+> The release channel for this release is `next`.
+
+### Other changes
+
+* **[release-tools](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-release-tools)**: Do not use the cached values when asking the npm registry about a package. Closes [ckeditor/ckeditor5#17328](https://github.com/ckeditor/ckeditor5/issues/17328). ([commit](https://github.com/ckeditor/ckeditor5-dev/commit/42f5c98b01d2dbd84f55ad56ee0580c9ddfd7d31))
+
+### Released packages
+
+Check out the [Versioning policy](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/support/versioning-policy.html) guide for more information.
+
+<details>
+<summary>Released packages (summary)</summary>
+
+Other releases:
+
+* [@ckeditor/ckeditor5-dev-build-tools](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-build-tools/v/45.0.3): v45.0.2 => v45.0.3
+* [@ckeditor/ckeditor5-dev-bump-year](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-bump-year/v/45.0.3): v45.0.2 => v45.0.3
+* [@ckeditor/ckeditor5-dev-ci](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-ci/v/45.0.3): v45.0.2 => v45.0.3
+* [@ckeditor/ckeditor5-dev-dependency-checker](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-dependency-checker/v/45.0.3): v45.0.2 => v45.0.3
+* [@ckeditor/ckeditor5-dev-docs](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-docs/v/45.0.3): v45.0.2 => v45.0.3
+* [@ckeditor/ckeditor5-dev-release-tools](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-release-tools/v/45.0.3): v45.0.2 => v45.0.3
+* [@ckeditor/ckeditor5-dev-stale-bot](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-stale-bot/v/45.0.3): v45.0.2 => v45.0.3
+* [@ckeditor/ckeditor5-dev-tests](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-tests/v/45.0.3): v45.0.2 => v45.0.3
+* [@ckeditor/ckeditor5-dev-translations](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-translations/v/45.0.3): v45.0.2 => v45.0.3
+* [@ckeditor/ckeditor5-dev-utils](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-utils/v/45.0.3): v45.0.2 => v45.0.3
+* [@ckeditor/ckeditor5-dev-web-crawler](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-web-crawler/v/45.0.3): v45.0.2 => v45.0.3
+* [@ckeditor/typedoc-plugins](https://www.npmjs.com/package/@ckeditor/typedoc-plugins/v/45.0.3): v45.0.2 => v45.0.3
+</details>
+
+
 ## [45.0.2](https://github.com/ckeditor/ckeditor5-dev/compare/v45.0.1...v45.0.2) (2024-10-25)
 
 > [!NOTE]
@@ -150,43 +183,6 @@ Other releases:
 * [@ckeditor/ckeditor5-dev-utils](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-utils/v/44.2.1): v44.2.0 => v44.2.1
 * [@ckeditor/ckeditor5-dev-web-crawler](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-web-crawler/v/44.2.1): v44.2.0 => v44.2.1
 * [@ckeditor/typedoc-plugins](https://www.npmjs.com/package/@ckeditor/typedoc-plugins/v/44.2.1): v44.2.0 => v44.2.1
-</details>
-
-
-## [44.2.0](https://github.com/ckeditor/ckeditor5-dev/compare/v44.1.1...v44.2.0) (2024-10-17)
-
-> [!NOTE]
-> The release channel for this release is `next`.
-
-### Features
-
-* **[release-tools](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-release-tools)**: Created a new util exposed as `getNextInternal()` to generate an internal release version, e.g. `0.0.0-internal-20240102.0`. ([commit](https://github.com/ckeditor/ckeditor5-dev/commit/38346c679a8cb7ce328a9584a18529110f641325))
-
-### Released packages
-
-Check out the [Versioning policy](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/support/versioning-policy.html) guide for more information.
-
-<details>
-<summary>Released packages (summary)</summary>
-
-Releases containing new features:
-
-* [@ckeditor/ckeditor5-dev-release-tools](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-release-tools/v/44.2.0): v44.1.1 => v44.2.0
-
-Other releases:
-
-* [@ckeditor/ckeditor5-dev-build-tools](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-build-tools/v/44.2.0): v44.1.1 => v44.2.0
-* [@ckeditor/ckeditor5-dev-bump-year](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-bump-year/v/44.2.0): v44.1.1 => v44.2.0
-* [@ckeditor/ckeditor5-dev-ci](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-ci/v/44.2.0): v44.1.1 => v44.2.0
-* [@ckeditor/ckeditor5-dev-dependency-checker](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-dependency-checker/v/44.2.0): v44.1.1 => v44.2.0
-* [@ckeditor/ckeditor5-dev-docs](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-docs/v/44.2.0): v44.1.1 => v44.2.0
-* [@ckeditor/ckeditor5-dev-stale-bot](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-stale-bot/v/44.2.0): v44.1.1 => v44.2.0
-* [@ckeditor/ckeditor5-dev-tests](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-tests/v/44.2.0): v44.1.1 => v44.2.0
-* [@ckeditor/ckeditor5-dev-transifex](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-transifex/v/44.2.0): v44.1.1 => v44.2.0
-* [@ckeditor/ckeditor5-dev-translations](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-translations/v/44.2.0): v44.1.1 => v44.2.0
-* [@ckeditor/ckeditor5-dev-utils](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-utils/v/44.2.0): v44.1.1 => v44.2.0
-* [@ckeditor/ckeditor5-dev-web-crawler](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-web-crawler/v/44.2.0): v44.1.1 => v44.2.0
-* [@ckeditor/typedoc-plugins](https://www.npmjs.com/package/@ckeditor/typedoc-plugins/v/44.2.0): v44.1.1 => v44.2.0
 </details>
 
 ---

--- a/packages/ckeditor5-dev-release-tools/lib/utils/checkversionavailability.js
+++ b/packages/ckeditor5-dev-release-tools/lib/utils/checkversionavailability.js
@@ -15,7 +15,7 @@ import pacote from 'pacote';
  * @returns {Promise}
  */
 export default async function checkVersionAvailability( version, packageName ) {
-	return pacote.manifest( `${ packageName }@${ version }` )
+	return pacote.manifest( `${ packageName }@${ version }`, { cache: null } )
 		.then( () => {
 			// If `pacote.manifest` resolves, a package with the given version exists.
 			return false;

--- a/packages/ckeditor5-dev-release-tools/lib/utils/isversionpublishablefortag.js
+++ b/packages/ckeditor5-dev-release-tools/lib/utils/isversionpublishablefortag.js
@@ -15,7 +15,7 @@ import pacote from 'pacote';
  * @returns {Promise.<boolean>}
  */
 export default async function isVersionPublishableForTag( packageName, version, npmTag ) {
-	const npmVersion = await pacote.manifest( `${ packageName }@${ npmTag }` )
+	const npmVersion = await pacote.manifest( `${ packageName }@${ npmTag }`, { cache: null } )
 		.then( ( { version } ) => version )
 		// An `npmTag` does not exist, or it's a first release of a package.
 		.catch( () => null );

--- a/packages/ckeditor5-dev-release-tools/lib/utils/versions.js
+++ b/packages/ckeditor5-dev-release-tools/lib/utils/versions.js
@@ -38,7 +38,7 @@ export function getLastFromChangelog( cwd = process.cwd() ) {
 export function getLastPreRelease( releaseIdentifier, cwd = process.cwd() ) {
 	const packageName = getPackageJson( cwd ).name;
 
-	return pacote.packument( packageName )
+	return pacote.packument( packageName, { cache: null } )
 		.then( result => {
 			const lastVersion = Object.keys( result.versions )
 				.filter( version => version.startsWith( releaseIdentifier ) )

--- a/packages/ckeditor5-dev-release-tools/tests/utils/checkversionavailability.js
+++ b/packages/ckeditor5-dev-release-tools/tests/utils/checkversionavailability.js
@@ -15,7 +15,7 @@ describe( 'checkVersionAvailability()', () => {
 
 		await expect( checkVersionAvailability( '1.0.1', 'stub-package' ) ).resolves.toBe( true );
 
-		expect( pacote.manifest ).toHaveBeenCalledExactlyOnceWith( 'stub-package@1.0.1' );
+		expect( pacote.manifest ).toHaveBeenCalledExactlyOnceWith( 'stub-package@1.0.1', { cache: null } );
 	} );
 	it( 'should resolve to false if version exists', async () => {
 		pacote.manifest.mockResolvedValue( '1.0.1' );

--- a/packages/ckeditor5-dev-release-tools/tests/utils/isversionpublishablefortag.js
+++ b/packages/ckeditor5-dev-release-tools/tests/utils/isversionpublishablefortag.js
@@ -23,7 +23,7 @@ describe( 'isVersionPublishableForTag()', () => {
 
 		expect( result ).to.equal( false );
 		expect( semver.lte ).toHaveBeenCalledExactlyOnceWith( '1.0.0', '1.0.0' );
-		expect( pacote.manifest ).toHaveBeenCalledExactlyOnceWith( 'package-name@latest' );
+		expect( pacote.manifest ).toHaveBeenCalledExactlyOnceWith( 'package-name@latest', { cache: null } );
 	} );
 
 	it( 'should return false if given version is not higher than the latest published', async () => {
@@ -46,6 +46,6 @@ describe( 'isVersionPublishableForTag()', () => {
 
 		expect( result ).to.equal( true );
 		expect( semver.lte ).not.toHaveBeenCalled();
-		expect( pacote.manifest ).toHaveBeenCalledExactlyOnceWith( 'package-name@alpha' );
+		expect( pacote.manifest ).toHaveBeenCalledExactlyOnceWith( 'package-name@alpha', expect.any( Object ) );
 	} );
 } );

--- a/packages/ckeditor5-dev-release-tools/tests/utils/versions.js
+++ b/packages/ckeditor5-dev-release-tools/tests/utils/versions.js
@@ -114,7 +114,7 @@ describe( 'versions', () => {
 			return getLastPreRelease( '42.0.0-alpha' )
 				.then( () => {
 					expect( vi.mocked( pacote ).packument ).toHaveBeenCalledTimes( 1 );
-					expect( vi.mocked( pacote ).packument ).toHaveBeenCalledWith( 'ckeditor5' );
+					expect( vi.mocked( pacote ).packument ).toHaveBeenCalledWith( 'ckeditor5', { cache: null } );
 				} );
 		} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal (release-tools): Do not use the cached values when asking the npm registry about a package. Closes ckeditor/ckeditor5#17328.

Internal: Changelog for v45.0.3.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
