### PR TITLE
Feature (web-crawler): Block requests from `IGNORED_HOSTS`.

### DIFF
--- a/packages/ckeditor5-dev-web-crawler/src/constants.ts
+++ b/packages/ckeditor5-dev-web-crawler/src/constants.ts
@@ -26,15 +26,15 @@ export interface ErrorType {
  * Errors from the following hosts will be ignored.
  */
 export const IGNORED_HOSTS = [
-	'ucarecdn.com',
+	'visualwebsiteoptimizer.com',
 	'fury.io',
 	'shields.io',
 	'coveralls.io',
 	'spotify.com',
 	'vimeo.com',
+	'youtube.com',
 	'facebook.com',
 	'challenges.cloudflare.com',
-	'svc.webspellchecker.net',
 	'binance.com',
 	'jsfiddle.net'
 ];

--- a/packages/ckeditor5-dev-web-crawler/src/constants.ts
+++ b/packages/ckeditor5-dev-web-crawler/src/constants.ts
@@ -7,7 +7,7 @@
 
 /* eslint-env node */
 
-import { cpus, freemem } from 'os';
+import { cpus } from 'os';
 
 export interface ErrorType {
 
@@ -44,22 +44,7 @@ export const IGNORED_HOSTS = [
 	'fonts.googleapis.com'
 ];
 
-/**
- * The default concurrency for the crawler. This is calculated to provide each browser
- * tag with one CPU core and 1.5 GB of memory, but not more than 16 browser tags.
- * This is to prevent the system from running out of memory or timing out.
- */
-export const DEFAULT_CONCURRENCY = Math.min(
-	cpus().length,
-	Math.floor(
-		freemem() /* B */ /
-		1024 /* KB */ /
-		1024 /* MB */ /
-		1024 /* GB */ /
-		1.5
-	),
-	16
-);
+export const DEFAULT_CONCURRENCY = Math.min( cpus().length, 16 );
 
 export const DEFAULT_TIMEOUT = 15 * 1000;
 

--- a/packages/ckeditor5-dev-web-crawler/src/constants.ts
+++ b/packages/ckeditor5-dev-web-crawler/src/constants.ts
@@ -7,7 +7,7 @@
 
 /* eslint-env node */
 
-import { cpus } from 'os';
+import { cpus, freemem } from 'os';
 
 export interface ErrorType {
 
@@ -44,7 +44,22 @@ export const IGNORED_HOSTS = [
 	'fonts.googleapis.com'
 ];
 
-export const DEFAULT_CONCURRENCY = Math.min( cpus().length, 16 );
+/**
+ * The default concurrency for the crawler. This is calculated to provide each browser
+ * tag with one CPU core and 1.5 GB of memory, but not more than 16 browser tags.
+ * This is to prevent the system from running out of memory or timing out.
+ */
+export const DEFAULT_CONCURRENCY = Math.min(
+	cpus().length,
+	Math.floor(
+		freemem() /* B */ /
+		1024 /* KB */ /
+		1024 /* MB */ /
+		1024 /* GB */ /
+		1.5
+	),
+	16
+);
 
 export const DEFAULT_TIMEOUT = 15 * 1000;
 

--- a/packages/ckeditor5-dev-web-crawler/src/constants.ts
+++ b/packages/ckeditor5-dev-web-crawler/src/constants.ts
@@ -33,10 +33,15 @@ export const IGNORED_HOSTS = [
 	'spotify.com',
 	'vimeo.com',
 	'youtube.com',
+	'twitter.com',
+	'twimg.com',
 	'facebook.com',
+	'facebook.net',
 	'challenges.cloudflare.com',
 	'binance.com',
-	'jsfiddle.net'
+	'iframe.ly',
+	'jsfiddle.net',
+	'fonts.googleapis.com'
 ];
 
 export const DEFAULT_CONCURRENCY = Math.min( cpus().length, 16 );

--- a/packages/ckeditor5-dev-web-crawler/src/runcrawler.ts
+++ b/packages/ckeditor5-dev-web-crawler/src/runcrawler.ts
@@ -165,21 +165,25 @@ export default async function runCrawler( options: CrawlerOptions ): Promise<voi
 		const pageErrors: Array<CrawlerError> = [];
 
 		page.on( 'request', request => {
-			const url = request.url();
-			const resourceType = request.resourceType();
+			const { hostname, pathname } = new URL( request.url() );
 
-			if ( resourceType === 'media' ) {
+			if ( !hostname ) {
+				// Don't block requests without a hostname (e.g. data URLs).
+				return request.continue();
+			}
+
+			if ( request.resourceType() === 'media' ) {
 				// Block all 'media' requests, as they are likely to fail anyway due to limitations in Puppeteer.
 				return request.abort( 'blockedbyclient' );
 			}
 
-			if ( url.includes( 'visualwebsiteoptimizer' ) ) {
-				// We don't need this when doing testing.
+			if ( IGNORED_HOSTS.some( host => hostname.endsWith( host ) ) ) {
+				// Block all requests to ignored hosts.
 				return request.abort( 'blockedbyclient' );
 			}
 
-			if ( url.endsWith( 'api.json' ) ) {
-				// This file is huge and loaded on every page, but doesn't need to be tested.
+			if ( pathname.endsWith( 'api.json' ) ) {
+				// This file is huge and loaded on every page, but isn't required during testing.
 				return request.abort( 'blockedbyclient' );
 			}
 
@@ -209,38 +213,31 @@ export default async function runCrawler( options: CrawlerOptions ): Promise<voi
 				return;
 			}
 
-			const url = request.url();
-
-			if ( IGNORED_HOSTS.some( ignoredHost => url.includes( ignoredHost ) ) ) {
+			if ( errorText?.includes( 'net::ERR_BLOCKED_BY_CLIENT' ) ) {
+				// Do not log errors explicitly aborted by the crawler.
 				return;
 			}
 
-			// Do not log errors explicitly aborted by the crawler.
-			if ( errorText !== 'net::ERR_BLOCKED_BY_CLIENT.Inspector' ) {
-				const host = new URL( url ).host;
-				const isNavigation = isNavigationRequest( request );
-				const message = isNavigation ?
-					`Failed to open link ${ chalk.bold( url ) }` :
-					`Failed to load resource from ${ chalk.bold( host ) }`;
+			const url = request.url();
+			const host = new URL( url ).host;
+			const isNavigation = isNavigationRequest( request );
+			const message = isNavigation ?
+				`Failed to open link ${ chalk.bold( url ) }` :
+				`Failed to load resource from ${ chalk.bold( host ) }`;
 
-				pageErrors.push( {
-					pageUrl: isNavigation ? data.parentUrl : data.url,
-					type: ERROR_TYPES.REQUEST_FAILURE,
-					message: `${ message } (failure message: ${ chalk.bold( errorText ) })`,
-					failedResourceUrl: url
-				} );
-			}
+			pageErrors.push( {
+				pageUrl: isNavigation ? data.parentUrl : data.url,
+				type: ERROR_TYPES.REQUEST_FAILURE,
+				message: `${ message } (failure message: ${ chalk.bold( errorText ) })`,
+				failedResourceUrl: url
+			} );
 		} );
 
 		page.on( ERROR_TYPES.RESPONSE_FAILURE.event, response => {
 			const responseStatus = response.status();
-			const url = response.url();
-
-			if ( IGNORED_HOSTS.some( ignoredHost => url.includes( ignoredHost ) ) ) {
-				return;
-			}
 
 			if ( responseStatus > 399 ) {
+				const url = response.url();
 				const host = new URL( url ).host;
 				const isNavigation = isNavigationRequest( response.request() );
 				const message = isNavigation ?
@@ -378,7 +375,6 @@ function getErrorHandler( errors: Map<ErrorType, Map<string, ErrorCollection>> )
 		const messageLines = error.message.split( '\n' );
 		const firstMessageLine = messageLines.shift()!;
 		const nextMessageLines = messageLines.join( '\n' );
-
 		const errorCollection = errors.get( error.type )!;
 
 		if ( !errorCollection.has( firstMessageLine ) ) {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature (web-crawler): Block requests from `IGNORED_HOSTS`.

---

See ckeditor/ckeditor5#18426.

I removed `ucarecdn.com` and `svc.webspellchecker.net` from `IGNORED_HOSTS`, because resources from these hosts are used in the editors. While `ucarecdn.com` can be re-added if it later causes issues for us, the `svc.webspellchecker.net` is required for the editor to function properly.

---

To test this PR, run the `yarn run docs --dev --skip-validation` command.

Then, run the following commands few times:
- `bash scripts/check-manual-tests.sh -r ckeditor5 -f ckeditor5`
- `bash external/ckeditor5-commercial/scripts/ci/check-documentation.sh`

No runs should fail due to timeout or failed request/response from external hosts.

To confirm, you can also run these two commands on current `master` branch. After few runs, some may fail, but due to nature of this bug, you may not get any errors at all ¯\\\_(ツ)\_/¯