### PR TITLE
Enabled returning changelog instead of writing it

### DIFF
--- a/packages/ckeditor5-dev-changelog/src/generatechangelog.ts
+++ b/packages/ckeditor5-dev-changelog/src/generatechangelog.ts
@@ -26,11 +26,19 @@ import { getNewChangelog } from './utils/getnewchangelog.js';
 import { removeChangesetFiles } from './utils/removechangesetfiles.js';
 import { removeScope } from './utils/removescope.js';
 
+export async function generateChangelog(
+  config: RepositoryConfig & GenerateChangelog & { noWrite?: false | undefined }
+): Promise<void>;
+
+export async function generateChangelog(
+  config: RepositoryConfig & GenerateChangelog & { noWrite: true }
+): Promise<string>;
+
 /**
  * This function handles the entire changelog generation process including version management,
  * package information gathering, and changelog file updates.
  */
-export async function generateChangelog<T extends boolean | undefined>( {
+export async function generateChangelog( {
 	nextVersion,
 	cwd = process.cwd(),
 	packagesDirectory = PACKAGES_DIRECTORY_NAME,
@@ -43,7 +51,7 @@ export async function generateChangelog<T extends boolean | undefined>( {
 	singlePackage = false,
 	noWrite = false,
 	removeInputFiles = true
-}: RepositoryConfig & GenerateChangelog<T> ): Promise<string | undefined> {
+}: RepositoryConfig & GenerateChangelog ): Promise<string | void> { // eslint-disable-line @typescript-eslint/no-invalid-void-type
 	const externalRepositoriesWithDefaults = getExternalRepositoriesWithDefaults( externalRepositories );
 	const packageJsons = await getPackageJsons( cwd, packagesDirectory, externalRepositoriesWithDefaults );
 	const gitHubUrl = await getRepositoryUrl( cwd );

--- a/packages/ckeditor5-dev-changelog/src/generatechangelog.ts
+++ b/packages/ckeditor5-dev-changelog/src/generatechangelog.ts
@@ -30,7 +30,7 @@ import { removeScope } from './utils/removescope.js';
  * This function handles the entire changelog generation process including version management,
  * package information gathering, and changelog file updates.
  */
-export async function generateChangelog( {
+export async function generateChangelog<T extends boolean | undefined>( {
 	nextVersion,
 	cwd = process.cwd(),
 	packagesDirectory = PACKAGES_DIRECTORY_NAME,
@@ -41,8 +41,9 @@ export async function generateChangelog( {
 	changesetsDirectory = CHANGESET_DIRECTORY,
 	skipLinks = false,
 	singlePackage = false,
-	returnChangelog = false
-}: RepositoryConfig & GenerateChangelog ): Promise<string | undefined> {
+	noWrite = false,
+	removeInputFiles = true
+}: RepositoryConfig & GenerateChangelog<T> ): Promise<string | undefined> {
 	const externalRepositoriesWithDefaults = getExternalRepositoriesWithDefaults( externalRepositories );
 	const packageJsons = await getPackageJsons( cwd, packagesDirectory, externalRepositoriesWithDefaults );
 	const gitHubUrl = await getRepositoryUrl( cwd );
@@ -74,7 +75,7 @@ export async function generateChangelog( {
 		oldVersion,
 		packageName,
 		nextVersion,
-		returnChangelog
+		noWrite
 	} );
 
 	const releasedPackagesInfo = await getReleasedPackagesInfo( {
@@ -97,8 +98,11 @@ export async function generateChangelog( {
 		singlePackage
 	} );
 
-	if ( !returnChangelog ) {
+	if ( !noWrite ) {
 		await modifyChangelog( newChangelog, cwd );
+	}
+
+	if ( removeInputFiles ) {
 		await removeChangesetFiles( changesetFilePaths, cwd, changesetsDirectory, externalRepositories );
 	}
 
@@ -106,7 +110,7 @@ export async function generateChangelog( {
 
 	logInfo( '○ ' + chalk.green( 'Done!' ) );
 
-	if ( returnChangelog ) {
+	if ( noWrite ) {
 		return newChangelog;
 	}
 }

--- a/packages/ckeditor5-dev-changelog/src/generatechangelog.ts
+++ b/packages/ckeditor5-dev-changelog/src/generatechangelog.ts
@@ -82,8 +82,7 @@ export async function generateChangelog( {
 		sectionsWithEntries,
 		oldVersion,
 		packageName,
-		nextVersion,
-		noWrite
+		nextVersion
 	} );
 
 	const releasedPackagesInfo = await getReleasedPackagesInfo( {

--- a/packages/ckeditor5-dev-changelog/src/types.ts
+++ b/packages/ckeditor5-dev-changelog/src/types.ts
@@ -8,7 +8,7 @@ import type { SECTIONS } from './constants.js';
 /**
  * Configuration options for generating a changelog.
  */
-export type GenerateChangelog<T extends boolean | undefined> = {
+export type GenerateChangelog = {
 
 	/**
 	 * The current working directory of the repository.
@@ -55,7 +55,7 @@ export type GenerateChangelog<T extends boolean | undefined> = {
 	 * Whether changelog should be returned by the script instead of saving it to a file.
 	 * Using this option will also pick version automatically, instead of asking user.
 	 */
-	noWrite?: T;
+	noWrite?: boolean;
 
 	/**
 	 * Controls whether changeset files will be deleted after generating changelog.

--- a/packages/ckeditor5-dev-changelog/src/types.ts
+++ b/packages/ckeditor5-dev-changelog/src/types.ts
@@ -8,7 +8,7 @@ import type { SECTIONS } from './constants.js';
 /**
  * Configuration options for generating a changelog.
  */
-export type GenerateChangelog = {
+export type GenerateChangelog<T extends boolean | undefined> = {
 
 	/**
 	 * The current working directory of the repository.
@@ -53,10 +53,14 @@ export type GenerateChangelog = {
 
 	/**
 	 * Whether changelog should be returned by the script instead of saving it to a file.
-	 * Using this option will also prevent changeset files from being deleted,
-	 * and version will be chosen automatically.
+	 * Using this option will also pick version automatically, instead of asking user.
 	 */
-	returnChangelog?: boolean;
+	noWrite?: T;
+
+	/**
+	 * Controls whether changeset files will be deleted after generating changelog.
+	 */
+	removeInputFiles?: boolean;
 };
 
 /**

--- a/packages/ckeditor5-dev-changelog/src/types.ts
+++ b/packages/ckeditor5-dev-changelog/src/types.ts
@@ -53,7 +53,6 @@ export type GenerateChangelog = {
 
 	/**
 	 * Whether changelog should be returned by the script instead of saving it to a file.
-	 * Using this option will also pick version automatically, instead of asking user.
 	 */
 	noWrite?: boolean;
 

--- a/packages/ckeditor5-dev-changelog/src/types.ts
+++ b/packages/ckeditor5-dev-changelog/src/types.ts
@@ -50,6 +50,13 @@ export type GenerateChangelog = {
 	 * Whether changelog is for a single package rather than a monorepo.
 	 */
 	singlePackage?: boolean;
+
+	/**
+	 * Whether changelog should be returned by the script instead of saving it to a file.
+	 * Using this option will also prevent changeset files from being deleted,
+	 * and version will be chosen automatically.
+	 */
+	returnChangelog?: boolean;
 };
 
 /**

--- a/packages/ckeditor5-dev-changelog/src/utils/getnewversion.ts
+++ b/packages/ckeditor5-dev-changelog/src/utils/getnewversion.ts
@@ -19,7 +19,6 @@ export type GetNewVersionArgs = {
 	oldVersion: string;
 	packageName: string;
 	nextVersion: string | undefined;
-	noWrite: boolean;
 };
 
 /**
@@ -29,8 +28,7 @@ export async function getNewVersion( {
 	sectionsWithEntries,
 	oldVersion,
 	packageName,
-	nextVersion,
-	noWrite
+	nextVersion
 }: GetNewVersionArgs ): Promise<NewVersionObj> {
 	logInfo( `○ ${ chalk.cyan( 'Determining the new version...' ) }` );
 
@@ -50,13 +48,6 @@ export async function getNewVersion( {
 
 	if ( sectionsWithEntries.major.entries.length ) {
 		bumpType = 'major';
-	}
-
-	if ( noWrite ) {
-		return {
-			newVersion: semver.inc( oldVersion, bumpType ) || oldVersion,
-			isInternal: false
-		};
 	}
 
 	const userProvidedVersion = await provideNewVersionForMonorepository( { version: oldVersion, packageName, bumpType } );

--- a/packages/ckeditor5-dev-changelog/src/utils/getnewversion.ts
+++ b/packages/ckeditor5-dev-changelog/src/utils/getnewversion.ts
@@ -14,15 +14,24 @@ type NewVersionObj = {
 	newVersion: string;
 };
 
+export type GetNewVersionArgs = {
+	sectionsWithEntries: SectionsWithEntries;
+	oldVersion: string;
+	packageName: string;
+	nextVersion: string | undefined;
+	returnChangelog: boolean;
+};
+
 /**
  * This function analyzes the changes and suggests the appropriate version bump.
  */
-export async function getNewVersion(
-	sectionsWithEntries: SectionsWithEntries,
-	oldVersion: string,
-	packageName: string,
-	nextVersion: string | undefined ): Promise<NewVersionObj>
-{
+export async function getNewVersion( {
+	sectionsWithEntries,
+	oldVersion,
+	packageName,
+	nextVersion,
+	returnChangelog
+}: GetNewVersionArgs ): Promise<NewVersionObj> {
 	logInfo( `○ ${ chalk.cyan( 'Determining the new version...' ) }` );
 
 	if ( nextVersion === 'internal' ) {
@@ -41,6 +50,13 @@ export async function getNewVersion(
 
 	if ( sectionsWithEntries.major.entries.length ) {
 		bumpType = 'major';
+	}
+
+	if ( returnChangelog ) {
+		return {
+			newVersion: semver.inc( oldVersion, bumpType ) || oldVersion,
+			isInternal: false
+		};
 	}
 
 	const userProvidedVersion = await provideNewVersionForMonorepository( { version: oldVersion, packageName, bumpType } );

--- a/packages/ckeditor5-dev-changelog/src/utils/getnewversion.ts
+++ b/packages/ckeditor5-dev-changelog/src/utils/getnewversion.ts
@@ -19,7 +19,7 @@ export type GetNewVersionArgs = {
 	oldVersion: string;
 	packageName: string;
 	nextVersion: string | undefined;
-	returnChangelog: boolean;
+	noWrite: boolean;
 };
 
 /**
@@ -30,7 +30,7 @@ export async function getNewVersion( {
 	oldVersion,
 	packageName,
 	nextVersion,
-	returnChangelog
+	noWrite
 }: GetNewVersionArgs ): Promise<NewVersionObj> {
 	logInfo( `○ ${ chalk.cyan( 'Determining the new version...' ) }` );
 
@@ -52,7 +52,7 @@ export async function getNewVersion( {
 		bumpType = 'major';
 	}
 
-	if ( returnChangelog ) {
+	if ( noWrite ) {
 		return {
 			newVersion: semver.inc( oldVersion, bumpType ) || oldVersion,
 			isInternal: false

--- a/packages/ckeditor5-dev-changelog/src/utils/getsectionswithentries.ts
+++ b/packages/ckeditor5-dev-changelog/src/utils/getsectionswithentries.ts
@@ -115,6 +115,7 @@ function getSection( {
 } ): SectionName {
 	const packagesNamesNoNamespace = packagesNames.map( packageName => packageName.replace( `${ organisationNamespace }/`, '' ) );
 	const breakingChange = entry.data[ 'breaking-change' ];
+	const type = entry.data.type;
 
 	if ( closes === 'invalid' ) {
 		return 'invalid';
@@ -129,7 +130,7 @@ function getSection( {
 	}
 
 	// If someone tries to use generic breaking change instead of minor/major in monorepo, the entry is invalid.
-	if ( !singlePackage && entry.data[ 'breaking-change' ] === true ) {
+	if ( !singlePackage && breakingChange === true ) {
 		return 'invalid';
 	}
 
@@ -146,15 +147,15 @@ function getSection( {
 		return 'breaking';
 	}
 
-	if ( entry.data.type === 'Feature' ) {
+	if ( type === 'Feature' ) {
 		return 'feature';
 	}
 
-	if ( entry.data.type === 'Fix' ) {
+	if ( type === 'Fix' ) {
 		return 'fix';
 	}
 
-	if ( entry.data.type === 'Other' ) {
+	if ( type === 'Other' ) {
 		return 'other';
 	}
 

--- a/packages/ckeditor5-dev-changelog/tests/generatechangelog.test.ts
+++ b/packages/ckeditor5-dev-changelog/tests/generatechangelog.test.ts
@@ -182,7 +182,6 @@ describe( 'generateChangelog()', () => {
 		expect( getPackageJsons ).toHaveBeenCalledWith( '/home/ckeditor', 'packages', [] );
 		expect( getDateFormatted ).toHaveBeenCalledWith( '2024-03-26' );
 
-		// Check that getNewChangelog is called with correct arguments
 		expect( getNewChangelog ).toHaveBeenCalledWith( {
 			oldVersion: '1.0.0',
 			newVersion: '1.0.1',
@@ -247,7 +246,6 @@ describe( 'generateChangelog()', () => {
 		expect( getPackageJsons ).toHaveBeenCalledWith( '/home/ckeditor', 'packages', [] );
 		expect( getDateFormatted ).toHaveBeenCalledWith( '2024-03-26' );
 
-		// Check that getNewChangelog is called with correct arguments
 		expect( getNewChangelog ).toHaveBeenCalledWith( {
 			oldVersion: '1.0.0',
 			newVersion: '1.0.1',
@@ -326,14 +324,13 @@ describe( 'generateChangelog()', () => {
 		expect( logInfo ).toHaveBeenCalledWith( '○ Done!' );
 	} );
 
-	it( 'generates changelog and returns it instead of writing to a file in `returnChangelog` mode', async () => {
-		const result = await generateChangelog( { ...defaultOptions, returnChangelog: true } );
+	it( 'generates changelog and returns it instead of writing to a file in `noWrite` mode', async () => {
+		const result = await generateChangelog( { ...defaultOptions, noWrite: true } );
 
 		expect( getExternalRepositoriesWithDefaults ).toHaveBeenCalledWith( [] );
 		expect( getPackageJsons ).toHaveBeenCalledWith( '/home/ckeditor', 'packages', [] );
 		expect( getDateFormatted ).toHaveBeenCalledWith( '2024-03-26' );
 
-		// Check that getNewChangelog is called with correct arguments
 		expect( getNewChangelog ).toHaveBeenCalledWith( {
 			oldVersion: '1.0.0',
 			newVersion: '1.0.1',
@@ -373,10 +370,96 @@ describe( 'generateChangelog()', () => {
 		} );
 
 		expect( modifyChangelog ).toHaveBeenCalledTimes( 0 );
-		expect( removeChangesetFiles ).toHaveBeenCalledTimes( 0 );
+		expect( removeChangesetFiles ).toHaveBeenCalledWith(
+			[
+				{
+					changesetPaths: [ '/home/ckeditor/.changelog/changeset-1.md' ],
+					gitHubUrl: 'https://github.com/ckeditor/ckeditor5',
+					skipLinks: false
+				}
+			],
+			'/home/ckeditor',
+			'.changelog',
+			[]
+		);
 		expect( logInfo ).toHaveBeenCalledWith( '○ Done!' );
 
 		expect( result ).toEqual( 'Mocked changelog content' );
+	} );
+
+	it( 'does not delete input files when `removeInputFiles` is false', async () => {
+		await generateChangelog( { ...defaultOptions, removeInputFiles: false } );
+
+		expect( getExternalRepositoriesWithDefaults ).toHaveBeenCalledWith( [] );
+		expect( getPackageJsons ).toHaveBeenCalledWith( '/home/ckeditor', 'packages', [] );
+		expect( getDateFormatted ).toHaveBeenCalledWith( '2024-03-26' );
+
+		expect( getNewChangelog ).toHaveBeenCalledWith( {
+			oldVersion: '1.0.0',
+			newVersion: '1.0.1',
+			dateFormatted: 'March 26, 2024',
+			gitHubUrl: 'https://github.com/ckeditor/ckeditor5',
+			sectionsToDisplay: [
+				{
+					title: SECTIONS.feature.title,
+					entries: [
+						{
+							message: 'Test feature',
+							data: {
+								type: 'Feature',
+								scope: [ 'test-package' ],
+								closes: [],
+								see: [],
+								mainContent: 'Test feature',
+								restContent: []
+							},
+							changesetPath: '/home/ckeditor/.changelog/changeset-1.md'
+						}
+					]
+				}
+			],
+			releasedPackagesInfo: [
+				{
+					title: 'Released packages',
+					version: '1.0.1',
+					packages: [ 'test-package' ]
+				}
+			],
+			isInternal: false,
+			singlePackage: false,
+			packageJsons: [
+				{ name: 'test-package', version: '1.0.0' }
+			]
+		} );
+
+		expect( getSectionsWithEntries ).toHaveBeenCalledWith( {
+			organisationNamespace: '@ckeditor',
+			packageJsons: [ {
+				name: 'test-package',
+				version: '1.0.0'
+			} ],
+			parsedFiles: [ {
+				changesetPath: '/home/ckeditor/.changelog/changeset-1.md',
+				content: 'Test changeset',
+				data: {
+					closes: [],
+					see: [],
+					scope: [ 'test-package' ],
+					type: 'Feature'
+				},
+				gitHubUrl: 'https://github.com/ckeditor/ckeditor5',
+				skipLinks: false
+			} ],
+			singlePackage: false,
+			transformScope: expect.any( Function )
+		} );
+
+		expect( modifyChangelog ).toHaveBeenCalledWith(
+			'Mocked changelog content',
+			'/home/ckeditor'
+		);
+		expect( removeChangesetFiles ).toHaveBeenCalledTimes( 0 );
+		expect( logInfo ).toHaveBeenCalledWith( '○ Done!' );
 	} );
 
 	it( 'handles first release (version 0.0.1)', async () => {
@@ -536,7 +619,7 @@ describe( 'generateChangelog()', () => {
 			oldVersion: '1.0.0',
 			packageName: 'test-package',
 			nextVersion: 'internal',
-			returnChangelog: false
+			noWrite: false
 		} );
 		expect( getNewChangelog ).toHaveBeenCalledWith( expect.objectContaining( {
 			isInternal: true,
@@ -579,7 +662,7 @@ describe( 'generateChangelog()', () => {
 			oldVersion: '1.0.0',
 			packageName: 'test-package',
 			nextVersion: 'internal',
-			returnChangelog: false
+			noWrite: false
 		} );
 		expect( getNewChangelog ).toHaveBeenCalledWith( expect.objectContaining( {
 			isInternal: true,

--- a/packages/ckeditor5-dev-changelog/tests/generatechangelog.test.ts
+++ b/packages/ckeditor5-dev-changelog/tests/generatechangelog.test.ts
@@ -326,6 +326,59 @@ describe( 'generateChangelog()', () => {
 		expect( logInfo ).toHaveBeenCalledWith( '○ Done!' );
 	} );
 
+	it( 'generates changelog and returns it instead of writing to a file in `returnChangelog` mode', async () => {
+		const result = await generateChangelog( { ...defaultOptions, returnChangelog: true } );
+
+		expect( getExternalRepositoriesWithDefaults ).toHaveBeenCalledWith( [] );
+		expect( getPackageJsons ).toHaveBeenCalledWith( '/home/ckeditor', 'packages', [] );
+		expect( getDateFormatted ).toHaveBeenCalledWith( '2024-03-26' );
+
+		// Check that getNewChangelog is called with correct arguments
+		expect( getNewChangelog ).toHaveBeenCalledWith( {
+			oldVersion: '1.0.0',
+			newVersion: '1.0.1',
+			dateFormatted: 'March 26, 2024',
+			gitHubUrl: 'https://github.com/ckeditor/ckeditor5',
+			sectionsToDisplay: [
+				{
+					title: SECTIONS.feature.title,
+					entries: [
+						{
+							message: 'Test feature',
+							data: {
+								type: 'Feature',
+								scope: [ 'test-package' ],
+								closes: [],
+								see: [],
+								mainContent: 'Test feature',
+								restContent: []
+							},
+							changesetPath: '/home/ckeditor/.changelog/changeset-1.md'
+						}
+					]
+				}
+			],
+			releasedPackagesInfo: [
+				{
+					title: 'Released packages',
+					version: '1.0.1',
+					packages: [ 'test-package' ]
+				}
+			],
+			isInternal: false,
+			singlePackage: false,
+			packageJsons: [
+				{ name: 'test-package', version: '1.0.0' }
+			]
+		} );
+
+		expect( modifyChangelog ).toHaveBeenCalledTimes( 0 );
+		expect( removeChangesetFiles ).toHaveBeenCalledTimes( 0 );
+		expect( logInfo ).toHaveBeenCalledWith( '○ Done!' );
+
+		expect( result ).toEqual( 'Mocked changelog content' );
+	} );
+
 	it( 'handles first release (version 0.0.1)', async () => {
 		vi.mocked( getPackageJson ).mockResolvedValue( { version: '0.0.1', name: 'test-package' } );
 
@@ -478,12 +531,13 @@ describe( 'generateChangelog()', () => {
 		} );
 
 		// In the actual implementation, getNewVersion is called with nextVersion 'internal'
-		expect( getNewVersion ).toHaveBeenCalledWith(
-			expect.any( Object ),
-			'1.0.0',
-			'test-package',
-			'internal'
-		);
+		expect( getNewVersion ).toHaveBeenCalledWith( {
+			sectionsWithEntries: expect.any( Object ),
+			oldVersion: '1.0.0',
+			packageName: 'test-package',
+			nextVersion: 'internal',
+			returnChangelog: false
+		} );
 		expect( getNewChangelog ).toHaveBeenCalledWith( expect.objectContaining( {
 			isInternal: true,
 			newVersion: '1.0.1'
@@ -520,12 +574,13 @@ describe( 'generateChangelog()', () => {
 			nextVersion: 'internal'
 		} );
 
-		expect( getNewVersion ).toHaveBeenCalledWith(
-			expect.any( Object ),
-			'1.0.0',
-			'test-package',
-			'internal'
-		);
+		expect( getNewVersion ).toHaveBeenCalledWith( {
+			sectionsWithEntries: expect.any( Object ),
+			oldVersion: '1.0.0',
+			packageName: 'test-package',
+			nextVersion: 'internal',
+			returnChangelog: false
+		} );
 		expect( getNewChangelog ).toHaveBeenCalledWith( expect.objectContaining( {
 			isInternal: true,
 			newVersion: '1.0.1',

--- a/packages/ckeditor5-dev-changelog/tests/generatechangelog.test.ts
+++ b/packages/ckeditor5-dev-changelog/tests/generatechangelog.test.ts
@@ -618,8 +618,7 @@ describe( 'generateChangelog()', () => {
 			sectionsWithEntries: expect.any( Object ),
 			oldVersion: '1.0.0',
 			packageName: 'test-package',
-			nextVersion: 'internal',
-			noWrite: false
+			nextVersion: 'internal'
 		} );
 		expect( getNewChangelog ).toHaveBeenCalledWith( expect.objectContaining( {
 			isInternal: true,
@@ -661,8 +660,7 @@ describe( 'generateChangelog()', () => {
 			sectionsWithEntries: expect.any( Object ),
 			oldVersion: '1.0.0',
 			packageName: 'test-package',
-			nextVersion: 'internal',
-			noWrite: false
+			nextVersion: 'internal'
 		} );
 		expect( getNewChangelog ).toHaveBeenCalledWith( expect.objectContaining( {
 			isInternal: true,

--- a/packages/ckeditor5-dev-changelog/tests/utils/getnewversion.test.ts
+++ b/packages/ckeditor5-dev-changelog/tests/utils/getnewversion.test.ts
@@ -65,7 +65,7 @@ describe( 'getNewVersion()', () => {
 			oldVersion: '1.0.0',
 			packageName: 'test-package',
 			nextVersion: undefined,
-			returnChangelog: false
+			noWrite: false
 		};
 	} );
 
@@ -175,8 +175,8 @@ describe( 'getNewVersion()', () => {
 		} );
 	} );
 
-	it( 'should return a version without asking user when returnChangelog is true', async () => {
-		options.returnChangelog = true;
+	it( 'should return a version without asking user when noWrite is true', async () => {
+		options.noWrite = true;
 
 		const result = await getNewVersion( options );
 
@@ -185,8 +185,8 @@ describe( 'getNewVersion()', () => {
 		expect( mockedProvideNewVersion ).toHaveBeenCalledTimes( 0 );
 	} );
 
-	it( 'should return the old version without asking user when returnChangelog is true and semver cannot resolve one', async () => {
-		options.returnChangelog = true;
+	it( 'should return the old version without asking user when noWrite is true and semver cannot resolve one', async () => {
+		options.noWrite = true;
 		options.oldVersion = '1.2.3';
 
 		const result = await getNewVersion( options );

--- a/packages/ckeditor5-dev-changelog/tests/utils/getnewversion.test.ts
+++ b/packages/ckeditor5-dev-changelog/tests/utils/getnewversion.test.ts
@@ -64,8 +64,7 @@ describe( 'getNewVersion()', () => {
 			sectionsWithEntries: createSectionsWithEntries(),
 			oldVersion: '1.0.0',
 			packageName: 'test-package',
-			nextVersion: undefined,
-			noWrite: false
+			nextVersion: undefined
 		};
 	} );
 
@@ -173,27 +172,6 @@ describe( 'getNewVersion()', () => {
 			packageName: 'test-package',
 			bumpType: 'major'
 		} );
-	} );
-
-	it( 'should return a version without asking user when noWrite is true', async () => {
-		options.noWrite = true;
-
-		const result = await getNewVersion( options );
-
-		expect( result.newVersion ).toBe( '1.0.1' );
-		expect( result.isInternal ).toBe( false );
-		expect( mockedProvideNewVersion ).toHaveBeenCalledTimes( 0 );
-	} );
-
-	it( 'should return the old version without asking user when noWrite is true and semver cannot resolve one', async () => {
-		options.noWrite = true;
-		options.oldVersion = '1.2.3';
-
-		const result = await getNewVersion( options );
-
-		expect( result.newVersion ).toBe( '1.2.3' );
-		expect( result.isInternal ).toBe( false );
-		expect( mockedProvideNewVersion ).toHaveBeenCalledTimes( 0 );
 	} );
 
 	it( 'should handle internal version when nextVersion is set to "internal"', async () => {

--- a/packages/ckeditor5-dev-changelog/tests/utils/getsectionswithentries.test.ts
+++ b/packages/ckeditor5-dev-changelog/tests/utils/getsectionswithentries.test.ts
@@ -185,9 +185,20 @@ describe( 'getSectionsWithEntries()', () => {
 		);
 	} );
 
-	it( 'should generate invalid entry when links for issues are invalid', () => {
+	it( 'should generate invalid entry when links for issues to close are invalid', () => {
 		const parsedFiles = [ createParsedFile( { data: {
 			closes: [ 'foo/bar' ]
+		} } ) ];
+
+		const result = getSectionsWithEntries( { parsedFiles, packageJsons, transformScope, organisationNamespace, singlePackage } );
+
+		expect( result.feature.entries.length ).toEqual( 0 );
+		expect( result.invalid.entries.length ).toEqual( 1 );
+	} );
+
+	it( 'should generate invalid entry when links for related issues are invalid', () => {
+		const parsedFiles = [ createParsedFile( { data: {
+			see: [ 'foo/bar' ]
 		} } ) ];
 
 		const result = getSectionsWithEntries( { parsedFiles, packageJsons, transformScope, organisationNamespace, singlePackage } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Added `returnChangelog` option for the `generateChangelog()` function that makes the function return the changelog instead of writing it to a file. Closes ckeditor/ckeditor5#18064.

---

### Additional information

The option also prevents changesets from deletion, and handles version automatically instead of asking the user to pick one.
