### PR TITLE
Internal: Update target in `build-tools` tests to `es2022`.

### DIFF
--- a/packages/ckeditor5-dev-build-tools/tests/_utils/utils.ts
+++ b/packages/ckeditor5-dev-build-tools/tests/_utils/utils.ts
@@ -81,7 +81,7 @@ export function swcPlugin(): Plugin {
 		include: [ '**/*.[jt]s' ],
 		swc: {
 			jsc: {
-				target: 'es2019'
+				target: 'es2022'
 			},
 			module: {
 				type: 'es6'


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Update target in `build-tools` tests to `es2022`.

---

This should be set to `es2022` from the beginning.
