### PR TITLE
Added default manual tests preset

### DIFF
--- a/packages/ckeditor5-dev-tests/lib/utils/automated-tests/parsearguments.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/automated-tests/parsearguments.js
@@ -4,7 +4,7 @@
  */
 
 import fs from 'fs-extra';
-import path from 'path';
+import path from 'upath';
 import minimist from 'minimist';
 import { tools, logger } from '@ckeditor/ckeditor5-dev-utils';
 
@@ -108,6 +108,7 @@ export default function parseArguments( args ) {
 	parseDebugOption( options );
 	parseRepositoriesOption( options );
 	parseTsconfigPath( options );
+	useDefaultIdentityFile( options );
 
 	return options;
 
@@ -263,5 +264,26 @@ export default function parseArguments( args ) {
 		} catch ( e ) {
 			return false;
 		}
+	}
+
+	/**
+	 * @param {object} options
+	 */
+	function useDefaultIdentityFile( options ) {
+		// This option has three possible states:
+		// null - meaning that `--identity-file` was not passed, and default value should be injected.
+		// false - meaning that `--no-identity-file` was passed, and default value should not be injected.
+		// string - meaning that `--identity-file` was passed, and default value should not be injected.
+		if ( options.identityFile !== null ) {
+			return;
+		}
+
+		const defaultFilePath = path.join( options.cwd, 'external', 'ckeditor5-commercial', 'scripts', 'presets', 'staging-ff.js' );
+
+		if ( !fs.existsSync( defaultFilePath ) ) {
+			return;
+		}
+
+		options.identityFile = defaultFilePath;
 	}
 }

--- a/packages/ckeditor5-dev-tests/tests/utils/automated-tests/parsearguments.js
+++ b/packages/ckeditor5-dev-tests/tests/utils/automated-tests/parsearguments.js
@@ -30,11 +30,7 @@ describe( 'parseArguments()', () => {
 			warning: logWarningStub
 		} );
 
-		vi.mocked( fs ).existsSync.mockImplementation( path => {
-			console.log( path );
-
-			return existingFiles.includes( path );
-		} );
+		vi.mocked( fs ).existsSync.mockImplementation( path => existingFiles.includes( path ) );
 	} );
 
 	it( 'replaces kebab-case strings with camelCase values', () => {

--- a/packages/ckeditor5-dev-tests/tests/utils/automated-tests/parsearguments.js
+++ b/packages/ckeditor5-dev-tests/tests/utils/automated-tests/parsearguments.js
@@ -8,7 +8,7 @@ import fs from 'fs-extra';
 import { tools, logger } from '@ckeditor/ckeditor5-dev-utils';
 import parseArguments from '../../../lib/utils/automated-tests/parsearguments.js';
 
-vi.mock( 'path', () => ( {
+vi.mock( 'upath', () => ( {
 	default: {
 		join: vi.fn( ( ...chunks ) => chunks.join( '/' ) ),
 		dirname: vi.fn()
@@ -18,14 +18,22 @@ vi.mock( 'fs-extra' );
 vi.mock( '@ckeditor/ckeditor5-dev-utils' );
 
 describe( 'parseArguments()', () => {
-	let logWarningStub;
+	let logWarningStub, existingFiles;
 
 	beforeEach( () => {
 		logWarningStub = vi.fn();
 
+		existingFiles = [];
+
 		vi.spyOn( process, 'cwd' ).mockReturnValue( '/home/project' );
 		vi.mocked( logger ).mockReturnValue( {
 			warning: logWarningStub
+		} );
+
+		vi.mocked( fs ).existsSync.mockImplementation( path => {
+			console.log( path );
+
+			return existingFiles.includes( path );
 		} );
 	} );
 
@@ -319,15 +327,13 @@ describe( 'parseArguments()', () => {
 
 	describe( 'tsconfig', () => {
 		it( 'should be null by default, if `tsconfig.test.json` does not exist', () => {
-			vi.mocked( fs ).existsSync.mockReturnValue( false );
-
 			const options = parseArguments( [] );
 
 			expect( options.tsconfig ).to.equal( null );
 		} );
 
 		it( 'should use `tsconfig.test.json` from `cwd` if it is available by default', () => {
-			vi.mocked( fs ).existsSync.mockReturnValue( true );
+			existingFiles.push( '/home/project/tsconfig.test.json' );
 
 			const options = parseArguments( [] );
 
@@ -335,7 +341,7 @@ describe( 'parseArguments()', () => {
 		} );
 
 		it( 'should parse `--tsconfig` to absolute path if it is set and it exists', () => {
-			vi.mocked( fs ).existsSync.mockReturnValue( true );
+			existingFiles.push( '/home/project/configs/tsconfig.json' );
 
 			const options = parseArguments( [ '--tsconfig', 'configs/tsconfig.json' ] );
 
@@ -343,11 +349,41 @@ describe( 'parseArguments()', () => {
 		} );
 
 		it( 'should be null if `--tsconfig` points to non-existing file', () => {
-			vi.mocked( fs ).existsSync.mockReturnValue( false );
-
 			const options = parseArguments( [ '--tsconfig', './configs/tsconfig.json' ] );
 
 			expect( options.tsconfig ).to.equal( null );
+		} );
+	} );
+
+	describe( 'identity-file', () => {
+		it( 'should be null by default, if `staging-ff.js` does not exist', () => {
+			const options = parseArguments( [] );
+
+			expect( options.identityFile ).to.equal( null );
+		} );
+
+		it( 'should point to the default value by default, if `staging-ff.js` does exist', () => {
+			existingFiles.push( '/home/project/external/ckeditor5-commercial/scripts/presets/staging-ff.js' );
+
+			const options = parseArguments( [] );
+
+			expect( options.identityFile ).to.equal( '/home/project/external/ckeditor5-commercial/scripts/presets/staging-ff.js' );
+		} );
+
+		it( 'should point to the passed value, if `staging-ff.js` does exist', () => {
+			existingFiles.push( '/home/project/external/ckeditor5-commercial/scripts/presets/staging-ff.js' );
+
+			const options = parseArguments( [ '--identity-file', 'configs/identity.js' ] );
+
+			expect( options.identityFile ).to.equal( 'configs/identity.js' );
+		} );
+
+		it( 'should be false if --no-identity-file was passed, if `staging-ff.js` does exist', () => {
+			existingFiles.push( '/home/project/external/ckeditor5-commercial/scripts/presets/staging-ff.js' );
+
+			const options = parseArguments( [ '--no-identity-file' ] );
+
+			expect( options.identityFile ).to.equal( false );
 		} );
 	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature (tests): Manual tests script will now load a default predefined identity file, if it exists.

MAJOR BREAKING CHANGE (tests): Manual tests script will now load a default predefined identity file, if it exists.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
