### PR TITLE
Internal: Properly handle and filter `UNCAUGHT_EXCEPTION` errors.

### DIFF
--- a/packages/ckeditor5-dev-web-crawler/src/runcrawler.ts
+++ b/packages/ckeditor5-dev-web-crawler/src/runcrawler.ts
@@ -194,7 +194,7 @@ export default async function runCrawler( options: CrawlerOptions ): Promise<voi
 			message: ( error as Error ).message || '(empty message)'
 		} ) );
 
-		page.on( ERROR_TYPES.UNCAUGHT_EXCEPTION.event, error => onError( {
+		page.on( ERROR_TYPES.UNCAUGHT_EXCEPTION.event, error => pageErrors.push( {
 			pageUrl: data.url,
 			type: ERROR_TYPES.UNCAUGHT_EXCEPTION,
 			message: error.message || '(empty message)'


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Properly handle and filter `UNCAUGHT_EXCEPTION` errors.

---

Errors detected on the page should be added to `pageErrors` array first, so they can be filtered out before being added to the root `errors` map. See changes made in #1108.
