### PR TITLE
Increased timeout for re-publishing packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,39 @@
 Changelog
 =========
 
+## [45.0.4](https://github.com/ckeditor/ckeditor5-dev/compare/v45.0.3...v45.0.4) (2024-10-25)
+
+> [!NOTE]
+> The release channel for this release is `next`.
+
+### Other changes
+
+* **[release-tools](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-release-tools)**: Increases the timeout value between the publishing packages phase and republishing the failed ones. Closes [ckeditor/ckeditor5#17329](https://github.com/ckeditor/ckeditor5/issues/17329). ([commit](https://github.com/ckeditor/ckeditor5-dev/commit/1fafa92b4a201ab70cca8e8e4e46743f179d2b86))
+
+### Released packages
+
+Check out the [Versioning policy](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/support/versioning-policy.html) guide for more information.
+
+<details>
+<summary>Released packages (summary)</summary>
+
+Other releases:
+
+* [@ckeditor/ckeditor5-dev-build-tools](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-build-tools/v/45.0.4): v45.0.3 => v45.0.4
+* [@ckeditor/ckeditor5-dev-bump-year](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-bump-year/v/45.0.4): v45.0.3 => v45.0.4
+* [@ckeditor/ckeditor5-dev-ci](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-ci/v/45.0.4): v45.0.3 => v45.0.4
+* [@ckeditor/ckeditor5-dev-dependency-checker](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-dependency-checker/v/45.0.4): v45.0.3 => v45.0.4
+* [@ckeditor/ckeditor5-dev-docs](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-docs/v/45.0.4): v45.0.3 => v45.0.4
+* [@ckeditor/ckeditor5-dev-release-tools](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-release-tools/v/45.0.4): v45.0.3 => v45.0.4
+* [@ckeditor/ckeditor5-dev-stale-bot](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-stale-bot/v/45.0.4): v45.0.3 => v45.0.4
+* [@ckeditor/ckeditor5-dev-tests](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-tests/v/45.0.4): v45.0.3 => v45.0.4
+* [@ckeditor/ckeditor5-dev-translations](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-translations/v/45.0.4): v45.0.3 => v45.0.4
+* [@ckeditor/ckeditor5-dev-utils](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-utils/v/45.0.4): v45.0.3 => v45.0.4
+* [@ckeditor/ckeditor5-dev-web-crawler](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-web-crawler/v/45.0.4): v45.0.3 => v45.0.4
+* [@ckeditor/typedoc-plugins](https://www.npmjs.com/package/@ckeditor/typedoc-plugins/v/45.0.4): v45.0.3 => v45.0.4
+</details>
+
+
 ## [45.0.3](https://github.com/ckeditor/ckeditor5-dev/compare/v45.0.2...v45.0.3) (2024-10-25)
 
 > [!NOTE]
@@ -149,40 +182,6 @@ Other releases:
 * [@ckeditor/ckeditor5-dev-utils](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-utils/v/45.0.0): v44.2.1 => v45.0.0
 * [@ckeditor/ckeditor5-dev-web-crawler](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-web-crawler/v/45.0.0): v44.2.1 => v45.0.0
 * [@ckeditor/typedoc-plugins](https://www.npmjs.com/package/@ckeditor/typedoc-plugins/v/45.0.0): v44.2.1 => v45.0.0
-</details>
-
-
-## [44.2.1](https://github.com/ckeditor/ckeditor5-dev/compare/v44.2.0...v44.2.1) (2024-10-17)
-
-> [!NOTE]
-> The release channel for this release is `next`.
-
-### Bug fixes
-
-* **[release-tools](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-release-tools)**: The `getNpmTagFromVersion()` function handles internal releases correctly. ([commit](https://github.com/ckeditor/ckeditor5-dev/commit/baad1a6ae3b3fe0ff0b4711ae04067d44f128c92))
-
-### Released packages
-
-Check out the [Versioning policy](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/support/versioning-policy.html) guide for more information.
-
-<details>
-<summary>Released packages (summary)</summary>
-
-Other releases:
-
-* [@ckeditor/ckeditor5-dev-build-tools](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-build-tools/v/44.2.1): v44.2.0 => v44.2.1
-* [@ckeditor/ckeditor5-dev-bump-year](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-bump-year/v/44.2.1): v44.2.0 => v44.2.1
-* [@ckeditor/ckeditor5-dev-ci](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-ci/v/44.2.1): v44.2.0 => v44.2.1
-* [@ckeditor/ckeditor5-dev-dependency-checker](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-dependency-checker/v/44.2.1): v44.2.0 => v44.2.1
-* [@ckeditor/ckeditor5-dev-docs](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-docs/v/44.2.1): v44.2.0 => v44.2.1
-* [@ckeditor/ckeditor5-dev-release-tools](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-release-tools/v/44.2.1): v44.2.0 => v44.2.1
-* [@ckeditor/ckeditor5-dev-stale-bot](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-stale-bot/v/44.2.1): v44.2.0 => v44.2.1
-* [@ckeditor/ckeditor5-dev-tests](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-tests/v/44.2.1): v44.2.0 => v44.2.1
-* [@ckeditor/ckeditor5-dev-transifex](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-transifex/v/44.2.1): v44.2.0 => v44.2.1
-* [@ckeditor/ckeditor5-dev-translations](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-translations/v/44.2.1): v44.2.0 => v44.2.1
-* [@ckeditor/ckeditor5-dev-utils](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-utils/v/44.2.1): v44.2.0 => v44.2.1
-* [@ckeditor/ckeditor5-dev-web-crawler](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-web-crawler/v/44.2.1): v44.2.0 => v44.2.1
-* [@ckeditor/typedoc-plugins](https://www.npmjs.com/package/@ckeditor/typedoc-plugins/v/44.2.1): v44.2.0 => v44.2.1
 </details>
 
 ---

--- a/packages/ckeditor5-dev-release-tools/lib/tasks/publishpackages.js
+++ b/packages/ckeditor5-dev-release-tools/lib/tasks/publishpackages.js
@@ -108,7 +108,7 @@ export default async function publishPackages( options ) {
 	}
 
 	// Let's give an npm a moment for taking a breath...
-	await wait( 1000 );
+	await wait( 1000 * 15 );
 
 	// ...and try again.
 	return publishPackages( {

--- a/packages/ckeditor5-dev-release-tools/tests/tasks/publishpackages.js
+++ b/packages/ckeditor5-dev-release-tools/tests/tasks/publishpackages.js
@@ -499,7 +499,7 @@ describe( 'publishPackages()', () => {
 			await promise;
 			const dateAfter = new Date();
 
-			expect( differenceInMilliseconds( dateAfter, dateBefore ) ).toEqual( 1000 );
+			expect( differenceInMilliseconds( dateAfter, dateBefore ) ).toEqual( 15000 );
 		} );
 
 		it( 'should try to publish packages thrice before rejecting a promise', async () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal (release-tools): Increases the timeout value between the publishing packages phase and republishing the failed ones. Closes ckeditor/ckeditor5#17329.

Internal: Changelog for v45.0.4.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
…hing packages phase and republishing the failed ones. Closes ckeditor/ckeditor5#17329.