### PR TITLE
Ignore false positive ERR_ABORTED for 204 responses in requestfailed logging

### DIFF
--- a/packages/ckeditor5-dev-web-crawler/lib/constants.js
+++ b/packages/ckeditor5-dev-web-crawler/lib/constants.js
@@ -59,3 +59,5 @@ export const IGNORE_ALL_ERRORS_WILDCARD = '*';
 export const META_TAG_NAME = 'x-cke-crawler-ignore-patterns';
 
 export const DATA_ATTRIBUTE_NAME = 'data-cke-crawler-skip';
+
+export const SUCCESSFUL_HTTP_STATUS_CODES = [ 200, 201, 202, 203, 204, 205, 206, 207, 208, 226 ];

--- a/packages/ckeditor5-dev-web-crawler/lib/constants.js
+++ b/packages/ckeditor5-dev-web-crawler/lib/constants.js
@@ -59,5 +59,3 @@ export const IGNORE_ALL_ERRORS_WILDCARD = '*';
 export const META_TAG_NAME = 'x-cke-crawler-ignore-patterns';
 
 export const DATA_ATTRIBUTE_NAME = 'data-cke-crawler-skip';
-
-export const SUCCESSFUL_HTTP_STATUS_CODES = [ 200, 201, 202, 203, 204, 205, 206, 207, 208, 226 ];

--- a/packages/ckeditor5-dev-web-crawler/lib/runcrawler.js
+++ b/packages/ckeditor5-dev-web-crawler/lib/runcrawler.js
@@ -22,8 +22,7 @@ import {
 	PATTERN_TYPE_TO_ERROR_TYPE_MAP,
 	IGNORE_ALL_ERRORS_WILDCARD,
 	META_TAG_NAME,
-	DATA_ATTRIBUTE_NAME,
-	SUCCESSFUL_HTTP_STATUS_CODES
+	DATA_ATTRIBUTE_NAME
 } from './constants.js';
 
 /**
@@ -511,7 +510,7 @@ function registerErrorHandlers( page, { link, onError } ) {
 	page.on( ERROR_TYPES.REQUEST_FAILURE.event, request => {
 		const errorText = request.failure().errorText;
 
-		if ( SUCCESSFUL_HTTP_STATUS_CODES.includes( request.response()?.status() ) && request.method() === 'POST' ) {
+		if ( request.response()?.ok() && request.method() === 'POST' ) {
 			// Ignore a false positive due to a bug in Puppeteer.
 			// https://github.com/puppeteer/puppeteer/issues/9458
 			return;

--- a/packages/ckeditor5-dev-web-crawler/lib/runcrawler.js
+++ b/packages/ckeditor5-dev-web-crawler/lib/runcrawler.js
@@ -22,7 +22,8 @@ import {
 	PATTERN_TYPE_TO_ERROR_TYPE_MAP,
 	IGNORE_ALL_ERRORS_WILDCARD,
 	META_TAG_NAME,
-	DATA_ATTRIBUTE_NAME
+	DATA_ATTRIBUTE_NAME,
+	SUCCESSFUL_HTTP_STATUS_CODES
 } from './constants.js';
 
 /**
@@ -509,6 +510,12 @@ function registerErrorHandlers( page, { link, onError } ) {
 
 	page.on( ERROR_TYPES.REQUEST_FAILURE.event, request => {
 		const errorText = request.failure().errorText;
+
+		if ( SUCCESSFUL_HTTP_STATUS_CODES.includes( request.response()?.status() ) && request.method() === 'POST' ) {
+			// Ignore a false positive due to a bug in Puppeteer.
+			// https://github.com/puppeteer/puppeteer/issues/9458
+			return;
+		}
 
 		// Do not log errors explicitly aborted by the crawler.
 		if ( errorText !== 'net::ERR_BLOCKED_BY_CLIENT.Inspector' ) {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix (web-crawler): Ignore false positive `net::ERR_ABORTED` error reported when POST request responds with 204 HTTP status code. Closes ckeditor/ckeditor5#17969.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
