### PR TITLE
Feature (web-crawler): Block requests to `if-cdn.com` domain.

### DIFF
--- a/packages/ckeditor5-dev-web-crawler/src/constants.ts
+++ b/packages/ckeditor5-dev-web-crawler/src/constants.ts
@@ -40,6 +40,7 @@ export const IGNORED_HOSTS = [
 	'challenges.cloudflare.com',
 	'binance.com',
 	'iframe.ly',
+	'if-cdn.com',
 	'jsfiddle.net',
 	'fonts.googleapis.com'
 ];


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature (web-crawler): Block requests to `if-cdn.com` domain.

---

This domain seems to be a CDN for `iframe.ly` which we already block.

Tested on Uber docs.
