### PR TITLE
Pass path to a dynamically imported file as `file://` protocol URL to make it work in Windows

### DIFF
--- a/packages/ckeditor5-dev-release-tools/lib/utils/executeinparallel.js
+++ b/packages/ckeditor5-dev-release-tools/lib/utils/executeinparallel.js
@@ -70,7 +70,13 @@ export default async function executeInParallel( options ) {
 		return createWorker( {
 			signal: signal || defaultAbortController.signal,
 			onPackageDone,
-			workerData: { packages, callbackModule, taskOptions }
+			workerData: {
+				packages,
+				taskOptions,
+				// The callback module is dynamically imported inside worker script.
+				// To make it work in Windows, absolute path to a dynamically imported file must start with the "file:" protocol URL.
+				callbackModule: 'file://' + callbackModule
+			}
 		} );
 	} );
 

--- a/packages/ckeditor5-dev-release-tools/tests/utils/executeinparallel.js
+++ b/packages/ckeditor5-dev-release-tools/tests/utils/executeinparallel.js
@@ -105,11 +105,11 @@ describe( 'executeInParallel()', () => {
 			'utf-8'
 		);
 		expect( firstWorker.workerData ).toBeInstanceOf( Object );
-		expect( firstWorker.workerData ).toHaveProperty( 'callbackModule', '/home/ckeditor/uuid-4.mjs' );
+		expect( firstWorker.workerData ).toHaveProperty( 'callbackModule', 'file:///home/ckeditor/uuid-4.mjs' );
 		expect( firstWorker.workerData ).toHaveProperty( 'packages' );
 
 		expect( secondWorker.workerData ).toBeInstanceOf( Object );
-		expect( secondWorker.workerData ).toHaveProperty( 'callbackModule', '/home/ckeditor/uuid-4.mjs' );
+		expect( secondWorker.workerData ).toHaveProperty( 'callbackModule', 'file:///home/ckeditor/uuid-4.mjs' );
 		expect( secondWorker.workerData ).toHaveProperty( 'packages' );
 
 		// Workers did not emit an error.
@@ -231,11 +231,11 @@ describe( 'executeInParallel()', () => {
 		const [ firstWorker, secondWorker ] = stubs.WorkerMock.instances;
 
 		expect( firstWorker.workerData ).toBeInstanceOf( Object );
-		expect( firstWorker.workerData ).toHaveProperty( 'callbackModule', 'C:/Users/ckeditor/uuid-4.mjs' );
+		expect( firstWorker.workerData ).toHaveProperty( 'callbackModule', 'file://C:/Users/ckeditor/uuid-4.mjs' );
 		expect( firstWorker.workerData ).toHaveProperty( 'packages' );
 
 		expect( secondWorker.workerData ).toBeInstanceOf( Object );
-		expect( secondWorker.workerData ).toHaveProperty( 'callbackModule', 'C:/Users/ckeditor/uuid-4.mjs' );
+		expect( secondWorker.workerData ).toHaveProperty( 'callbackModule', 'file://C:/Users/ckeditor/uuid-4.mjs' );
 		expect( secondWorker.workerData ).toHaveProperty( 'packages' );
 
 		// Workers did not emit an error.


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix (release-tools): Fixed path calculation in `executeInParallel()` util that prepares a path to a dynamically imported worker script. Previously, it did not work in Windows, because there is a specific requirement that absolute path must be valid `file://` protocol URL. Now, the worker script is always imported using `file://` protocol URL.

---

### Additional information

Closes cksource/ckeditor5-internal#3882.

I'm not using `url.pathToFileURL()` to convert the path to a `file://` protocol URL, because it produces unexpected results in tests where we mock `process.cwd()` to be Windows-style.

Example: when mocked `process.cwd()` is `C:\Users\ckeditor`, then `url.pathToFileURL( 'C:/Users/ckeditor/uuid-4.mjs' )` internally tries to create an URL from `file://C:%5CUsers%5Cckeditor/C:/Users/ckeditor/uuid-4.mjs` and throws `ERR_INVALID_URL`.
