### PR TITLE
Restored the missing `--quiet` parameter for a pre-commit hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   },
   "lint-staged": {
     "**/*": [
-      "eslint"
+      "eslint --quiet"
     ]
   },
   "workspaces": {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal: Restored the missing `--quiet` parameter for a pre-commit hook

### Tickets to close

Part of https://github.com/cksource/ckeditor5-internal/issues/4027.
