### PR TITLE
Mark v43.0.1 as the `@latest` release

### DIFF
--- a/scripts/publishpackages.js
+++ b/scripts/publishpackages.js
@@ -81,7 +81,7 @@ const tasks = new Listr( [
 			return github.request( 'PATCH /repos/{owner}/{repo}/releases/{release_id}', {
 				owner: 'ckeditor',
 				repo: 'ckeditor5-dev',
-				release_id: 174058828, // v43.0.0
+				release_id: 185171763, // v43.0.1
 				make_latest: true
 			} );
 		}


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Updated the `release_id` property to point to the `v43.0.1` tag.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
