### PR TITLE
Fixed calculating npm tag for the `nightly-next` pre-release version

### DIFF
--- a/packages/ckeditor5-dev-release-tools/lib/utils/getnpmtagfromversion.js
+++ b/packages/ckeditor5-dev-release-tools/lib/utils/getnpmtagfromversion.js
@@ -17,6 +17,10 @@ import semver from 'semver';
 export default function getNpmTagFromVersion( version ) {
 	const [ versionTag ] = semver.prerelease( version ) || [ 'latest' ];
 
+	if ( versionTag.startsWith( 'nightly-next' ) ) {
+		return 'nightly-next';
+	}
+
 	if ( versionTag.startsWith( 'nightly' ) ) {
 		return 'nightly';
 	}

--- a/packages/ckeditor5-dev-release-tools/tests/utils/getnpmtagfromversion.js
+++ b/packages/ckeditor5-dev-release-tools/tests/utils/getnpmtagfromversion.js
@@ -24,6 +24,10 @@ describe( 'getNpmTagFromVersion()', () => {
 		expect( getNpmTagFromVersion( '0.0.0-nightly-20230517.0' ) ).to.equal( 'nightly' );
 	} );
 
+	it( 'should return "nightly-next" when processing a 0.0.0-nightly-next-YYYYMMDD.X version', () => {
+		expect( getNpmTagFromVersion( '0.0.0-nightly-next-20230517.0' ) ).to.equal( 'nightly-next' );
+	} );
+
 	it( 'should return "internal" when processing a 0.0.0-internal-YYYYMMDD.X version', () => {
 		expect( getNpmTagFromVersion( '0.0.0-internal-20230517.0' ) ).to.equal( 'internal' );
 	} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix (release-tools): Fixed calculating npm tag for the `nightly-next` pre-release version. Closes ckeditor/ckeditor5#17904.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
