### PR TITLE
Limit TypeScript version to v5.6.x

### DIFF
--- a/packages/ckeditor5-dev-build-tools/package.json
+++ b/packages/ckeditor5-dev-build-tools/package.json
@@ -60,7 +60,7 @@
     "@types/postcss-mixins": "^9.0.5",
     "@vitest/coverage-v8": "^2.0.0",
     "type-fest": "^4.10.2",
-    "typescript": "^5.3.3",
+    "typescript": "~5.6.0",
     "vitest": "^2.0.0"
   },
   "scripts": {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Limit TypeScript version to v5.6.x as the v5.7+ is not compatible with `ckeditor5-dev-build-tools`.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
