### PR TITLE
Improved the `postinstall` hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,8 +14,7 @@ executeinparallel-integration.log
 /release/
 
 # Compiled TS.
-packages/ckeditor5-dev-build-tools/dist
-packages/ckeditor5-dev-web-crawler/dist
+packages/*/dist
 
 packages/ckeditor5-dev-release-tools/tests/test-fixtures/**
 !packages/ckeditor5-dev-release-tools/tests/test-fixtures/.gitkeep

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -6,36 +6,46 @@
 /* eslint-env node */
 
 import path from 'path';
-import fs from 'fs';
+import fs from 'fs-extra';
 import { execSync } from 'child_process';
 import { fileURLToPath } from 'url';
+import { glob } from 'glob';
 
 const __filename = fileURLToPath( import.meta.url );
 const __dirname = path.dirname( __filename );
 
 const ROOT_DIRECTORY = path.join( __dirname, '..' );
 
-( async () => {
-	// When installing a repository as a dependency, the `.git` directory does not exist.
-	// In such a case, husky should not attach its hooks as npm treats it as a package, not a git repository.
-	if ( fs.existsSync( path.join( ROOT_DIRECTORY, '.git' ) ) ) {
-		const husky = ( await import( 'husky' ) ).default;
+// When installing a repository as a dependency, the `.git` directory does not exist.
+// In such a case, husky should not attach its hooks as npm treats it as a package, not a git repository.
+if ( fs.existsSync( path.join( ROOT_DIRECTORY, '.git' ) ) ) {
+	const husky = ( await import( 'husky' ) ).default;
 
-		husky.install();
+	husky.install();
 
-		execSync( 'npm run postinstall', {
-			cwd: path.join( ROOT_DIRECTORY, 'packages', 'ckeditor5-dev-tests' ),
-			stdio: 'inherit'
-		} );
+	execSync( 'npm run postinstall', {
+		cwd: path.join( ROOT_DIRECTORY, 'packages', 'ckeditor5-dev-tests' ),
+		stdio: 'inherit'
+	} );
 
+	const packageJsonPaths = await glob( 'packages/*/package.json', { cwd: ROOT_DIRECTORY, absolute: true } );
+	const packagesToProcess = packageJsonPaths
+		.map( async packagePath => ( {
+			packagePath: path.join( packagePath, '..' ),
+			packageJson: await fs.readJson( packagePath )
+		} ) );
+
+	const packagesToBuild = ( await Promise.allSettled( packagesToProcess ) )
+		.filter( ( { status } ) => status === 'fulfilled' )
+		.map( ( { value } ) => value )
+		.filter( ( { packageJson } ) => packageJson.scripts?.build )
+		.map( ( { packagePath } ) => packagePath );
+
+	for ( const singlePackage of packagesToBuild ) {
+		console.log( `Building: "${ singlePackage }"...` );
 		execSync( 'npm run build', {
-			cwd: path.join( ROOT_DIRECTORY, 'packages', 'ckeditor5-dev-build-tools' ),
-			stdio: 'inherit'
-		} );
-
-		execSync( 'npm run build', {
-			cwd: path.join( ROOT_DIRECTORY, 'packages', 'ckeditor5-dev-web-crawler' ),
+			cwd: singlePackage,
 			stdio: 'inherit'
 		} );
 	}
-} )();
+}


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Improved the `postinstall` hook. Right now, the script searches for packages to build automatically. When converting packages to TypeScript, it is no longer necessary to add a new package manually.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
