### PR TITLE
Disable tree-shaking in tests

### DIFF
--- a/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getwebpackconfig.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getwebpackconfig.js
@@ -35,8 +35,7 @@ export default function getWebpackConfigForAutomatedTests( options ) {
 			} ),
 
 			/**
-			 * Disable tree-shaking because it remove tests for packages with `sideEffects` field in
-			 * `package.json`.
+			 * Disable tree-shaking because it removes tests for packages with `sideEffects` field in `package.json`.
 			 *
 			 * Workaround for https://github.com/ckeditor/ckeditor5/issues/17767#issuecomment-2598263796.
 			 */

--- a/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getwebpackconfig.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getwebpackconfig.js
@@ -32,7 +32,22 @@ export default function getWebpackConfigForAutomatedTests( options ) {
 			new webpack.ProvidePlugin( {
 				Buffer: [ 'buffer', 'Buffer' ],
 				process: 'process/browser.js'
-			} )
+			} ),
+
+			/**
+			 * Disable tree-shaking because it remove tests for packages with `sideEffects` field in
+			 * `package.json`.
+			 *
+			 * Workaround for https://github.com/ckeditor/ckeditor5/issues/17767#issuecomment-2598263796.
+			 */
+			{
+				apply( compiler ) {
+					compiler.options.optimization = {
+						...compiler.options.optimization,
+						sideEffects: false
+					};
+				}
+			}
 		],
 
 		resolve: {
@@ -88,6 +103,7 @@ export default function getWebpackConfigForAutomatedTests( options ) {
 
 		// Since webpack v5 it looks like splitting out the source code into the commons and runtime chunks broke the source map support.
 		config.optimization = {
+			...config.optimization,
 			runtimeChunk: false,
 			splitChunks: false
 		};


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix (tests): Disable tree-shaking in webpack. See ckeditor/ckeditor5#17767.

