### PR TITLE
Changed loaded files order

### DIFF
--- a/packages/ckeditor5-dev-build-tools/src/config.ts
+++ b/packages/ckeditor5-dev-build-tools/src/config.ts
@@ -85,7 +85,7 @@ export async function getRollupConfig( options: BuildOptions ) {
 	/**
 	 * Valid extensions for JavaScript and TypeScript files.
 	 */
-	const extensions = [ '.mjs', '.js', '.json', '.node', '.ts', '.mts' ];
+	const extensions = [ '.mts', '.ts', '.mjs', '.js', '.json', '.node' ];
 
 	return {
 		input,


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix (build-tools): Redefined the order of loaded files so the TypeScript sources will take precedence over JavaScript files.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
