### PR TITLE
Fix rendering values of the `@default` tag in API docs

### DIFF
--- a/packages/ckeditor5-dev-docs/lib/build.js
+++ b/packages/ckeditor5-dev-docs/lib/build.js
@@ -36,6 +36,12 @@ export default async function build( config ) {
 		basePath: config.cwd,
 		readme: 'none',
 
+		jsDocCompatibility: {
+			// Disable TypeDoc attempt to infer the tag content whether it should be parsed as code.
+			// See: https://github.com/ckeditor/ckeditor5/issues/18526.
+			defaultTag: false
+		},
+
 		blockTags: [
 			...OptionDefaults.blockTags,
 			'@eventName',


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix (docs): Fixed rendering values of the `@default` tag in API docs. Previously, TypeDoc tried to guess whether the `@default` tag value should be treated as a code, which produced invalid outputs in some cases. Now it just takes the value from this tag and renders it as inline code. Closes ckeditor/ckeditor5#18526.

---

### Additional information

I checked a few `@default` tags and it seems they are now rendered correctly:
![obraz](https://github.com/user-attachments/assets/09995505-863e-44b4-aaf9-ae07ef11dca8)
![obraz](https://github.com/user-attachments/assets/b351bb70-09a6-47a4-a66c-a24737c81eeb)
![obraz](https://github.com/user-attachments/assets/2561e25a-38f5-4a69-a847-564ac21185be)
![obraz](https://github.com/user-attachments/assets/46b3bd44-83af-4aad-8dcd-28d65ffb1f58)
![obraz](https://github.com/user-attachments/assets/69702f48-f7fd-42d7-94ba-3261c9da4264)
![obraz](https://github.com/user-attachments/assets/9bd5fda5-4106-47fb-b67a-d2724fb7b2e7)
![obraz](https://github.com/user-attachments/assets/e2c6ceda-8c98-4d19-9dd8-d7e5261ed4e7)


