### PR TITLE
Fixed commits exceeding character limit

### DIFF
--- a/packages/ckeditor5-dev-release-tools/tests/tasks/commitandtag.js
+++ b/packages/ckeditor5-dev-release-tools/tests/tasks/commitandtag.js
@@ -189,11 +189,6 @@ describe( 'commitAndTag()', () => {
 
 		await commitAndTag( { version: '1.0.0', packagesDirectory: 'packages', files: [ '**/package.json' ] } );
 
-		expect( vi.mocked( glob ) ).toHaveBeenCalledExactlyOnceWith( expect.anything(), expect.objectContaining( {
-			absolute: true,
-			nodir: true
-		} ) );
-
 		expect( stubs.git.add ).toHaveBeenCalledTimes( 5 );
 
 		/**


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix (release-tools): Fixed `commitAndTag()` throwing an `ENAMETOOLONG` error when trying to commit a large number of files on Windows.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
