### PR TITLE
Support for SSH URL in `workspaces.getRepositoryUrl()`

### DIFF
--- a/packages/ckeditor5-dev-utils/src/workspaces/getrepositoryurl.ts
+++ b/packages/ckeditor5-dev-utils/src/workspaces/getrepositoryurl.ts
@@ -18,14 +18,11 @@ export default function getRepositoryUrl( cwd: string, { async = false }: { asyn
 		return findRepositoryUrl( packageJson );
 	}
 
-	return getPackageJson( cwd, { async: true } )
-		.then( packageJson => {
-			return findRepositoryUrl( packageJson );
-		} );
+	return getPackageJson( cwd, { async: true } ).then( findRepositoryUrl );
 }
 
 function findRepositoryUrl( packageJson: PackageJson ): string {
-// Due to merging our issue trackers, `packageJson.bugs` will point to the same place for every package.
+	// Due to merging our issue trackers, `packageJson.bugs` will point to the same place for every package.
 	// We cannot rely on this value anymore. See: https://github.com/ckeditor/ckeditor5/issues/1988.
 	// Instead of we can take a value from `packageJson.repository` and adjust it to match to our requirements.
 	let repositoryUrl = ( typeof packageJson.repository === 'object' ) ? packageJson.repository.url : packageJson.repository;
@@ -34,14 +31,24 @@ function findRepositoryUrl( packageJson: PackageJson ): string {
 		throw new Error( `The package.json for "${ packageJson.name }" must contain the "repository" property.` );
 	}
 
-	// If the value ends with ".git", we need to remove it.
-	repositoryUrl = repositoryUrl.replace( /\.git$/, '' );
+	if ( repositoryUrl.startsWith( 'git+' ) ) {
+		repositoryUrl = repositoryUrl.slice( 4 );
+	}
 
-	// If the value starts with "git+", we need to remove it.
-	repositoryUrl = repositoryUrl.replace( /^git\+/, '' );
+	const match = repositoryUrl.match(
+		/^(?:https?:\/\/|git@)github\.com[:/](?<owner>[^/\s]+)\/(?<repo>[^/\s]+?)(?:\.git)?(?:[/?#].*)?$/
+	);
 
-	// Remove "/issues" suffix as well.
-	repositoryUrl = repositoryUrl.replace( /\/issues/, '' );
+	if ( match ) {
+		const { owner, repo } = match.groups!;
 
-	return repositoryUrl;
+		return `https://github.com/${ owner }/${ repo }`;
+	}
+
+	// Short notation: `owner/repo`.
+	if ( /^[^/\s]+\/[^/\s]+$/.test( repositoryUrl ) ) {
+		return `https://github.com/${ repositoryUrl }`;
+	}
+
+	throw new Error( `The repository URL "${ repositoryUrl }" is not supported.` );
 }

--- a/packages/ckeditor5-dev-utils/tests/workspaces/getpackagejson.ts
+++ b/packages/ckeditor5-dev-utils/tests/workspaces/getpackagejson.ts
@@ -22,6 +22,7 @@ describe( 'getPackageJson()', () => {
 			expect( result ).toEqual( fakePackageJson );
 			expect( fs.readJsonSync ).toHaveBeenCalledWith( '/my/package/dir/package.json' );
 		} );
+
 		it( 'should read the package.json when cwd is a directory path (`async=false`)', () => {
 			const cwd = '/my/package/dir';
 			const fakePackageJson: PackageJson = { name: 'my-package', version: '1.0.0' };


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: The `workspaces.getRepositoryUrl()` function handles the SSH URLs correctly.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
