### PR TITLE
Restore TypeScript program after converting the sources

### DIFF
--- a/packages/ckeditor5-dev-docs/lib/build.js
+++ b/packages/ckeditor5-dev-docs/lib/build.js
@@ -7,6 +7,7 @@ import { glob } from 'glob';
 import upath from 'upath';
 import { Application, OptionDefaults } from 'typedoc';
 import {
+	typeDocRestoreProgramAfterConversion,
 	typeDocModuleFixer,
 	typeDocSymbolFixer,
 	typeDocTagError,
@@ -67,6 +68,7 @@ export default async function build( config ) {
 		]
 	} );
 
+	typeDocRestoreProgramAfterConversion( app );
 	typeDocModuleFixer( app );
 	typeDocSymbolFixer( app );
 	typeDocTagError( app );

--- a/packages/ckeditor5-dev-docs/tests/build.js
+++ b/packages/ckeditor5-dev-docs/tests/build.js
@@ -16,6 +16,7 @@ import {
 	typeDocEventInheritanceFixer,
 	typeDocInterfaceAugmentationFixer,
 	typeDocPurgePrivateApiDocs,
+	typeDocRestoreProgramAfterConversion,
 	validate
 } from '@ckeditor/typedoc-plugins';
 
@@ -124,7 +125,8 @@ describe( 'lib/build()', () => {
 			typeDocEventParamFixer,
 			typeDocEventInheritanceFixer,
 			typeDocInterfaceAugmentationFixer,
-			typeDocPurgePrivateApiDocs
+			typeDocPurgePrivateApiDocs,
+			typeDocRestoreProgramAfterConversion
 		];
 
 		expect( stubs.app.convert ).toHaveBeenCalledTimes( 1 );

--- a/packages/typedoc-plugins/src/index.ts
+++ b/packages/typedoc-plugins/src/index.ts
@@ -12,4 +12,5 @@ export { default as typeDocEventParamFixer } from './event-param-fixer/index.js'
 export { default as typeDocEventInheritanceFixer } from './event-inheritance-fixer/index.js';
 export { default as typeDocInterfaceAugmentationFixer } from './interface-augmentation-fixer/index.js';
 export { default as typeDocPurgePrivateApiDocs } from './purge-private-api-docs/index.js';
+export { default as typeDocRestoreProgramAfterConversion } from './restore-program-after-conversion/index.js';
 export { default as validate } from './validators/index.js';

--- a/packages/typedoc-plugins/src/restore-program-after-conversion/index.ts
+++ b/packages/typedoc-plugins/src/restore-program-after-conversion/index.ts
@@ -1,0 +1,26 @@
+/**
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+import {
+	Converter,
+	type Context,
+	type Application
+} from 'typedoc';
+
+/**
+ * The `typedoc-plugin-restore-program-after-conversion` restores TypeScript program used for source conversion.
+ *
+ * TypeDoc at some point, after the source compilation and conversion is finished, deletes the `context.program` property.
+ * This operation prevents from using custom TypeDoc plugins, which listen to `EVENT_END` event, because some TypeDoc internals
+ * require that `context.program` exists.
+ */
+export default function( app: Application ): void {
+	// Set non-default priority to ensure execution before other plugins.
+	app.converter.on( Converter.EVENT_END, onEventEnd, 1000 );
+}
+
+function onEventEnd( context: Context ) {
+	context.setActiveProgram( context.programs.at( 0 ) );
+}

--- a/packages/typedoc-plugins/tests/event-inheritance-fixer/index.ts
+++ b/packages/typedoc-plugins/tests/event-inheritance-fixer/index.ts
@@ -16,7 +16,8 @@ import {
 import { ROOT_TEST_DIRECTORY } from '../utils.js';
 import {
 	typeDocTagEvent,
-	typeDocEventInheritanceFixer
+	typeDocEventInheritanceFixer,
+	typeDocRestoreProgramAfterConversion
 } from '../../src/index.js';
 
 import typeDocRemoveClassC from './utils/typedoc-plugin-remove-class-c.js';
@@ -44,6 +45,7 @@ describe( 'typedoc-plugins/event-inheritance-fixer', function() {
 
 		typeDocTagEvent( typeDoc );
 		typeDocEventInheritanceFixer( typeDoc );
+		typeDocRestoreProgramAfterConversion( typeDoc );
 
 		expect( entryPoints ).to.not.lengthOf( 0 );
 
@@ -367,6 +369,7 @@ describe( 'typedoc-plugins/event-inheritance-fixer', function() {
 			typeDocRemoveClassC( typeDoc );
 			typeDocTagEvent( typeDoc );
 			typeDocEventInheritanceFixer( typeDoc );
+			typeDocRestoreProgramAfterConversion( typeDoc );
 
 			conversionResult = ( await typeDoc.convert() )!;
 		} );

--- a/packages/typedoc-plugins/tests/event-param-fixer/index.ts
+++ b/packages/typedoc-plugins/tests/event-param-fixer/index.ts
@@ -18,7 +18,8 @@ import { ROOT_TEST_DIRECTORY } from '../utils.js';
 import {
 	typeDocTagEvent,
 	typeDocTagObservable,
-	typeDocEventParamFixer
+	typeDocEventParamFixer,
+	typeDocRestoreProgramAfterConversion
 } from '../../src/index.js';
 
 function assertEventInfoParameter( eventInfoParameter: ParameterReflection, eventInfoClass: DeclarationReflection ) {
@@ -62,6 +63,7 @@ describe( 'typedoc-plugins/event-param-fixer', () => {
 		typeDocTagEvent( typeDoc );
 		typeDocTagObservable( typeDoc );
 		typeDocEventParamFixer( typeDoc );
+		typeDocRestoreProgramAfterConversion( typeDoc );
 
 		expect( entryPoints ).to.not.lengthOf( 0 );
 
@@ -97,6 +99,7 @@ describe( 'typedoc-plugins/event-param-fixer', () => {
 		typeDocTagEvent( typeDoc );
 		typeDocTagObservable( typeDoc );
 		typeDocEventParamFixer( typeDoc );
+		typeDocRestoreProgramAfterConversion( typeDoc );
 
 		const conversionResult = ( await typeDoc.convert() )!;
 		const eventInfoClass = conversionResult.getChildByName( [ 'utils/eventinfo', 'EventInfo' ] );

--- a/packages/typedoc-plugins/tests/interface-augmentation-fixer/index.ts
+++ b/packages/typedoc-plugins/tests/interface-augmentation-fixer/index.ts
@@ -15,7 +15,7 @@ import {
 } from 'typedoc';
 
 import { ROOT_TEST_DIRECTORY } from '../utils.js';
-import { typeDocInterfaceAugmentationFixer } from '../../src/index.js';
+import { typeDocInterfaceAugmentationFixer, typeDocRestoreProgramAfterConversion } from '../../src/index.js';
 
 describe( 'typedoc-plugins/interface-augmentation-fixer', function() {
 	let conversionResult: ProjectReflection;
@@ -37,6 +37,7 @@ describe( 'typedoc-plugins/interface-augmentation-fixer', function() {
 		} );
 
 		typeDocInterfaceAugmentationFixer( typeDoc );
+		typeDocRestoreProgramAfterConversion( typeDoc );
 
 		expect( entryPoints ).to.not.lengthOf( 0 );
 

--- a/packages/typedoc-plugins/tests/module-fixer/index.ts
+++ b/packages/typedoc-plugins/tests/module-fixer/index.ts
@@ -9,7 +9,7 @@ import upath from 'upath';
 import { Application, type ProjectReflection } from 'typedoc';
 
 import { ROOT_TEST_DIRECTORY } from '../utils.js';
-import { typeDocModuleFixer } from '../../src/index.js';
+import { typeDocModuleFixer, typeDocRestoreProgramAfterConversion } from '../../src/index.js';
 
 describe( 'typedoc-plugins/module-fixer', () => {
 	let conversionResult: ProjectReflection;
@@ -29,6 +29,7 @@ describe( 'typedoc-plugins/module-fixer', () => {
 		} );
 
 		typeDocModuleFixer( typeDoc );
+		typeDocRestoreProgramAfterConversion( typeDoc );
 
 		expect( files ).to.not.lengthOf( 0 );
 

--- a/packages/typedoc-plugins/tests/purge-private-api-docs/index.ts
+++ b/packages/typedoc-plugins/tests/purge-private-api-docs/index.ts
@@ -13,7 +13,7 @@ import {
 } from 'typedoc';
 
 import { ROOT_TEST_DIRECTORY } from '../utils.js';
-import { typeDocPurgePrivateApiDocs } from '../../src/index.js';
+import { typeDocPurgePrivateApiDocs, typeDocRestoreProgramAfterConversion } from '../../src/index.js';
 
 describe( 'typedoc-plugins/purge-private-api-docs', function() {
 	let conversionResult: ProjectReflection;
@@ -40,6 +40,7 @@ describe( 'typedoc-plugins/purge-private-api-docs', function() {
 		} );
 
 		typeDocPurgePrivateApiDocs( typeDoc );
+		typeDocRestoreProgramAfterConversion( typeDoc );
 
 		expect( entryPoints ).to.not.lengthOf( 0 );
 

--- a/packages/typedoc-plugins/tests/restore-program-after-conversion/fixtures/foo.ts
+++ b/packages/typedoc-plugins/tests/restore-program-after-conversion/fixtures/foo.ts
@@ -1,0 +1,12 @@
+/**
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/**
+ * @module fixtures/foo
+ */
+
+export interface Foo {
+	propertyFoo: number;
+}

--- a/packages/typedoc-plugins/tests/restore-program-after-conversion/fixtures/tsconfig.json
+++ b/packages/typedoc-plugins/tests/restore-program-after-conversion/fixtures/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.json"
+}

--- a/packages/typedoc-plugins/tests/restore-program-after-conversion/index.ts
+++ b/packages/typedoc-plugins/tests/restore-program-after-conversion/index.ts
@@ -1,0 +1,48 @@
+/**
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { glob } from 'glob';
+import upath from 'upath';
+import { Application, Converter, type Context } from 'typedoc';
+
+import { ROOT_TEST_DIRECTORY } from '../utils.js';
+import { typeDocRestoreProgramAfterConversion } from '../../src/index.js';
+
+function contextProgramChecker( app: Application ) {
+	// TODO: To resolve types.
+	// @ts-expect-error TS2339
+	// Property 'on' does not exist on type 'Converter'.
+	app.converter.on( Converter.EVENT_END, ( context: Context ) => {
+		expect( context.program ).not.toBeUndefined();
+	} );
+}
+
+describe( 'typedoc-plugins/restore-program-after-conversion', () => {
+	it( 'should not throw an error when accessing the `context.program` after the conversion is finished', async () => {
+		const fixturesPath = upath.join( ROOT_TEST_DIRECTORY, 'restore-program-after-conversion', 'fixtures' );
+		const sourceFilePatterns = [ upath.join( fixturesPath, '**', '*.ts' ) ];
+
+		const entryPoints = ( await glob( sourceFilePatterns ) ).map( file => upath.normalize( file ) );
+
+		expect( entryPoints ).to.not.lengthOf( 0 );
+
+		const app = await Application.bootstrapWithPlugins( {
+			logLevel: 'Error',
+			entryPoints,
+			tsconfig: upath.join( fixturesPath, 'tsconfig.json' ),
+			plugin: [
+				'typedoc-plugin-rename-defaults'
+			]
+		} );
+
+		// The order of loaded plugins is explicitly set to make sure that it does not matter: first, the test plugin is executed
+		// that reads `context.program` before the plugin that fixes TypeDoc behavior.
+		contextProgramChecker( app );
+		typeDocRestoreProgramAfterConversion( app );
+
+		await expect( app.convert() ).resolves.not.toBeUndefined();
+	} );
+} );

--- a/packages/typedoc-plugins/tests/symbol-fixer/index.ts
+++ b/packages/typedoc-plugins/tests/symbol-fixer/index.ts
@@ -9,7 +9,7 @@ import upath from 'upath';
 import { Application, type ProjectReflection, ReflectionKind } from 'typedoc';
 
 import { ROOT_TEST_DIRECTORY } from '../utils.js';
-import { typeDocSymbolFixer } from '../../src/index.js';
+import { typeDocRestoreProgramAfterConversion, typeDocSymbolFixer } from '../../src/index.js';
 
 describe( 'typedoc-plugins/symbol-fixer', () => {
 	let typeDoc: Application,
@@ -34,6 +34,7 @@ describe( 'typedoc-plugins/symbol-fixer', () => {
 		warnSpy = vi.spyOn( typeDoc.logger, 'warn' );
 
 		typeDocSymbolFixer( typeDoc );
+		typeDocRestoreProgramAfterConversion( typeDoc );
 
 		expect( files ).to.not.lengthOf( 0 );
 

--- a/packages/typedoc-plugins/tests/tag-error/fixtures/customerror.ts
+++ b/packages/typedoc-plugins/tests/tag-error/fixtures/customerror.ts
@@ -79,7 +79,8 @@ export function create( errorName: string ): CustomError {
  * @param {module:fixtures/error~ErrorFooBar} exampleMissingModule Just a non-existing module.
  * @param {module:fixtures/error~SystemError#customPropertyInInterface} exampleInterfaceChildren Just a named property.
  * @param {HTMLElement} domInstance An instance of an HTML element.
- * @param {obj.value} nestedObject A nested object.
+ * @param {object} nestedObject A nested object.
+ * @param {string} nestedObject.property A nested property in an object.
  * @param {any} linkInDescriptionAbsolute A name {@link module:utils/object~Object} `description`.
  * @param {any} linkInDescriptionRelative Description of the error. Please, see {@link ~CustomError}.
  * @param {any} paramMissingDescription

--- a/packages/typedoc-plugins/tests/tag-error/index.ts
+++ b/packages/typedoc-plugins/tests/tag-error/index.ts
@@ -16,7 +16,7 @@ import {
 } from 'typedoc';
 
 import { ROOT_TEST_DIRECTORY } from '../utils.js';
-import { typeDocTagError } from '../../src/index.js';
+import { typeDocRestoreProgramAfterConversion, typeDocTagError } from '../../src/index.js';
 
 describe( 'typedoc-plugins/tag-error', () => {
 	let conversionResult: ProjectReflection;
@@ -39,6 +39,7 @@ describe( 'typedoc-plugins/tag-error', () => {
 		} );
 
 		typeDocTagError( typeDoc );
+		typeDocRestoreProgramAfterConversion( typeDoc );
 
 		expect( files ).to.not.lengthOf( 0 );
 

--- a/packages/typedoc-plugins/tests/tag-event/index.ts
+++ b/packages/typedoc-plugins/tests/tag-event/index.ts
@@ -17,7 +17,7 @@ import {
 } from 'typedoc';
 
 import { ROOT_TEST_DIRECTORY } from '../utils.js';
-import { typeDocTagEvent } from '../../src/index.js';
+import { typeDocRestoreProgramAfterConversion, typeDocTagEvent } from '../../src/index.js';
 
 function assertEventExists( events: Array<DeclarationReflection>, eventName: string ) {
 	const event = events.find( event => {
@@ -51,6 +51,7 @@ describe( 'typedoc-plugins/tag-event', () => {
 		warnSpy = vi.spyOn( typeDoc.logger, 'warn' );
 
 		typeDocTagEvent( typeDoc );
+		typeDocRestoreProgramAfterConversion( typeDoc );
 
 		expect( files ).to.not.lengthOf( 0 );
 

--- a/packages/typedoc-plugins/tests/tag-observable/index.ts
+++ b/packages/typedoc-plugins/tests/tag-observable/index.ts
@@ -14,7 +14,7 @@ import {
 } from 'typedoc';
 
 import { ROOT_TEST_DIRECTORY } from '../utils.js';
-import { typeDocTagObservable } from '../../src/index.js';
+import { typeDocRestoreProgramAfterConversion, typeDocTagObservable } from '../../src/index.js';
 
 type AssertObservableExistsType = {
 	reflections: Array<DeclarationReflection>;
@@ -58,6 +58,7 @@ describe( 'typedoc-plugins/tag-observable', function() {
 		} );
 
 		typeDocTagObservable( typeDoc );
+		typeDocRestoreProgramAfterConversion( typeDoc );
 
 		expect( files ).to.not.lengthOf( 0 );
 

--- a/packages/typedoc-plugins/tests/validators/fires-validator/index.ts
+++ b/packages/typedoc-plugins/tests/validators/fires-validator/index.ts
@@ -17,7 +17,8 @@ import {
 	typeDocEventParamFixer,
 	typeDocEventInheritanceFixer,
 	typeDocInterfaceAugmentationFixer,
-	typeDocPurgePrivateApiDocs
+	typeDocPurgePrivateApiDocs,
+	typeDocRestoreProgramAfterConversion
 } from '../../../src/index.js';
 
 import { ROOT_TEST_DIRECTORY, assertCalls } from '../../utils.js';
@@ -49,6 +50,7 @@ describe( 'typedoc-plugins/validators/fires-validator', () => {
 		typeDocEventInheritanceFixer( app );
 		typeDocInterfaceAugmentationFixer( app );
 		typeDocPurgePrivateApiDocs( app );
+		typeDocRestoreProgramAfterConversion( app );
 
 		firesValidator( app, onError );
 

--- a/packages/typedoc-plugins/tests/validators/link-validator/index.ts
+++ b/packages/typedoc-plugins/tests/validators/link-validator/index.ts
@@ -17,7 +17,8 @@ import {
 	typeDocEventParamFixer,
 	typeDocEventInheritanceFixer,
 	typeDocInterfaceAugmentationFixer,
-	typeDocPurgePrivateApiDocs
+	typeDocPurgePrivateApiDocs,
+	typeDocRestoreProgramAfterConversion
 } from '../../../src/index.js';
 
 import { ROOT_TEST_DIRECTORY, assertCalls } from '../../utils.js';
@@ -50,6 +51,7 @@ describe( 'typedoc-plugins/validators/link-validator', function() {
 		typeDocEventInheritanceFixer( app );
 		typeDocInterfaceAugmentationFixer( app );
 		typeDocPurgePrivateApiDocs( app );
+		typeDocRestoreProgramAfterConversion( app );
 
 		linkValidator( app, onError );
 

--- a/packages/typedoc-plugins/tests/validators/module-validator/index.ts
+++ b/packages/typedoc-plugins/tests/validators/module-validator/index.ts
@@ -17,7 +17,8 @@ import {
 	typeDocEventParamFixer,
 	typeDocEventInheritanceFixer,
 	typeDocInterfaceAugmentationFixer,
-	typeDocPurgePrivateApiDocs
+	typeDocPurgePrivateApiDocs,
+	typeDocRestoreProgramAfterConversion
 } from '../../../src/index.js';
 
 import { ROOT_TEST_DIRECTORY, assertCalls } from '../../utils.js';
@@ -49,6 +50,7 @@ describe( 'typedoc-plugins/validators/module-validator', function() {
 		typeDocEventInheritanceFixer( app );
 		typeDocInterfaceAugmentationFixer( app );
 		typeDocPurgePrivateApiDocs( app );
+		typeDocRestoreProgramAfterConversion( app );
 
 		moduleValidator( app, onError );
 

--- a/packages/typedoc-plugins/tests/validators/overloads-validator/index.ts
+++ b/packages/typedoc-plugins/tests/validators/overloads-validator/index.ts
@@ -17,7 +17,8 @@ import {
 	typeDocEventParamFixer,
 	typeDocEventInheritanceFixer,
 	typeDocInterfaceAugmentationFixer,
-	typeDocPurgePrivateApiDocs
+	typeDocPurgePrivateApiDocs,
+	typeDocRestoreProgramAfterConversion
 } from '../../../src/index.js';
 
 import { ROOT_TEST_DIRECTORY, assertCalls } from '../../utils.js';
@@ -49,6 +50,7 @@ describe( 'typedoc-plugins/validators/overloads-validator', function() {
 		typeDocEventInheritanceFixer( app );
 		typeDocInterfaceAugmentationFixer( app );
 		typeDocPurgePrivateApiDocs( app );
+		typeDocRestoreProgramAfterConversion( app );
 
 		overloadsValidator( app, onError );
 

--- a/packages/typedoc-plugins/tests/validators/see-validator/index.ts
+++ b/packages/typedoc-plugins/tests/validators/see-validator/index.ts
@@ -17,7 +17,8 @@ import {
 	typeDocEventParamFixer,
 	typeDocEventInheritanceFixer,
 	typeDocInterfaceAugmentationFixer,
-	typeDocPurgePrivateApiDocs
+	typeDocPurgePrivateApiDocs,
+	typeDocRestoreProgramAfterConversion
 } from '../../../src/index.js';
 
 import { ROOT_TEST_DIRECTORY, assertCalls } from '../../utils.js';
@@ -49,6 +50,7 @@ describe( 'typedoc-plugins/validators/see-validator', function() {
 		typeDocEventInheritanceFixer( app );
 		typeDocInterfaceAugmentationFixer( app );
 		typeDocPurgePrivateApiDocs( app );
+		typeDocRestoreProgramAfterConversion( app );
 
 		seeValidator( app, onError );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Added support for `typedoc@0.28.3`, which requires that access to _TypeScript program_ takes place only during source files conversion and not later. Closes ckeditor/ckeditor5#18414.

---

### Additional information

#### How to test it
1. Setup: `ckeditor5`, `ckeditor5-dev` and `umberto` on `#ck/epic/15619-typedoc-28` branch. Reinstall dependencies to make sure `typedoc@0.28.3` is installed.
2. First, ensure that `yarn run docs` crashes:

    ```
    Error: Process exited with code 1
        at ChildProcess.<anonymous> (file:///D:/Projects/ckeditor/ckeditor5/scripts/docs/build-docs.mjs:107:13)
        at ChildProcess.emit (node:events:518:28)
        at maybeClose (node:internal/child_process:1104:16)
        at ChildProcess._handle.onexit (node:internal/child_process:304:5)
    ```

4. Then, switch `ckeditor5-dev` to `#ck/18414` branch and run `yarn run docs` again. The crash ☝️ should not be reported.
