### PR TITLE
Improved calculating pre-release versions that start with the same base name

### DIFF
--- a/packages/ckeditor5-dev-release-tools/lib/index.js
+++ b/packages/ckeditor5-dev-release-tools/lib/index.js
@@ -22,6 +22,7 @@ export {
 	getNextNightly,
 	getNextInternal,
 	getCurrent,
+	getDateIdentifier,
 	getLastTagFromGit
 } from './utils/versions.js';
 export { default as getChangesForVersion } from './utils/getchangesforversion.js';

--- a/packages/ckeditor5-dev-release-tools/lib/utils/versions.js
+++ b/packages/ckeditor5-dev-release-tools/lib/utils/versions.js
@@ -50,7 +50,7 @@ export function getLastPreRelease( releaseIdentifier, cwd = process.cwd() ) {
 			const lastVersion = Object.keys( result.versions )
 				.filter( version => {
 					const optionalDateIdentifier = '(-[0-9]{8})?';
-					const optionalSequenceNumber = '(.[0-9]+)?';
+					const optionalSequenceNumber = '(\\.[0-9]+)?';
 					const versionRegExp = new RegExp( `^${ releaseIdentifier }${ optionalDateIdentifier }${ optionalSequenceNumber }$` );
 
 					return versionRegExp.test( version );

--- a/packages/ckeditor5-dev-release-tools/lib/utils/versions.js
+++ b/packages/ckeditor5-dev-release-tools/lib/utils/versions.js
@@ -29,7 +29,14 @@ export function getLastFromChangelog( cwd = process.cwd() ) {
 
 /**
  * Returns the current (latest) pre-release version that matches the provided release identifier.
+ * It takes into account and distinguishes pre-release tags with different names but starting with the same base name.
  * If the package does not have any pre-releases with the provided identifier yet, `null` is returned.
+ *
+ * Examples:
+ * 	* "0.0.0-nightly" - Matches the last "nightly" version regardless of the publication date.
+ *	  It does not match other nightly tags that start with the same "nightly" base name, e.g. "0.0.0-nightly-next-YYYYMMDD.X".
+ * 	* "0.0.0-nightly-20230615" - Matches the last "nightly" version from the 2023-06-15 day.
+ * 	* "42.0.0-alpha" - Matches the last "alpha" version for the 42.0.0 version.
  *
  * @param {ReleaseIdentifier} releaseIdentifier
  * @param {string} [cwd=process.cwd()]
@@ -41,7 +48,13 @@ export function getLastPreRelease( releaseIdentifier, cwd = process.cwd() ) {
 	return packument( packageName )
 		.then( result => {
 			const lastVersion = Object.keys( result.versions )
-				.filter( version => version.startsWith( releaseIdentifier ) )
+				.filter( version => {
+					const optionalDateIdentifier = '(-[0-9]{8})?';
+					const optionalSequenceNumber = '(.[0-9]+)?';
+					const versionRegExp = new RegExp( `^${ releaseIdentifier }${ optionalDateIdentifier }${ optionalSequenceNumber }$` );
+
+					return versionRegExp.test( version );
+				} )
 				.sort( ( a, b ) => a.localeCompare( b, undefined, { numeric: true } ) )
 				.pop();
 
@@ -138,9 +151,11 @@ export function getCurrent( cwd = process.cwd() ) {
 }
 
 /**
+ * Returns current date in the "YYYYMMDD" format.
+ *
  * @returns {string}
  */
-function getDateIdentifier() {
+export function getDateIdentifier() {
 	const today = new Date();
 	const year = today.getFullYear().toString();
 	const month = ( today.getMonth() + 1 ).toString().padStart( 2, '0' );
@@ -152,9 +167,4 @@ function getDateIdentifier() {
 /**
  * @typedef {string} ReleaseIdentifier The pre-release identifier without the last dynamic part (the pre-release sequential number).
  * It consists of the core base version ("<major>.<minor>.<path>"), a hyphen ("-"), and a pre-release identifier name (e.g. "alpha").
- *
- * Examples:
- * 	* "0.0.0-nightly" - matches the last nightly version regardless of the publication date.
- * 	* "0.0.0-nightly-20230615" - matches the last nightly version from the 2023-06-15 day.
- * 	* "42.0.0-alpha" - matches the last alpha version for the 42.0.0 version.
  */

--- a/packages/ckeditor5-dev-release-tools/tests/index.js
+++ b/packages/ckeditor5-dev-release-tools/tests/index.js
@@ -26,6 +26,7 @@ import {
 	getNextNightly,
 	getNextInternal,
 	getCurrent,
+	getDateIdentifier,
 	getLastTagFromGit
 } from '../lib/utils/versions.js';
 import executeInParallel from '../lib/utils/executeinparallel.js';
@@ -147,6 +148,13 @@ describe( 'dev-release-tools/index', () => {
 		it( 'should be a function', () => {
 			expect( getCurrent ).to.be.a( 'function' );
 			expect( index.getCurrent ).to.equal( getCurrent );
+		} );
+	} );
+
+	describe( 'getDateIdentifier()', () => {
+		it( 'should be a function', () => {
+			expect( getDateIdentifier ).to.be.a( 'function' );
+			expect( index.getDateIdentifier ).to.equal( getDateIdentifier );
 		} );
 	} );
 

--- a/packages/ckeditor5-dev-release-tools/tests/utils/versions.js
+++ b/packages/ckeditor5-dev-release-tools/tests/utils/versions.js
@@ -432,7 +432,7 @@ describe( 'versions', () => {
 				name: 'ckeditor5',
 				versions: {
 					'0.0.0-nightly-20230615.0': {},
-					'0.0.0-nightly-next-20230616.0': {},
+					'0.0.0-nightly-next-20230615.5': {},
 					'37.0.0-alpha.0': {},
 					'42.0.0': {}
 				}

--- a/packages/ckeditor5-dev-release-tools/tests/utils/versions.js
+++ b/packages/ckeditor5-dev-release-tools/tests/utils/versions.js
@@ -17,7 +17,8 @@ import {
 	getNextNightly,
 	getNextInternal,
 	getLastTagFromGit,
-	getCurrent
+	getCurrent,
+	getDateIdentifier
 } from '../../lib/utils/versions.js';
 
 vi.mock( '@ckeditor/ckeditor5-dev-utils' );
@@ -245,6 +246,74 @@ describe( 'versions', () => {
 					expect( result ).to.equal( '0.0.0-nightly-20230615.2' );
 				} );
 		} );
+
+		it( 'returns last version from exactly the "nightly" tag when multiple nightly tags exist', () => {
+			vi.mocked( packument ).mockResolvedValue( {
+				name: 'ckeditor5',
+				versions: {
+					'0.0.0-nightly-20230615.0': {},
+					'0.0.0-nightly-20230615.1': {},
+					'0.0.0-nightly-20230615.2': {},
+					'0.0.0-nightly-next-20230615.3': {}
+				}
+			} );
+
+			return getLastPreRelease( '0.0.0-nightly' )
+				.then( result => {
+					expect( result ).to.equal( '0.0.0-nightly-20230615.2' );
+				} );
+		} );
+
+		it( 'returns last version from exactly the "nightly-next" tag when multiple nightly tags exist', () => {
+			vi.mocked( packument ).mockResolvedValue( {
+				name: 'ckeditor5',
+				versions: {
+					'0.0.0-nightly-next-20230615.0': {},
+					'0.0.0-nightly-next-20230615.1': {},
+					'0.0.0-nightly-next-20230615.2': {},
+					'0.0.0-nightly-20230615.3': {}
+				}
+			} );
+
+			return getLastPreRelease( '0.0.0-nightly-next' )
+				.then( result => {
+					expect( result ).to.equal( '0.0.0-nightly-next-20230615.2' );
+				} );
+		} );
+
+		it( 'returns last version from exactly the "nightly" tag when multiple nightly tags exist from a specific day', () => {
+			vi.mocked( packument ).mockResolvedValue( {
+				name: 'ckeditor5',
+				versions: {
+					'0.0.0-nightly-20230615.0': {},
+					'0.0.0-nightly-20230615.1': {},
+					'0.0.0-nightly-20230615.2': {},
+					'0.0.0-nightly-next-20230615.3': {}
+				}
+			} );
+
+			return getLastPreRelease( '0.0.0-nightly-20230615' )
+				.then( result => {
+					expect( result ).to.equal( '0.0.0-nightly-20230615.2' );
+				} );
+		} );
+
+		it( 'returns last version from exactly the "nightly-next" tag when multiple nightly tags exist from a specific day', () => {
+			vi.mocked( packument ).mockResolvedValue( {
+				name: 'ckeditor5',
+				versions: {
+					'0.0.0-nightly-next-20230615.0': {},
+					'0.0.0-nightly-next-20230615.1': {},
+					'0.0.0-nightly-next-20230615.2': {},
+					'0.0.0-nightly-20230615.3': {}
+				}
+			} );
+
+			return getLastPreRelease( '0.0.0-nightly-next-20230615' )
+				.then( result => {
+					expect( result ).to.equal( '0.0.0-nightly-next-20230615.2' );
+				} );
+		} );
 	} );
 
 	describe( 'getLastNightly()', () => {
@@ -252,7 +321,7 @@ describe( 'versions', () => {
 			vi.mocked( getPackageJson ).mockReturnValue( { name: 'ckeditor5' } );
 		} );
 
-		it( 'returns last nightly pre-release version', () => {
+		it( 'returns next pre-release version from exactly the "nightly" tag', () => {
 			vi.mocked( packument ).mockResolvedValue( {
 				name: 'ckeditor5',
 				versions: {
@@ -261,6 +330,7 @@ describe( 'versions', () => {
 					'0.0.0-nightly-20230614.1': {},
 					'0.0.0-nightly-20230614.2': {},
 					'0.0.0-nightly-20230615.0': {},
+					'0.0.0-nightly-next-20230616.0': {},
 					'37.0.0-alpha.0': {},
 					'42.0.0': {}
 				}
@@ -310,11 +380,12 @@ describe( 'versions', () => {
 				} );
 		} );
 
-		it( 'returns nightly version with incremented id if older nightly version was already published', () => {
+		it( 'returns version with incremented id from exactly the "nightly" tag if older version was already published', () => {
 			vi.mocked( packument ).mockResolvedValue( {
 				name: 'ckeditor5',
 				versions: {
 					'0.0.0-nightly-20230615.5': {},
+					'0.0.0-nightly-next-20230616.0': {},
 					'37.0.0-alpha.0': {},
 					'42.0.0': {}
 				}
@@ -323,6 +394,23 @@ describe( 'versions', () => {
 			return getNextPreRelease( '0.0.0-nightly' )
 				.then( result => {
 					expect( result ).to.equal( '0.0.0-nightly-20230615.6' );
+				} );
+		} );
+
+		it( 'returns version with incremented id from exactly the "nightly-next" tag if older version was already published', () => {
+			vi.mocked( packument ).mockResolvedValue( {
+				name: 'ckeditor5',
+				versions: {
+					'0.0.0-nightly-next-20230615.5': {},
+					'0.0.0-nightly-20230616.0': {},
+					'37.0.0-alpha.0': {},
+					'42.0.0': {}
+				}
+			} );
+
+			return getNextPreRelease( '0.0.0-nightly-next' )
+				.then( result => {
+					expect( result ).to.equal( '0.0.0-nightly-next-20230615.6' );
 				} );
 		} );
 	} );
@@ -339,11 +427,12 @@ describe( 'versions', () => {
 			vi.useRealTimers();
 		} );
 
-		it( 'asks for a last nightly pre-release version', () => {
+		it( 'returns next pre-release version from exactly the "nightly" tag', () => {
 			vi.mocked( packument ).mockResolvedValue( {
 				name: 'ckeditor5',
 				versions: {
 					'0.0.0-nightly-20230615.0': {},
+					'0.0.0-nightly-next-20230616.0': {},
 					'37.0.0-alpha.0': {},
 					'42.0.0': {}
 				}
@@ -368,7 +457,7 @@ describe( 'versions', () => {
 			vi.useRealTimers();
 		} );
 
-		it( 'asks for a last internal pre-release version', () => {
+		it( 'returns next internal pre-release version', () => {
 			vi.mocked( packument ).mockResolvedValue( {
 				name: 'ckeditor5',
 				versions: {
@@ -382,6 +471,21 @@ describe( 'versions', () => {
 				.then( result => {
 					expect( result ).to.equal( '0.0.0-internal-20230615.1' );
 				} );
+		} );
+	} );
+
+	describe( 'getDateIdentifier()', () => {
+		beforeEach( () => {
+			vi.useFakeTimers();
+			vi.setSystemTime( new Date( '2023-06-15 12:00:00' ) );
+		} );
+
+		afterEach( () => {
+			vi.useRealTimers();
+		} );
+
+		it( 'returns current date in the YYYYMMDD format', () => {
+			expect( getDateIdentifier() ).to.equal( '20230615' );
 		} );
 	} );
 

--- a/packages/ckeditor5-dev-release-tools/tests/utils/versions.js
+++ b/packages/ckeditor5-dev-release-tools/tests/utils/versions.js
@@ -375,7 +375,7 @@ describe( 'versions', () => {
 			vi.mocked( getPackageJson ).mockReturnValue( { name: 'ckeditor5' } );
 		} );
 
-		it( 'returns next pre-release version from exactly the "nightly" tag', () => {
+		it( 'returns last pre-release version from exactly the "nightly" tag', () => {
 			vi.mocked( packument ).mockResolvedValue( {
 				name: 'ckeditor5',
 				versions: {

--- a/packages/ckeditor5-dev-release-tools/tests/utils/versions.js
+++ b/packages/ckeditor5-dev-release-tools/tests/utils/versions.js
@@ -146,6 +146,23 @@ describe( 'versions', () => {
 				} );
 		} );
 
+		it( 'returns null if pre-release version matches the release identifier only partially', () => {
+			vi.mocked( packument ).mockResolvedValue( {
+				name: 'ckeditor5',
+				versions: {
+					'0.0.0-nightly-20230615.0': {},
+					'0.0.0-nightly-20230615.1': {},
+					'0.0.0-nightly-20230615.2': {},
+					'0.0.0-nightly-next-20230615.3': {}
+				}
+			} );
+
+			return getLastPreRelease( '0.0.0-nightly-2023' )
+				.then( result => {
+					expect( result ).to.equal( null );
+				} );
+		} );
+
 		it( 'returns last pre-release version matching the release identifier', () => {
 			vi.mocked( packument ).mockResolvedValue( {
 				name: 'ckeditor5',
@@ -312,6 +329,43 @@ describe( 'versions', () => {
 			return getLastPreRelease( '0.0.0-nightly-next-20230615' )
 				.then( result => {
 					expect( result ).to.equal( '0.0.0-nightly-next-20230615.2' );
+				} );
+		} );
+
+		it( 'returns last pre-release version matching the release identifier exactly', () => {
+			vi.mocked( packument ).mockResolvedValue( {
+				name: 'ckeditor5',
+				versions: {
+					'0.0.0-nightly-20230615.0': {},
+					'37.0.0-alpha.1': {},
+					'37.0.0-alpha.2': {},
+					'41.0.0': {},
+					'37.0.0-alpha.10': {},
+					'37.0.0-alpha.11': {}
+				}
+			} );
+
+			return getLastPreRelease( '37.0.0-alpha.10' )
+				.then( result => {
+					expect( result ).to.equal( '37.0.0-alpha.10' );
+				} );
+		} );
+
+		it( 'returns last nightly version matching the release identifier exactly', () => {
+			vi.mocked( packument ).mockResolvedValue( {
+				name: 'ckeditor5',
+				versions: {
+					'0.0.0-nightly-20230615.0': {},
+					'0.0.0-nightly-20230615.1': {},
+					'0.0.0-nightly-20230615.2': {},
+					'0.0.0-nightly-next-20230615.1': {},
+					'0.0.0-nightly-next-20230615.2': {}
+				}
+			} );
+
+			return getLastPreRelease( '0.0.0-nightly-20230615.1' )
+				.then( result => {
+					expect( result ).to.equal( '0.0.0-nightly-20230615.1' );
 				} );
 		} );
 	} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other (release-tools): Exported the `getDateIdentifier()` util that converts the current date into `YYYYMMDD` format.

Other (release-tools): Improved the `getLastPreRelease()` util to distinguish pre-release versions starting with the same base name. Previously, `getLastPreRelease( '0.0.0-nightly' )` matched both `0.0.0-nightly` and `0.0.0-nightly-next` versions, but now only the first one is matched.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
