### PR TITLE
Fix (build-tools): Prioritize `.ts` over `.js` files

### DIFF
--- a/packages/ckeditor5-dev-build-tools/src/config.ts
+++ b/packages/ckeditor5-dev-build-tools/src/config.ts
@@ -25,6 +25,7 @@ import { addBanner } from './plugins/banner.js';
 import { emitCss } from './plugins/emitCss.js';
 import { replaceImports } from './plugins/replace.js';
 import { splitCss } from './plugins/splitCss.js';
+import { loadTypeScriptSources } from './plugins/loadSources.js';
 import { translations as translationsPlugin } from './plugins/translations.js';
 
 /**
@@ -85,7 +86,7 @@ export async function getRollupConfig( options: BuildOptions ) {
 	/**
 	 * Valid extensions for JavaScript and TypeScript files.
 	 */
-	const extensions = [ '.mjs', '.js', '.json', '.node', '.ts', '.mts' ];
+	const extensions = [ '.ts', '.mts', '.mjs', '.js', '.json', '.node' ];
 
 	return {
 		input,
@@ -117,6 +118,11 @@ export async function getRollupConfig( options: BuildOptions ) {
 		},
 
 		plugins: [
+			/**
+			 * Ensures that `.ts` files are loaded over `.js` files if both exist.
+			 */
+			loadTypeScriptSources(),
+
 			/**
 			 * Converts CommonJS modules to ES6.
 			 */
@@ -204,7 +210,10 @@ export async function getRollupConfig( options: BuildOptions ) {
 			/**
 			 * Does type checking and generates `.d.ts` files.
 			 */
-			getTypeScriptPlugin( { tsconfig, output, sourceMap, declarations } ),
+			getOptionalPlugin(
+				declarations,
+				getTypeScriptPlugin( { tsconfig, output, sourceMap, declarations } )
+			),
 
 			/**
 			 * Replaces parts of the source code with the provided values.
@@ -308,11 +317,7 @@ function getTypeScriptPlugin( {
 		declaration: declarations,
 		declarationDir: declarations ? path.parse( output ).dir : undefined,
 		compilerOptions: {
-			// When `declarations` is set to `true`, we only want to emit declaration files.
-			emitDeclarationOnly: !!declarations,
-
-			// Otherwise, we don't want to emit anything.
-			noEmit: !declarations
+			emitDeclarationOnly: true
 		}
 	} );
 }

--- a/packages/ckeditor5-dev-build-tools/src/index.ts
+++ b/packages/ckeditor5-dev-build-tools/src/index.ts
@@ -7,6 +7,7 @@ export { build } from './build.js';
 export { addBanner, type RollupBannerOptions } from './plugins/banner.js';
 export { emitCss, type RollupEmitCssOptions } from './plugins/emitCss.js';
 export { loadSourcemaps } from './plugins/loadSourcemaps.js';
+export { loadTypeScriptSources } from './plugins/loadSources.js';
 export { replaceImports, type RollupReplaceOptions } from './plugins/replace.js';
 export { splitCss, type RollupSplitCssOptions } from './plugins/splitCss.js';
 export { translations, type RollupTranslationsOptions } from './plugins/translations.js';

--- a/packages/ckeditor5-dev-build-tools/src/plugins/loadSources.ts
+++ b/packages/ckeditor5-dev-build-tools/src/plugins/loadSources.ts
@@ -1,0 +1,34 @@
+import { accessSync } from 'fs';
+import { resolve, dirname } from 'path';
+import type { Plugin } from 'rollup';
+
+export function loadTypeScriptSources(): Plugin {
+  const cache: Record<string, string | null> = {};
+
+  return {
+    name: 'load-typescript-sources',
+
+    resolveId( source: string, importer: string | undefined ) {
+			if ( !importer || !source.startsWith( '.' ) || !source.endsWith( '.js' ) ) {
+        return null;
+      }
+
+      const path = resolve(
+				dirname( importer ),
+				source.replace( /\.js$/, '.ts' )
+			);
+
+      if ( cache[ path ] ) {
+        return cache[ path ];
+      }
+
+      try {
+        accessSync( path );
+
+        return cache[ path ] = path;
+      } catch {
+        return cache[ path ] = null;
+      }
+    }
+  };
+}

--- a/packages/ckeditor5-dev-build-tools/src/plugins/loadSources.ts
+++ b/packages/ckeditor5-dev-build-tools/src/plugins/loadSources.ts
@@ -1,34 +1,42 @@
+/**
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
 import { accessSync } from 'fs';
 import { resolve, dirname } from 'path';
 import type { Plugin } from 'rollup';
 
 export function loadTypeScriptSources(): Plugin {
-  const cache: Record<string, string | null> = {};
+	const cache: Record<string, string | null> = {};
 
-  return {
-    name: 'load-typescript-sources',
+	return {
+		name: 'load-typescript-sources',
 
-    resolveId( source: string, importer: string | undefined ) {
+		resolveId( source: string, importer: string | undefined ) {
 			if ( !importer || !source.startsWith( '.' ) || !source.endsWith( '.js' ) ) {
-        return null;
-      }
+				return null;
+			}
 
-      const path = resolve(
+			const path = resolve(
 				dirname( importer ),
 				source.replace( /\.js$/, '.ts' )
 			);
 
-      if ( cache[ path ] ) {
-        return cache[ path ];
-      }
+			if ( cache[ path ] ) {
+				return cache[ path ];
+			}
 
-      try {
-        accessSync( path );
+			try {
+				accessSync( path );
+				cache[ path ] = path;
 
-        return cache[ path ] = path;
-      } catch {
-        return cache[ path ] = null;
-      }
-    }
-  };
+				return path;
+			} catch {
+				cache[ path ] = null;
+
+				return null;
+			}
+		}
+	};
 }

--- a/packages/ckeditor5-dev-build-tools/tests/config/config.test.ts
+++ b/packages/ckeditor5-dev-build-tools/tests/config/config.test.ts
@@ -55,7 +55,7 @@ test( '--tsconfig', async () => {
 
 	expect( fileExists.plugins.some( plugin => plugin?.name === 'typescript' ) ).toBe( true );
 	expect( fileDoesntExist.plugins.some( plugin => plugin?.name === 'typescript' ) ).toBe( false );
-	expect( declarationsFalse.plugins.some( plugin => plugin?.name === 'typescript' ) ).toBe( true );
+	expect( declarationsFalse.plugins.some( plugin => plugin?.name === 'typescript' ) ).toBe( false );
 } );
 
 test( '--external', async () => {

--- a/packages/ckeditor5-dev-build-tools/tests/plugins/loadSources/fixtures/input.ts
+++ b/packages/ckeditor5-dev-build-tools/tests/plugins/loadSources/fixtures/input.ts
@@ -1,0 +1,8 @@
+/**
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+import { data } from './source.js';
+
+console.log( data );

--- a/packages/ckeditor5-dev-build-tools/tests/plugins/loadSources/fixtures/source.js
+++ b/packages/ckeditor5-dev-build-tools/tests/plugins/loadSources/fixtures/source.js
@@ -1,0 +1,7 @@
+/**
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+// This file intentionally has different data than `source.ts`
+export const data = 456;

--- a/packages/ckeditor5-dev-build-tools/tests/plugins/loadSources/fixtures/source.ts
+++ b/packages/ckeditor5-dev-build-tools/tests/plugins/loadSources/fixtures/source.ts
@@ -1,0 +1,7 @@
+/**
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+// This file intentionally has different data than `source.js`
+export const data = 123;

--- a/packages/ckeditor5-dev-build-tools/tests/plugins/loadSources/fixtures/tsconfig.json
+++ b/packages/ckeditor5-dev-build-tools/tests/plugins/loadSources/fixtures/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": [
+      "ES2022",
+      "DOM",
+      "DOM.Iterable"
+    ],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "skipLibCheck": true,
+    "resolveJsonModule": true
+  },
+  "include": [
+    "**/*"
+  ]
+}

--- a/packages/ckeditor5-dev-build-tools/tests/plugins/loadSources/loadSources.test.ts
+++ b/packages/ckeditor5-dev-build-tools/tests/plugins/loadSources/loadSources.test.ts
@@ -1,0 +1,47 @@
+/**
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+import { join } from 'path';
+import { test, expect } from 'vitest';
+import { rollup, type RollupOutput, type OutputAsset } from 'rollup';
+import { swcPlugin, verifyAsset, verifyChunk } from '../../_utils/utils.js';
+
+import { loadTypeScriptSources } from '../../../src/index.js';
+
+/**
+ * Helper function for creating a bundle that won't be written to the file system.
+ */
+async function generateBundle( enabled = true ): Promise<RollupOutput[ 'output' ]> {
+	const bundle = await rollup( {
+		input: join( import.meta.dirname, './fixtures/input.ts' ),
+		plugins: [
+			swcPlugin,
+
+			enabled && loadTypeScriptSources()
+		]
+	} );
+
+	const { output } = await bundle.generate( {
+		format: 'esm',
+		file: 'input.js',
+		assetFileNames: '[name][extname]',
+	} );
+
+	return output;
+}
+
+test( 'Prioritizes `.ts` files over `.js` files', async () => {
+	const output = await generateBundle();
+
+	verifyChunk( output, 'input.js', '123' );
+} );
+
+
+test( 'When not enabled, prioritizes `.js` files over `.ts` files', async () => {
+	const output = await generateBundle( false );
+
+	verifyChunk( output, 'input.js', '456' );
+} );
+

--- a/packages/ckeditor5-dev-build-tools/tests/plugins/loadSources/loadSources.test.ts
+++ b/packages/ckeditor5-dev-build-tools/tests/plugins/loadSources/loadSources.test.ts
@@ -4,9 +4,9 @@
  */
 
 import { join } from 'path';
-import { test, expect } from 'vitest';
-import { rollup, type RollupOutput, type OutputAsset } from 'rollup';
-import { swcPlugin, verifyAsset, verifyChunk } from '../../_utils/utils.js';
+import { test } from 'vitest';
+import { rollup, type RollupOutput } from 'rollup';
+import { swcPlugin, verifyChunk } from '../../_utils/utils.js';
 
 import { loadTypeScriptSources } from '../../../src/index.js';
 
@@ -26,7 +26,7 @@ async function generateBundle( enabled = true ): Promise<RollupOutput[ 'output' 
 	const { output } = await bundle.generate( {
 		format: 'esm',
 		file: 'input.js',
-		assetFileNames: '[name][extname]',
+		assetFileNames: '[name][extname]'
 	} );
 
 	return output;
@@ -37,7 +37,6 @@ test( 'Prioritizes `.ts` files over `.js` files', async () => {
 
 	verifyChunk( output, 'input.js', '123' );
 } );
-
 
 test( 'When not enabled, prioritizes `.js` files over `.ts` files', async () => {
 	const output = await generateBundle( false );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix (build-tools): Prioritize `.ts` over `.js` files.

---

This PR causes the `.ts` file to take precedence if both `.js` and `.ts` files are present on the file system. This prevents potentially old and obsolete build files from overriding current source files.

It also reverts the changes made in #1051 so that the TypeScript plugin is only used if the `declaration: true` option is passed. This improves the build time of:

* `ckeditor5-premium-features` by ~24s (from 65.5s down to 41.5s),
* documentation (`yarn docs --skip-validation --skip-api`) by ~20s (from 111s down to 89.5s).

