### PR TITLE
Added annotation to the tag created during a release process to fix the release process.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Changelog
 
 * **[release-tools](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-release-tools)**: Added the options.dryRun parameter to the commitAndTag() function to verify if a release commit passes validation, so releasing a project will not fail due to issues while committing. ([commit](https://github.com/ckeditor/ckeditor5-dev/commit/0e4779d403fbf22dd6f8a3f2a1de5d1b2183db81))
 
+### Other changes
+
+* **[release-tools](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-release-tools)**: Added annotation to the tag created during a release process to fix the release process on the CI. ([commit](https://github.com/ckeditor/ckeditor5-dev/commit/ecbcfd3a6767b1251400e67659ae326fa44b868a))
+
 ### Released packages
 
 Check out the [Versioning policy](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/support/versioning-policy.html) guide for more information.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Changelog
 
 ### Other changes
 
-* **[release-tools](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-release-tools)**: The `commitAndTag()` function now uses annotated tags instead of lightweight ones to allow signing commits while preparing a release. ([commit](https://github.com/ckeditor/ckeditor5-dev/commit/ecbcfd3a6767b1251400e67659ae326fa44b868a))
+* **[release-tools](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-release-tools)**: The `commitAndTag()` function now uses annotated tags instead of lightweight ones to allow signing tags while preparing a release. Closes [ckeditor/ckeditor5#18080](https://github.com/ckeditor/ckeditor5/issues/18080). ([commit](https://github.com/ckeditor/ckeditor5-dev/commit/ecbcfd3a6767b1251400e67659ae326fa44b868a))
 
 ### Released packages
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Changelog
 
 ### Other changes
 
-* **[release-tools](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-release-tools)**: Added annotation to the tag created during a release process to fix the release process on the CI. ([commit](https://github.com/ckeditor/ckeditor5-dev/commit/ecbcfd3a6767b1251400e67659ae326fa44b868a))
+* **[release-tools](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-release-tools)**: The `commitAndTag()` function now uses annotated tags instead of lightweight ones to allow signing commits while preparing a release. ([commit](https://github.com/ckeditor/ckeditor5-dev/commit/ecbcfd3a6767b1251400e67659ae326fa44b868a))
 
 ### Released packages
 

--- a/packages/ckeditor5-dev-release-tools/lib/tasks/commitandtag.js
+++ b/packages/ckeditor5-dev-release-tools/lib/tasks/commitandtag.js
@@ -54,6 +54,6 @@ export default async function commitAndTag( {
 	} else if ( !tagForVersion ) {
 		// Commit and create a tag if it does not exist yet. It might happen when a release job is restarted.
 		await makeCommit();
-		await git.addTag( `v${ version }` );
+		await git.addAnnotatedTag( `v${ version }`, `Release: v${ version }.` );
 	}
 }

--- a/packages/ckeditor5-dev-release-tools/tests/tasks/commitandtag.js
+++ b/packages/ckeditor5-dev-release-tools/tests/tasks/commitandtag.js
@@ -21,7 +21,7 @@ describe( 'commitAndTag()', () => {
 				commit: vi.fn(),
 				reset: vi.fn(),
 				log: vi.fn(),
-				addTag: vi.fn()
+				addAnnotatedTag: vi.fn()
 			}
 		};
 
@@ -40,7 +40,7 @@ describe( 'commitAndTag()', () => {
 		await commitAndTag( { files: [] } );
 
 		expect( stubs.git.commit ).not.toHaveBeenCalled();
-		expect( stubs.git.addTag ).not.toHaveBeenCalled();
+		expect( stubs.git.addAnnotatedTag ).not.toHaveBeenCalled();
 	} );
 
 	it( 'should not create a commit and tag if the specified version is already tagged', async () => {
@@ -52,7 +52,7 @@ describe( 'commitAndTag()', () => {
 		await commitAndTag( { files: [ 'package.json' ], version: '1.0.0' } );
 
 		expect( stubs.git.commit ).not.toHaveBeenCalled();
-		expect( stubs.git.addTag ).not.toHaveBeenCalled();
+		expect( stubs.git.addAnnotatedTag ).not.toHaveBeenCalled();
 	} );
 
 	it( 'should allow to specify custom cwd', async () => {
@@ -123,7 +123,15 @@ describe( 'commitAndTag()', () => {
 
 		await commitAndTag( { version: '1.0.0', packagesDirectory: 'packages' } );
 
-		expect( stubs.git.addTag ).toHaveBeenCalledExactlyOnceWith( 'v1.0.0' );
+		expect( stubs.git.addAnnotatedTag ).toHaveBeenCalledExactlyOnceWith( 'v1.0.0', 'Release: v1.0.0.' );
+	} );
+
+	it( 'should add a tag to the created commit with a correct message when skipCi is true', async () => {
+		vi.mocked( glob ).mockResolvedValue( [ 'package.json' ] );
+
+		await commitAndTag( { version: '1.0.0', packagesDirectory: 'packages', skipCi: true } );
+
+		expect( stubs.git.addAnnotatedTag ).toHaveBeenCalledExactlyOnceWith( 'v1.0.0', 'Release: v1.0.0.' );
 	} );
 
 	it( 'should create a commit in dry run mode without creating a tag and then reset it', async () => {
@@ -144,7 +152,7 @@ describe( 'commitAndTag()', () => {
 		] );
 		expect( stubs.git.reset ).toHaveBeenCalledExactlyOnceWith( [ 'previousmockhash' ] );
 
-		expect( stubs.git.addTag ).not.toHaveBeenCalled();
+		expect( stubs.git.addAnnotatedTag ).not.toHaveBeenCalled();
 	} );
 
 	it( 'should not run git reset when commit in dry run throws an error', async () => {
@@ -167,6 +175,6 @@ describe( 'commitAndTag()', () => {
 		] );
 
 		expect( stubs.git.reset ).not.toHaveBeenCalled();
-		expect( stubs.git.addTag ).not.toHaveBeenCalled();
+		expect( stubs.git.addAnnotatedTag ).not.toHaveBeenCalled();
 	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: The `commitAndTag()` function now uses annotated tags instead of lightweight ones to allow signing tags while preparing a release. Closes ckeditor/ckeditor5#18080.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
