### PR TITLE
Remove a package directory when npm says it was published

### DIFF
--- a/packages/ckeditor5-dev-release-tools/lib/utils/publishpackageonnpmcallback.js
+++ b/packages/ckeditor5-dev-release-tools/lib/utils/publishpackageonnpmcallback.js
@@ -13,6 +13,7 @@
  */
 export default async function publishPackageOnNpmCallback( packagePath, taskOptions ) {
 	const { tools } = await import( '@ckeditor/ckeditor5-dev-utils' );
+	const { default: fs } = await import( 'fs-extra' );
 
 	try {
 		await tools.shExec( `npm publish --access=public --tag ${ taskOptions.npmTag }`, {
@@ -21,7 +22,7 @@ export default async function publishPackageOnNpmCallback( packagePath, taskOpti
 			verbosity: 'silent'
 		} );
 
-		// Do nothing if `npm publish` says "OK". We cannot trust anything npm says.
+		await fs.remove( packagePath );
 	} catch {
 		// Do nothing if an error occurs. A parent task will handle it.
 	}

--- a/packages/ckeditor5-dev-release-tools/tests/utils/publishpackageonnpmcallback.js
+++ b/packages/ckeditor5-dev-release-tools/tests/utils/publishpackageonnpmcallback.js
@@ -62,18 +62,18 @@ describe( 'publishPackageOnNpmCallback()', () => {
 			} );
 	} );
 
-	// See: https://github.com/ckeditor/ckeditor5/issues/17322.
-	it( 'should not remove package directory after publishing on npm', async () => {
+	it( 'should remove package directory after publishing on npm', () => {
 		const packagePath = '/workspace/ckeditor5/packages/ckeditor5-foo';
 
-		await publishPackageOnNpmCallback( packagePath, { npmTag: 'nightly' } );
-
-		expect( fs.remove ).not.toHaveBeenCalled();
+		return publishPackageOnNpmCallback( packagePath, { npmTag: 'nightly' } )
+			.then( () => {
+				expect( fs.remove ).toHaveBeenCalledTimes( 1 );
+				expect( fs.remove ).toHaveBeenCalledWith( packagePath );
+			} );
 	} );
 
-	// See: https://github.com/ckeditor/ckeditor5/issues/17120
-	it( 'should not remove a package directory and not throw error when publishing on npm failed', async () => {
-		vi.mocked( tools.shExec ).mockRejectedValue( new Error( 'I failed because I can' ) );
+	it( 'should not remove a package directory and not throw error when publishing on npm failed with code 409', async () => {
+		vi.mocked( tools.shExec ).mockRejectedValue( new Error( 'code E409' ) );
 
 		const packagePath = '/workspace/ckeditor5/packages/ckeditor5-foo';
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other (release-tools): The `publishPackageOnNpmCallback()` util removes a package directory if npm says it was published. This reverts commit [`a1b37c7`](https://github.com/ckeditor/ckeditor5-dev/commit/a1b37c79347a7f74f88f6d945526e90b8ea96a67). Closes ckeditor/ckeditor5#17348.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
