### PR TITLE
Fixed types mismatch between different `@types/estree` versions

### DIFF
--- a/packages/ckeditor5-dev-build-tools/src/plugins/replace.ts
+++ b/packages/ckeditor5-dev-build-tools/src/plugins/replace.ts
@@ -73,7 +73,7 @@ export function replaceImports( pluginOptions: RollupReplaceOptions ): Plugin {
 			const magic = new MagicString( source );
 			const ast = this.parse( source );
 
-			walk( ast, {
+			walk( ast as Node, {
 				enter( node ) {
 					if ( !isModule( node ) || !node.source ) {
 						return;


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal (build-tools): Fixed types mismatch between different `@types/estree` versions. Closes ckeditor/ckeditor5#18220.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
