### PR TITLE
Added support for providing custom current working directory

### DIFF
--- a/packages/ckeditor5-dev-build-tools/src/utils.ts
+++ b/packages/ckeditor5-dev-build-tools/src/utils.ts
@@ -4,18 +4,10 @@
  */
 
 import { createRequire } from 'module';
-import path from 'upath';
 import type { CamelCase, CamelCasedProperties } from 'type-fest';
 import type { InputPluginOption } from 'rollup';
 
 const require = createRequire( import.meta.url );
-
-/**
- * Returns path relative to the current working directory.
- */
-export function getCwdPath( ...paths: Array<string> ): string {
-	return path.resolve( process.cwd(), ...paths );
-}
 
 /**
  * Transforms `kebab-case` strings to `camelCase`.

--- a/packages/ckeditor5-dev-build-tools/tests/build/arguments.test.ts
+++ b/packages/ckeditor5-dev-build-tools/tests/build/arguments.test.ts
@@ -67,8 +67,8 @@ function mockCliArgs( ...args: Array<string> ) {
 /**
  * Returns an absolute path to the file.
  */
-function getCwdPath( fileName: string ) {
-	return upath.join( process.cwd(), fileName );
+function getCwdPath( ...paths: Array<string> ) {
+	return upath.resolve( process.cwd(), ...paths );
 }
 
 test( 'paths are normalized', async () => {
@@ -86,13 +86,22 @@ test( 'paths are normalized', async () => {
  * CLI arguments
  */
 
+test( '--cwd', async () => {
+	const spy = getConfigMock();
+
+	mockCliArgs( '--cwd=/path/to/directory' );
+	await build();
+
+	expect( spy ).toHaveBeenCalledWith( expect.objectContaining( { input: getCwdPath( '/path/to/directory', 'src/index.ts' ) } ) );
+} );
+
 test( '--input', async () => {
 	const spy = getConfigMock();
 
 	mockCliArgs( '--input=main.js' );
 	await build();
 
-	expect( spy ).toHaveBeenCalledWith( expect.objectContaining( { input: getCwdPath( '/main.js' ) } ) );
+	expect( spy ).toHaveBeenCalledWith( expect.objectContaining( { input: getCwdPath( 'main.js' ) } ) );
 } );
 
 test( '--output', async () => {
@@ -101,7 +110,7 @@ test( '--output', async () => {
 	mockCliArgs( '--output=dist/test.js' );
 	await build();
 
-	expect( spy ).toHaveBeenCalledWith( expect.objectContaining( { output: getCwdPath( '/dist/test.js' ) } ) );
+	expect( spy ).toHaveBeenCalledWith( expect.objectContaining( { output: getCwdPath( 'dist/test.js' ) } ) );
 } );
 
 test( '--tsconfig', async () => {
@@ -110,7 +119,7 @@ test( '--tsconfig', async () => {
 	mockCliArgs( '--tsconfig=tsconf.json' );
 	await build();
 
-	expect( spy ).toHaveBeenCalledWith( expect.objectContaining( { tsconfig: getCwdPath( '/tsconf.json' ) } ) );
+	expect( spy ).toHaveBeenCalledWith( expect.objectContaining( { tsconfig: getCwdPath( 'tsconf.json' ) } ) );
 } );
 
 test( '--external', async () => {
@@ -146,7 +155,7 @@ test( '--translations', async () => {
 	mockCliArgs( '--translations=translations/**/*.po' );
 	await build();
 
-	expect( spy ).toHaveBeenCalledWith( expect.objectContaining( { translations: getCwdPath( '/translations/**/*.po' ) } ) );
+	expect( spy ).toHaveBeenCalledWith( expect.objectContaining( { translations: getCwdPath( 'translations/**/*.po' ) } ) );
 } );
 
 test( '--source-map', async () => {
@@ -194,7 +203,7 @@ test( '.input', async () => {
 
 	await build( { input: 'main.js' } );
 
-	expect( spy ).toHaveBeenCalledWith( expect.objectContaining( { input: getCwdPath( '/main.js' ) } ) );
+	expect( spy ).toHaveBeenCalledWith( expect.objectContaining( { input: getCwdPath( 'main.js' ) } ) );
 } );
 
 test( '.output', async () => {
@@ -202,7 +211,7 @@ test( '.output', async () => {
 
 	await build( { input: 'dist/test.js' } );
 
-	expect( spy ).toHaveBeenCalledWith( expect.objectContaining( { input: getCwdPath( '/dist/test.js' ) } ) );
+	expect( spy ).toHaveBeenCalledWith( expect.objectContaining( { input: getCwdPath( 'dist/test.js' ) } ) );
 } );
 
 test( '.tsconfig', async () => {
@@ -210,7 +219,7 @@ test( '.tsconfig', async () => {
 
 	await build( { tsconfig: 'tsconf.json' } );
 
-	expect( spy ).toHaveBeenCalledWith( expect.objectContaining( { tsconfig: getCwdPath( '/tsconf.json' ) } ) );
+	expect( spy ).toHaveBeenCalledWith( expect.objectContaining( { tsconfig: getCwdPath( 'tsconf.json' ) } ) );
 } );
 
 test( '.external', async () => {
@@ -258,7 +267,7 @@ test( '.translations', async () => {
 
 	await build( { translations: 'translations/**/*.po' } );
 
-	expect( spy ).toHaveBeenCalledWith( expect.objectContaining( { translations: getCwdPath( '/translations/**/*.po' ) } ) );
+	expect( spy ).toHaveBeenCalledWith( expect.objectContaining( { translations: getCwdPath( 'translations/**/*.po' ) } ) );
 } );
 
 test( '.sourceMap', async () => {
@@ -291,7 +300,7 @@ test( '.clean removes directory based on .output', async () => {
 	await build( { output: 'custom/index.js', clean: true } );
 
 	expect( spy ).toHaveBeenCalledWith(
-		getCwdPath( '/custom' ),
+		getCwdPath( 'custom' ),
 		{ force: true, recursive: true }
 	);
 } );

--- a/packages/ckeditor5-dev-build-tools/tests/build/build.test.ts
+++ b/packages/ckeditor5-dev-build-tools/tests/build/build.test.ts
@@ -139,7 +139,22 @@ test( 'Browser parameter set to `false`', async () => {
 	] );
 } );
 
-test( 'Browser parameter set to `true`', async () => {
+test( 'Browser parameter set to `true` and name parameter not set', async () => {
+	const { output } = await build( {
+		input: 'src/input.ts',
+		tsconfig: 'tsconfig.json',
+		browser: true
+	} );
+
+	expect( output.map( o => o.fileName ) ).toMatchObject( [
+		'index.js',
+		'index.css',
+		'index-editor.css',
+		'index-content.css'
+	] );
+} );
+
+test( 'Browser parameter set to `true` and name parameter set', async () => {
 	const { output } = await build( {
 		input: 'src/input.ts',
 		tsconfig: 'tsconfig.json',

--- a/packages/ckeditor5-dev-build-tools/tests/config/config.test.ts
+++ b/packages/ckeditor5-dev-build-tools/tests/config/config.test.ts
@@ -23,7 +23,8 @@ const defaults: Options = {
 	minify: false,
 	clean: false,
 	browser: false,
-	name: ''
+	name: '',
+	cwd: ''
 };
 
 function getConfig( config: Partial<Options> = {} ) {

--- a/packages/ckeditor5-dev-build-tools/tests/utils.test.ts
+++ b/packages/ckeditor5-dev-build-tools/tests/utils.test.ts
@@ -4,12 +4,7 @@
  */
 
 import { test, expect } from 'vitest';
-import upath from 'upath';
-import { getCwdPath, camelize, camelizeObjectKeys, removeNewline } from '../src/utils.js';
-
-test( 'getPath()', () => {
-	expect( getCwdPath( 'dist', 'index.js' ) ).toBe( upath.join( process.cwd(), '/dist/index.js' ) );
-} );
+import { camelize, camelizeObjectKeys, removeNewline } from '../src/utils.js';
 
 test( 'camelize()', () => {
 	expect( camelize( 'this-is-a-test' ) ).toBe( 'thisIsATest' );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other (build-tools): Added support for providing custom current working directory.

Other (build-tools): Do not start generating UMD build if both `browser` and `name` parameters are missing, because both are required.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
