### PR TITLE
Adjusted resource class for the "trigger_*" jobs on CI

### DIFF
--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -151,7 +151,6 @@ jobs:
 
   trigger_release_process:
     machine: true
-    resource_class: large
     steps:
       - checkout
       - bootstrap_repository_command

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Before you start, you need to prepare the changelog entries.
     * This task checks what changed in each package and bumps the version accordingly. It won't create a new changelog entry if nothing changes at all. If changes were irrelevant (e.g., only dependencies), it would make an "_internal changes_" entry.
     * Scan the logs printed by the tool to search for errors (incorrect changelog entries). Incorrect entries (e.g., ones without the type) should be addressed. You may need to create entries for them manually. This is done directly in CHANGELOG.md (in the root directory). Make sure to verify the proposed version after you modify the changelog.
 1. Commit all changes and prepare a new pull request targeting the `#master` branch.
-1. Ping the `@ckeditor/ckeditor-5-devops` team to review the pull request and trigger the release process.
+1. Ping the `@ckeditor/ckeditor-5-platform` team to review the pull request and trigger the release process.
 
 ## License
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Adjusted resource class for the "trigger_*" jobs on CI.

Internal: Fixed a README typo.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
