### PR TITLE
Feature (web-crawler): Improve performance.

### DIFF
--- a/packages/ckeditor5-dev-web-crawler/package.json
+++ b/packages/ckeditor5-dev-web-crawler/package.json
@@ -23,7 +23,8 @@
     "dist"
   ],
   "scripts": {
-    "build": "rollup -c rollup.config.js"
+    "build": "rollup -c rollup.config.js",
+    "dev": "rollup -c rollup.config.js --watch"
   },
   "dependencies": {
     "chalk": "^5.0.0",

--- a/packages/ckeditor5-dev-web-crawler/src/constants.ts
+++ b/packages/ckeditor5-dev-web-crawler/src/constants.ts
@@ -39,7 +39,7 @@ export const IGNORED_HOSTS = [
 	'jsfiddle.net'
 ];
 
-export const DEFAULT_CONCURRENCY = cpus().length / 2;
+export const DEFAULT_CONCURRENCY = Math.min( cpus().length, 16 );
 
 export const DEFAULT_TIMEOUT = 15 * 1000;
 
@@ -51,6 +51,10 @@ export const ERROR_TYPES = {
 	PAGE_CRASH: {
 		event: 'error',
 		description: 'Page crash'
+	},
+	UNCAUGHT_EXCEPTION: {
+		event: 'pageerror',
+		description: 'Uncaught exception'
 	},
 	REQUEST_FAILURE: {
 		event: 'requestfailed',
@@ -73,6 +77,7 @@ export const ERROR_TYPES = {
 
 export const PATTERN_TYPE_TO_ERROR_TYPE_MAP = {
 	'page-crash': ERROR_TYPES.PAGE_CRASH,
+	'uncaught-exception': ERROR_TYPES.UNCAUGHT_EXCEPTION,
 	'request-failure': ERROR_TYPES.REQUEST_FAILURE,
 	'response-failure': ERROR_TYPES.RESPONSE_FAILURE,
 	'console-error': ERROR_TYPES.CONSOLE_ERROR,

--- a/packages/ckeditor5-dev-web-crawler/src/getlinks.ts
+++ b/packages/ckeditor5-dev-web-crawler/src/getlinks.ts
@@ -1,0 +1,34 @@
+/**
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/* eslint-env browser */
+// eslint-disable-next-line spaced-comment
+/// <reference lib="dom" />
+
+/**
+ * Returns all links on the page.
+ *
+ * This function is in a separate file to allow using DOM APIs thanks to TypeScript
+ * and eslint magic comments above.
+ */
+export function getAllLinks( ignoreAttribute: string ): Array<string> {
+	return Array
+		// Get all links from the document.
+		.from( document.links )
+
+		// Filter out links with the given attribute, downloads and protocols other than http(s).
+		.filter( link =>
+			link.href &&
+			!link.hasAttribute( ignoreAttribute ) &&
+			!link.hasAttribute( 'download' ) &&
+			/^https?:$/.test( link.protocol )
+		)
+
+		// Convert to absolute URL.
+		.map( link => link.origin + link.pathname )
+
+		// Remove duplicates.
+		.filter( ( link, index, array ) => array.indexOf( link ) === index );
+}

--- a/packages/ckeditor5-dev-web-crawler/src/runcrawler.ts
+++ b/packages/ckeditor5-dev-web-crawler/src/runcrawler.ts
@@ -296,7 +296,10 @@ export default async function runCrawler( options: CrawlerOptions ): Promise<voi
 		} );
 
 		try {
-			await page.goto( data.url, { waitUntil: 'load' } );
+			// `networkidle0` forces loading CKEditor snippets. API pages to not contain them, so let's speed up.
+			const waitUntil = data.url.includes( '/api/' ) ? 'load' : 'networkidle0';
+
+			await page.goto( data.url, { waitUntil } );
 		} catch ( error ) {
 			const errorMessage = ( error as Error ).message || '(empty message)';
 

--- a/packages/ckeditor5-dev-web-crawler/src/runcrawler.ts
+++ b/packages/ckeditor5-dev-web-crawler/src/runcrawler.ts
@@ -10,6 +10,7 @@
 import util from 'util';
 import chalk from 'chalk';
 import { Cluster } from 'puppeteer-cluster';
+import { getAllLinks } from './getlinks.js';
 import { getBaseUrl, toArray } from './utils.js';
 import type { LaunchOptions, Page } from 'puppeteer';
 
@@ -73,7 +74,7 @@ interface CrawlerOptions {
 	 *
 	 * @default false
 	 */
-	noSpinner?: boolean;
+	silent?: boolean;
 }
 
 interface CrawlerError {
@@ -106,24 +107,26 @@ export default async function runCrawler( options: CrawlerOptions ): Promise<voi
 		concurrency = DEFAULT_CONCURRENCY,
 		disableBrowserSandbox = false,
 		ignoreHTTPSErrors = false,
-		noSpinner = false
+		silent = false
 	} = options;
 
 	console.log( chalk.bold( '\n🔎 Starting the Crawler…\n' ) );
 
-	process.on( 'unhandledRejection', reason => {
-		const error = util.inspect( reason, {
-			breakLength: Infinity,
-			compact: true
-		} );
-
-		console.log( chalk.red.bold( `\n🔥 Caught the \`unhandledRejection\` error: ${ error }\n` ) );
-
-		process.exit( 1 );
-	} );
-
 	const puppeteerOptions = {
-		args: [] as Array<string>,
+		args: [
+			'--disable-extensions', // Disables all browser extensions.
+			'--disable-plugins', // Disables all plugins.
+			'--disable-gpu', // Disables GPU hardware acceleration.
+			'--disable-software-rasterizer', // Disables software fallback for GPU rendering.
+			'--disable-renderer-backgrounding', // Prevents throttling of background tabs renderers.
+			'--disable-background-timer-throttling', // Stops throttling of JavaScript timers in background tabs.
+			'--disable-backgrounding-occluded-windows', // Avoids deprioritizing windows that are not visible.
+			'--disable-sync', // Disables browser sync services.
+			'--disable-translate', // Disables built-in translation features.
+			'--disable-infobars', // Hides infobars (e.g., automation warnings).
+			'--no-first-run', // Skips first run tasks and setup dialogs.
+			'--no-default-browser-check' // Prevents default browser check at startup.
+		],
 		headless: true,
 		acceptInsecureCerts: ignoreHTTPSErrors
 	} satisfies LaunchOptions;
@@ -145,7 +148,7 @@ export default async function runCrawler( options: CrawlerOptions ): Promise<voi
 		maxConcurrency: concurrency,
 		puppeteerOptions,
 		skipDuplicateUrls: true,
-		monitor: !noSpinner
+		monitor: !silent
 	} );
 
 	cluster.on( 'taskerror', ( err, data ) => {
@@ -162,22 +165,39 @@ export default async function runCrawler( options: CrawlerOptions ): Promise<voi
 		const pageErrors: Array<CrawlerError> = [];
 
 		page.on( 'request', request => {
+			const url = request.url();
 			const resourceType = request.resourceType();
 
-			// Block all 'media' requests, as they are likely to fail anyway due to limitations in Puppeteer.
 			if ( resourceType === 'media' ) {
-				request.abort( 'blockedbyclient' );
-			} else {
-				request.continue();
+				// Block all 'media' requests, as they are likely to fail anyway due to limitations in Puppeteer.
+				return request.abort( 'blockedbyclient' );
 			}
+
+			if ( url.includes( 'visualwebsiteoptimizer' ) ) {
+				// We don't need this when doing testing.
+				return request.abort( 'blockedbyclient' );
+			}
+
+			if ( url.endsWith( 'api.json' ) ) {
+				// This file is huge and loaded on every page, but doesn't need to be tested.
+				return request.abort( 'blockedbyclient' );
+			}
+
+			return request.continue();
 		} );
 
 		page.on( 'dialog', dialog => dialog.dismiss() );
 
 		page.on( ERROR_TYPES.PAGE_CRASH.event, error => pageErrors.push( {
-			pageUrl: page.url(),
+			pageUrl: data.url,
 			type: ERROR_TYPES.PAGE_CRASH,
 			message: ( error as Error ).message || '(empty message)'
+		} ) );
+
+		page.on( ERROR_TYPES.UNCAUGHT_EXCEPTION.event, error => onError( {
+			pageUrl: data.url,
+			type: ERROR_TYPES.UNCAUGHT_EXCEPTION,
+			message: error.message || '(empty message)'
 		} ) );
 
 		page.on( ERROR_TYPES.REQUEST_FAILURE.event, request => {
@@ -204,7 +224,7 @@ export default async function runCrawler( options: CrawlerOptions ): Promise<voi
 					`Failed to load resource from ${ chalk.bold( host ) }`;
 
 				pageErrors.push( {
-					pageUrl: isNavigation ? data.parentUrl : page.url(),
+					pageUrl: isNavigation ? data.parentUrl : data.url,
 					type: ERROR_TYPES.REQUEST_FAILURE,
 					message: `${ message } (failure message: ${ chalk.bold( errorText ) })`,
 					failedResourceUrl: url
@@ -228,7 +248,7 @@ export default async function runCrawler( options: CrawlerOptions ): Promise<voi
 					`Failed to load resource from ${ chalk.bold( host ) }`;
 
 				pageErrors.push( {
-					pageUrl: isNavigation ? data.parentUrl : page.url(),
+					pageUrl: isNavigation ? data.parentUrl : data.url,
 					type: ERROR_TYPES.RESPONSE_FAILURE,
 					message: `${ message } (HTTP response status code: ${ chalk.bold( responseStatus ) })`,
 					failedResourceUrl: url
@@ -236,33 +256,53 @@ export default async function runCrawler( options: CrawlerOptions ): Promise<voi
 			}
 		} );
 
-		const session = await page.createCDPSession();
+		page.on( ERROR_TYPES.CONSOLE_ERROR.event, async message => {
+			if ( message.type() !== 'error' ) {
+				return;
+			}
 
-		await session.send( 'Runtime.enable' );
+			const serializedMessage = await Promise.all( message.args().map( arg => {
+				const remoteObject = arg.remoteObject();
 
-		session.on( 'Runtime.exceptionThrown', event => {
-			const message = event.exceptionDetails.exception?.description ||
-				event.exceptionDetails.exception?.value ||
-				event.exceptionDetails.text ||
-				'(No description provided)';
+				if ( remoteObject.type === 'string' ) {
+					return remoteObject.value;
+				}
+
+				if ( remoteObject.type === 'object' && remoteObject.subtype === 'error' ) {
+					return remoteObject.description;
+				}
+
+				return arg.jsonValue();
+			} ) );
+
+			const text = serializedMessage.join( ' ' ).trim();
+
+			if ( !text ) {
+				return;
+			}
+
+			if ( text.startsWith( 'Failed to load resource:' ) ) {
+				// The resource loading failure is already covered by the "request" or "response" error handlers, so it should
+				// not be also reported as the "console error".
+				return;
+			}
 
 			pageErrors.push( {
-				pageUrl: page.url(),
+				pageUrl: data.url,
 				type: ERROR_TYPES.CONSOLE_ERROR,
-				message
+				// First line of the message is the most important one, so we will use it as a message.
+				message: text.split( '\n' )[ 0 ] || '(empty message)'
 			} );
 		} );
 
 		try {
-			await page.goto( data.url, { waitUntil: [ 'load', 'networkidle0' ] } );
+			await page.goto( data.url, { waitUntil: 'load' } );
 		} catch ( error ) {
 			const errorMessage = ( error as Error ).message || '(empty message)';
 
 			// All navigation errors starting with the `net::` prefix are already covered by the "request" error handler, so it should
 			// not be also reported as the "navigation error".
-			const ignoredMessage = 'net::';
-
-			if ( !errorMessage.startsWith( ignoredMessage ) ) {
+			if ( !errorMessage.startsWith( 'net::' ) ) {
 				pageErrors.push( {
 					pageUrl: data.url,
 					type: ERROR_TYPES.NAVIGATION_ERROR,
@@ -271,15 +311,19 @@ export default async function runCrawler( options: CrawlerOptions ): Promise<voi
 			}
 		}
 
-		// Create patterns from meta tags to ignore errors.
-		const errorIgnorePatterns = await getErrorIgnorePatternsFromPage( page );
+		if ( pageErrors.length ) {
+			// If page contains errors, check if there are any meta tags that define patterns to ignore errors.
 
-		// Iterates over recently found errors to mark them as ignored ones, if they match the patterns.
-		markErrorsAsIgnored( pageErrors, errorIgnorePatterns );
+			// Create patterns from meta tags to ignore errors.
+			const errorIgnorePatterns = await getErrorIgnorePatternsFromPage( page );
 
-		pageErrors
-			.filter( error => !error.ignored )
-			.forEach( error => onError( error ) );
+			// Iterates over recently found errors to mark them as ignored ones, if they match the patterns.
+			markErrorsAsIgnored( pageErrors, errorIgnorePatterns );
+
+			pageErrors
+				.filter( error => !error.ignored )
+				.forEach( error => onError( error ) );
+		}
 
 		if ( data.remainingNestedLevels === 0 ) {
 			// Skip crawling deeper, if the bottom has been reached
@@ -353,13 +397,7 @@ async function getLinksFromPage(
 	page: Page,
 	{ baseUrl, foundLinks, exclusions }: { baseUrl: string; foundLinks: Array<string>; exclusions: Array<string> }
 ): Promise<Array<string>> {
-	const links = await page.$$eval(
-		`body a[href]:not([${ DATA_ATTRIBUTE_NAME }]):not([download])`,
-		anchors => [ ...new Set( anchors
-			.filter( anchor => /http(s)?:/.test( anchor.protocol ) )
-			.map( anchor => `${ anchor.origin }${ anchor.pathname }` ) )
-		]
-	);
+	const links = await page.evaluate( getAllLinks, DATA_ATTRIBUTE_NAME );
 
 	return links.filter( link => {
 		return link.startsWith( baseUrl ) && // Skip external link.
@@ -387,7 +425,7 @@ async function getErrorIgnorePatternsFromPage( page: Page ): Promise<Map<ErrorTy
 
 	try {
 		// Try to parse value from meta tag...
-		content = JSON.parse( contentString );
+		content = JSON.parse( contentString as any );
 	} catch ( error ) {
 		// ...but if it is not a valid JSON, return an empty map.
 		return patterns;


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal (web-crawler): Increase the number of concurrent workers to equal the number of CPU threads, but no more than 16.

Internal (web-crawler): Properly read console errors.

Feature (web-crawler): Improve performance.

MINOR BREAKING CHANGE (web-crawler): Rename `noSpinner` to `silent`.

---

While the old implementation took about **45 to 50 minutes** to validate all uber docs, the new one does it in **less than 4 minutes** on my laptop.

```text
== Start:     2025-04-15 09:39:05.055
== Now:       2025-04-15 09:42:52.254 (running for 3.8 minutes)
== Progress:  3828 / 3828 (100.00%), errors: 0 (0.00%)
== Remaining: 0.0 ms (@ 16.85 pages/second)
== Sys. load: 92.1% CPU / 41.8% memory
== Workers:   16
```

Here's the breakdown of the changes and how they reduced the build time:

1. Base: **50 minutes**
2. Using `document.links` instead of `page.$$eval( ... )`: **13 minutes**
3. Increasing the worker count: **8.5 minutes**
4. Adding Chrome flags, blocking `api.json`, reading `x-cke-crawler-ignore-patterns` only when there's an error on the page: **6.5 minutes**
5. Changing `waitUntil` to `load` instead of `[ 'load', 'networkidle0' ]`: **3.8 minutes**
