### PR TITLE
Upgrade postcss-nesting to latest version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,7 @@ commands:
             CKE5_GITHUB_ORGANIZATION="ckeditor"
             CKE5_GITHUB_REPOSITORY="ckeditor5-dev"
             CKE5_CIRCLE_APPROVAL_JOB_NAME="release_approval"
-            CKE5_GITHUB_RELEASE_BRANCH="master"
+            CKE5_GITHUB_RELEASE_BRANCH="master-v43"
 
             echo export CKE5_CIRCLE_APPROVAL_JOB_NAME=$CKE5_CIRCLE_APPROVAL_JOB_NAME >> $BASH_ENV
             echo export CKE5_GITHUB_RELEASE_BRANCH=$CKE5_GITHUB_RELEASE_BRANCH >> $BASH_ENV
@@ -171,11 +171,11 @@ jobs:
           command: |
             #!/bin/bash
 
-            CKE5_LATEST_COMMIT_HASH=$( git log -n 1 --pretty=format:%H origin/master )
+            CKE5_LATEST_COMMIT_HASH=$( git log -n 1 --pretty=format:%H origin/master-v43 )
             CKE5_TRIGGER_COMMIT_HASH=<< pipeline.parameters.triggerCommitHash >>
 
             if [[ "${CKE5_LATEST_COMMIT_HASH}" != "${CKE5_TRIGGER_COMMIT_HASH}" ]]; then
-              echo "There is a newer commit in the repository on the \`#master\` branch. Use its build to start the release."
+              echo "There is a newer commit in the repository on the \`#master-v43\` branch. Use its build to start the release."
               circleci-agent step halt
             fi
       - npm_login_command
@@ -235,12 +235,12 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - master-v43
       - notify_ci_failure:
           filters:
             branches:
               only:
-                - master
+                - master-v43
 
   release:
     when:
@@ -266,4 +266,4 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - master-v43

--- a/packages/ckeditor5-dev-build-tools/package.json
+++ b/packages/ckeditor5-dev-build-tools/package.json
@@ -45,7 +45,7 @@
     "pofile": "^1.1.4",
     "postcss": "^8.0.0",
     "postcss-mixins": "^9.0.4",
-    "postcss-nesting": "^12.0.2",
+    "postcss-nesting": "^13.0.0",
     "purgecss": "^6.0.0",
     "rollup": "^4.9.5",
     "rollup-plugin-styles": "^4.0.0",

--- a/packages/ckeditor5-dev-build-tools/src/config.ts
+++ b/packages/ckeditor5-dev-build-tools/src/config.ts
@@ -152,7 +152,8 @@ export async function getRollupConfig( options: BuildOptions ) {
 				plugins: [
 					postcssMixins,
 					postcssNesting( {
-						noIsPseudoSelector: true
+						noIsPseudoSelector: true,
+						edition: '2021'
 					} )
 				],
 				minimize: minify,

--- a/packages/ckeditor5-dev-utils/lib/styles/getpostcssconfig.js
+++ b/packages/ckeditor5-dev-utils/lib/styles/getpostcssconfig.js
@@ -25,7 +25,8 @@ module.exports = function getPostCssConfig( options = {} ) {
 			require( 'postcss-mixins' )(),
 			require( 'postcss-nesting' )( {
 				// https://github.com/ckeditor/ckeditor5/issues/11730
-				noIsPseudoSelector: true
+				noIsPseudoSelector: true,
+				edition: '2021'
 			} ),
 			require( './themelogger' )()
 		]

--- a/packages/ckeditor5-dev-utils/package.json
+++ b/packages/ckeditor5-dev-utils/package.json
@@ -38,7 +38,7 @@
     "postcss-import": "^14.1.0",
     "postcss-loader": "^4.3.0",
     "postcss-mixins": "^9.0.2",
-    "postcss-nesting": "^10.1.4",
+    "postcss-nesting": "^13.0.0",
     "raw-loader": "^4.0.1",
     "shelljs": "^0.8.1",
     "style-loader": "^2.0.0",

--- a/packages/ckeditor5-dev-utils/tests/styles/getpostcssconfig.js
+++ b/packages/ckeditor5-dev-utils/tests/styles/getpostcssconfig.js
@@ -71,7 +71,8 @@ describe( 'styles', () => {
 			getPostCssConfig();
 
 			sinon.assert.calledWithExactly( stubs[ 'postcss-nesting' ], {
-				noIsPseudoSelector: true
+				noIsPseudoSelector: true,
+				edition: '2021'
 			} );
 		} );
 

--- a/scripts/utils/parsearguments.js
+++ b/scripts/utils/parsearguments.js
@@ -38,7 +38,7 @@ module.exports = function parseArguments( cliArguments ) {
 			ci: false,
 			verbose: false,
 			'compile-only': false,
-			branch: 'master',
+			branch: 'master-v43',
 			'npm-tag': null
 		}
 	};
@@ -73,7 +73,7 @@ module.exports = function parseArguments( cliArguments ) {
  *
  * @property {String} [from]
  *
- * @property {String} [branch='master']
+ * @property {String} [branch='master-v43']
  *
  * @property {Boolean} [compileOnly=false]
  *


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix (utils): Upgrade the `postcss-nesting` package to the latest version to avoid issues with non-supported `@nest` selectors. Closes ckeditor/ckeditor5#17449.

Internal (build-tools): Upgrade `postcss-nesting` to the latest version.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
