### PR TITLE
Internal: Bump required Node version to `>=20.12.0`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "homepage": "https://github.com/ckeditor/ckeditor5-dev#readme",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=20.12.0"
   },
   "type": "module",
   "devDependencies": {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Bump required Node version to `>=20.12.0`.

---

We already use `util.styleText` which requires Node 20.12.0.
