### PR TITLE
Feature (dependency-checker): Treat paths used in `import.meta.resolve` as potential dependencies.

### DIFF
--- a/packages/ckeditor5-dev-dependency-checker/package.json
+++ b/packages/ckeditor5-dev-dependency-checker/package.json
@@ -31,6 +31,8 @@
     "fs-extra": "^11.0.0",
     "glob": "^10.0.0",
     "minimist": "^1.2.8",
+    "oxc-parser": "^0.64.0",
+    "oxc-walker": "^0.2.5",
     "upath": "^2.0.1"
   }
 }


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature (dependency-checker): Treat paths used in `import.meta.resolve` as potential dependencies.
Feature (dependency-checker): Improve performance.

---

**Using `oxc-parser` improves the performance by about 30%.**