### PR TITLE
Bumped NodeJS version

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "homepage": "https://github.com/ckeditor/ckeditor5-dev#readme",
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   },
   "type": "module",
   "devDependencies": {

--- a/packages/ckeditor5-dev-build-tools/package.json
+++ b/packages/ckeditor5-dev-build-tools/package.json
@@ -13,7 +13,7 @@
     "directory": "packages/ckeditor5-dev-build-tools"
   },
   "engines": {
-    "node": ">=18.0.0",
+    "node": ">=20.0.0",
     "npm": ">=5.7.1"
   },
   "type": "module",

--- a/packages/ckeditor5-dev-bump-year/package.json
+++ b/packages/ckeditor5-dev-bump-year/package.json
@@ -13,7 +13,7 @@
     "directory": "packages/ckeditor5-dev-bump-year"
   },
   "engines": {
-    "node": ">=18.0.0",
+    "node": ">=20.0.0",
     "npm": ">=5.7.1"
   },
   "main": "lib/index.js",

--- a/packages/ckeditor5-dev-ci/package.json
+++ b/packages/ckeditor5-dev-ci/package.json
@@ -13,7 +13,7 @@
     "directory": "packages/ckeditor5-dev-ci"
   },
   "engines": {
-    "node": ">=18.0.0",
+    "node": ">=20.0.0",
     "npm": ">=5.7.1"
   },
   "type": "module",

--- a/packages/ckeditor5-dev-dependency-checker/package.json
+++ b/packages/ckeditor5-dev-dependency-checker/package.json
@@ -13,7 +13,7 @@
     "directory": "packages/ckeditor5-dev-dependency-checker"
   },
   "engines": {
-    "node": ">=18.0.0",
+    "node": ">=20.0.0",
     "npm": ">=5.7.1"
   },
   "type": "module",

--- a/packages/ckeditor5-dev-docs/package.json
+++ b/packages/ckeditor5-dev-docs/package.json
@@ -13,7 +13,7 @@
     "directory": "packages/ckeditor5-dev-docs"
   },
   "engines": {
-    "node": ">=18.0.0",
+    "node": ">=20.0.0",
     "npm": ">=5.7.1"
   },
   "type": "module",

--- a/packages/ckeditor5-dev-release-tools/package.json
+++ b/packages/ckeditor5-dev-release-tools/package.json
@@ -13,7 +13,7 @@
     "directory": "packages/ckeditor5-dev-release-tools"
   },
   "engines": {
-    "node": ">=18.0.0",
+    "node": ">=20.0.0",
     "npm": ">=5.7.1"
   },
   "type": "module",

--- a/packages/ckeditor5-dev-stale-bot/package.json
+++ b/packages/ckeditor5-dev-stale-bot/package.json
@@ -13,7 +13,7 @@
     "directory": "packages/ckeditor5-dev-stale-bot"
   },
   "engines": {
-    "node": ">=18.0.0",
+    "node": ">=20.0.0",
     "npm": ">=5.7.1"
   },
   "type": "module",

--- a/packages/ckeditor5-dev-tests/package.json
+++ b/packages/ckeditor5-dev-tests/package.json
@@ -13,7 +13,7 @@
     "directory": "packages/ckeditor5-dev-tests"
   },
   "engines": {
-    "node": ">=18.0.0",
+    "node": ">=20.0.0",
     "npm": ">=5.7.1"
   },
   "type": "module",

--- a/packages/ckeditor5-dev-translations/package.json
+++ b/packages/ckeditor5-dev-translations/package.json
@@ -13,7 +13,7 @@
     "directory": "packages/ckeditor5-dev-translations"
   },
   "engines": {
-    "node": ">=18.0.0",
+    "node": ">=20.0.0",
     "npm": ">=5.7.1"
   },
   "main": "lib/index.js",

--- a/packages/ckeditor5-dev-utils/package.json
+++ b/packages/ckeditor5-dev-utils/package.json
@@ -13,7 +13,7 @@
     "directory": "packages/ckeditor5-dev-utils"
   },
   "engines": {
-    "node": ">=18.0.0",
+    "node": ">=20.0.0",
     "npm": ">=5.7.1"
   },
   "main": "lib/index.js",

--- a/packages/ckeditor5-dev-web-crawler/package.json
+++ b/packages/ckeditor5-dev-web-crawler/package.json
@@ -13,7 +13,7 @@
     "directory": "packages/ckeditor5-dev-web-crawler"
   },
   "engines": {
-    "node": ">=18.0.0",
+    "node": ">=20.0.0",
     "npm": ">=5.7.1"
   },
   "main": "lib/index.js",

--- a/packages/typedoc-plugins/package.json
+++ b/packages/typedoc-plugins/package.json
@@ -13,7 +13,7 @@
     "directory": "packages/typedoc-plugins"
   },
   "engines": {
-    "node": ">=18.0.0",
+    "node": ">=20.0.0",
     "npm": ">=5.7.1"
   },
   "main": "lib/index.js",


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

MAJOR BREAKING CHANGE: Upgraded the minimal version of Node.js to 20.0.0 due to the end of LTS.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
