### PR TITLE
Added sorting entries by date and scope count

### DIFF
--- a/packages/ckeditor5-dev-changelog/src/types.ts
+++ b/packages/ckeditor5-dev-changelog/src/types.ts
@@ -91,7 +91,7 @@ export type ParsedFile<T = FileMetadata> = {
 	content: string;
 	data: T;
 	changesetPath: string;
-	dateCreated: Date;
+	createdAt: Date;
 	gitHubUrl: string;
 	shouldSkipLinks: boolean;
 };

--- a/packages/ckeditor5-dev-changelog/src/types.ts
+++ b/packages/ckeditor5-dev-changelog/src/types.ts
@@ -91,6 +91,7 @@ export type ParsedFile<T = FileMetadata> = {
 	content: string;
 	data: T;
 	changesetPath: string;
+	dateCreated: Date;
 	gitHubUrl: string;
 	shouldSkipLinks: boolean;
 };

--- a/packages/ckeditor5-dev-changelog/src/utils/generatechangelog.ts
+++ b/packages/ckeditor5-dev-changelog/src/utils/generatechangelog.ts
@@ -69,7 +69,7 @@ const main: GenerateChangelogEntryPoint<GenerateChangelogConfig> = async options
 		externalRepositories,
 		shouldSkipLinks
 	} );
-	const parsedChangesetFiles = await parseChangelogEntries( entryPaths );
+	const parsedChangesetFiles = await parseChangelogEntries( entryPaths, isSinglePackage );
 	const sectionsWithEntries = groupEntriesBySection( {
 		packagesMetadata,
 		transformScope,

--- a/packages/ckeditor5-dev-changelog/src/utils/groupentriesbysection.ts
+++ b/packages/ckeditor5-dev-changelog/src/utils/groupentriesbysection.ts
@@ -111,7 +111,8 @@ function formatContent( content: string ) {
 
 	const cleanedRestContent = restContent.reduce( ( acc, line ) => {
 		if ( line.trim() === '' ) {
-			if ( acc.at( -1 ) !== '' ) {
+			// Only add empty line if the last item is not already an empty line
+			if ( acc.length > 0 && acc.at( -1 ) !== '' ) {
 				acc.push( '' );
 			}
 		} else {

--- a/packages/ckeditor5-dev-changelog/src/utils/groupentriesbysection.ts
+++ b/packages/ckeditor5-dev-changelog/src/utils/groupentriesbysection.ts
@@ -5,7 +5,6 @@
 
 import { ISSUE_PATTERN, ISSUE_SLUG_PATTERN, ISSUE_URL_PATTERN, SECTIONS } from './constants.js';
 import { linkToGitHubUser } from './linktogithubuser.js';
-import { normalizeEntry } from './normalizeentry.js';
 import { validateEntry } from './validateentry.js';
 import type { Entry, ParsedFile, SectionName, SectionsWithEntries, TransformScope } from '../types.js';
 
@@ -27,8 +26,7 @@ export function groupEntriesBySection( options: GroupEntriesBySectionOptions ): 
 	const packageNames = [ ...packagesMetadata.keys() ];
 
 	return files.reduce<SectionsWithEntries>( ( sections, entry ) => {
-		const normalizedEntry = normalizeEntry( entry, isSinglePackage );
-		const { validatedEntry, isValid } = validateEntry( normalizedEntry, packageNames, isSinglePackage );
+		const { validatedEntry, isValid } = validateEntry( entry, packageNames, isSinglePackage );
 		const validatedData = validatedEntry.data;
 
 		const scope = isSinglePackage ? null : getScopesLinks( validatedData.scope, transformScope! );

--- a/packages/ckeditor5-dev-changelog/src/utils/parsechangelogentries.ts
+++ b/packages/ckeditor5-dev-changelog/src/utils/parsechangelogentries.ts
@@ -7,6 +7,7 @@ import fs from 'fs-extra';
 import matter from 'gray-matter';
 import { AsyncArray } from './asyncarray.js';
 import type { ChangesetPathsWithGithubUrl, FileMetadata, ParsedFile } from '../types.js';
+import { sortEntriesByScopeAndDate } from './sortentriesbyscopeanddate.js';
 
 type SimpleParsedFile = Pick<ParsedFile, 'changesetPath' | 'gitHubUrl' | 'shouldSkipLinks'>;
 
@@ -29,5 +30,5 @@ export function parseChangelogEntries( entryPaths: Array<ChangesetPathsWithGithu
 			changesetPath,
 			shouldSkipLinks
 		} ) )
-		.then( value => value );
+		.then( entries => sortEntriesByScopeAndDate( entries ) );
 }

--- a/packages/ckeditor5-dev-changelog/src/utils/parsechangelogentries.ts
+++ b/packages/ckeditor5-dev-changelog/src/utils/parsechangelogentries.ts
@@ -5,11 +5,11 @@
 
 import fs from 'fs-extra';
 import matter from 'gray-matter';
-import { AsyncArray } from './asyncarray.js';
-import type { ChangesetPathsWithGithubUrl, FileMetadata, ParsedFile } from '../types.js';
-import { sortEntriesByScopeAndDate } from './sortentriesbyscopeanddate.js';
 import { isValid, parse } from 'date-fns';
+import { AsyncArray } from './asyncarray.js';
+import { sortEntriesByScopeAndDate } from './sortentriesbyscopeanddate.js';
 import { normalizeEntry } from './normalizeentry.js';
+import type { ChangesetPathsWithGithubUrl, FileMetadata, ParsedFile } from '../types.js';
 
 type SimpleParsedFile = Pick<ParsedFile, 'changesetPath' | 'gitHubUrl' | 'shouldSkipLinks'>;
 
@@ -41,25 +41,25 @@ export function parseChangelogEntries(
 }
 
 /**
- * Extracts date from changeset filename.
- * Expects format: YYYYMMDDHHMMSS_description.md
+ * Extracts date from an entry filename (`YYYYMMDDHHMMSS_*.md`).
+ *
+ * Defaults to the current date if the filename does not match the expected format.
  */
 function extractDateFromFilename( changesetPath: string ): Date {
+	const now = new Date();
 	const filename = changesetPath.split( '/' ).pop() || '';
 	const dateMatch = filename.match( /^(\d{14})_/ );
 
 	if ( !dateMatch || !dateMatch[ 1 ] ) {
-		// Fallback to current date if no date pattern found
-		return new Date();
+		// Fallback to the current date if no date pattern found.
+		return now;
 	}
 
-	const dateStr = dateMatch[ 1 ];
-	const parsedDate = parse( dateStr, 'yyyyMMddHHmmss', new Date() );
+	const parsedDate = parse( dateMatch[ 1 ], 'yyyyMMddHHmmss', now );
 
-	// Validate the parsed date
+	// Validate the parsed date and fallback to the current date when failed.
 	if ( !isValid( parsedDate ) ) {
-		// Fallback to current date if parsing failed
-		return new Date();
+		return now;
 	}
 
 	return parsedDate;

--- a/packages/ckeditor5-dev-changelog/src/utils/parsechangelogentries.ts
+++ b/packages/ckeditor5-dev-changelog/src/utils/parsechangelogentries.ts
@@ -8,13 +8,18 @@ import matter from 'gray-matter';
 import { AsyncArray } from './asyncarray.js';
 import type { ChangesetPathsWithGithubUrl, FileMetadata, ParsedFile } from '../types.js';
 import { sortEntriesByScopeAndDate } from './sortentriesbyscopeanddate.js';
+import { isValid, parse } from 'date-fns';
+import { normalizeEntry } from './normalizeentry.js';
 
 type SimpleParsedFile = Pick<ParsedFile, 'changesetPath' | 'gitHubUrl' | 'shouldSkipLinks'>;
 
 /**
  * Reads and processes input files to extract changelog entries.
  */
-export function parseChangelogEntries( entryPaths: Array<ChangesetPathsWithGithubUrl> ): Promise<Array<ParsedFile>> {
+export function parseChangelogEntries(
+	entryPaths: Array<ChangesetPathsWithGithubUrl>,
+	isSinglePackage: boolean
+): Promise<Array<ParsedFile>> {
 	const fileEntries = entryPaths.reduce<Array<SimpleParsedFile>>( ( acc, { filePaths, gitHubUrl, shouldSkipLinks } ) => {
 		for ( const changesetPath of filePaths ) {
 			acc.push( { changesetPath, gitHubUrl, shouldSkipLinks } );
@@ -28,7 +33,34 @@ export function parseChangelogEntries( entryPaths: Array<ChangesetPathsWithGithu
 			...( matter( await fs.readFile( changesetPath, 'utf-8' ) ) as unknown as { content: string; data: FileMetadata } ),
 			gitHubUrl,
 			changesetPath,
-			shouldSkipLinks
+			shouldSkipLinks,
+			dateCreated: extractDateFromFilename( changesetPath )
 		} ) )
+		.map( entry => normalizeEntry( entry, isSinglePackage ) )
 		.then( entries => sortEntriesByScopeAndDate( entries ) );
+}
+
+/**
+ * Extracts date from changeset filename.
+ * Expects format: YYYYMMDDHHMMSS_description.md
+ */
+function extractDateFromFilename( changesetPath: string ): Date {
+	const filename = changesetPath.split( '/' ).pop() || '';
+	const dateMatch = filename.match( /^(\d{14})_/ );
+
+	if ( !dateMatch || !dateMatch[ 1 ] ) {
+		// Fallback to current date if no date pattern found
+		return new Date();
+	}
+
+	const dateStr = dateMatch[ 1 ];
+	const parsedDate = parse( dateStr, 'yyyyMMddHHmmss', new Date() );
+
+	// Validate the parsed date
+	if ( !isValid( parsedDate ) ) {
+		// Fallback to current date if parsing failed
+		return new Date();
+	}
+
+	return parsedDate;
 }

--- a/packages/ckeditor5-dev-changelog/src/utils/parsechangelogentries.ts
+++ b/packages/ckeditor5-dev-changelog/src/utils/parsechangelogentries.ts
@@ -34,7 +34,7 @@ export function parseChangelogEntries(
 			gitHubUrl,
 			changesetPath,
 			shouldSkipLinks,
-			dateCreated: extractDateFromFilename( changesetPath )
+			createdAt: extractDateFromFilename( changesetPath )
 		} ) )
 		.map( entry => normalizeEntry( entry, isSinglePackage ) )
 		.then( entries => sortEntriesByScopeAndDate( entries ) );

--- a/packages/ckeditor5-dev-changelog/src/utils/sortentriesbyscopeanddate.ts
+++ b/packages/ckeditor5-dev-changelog/src/utils/sortentriesbyscopeanddate.ts
@@ -3,7 +3,6 @@
  * For licensing, see LICENSE.md.
  */
 
-import { parse, isValid } from 'date-fns';
 import type { ParsedFile } from '../types.js';
 
 /**
@@ -27,44 +26,15 @@ export function sortEntriesByScopeAndDate( entries: Array<ParsedFile> ): Array<P
 			}
 
 			// Same scope - sort by date (older first)
-			const aDate = extractDateFromFilename( a.changesetPath );
-			const bDate = extractDateFromFilename( b.changesetPath );
-			return aDate.getTime() - bDate.getTime();
+			return a.dateCreated.getTime() - b.dateCreated.getTime();
 		}
 
 		// Both have same amount of scopes - sort by date (older first)
 		if ( aScopeCount === bScopeCount ) {
-			const aDate = extractDateFromFilename( a.changesetPath );
-			const bDate = extractDateFromFilename( b.changesetPath );
-			return aDate.getTime() - bDate.getTime();
+			return a.dateCreated.getTime() - b.dateCreated.getTime();
 		}
 
 		// Sort by amount of scopes
 		return bScopeCount - aScopeCount;
 	} );
-}
-
-/**
- * Extracts date from changeset filename.
- * Expects format: YYYYMMDDHHMMSS_description.md
- */
-function extractDateFromFilename( changesetPath: string ): Date {
-	const filename = changesetPath.split( '/' ).pop() || '';
-	const dateMatch = filename.match( /^(\d{14})_/ );
-
-	if ( !dateMatch || !dateMatch[ 1 ] ) {
-		// Fallback to current date if no date pattern found
-		return new Date();
-	}
-
-	const dateStr = dateMatch[ 1 ];
-	const parsedDate = parse( dateStr, 'yyyyMMddHHmmss', new Date() );
-
-	// Validate the parsed date
-	if ( !isValid( parsedDate ) ) {
-		// Fallback to current date if parsing failed
-		return new Date();
-	}
-
-	return parsedDate;
 }

--- a/packages/ckeditor5-dev-changelog/src/utils/sortentriesbyscopeanddate.ts
+++ b/packages/ckeditor5-dev-changelog/src/utils/sortentriesbyscopeanddate.ts
@@ -8,33 +8,33 @@ import type { ParsedFile } from '../types.js';
 /**
  * Sorts parsed files according to the rules:
  * 1. Entries with more scopes at the top.
- * 2. Entries with single scope grouped by scope and sorted by date within group.
+ * 2. Entries with single scope grouped by scope and sorted by date within a group.
  * 3. Entries with no scope at the bottom.
  */
 export function sortEntriesByScopeAndDate( entries: Array<ParsedFile> ): Array<ParsedFile> {
-	return entries.sort( ( a, b ) => {
-		const aScopeCount = ( a.data.scope || [] ).length;
-		const bScopeCount = ( b.data.scope || [] ).length;
+	return entries.sort( ( itemBefore, itemAfter ) => {
+		const beforeScopeCount = itemBefore.data.scope.length;
+		const afterScopeCount = itemAfter.data.scope.length;
 
-		// // Both have single scope - group by scope name first
-		if ( aScopeCount === 1 && bScopeCount === 1 ) {
-			const aScope = a.data.scope![ 0 ];
-			const bScope = b.data.scope![ 0 ];
+		// Both have single scope - group by scope name first.
+		if ( beforeScopeCount === 1 && afterScopeCount === 1 ) {
+			const firstScope = itemBefore.data.scope.at( 0 )!;
+			const secondScope = itemAfter.data.scope.at( 0 )!;
 
-			if ( aScope && bScope && aScope !== bScope ) {
-				return aScope.localeCompare( bScope ); // Alphabetical scope order
+			if ( firstScope !== secondScope ) {
+				return firstScope.localeCompare( secondScope ); // Alphabetical scope order.
 			}
 
-			// Same scope - sort by date (older first)
-			return a.createdAt.getTime() - b.createdAt.getTime();
+			// Same scope - sort by date (older first).
+			return itemBefore.createdAt.getTime() - itemAfter.createdAt.getTime();
 		}
 
-		// Both have same amount of scopes - sort by date (older first)
-		if ( aScopeCount === bScopeCount ) {
-			return a.createdAt.getTime() - b.createdAt.getTime();
+		// Both have the same number of scopes - sort by date (older first).
+		if ( beforeScopeCount === afterScopeCount ) {
+			return itemBefore.createdAt.getTime() - itemAfter.createdAt.getTime();
 		}
 
-		// Sort by amount of scopes
-		return bScopeCount - aScopeCount;
+		// Sort by number of scopes.
+		return afterScopeCount - beforeScopeCount;
 	} );
 }

--- a/packages/ckeditor5-dev-changelog/src/utils/sortentriesbyscopeanddate.ts
+++ b/packages/ckeditor5-dev-changelog/src/utils/sortentriesbyscopeanddate.ts
@@ -26,12 +26,12 @@ export function sortEntriesByScopeAndDate( entries: Array<ParsedFile> ): Array<P
 			}
 
 			// Same scope - sort by date (older first)
-			return a.dateCreated.getTime() - b.dateCreated.getTime();
+			return a.createdAt.getTime() - b.createdAt.getTime();
 		}
 
 		// Both have same amount of scopes - sort by date (older first)
 		if ( aScopeCount === bScopeCount ) {
-			return a.dateCreated.getTime() - b.dateCreated.getTime();
+			return a.createdAt.getTime() - b.createdAt.getTime();
 		}
 
 		// Sort by amount of scopes

--- a/packages/ckeditor5-dev-changelog/src/utils/sortentriesbyscopeanddate.ts
+++ b/packages/ckeditor5-dev-changelog/src/utils/sortentriesbyscopeanddate.ts
@@ -1,0 +1,70 @@
+/**
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+import { parse, isValid } from 'date-fns';
+import type { ParsedFile } from '../types.js';
+
+/**
+ * Sorts parsed files according to the rules:
+ * 1. Entries with more scopes at the top.
+ * 2. Entries with single scope grouped by scope and sorted by date within group.
+ * 3. Entries with no scope at the bottom.
+ */
+export function sortEntriesByScopeAndDate( entries: Array<ParsedFile> ): Array<ParsedFile> {
+	return entries.sort( ( a, b ) => {
+		const aScopeCount = ( a.data.scope || [] ).length;
+		const bScopeCount = ( b.data.scope || [] ).length;
+
+		// // Both have single scope - group by scope name first
+		if ( aScopeCount === 1 && bScopeCount === 1 ) {
+			const aScope = a.data.scope![ 0 ];
+			const bScope = b.data.scope![ 0 ];
+
+			if ( aScope && bScope && aScope !== bScope ) {
+				return aScope.localeCompare( bScope ); // Alphabetical scope order
+			}
+
+			// Same scope - sort by date (older first)
+			const aDate = extractDateFromFilename( a.changesetPath );
+			const bDate = extractDateFromFilename( b.changesetPath );
+			return aDate.getTime() - bDate.getTime();
+		}
+
+		// Both have same amount of scopes - sort by date (older first)
+		if ( aScopeCount === bScopeCount ) {
+			const aDate = extractDateFromFilename( a.changesetPath );
+			const bDate = extractDateFromFilename( b.changesetPath );
+			return aDate.getTime() - bDate.getTime();
+		}
+
+		// Sort by amount of scopes
+		return bScopeCount - aScopeCount;
+	} );
+}
+
+/**
+ * Extracts date from changeset filename.
+ * Expects format: YYYYMMDDHHMMSS_description.md
+ */
+function extractDateFromFilename( changesetPath: string ): Date {
+	const filename = changesetPath.split( '/' ).pop() || '';
+	const dateMatch = filename.match( /^(\d{14})_/ );
+
+	if ( !dateMatch || !dateMatch[ 1 ] ) {
+		// Fallback to current date if no date pattern found
+		return new Date();
+	}
+
+	const dateStr = dateMatch[ 1 ];
+	const parsedDate = parse( dateStr, 'yyyyMMddHHmmss', new Date() );
+
+	// Validate the parsed date
+	if ( !isValid( parsedDate ) ) {
+		// Fallback to current date if parsing failed
+		return new Date();
+	}
+
+	return parsedDate;
+}

--- a/packages/ckeditor5-dev-changelog/tests/utils/generatechangelog.ts
+++ b/packages/ckeditor5-dev-changelog/tests/utils/generatechangelog.ts
@@ -83,6 +83,7 @@ describe( 'generateChangelog()', () => {
 					communityCredits: [],
 					validations: []
 				},
+				createdAt: new Date(),
 				changesetPath: '/home/ckeditor/.changelog/changeset-1.md',
 				gitHubUrl: 'https://github.com/ckeditor/ckeditor5',
 				shouldSkipLinks: false

--- a/packages/ckeditor5-dev-changelog/tests/utils/groupentriesbysection.ts
+++ b/packages/ckeditor5-dev-changelog/tests/utils/groupentriesbysection.ts
@@ -474,4 +474,33 @@ Let us know what you think!
 			'  Let us know what you think!'
 		] );
 	} );
+
+	it( 'should remove multiple consecutive empty lines and preserve maximum two line breaks', () => {
+		const content = `
+
+Message.
+
+
+Line two.
+
+
+Line three.
+
+`;
+		const files = [ createParsedFile( { content } ) ];
+
+		const result = groupEntriesBySection( { files, packagesMetadata, transformScope, isSinglePackage } );
+		const message = result.feature.entries[ 0 ]!.message;
+
+		const messageAsArray = message.split( '\n' );
+
+		expect( messageAsArray ).toStrictEqual( [
+			// eslint-disable-next-line @stylistic/max-len
+			'* **[DisplayName-package-1](https://npmjs.com/package/package-1)**: Message. See [#456](https://github.com/ckeditor/issues/456). Closes [#123](https://github.com/ckeditor/issues/123).',
+			'',
+			'  Line two.',
+			'',
+			'  Line three.'
+		] );
+	} );
 } );

--- a/packages/ckeditor5-dev-changelog/tests/utils/normalizeentry.ts
+++ b/packages/ckeditor5-dev-changelog/tests/utils/normalizeentry.ts
@@ -11,6 +11,7 @@ function wrapInput(
 	partialData: Partial<FileMetadata>
 ): ParsedFile<Partial<FileMetadata>> {
 	return {
+		createdAt: new Date(),
 		content: '',
 		changesetPath: '',
 		gitHubUrl: '',

--- a/packages/ckeditor5-dev-changelog/tests/utils/parsechangelogentries.ts
+++ b/packages/ckeditor5-dev-changelog/tests/utils/parsechangelogentries.ts
@@ -21,8 +21,8 @@ describe( 'parseChangelogEntries()', () => {
 
 	it( 'should parse changeset files and return array of parsed files', async () => {
 		// Mock data
-		const changesetPath1 = '/path/to/changeset1.md';
-		const changesetPath2 = '/path/to/changeset2.md';
+		const changesetPath1 = '/path/to/20240101120000_changeset1.md';
+		const changesetPath2 = '/path/to/20240101120001_changeset2.md';
 		const gitHubUrl = 'https://github.com/ckeditor/ckeditor5';
 		const fileContent1 = 'File content 1';
 		const fileContent2 = 'File content 2';
@@ -83,27 +83,52 @@ describe( 'parseChangelogEntries()', () => {
 			}
 		];
 
-		// Expected results
-		const expectedResults = [
-			{
-				...matterResult1,
-				gitHubUrl,
-				changesetPath: changesetPath1,
-				shouldSkipLinks: false
-			},
-			{
-				...matterResult2,
-				gitHubUrl,
-				changesetPath: changesetPath2,
-				shouldSkipLinks: false
-			}
-		];
-
 		// Execute the function
-		const result = await parseChangelogEntries( filePathsWithGithubUrl );
+		const result = await parseChangelogEntries( filePathsWithGithubUrl, true );
 
-		// Assertions
-		expect( result ).toEqual( expectedResults );
+		// Assertions - check the structure without exact date matching
+		expect( result ).toHaveLength( 2 );
+
+		// Check first entry
+		expect( result[ 0 ] ).toMatchObject( {
+			content: 'Parsed content 1',
+			data: {
+				type: 'Feature',
+				scope: [ 'ui' ],
+				closes: [],
+				see: [],
+				communityCredits: [],
+				validations: []
+			},
+			gitHubUrl,
+			changesetPath: changesetPath1,
+			shouldSkipLinks: false,
+			orig: fileContent1,
+			language: 'md',
+			matter: ''
+		} );
+		expect( result[ 0 ]?.dateCreated ).toBeInstanceOf( Date );
+
+		// Check second entry
+		expect( result[ 1 ] ).toMatchObject( {
+			content: 'Parsed content 2',
+			data: {
+				type: 'Fix',
+				scope: [ 'engine' ],
+				closes: [],
+				see: [],
+				communityCredits: [],
+				validations: []
+			},
+			gitHubUrl,
+			changesetPath: changesetPath2,
+			shouldSkipLinks: false,
+			orig: fileContent2,
+			language: 'md',
+			matter: ''
+		} );
+		expect( result[ 1 ]?.dateCreated ).toBeInstanceOf( Date );
+
 		expect( fs.readFile ).toHaveBeenCalledTimes( 2 );
 		expect( fs.readFile ).toHaveBeenCalledWith( changesetPath1, 'utf-8' );
 		expect( fs.readFile ).toHaveBeenCalledWith( changesetPath2, 'utf-8' );
@@ -114,8 +139,8 @@ describe( 'parseChangelogEntries()', () => {
 
 	it( 'should handle multiple repositories with different skipLinks values', async () => {
 		// Mock data
-		const changesetPath1 = '/path/to/repo1/changeset.md';
-		const changesetPath2 = '/path/to/repo2/changeset.md';
+		const changesetPath1 = '/path/to/repo1/20240101120000_changeset.md';
+		const changesetPath2 = '/path/to/repo2/20240101120001_changeset.md';
 		const gitHubUrl1 = 'https://github.com/ckeditor/ckeditor5';
 		const gitHubUrl2 = 'https://github.com/ckeditor/ckeditor5-dev';
 		const fileContent1 = 'File content 1';
@@ -184,27 +209,52 @@ describe( 'parseChangelogEntries()', () => {
 			}
 		];
 
-		// Expected results
-		const expectedResults = [
-			{
-				...matterResult1,
-				gitHubUrl: gitHubUrl1,
-				changesetPath: changesetPath1,
-				shouldSkipLinks: false
-			},
-			{
-				...matterResult2,
-				gitHubUrl: gitHubUrl2,
-				changesetPath: changesetPath2,
-				shouldSkipLinks: true
-			}
-		];
-
 		// Execute the function
-		const result = await parseChangelogEntries( filePathsWithGithubUrl );
+		const result = await parseChangelogEntries( filePathsWithGithubUrl, true );
 
-		// Assertions
-		expect( result ).toEqual( expectedResults );
+		// Assertions - check the structure without exact date matching
+		expect( result ).toHaveLength( 2 );
+
+		// Check first entry
+		expect( result[ 0 ] ).toMatchObject( {
+			content: 'Parsed content 1',
+			data: {
+				type: 'Feature',
+				scope: [],
+				closes: [],
+				see: [],
+				communityCredits: [],
+				validations: []
+			},
+			gitHubUrl: gitHubUrl1,
+			changesetPath: changesetPath1,
+			shouldSkipLinks: false,
+			orig: fileContent1,
+			language: 'md',
+			matter: ''
+		} );
+		expect( result[ 0 ]?.dateCreated ).toBeInstanceOf( Date );
+
+		// Check second entry
+		expect( result[ 1 ] ).toMatchObject( {
+			content: 'Parsed content 2',
+			data: {
+				type: 'Fix',
+				scope: [],
+				closes: [],
+				see: [],
+				communityCredits: [],
+				validations: []
+			},
+			gitHubUrl: gitHubUrl2,
+			changesetPath: changesetPath2,
+			shouldSkipLinks: true,
+			orig: fileContent2,
+			language: 'md',
+			matter: ''
+		} );
+		expect( result[ 1 ]?.dateCreated ).toBeInstanceOf( Date );
+
 		expect( fs.readFile ).toHaveBeenCalledTimes( 2 );
 		expect( fs.readFile ).toHaveBeenCalledWith( changesetPath1, 'utf-8' );
 		expect( fs.readFile ).toHaveBeenCalledWith( changesetPath2, 'utf-8' );
@@ -226,7 +276,7 @@ describe( 'parseChangelogEntries()', () => {
 		];
 
 		// Execute the function
-		const result = await parseChangelogEntries( filePathsWithGithubUrl );
+		const result = await parseChangelogEntries( filePathsWithGithubUrl, true );
 
 		// Assertions
 		expect( result ).toEqual( [] );
@@ -239,7 +289,7 @@ describe( 'parseChangelogEntries()', () => {
 		const filePathsWithGithubUrl: Array<ChangesetPathsWithGithubUrl> = [];
 
 		// Execute the function
-		const result = await parseChangelogEntries( filePathsWithGithubUrl );
+		const result = await parseChangelogEntries( filePathsWithGithubUrl, true );
 
 		// Assertions
 		expect( result ).toEqual( [] );
@@ -249,7 +299,7 @@ describe( 'parseChangelogEntries()', () => {
 
 	it( 'should call sortEntriesByScopeAndDate', async () => {
 		// Mock data
-		const changesetPath = '/path/to/changeset.md';
+		const changesetPath = '/path/to/20240101120000_changeset.md';
 		const gitHubUrl = 'https://github.com/test/repo';
 		const fileContent = 'file content';
 		const matterResult = {
@@ -272,21 +322,127 @@ describe( 'parseChangelogEntries()', () => {
 			}
 		];
 
-		// Expected parsed entry that should be passed to sortEntriesByScopeAndDate
-		const expectedParsedEntries = [
-			{
-				...matterResult,
-				gitHubUrl,
-				changesetPath,
-				shouldSkipLinks: false
-			}
-		];
+		await parseChangelogEntries( filePathsWithGithubUrl, true );
 
-		// Execute the function
-		await parseChangelogEntries( filePathsWithGithubUrl );
-
-		// Verify sortEntriesByScopeAndDate is called with correct arguments
+		// Verify sortEntriesByScopeAndDate is called with correct arguments structure
 		expect( sortEntriesByScopeAndDate ).toHaveBeenCalledTimes( 1 );
-		expect( sortEntriesByScopeAndDate ).toHaveBeenCalledWith( expectedParsedEntries );
+		const callArgs = vi.mocked( sortEntriesByScopeAndDate ).mock.calls[ 0 ]?.[ 0 ];
+		expect( callArgs ).toHaveLength( 1 );
+		expect( callArgs?.[ 0 ] ).toMatchObject( {
+			content: 'parsed content',
+			data: {
+				type: 'Feature',
+				scope: [ 'ui' ],
+				closes: [],
+				see: [],
+				communityCredits: [],
+				validations: []
+			},
+			gitHubUrl,
+			changesetPath,
+			shouldSkipLinks: false
+		} );
+		expect( callArgs?.[ 0 ]?.dateCreated ).toBeInstanceOf( Date );
+	} );
+
+	describe( 'date extraction from filename', () => {
+		it( 'should handle filenames without date pattern', async () => {
+			// Mock data with filename that doesn't match date pattern
+			const changesetPath = '/path/to/invalid_filename.md';
+			const gitHubUrl = 'https://github.com/test/repo';
+			const fileContent = 'file content';
+			const matterResult = {
+				content: 'parsed content',
+				data: { type: 'feature', scope: [] }
+			};
+
+			// Mock setup
+			vi.mocked( fs.readFile ).mockResolvedValue( fileContent as any );
+			vi.mocked( matter ).mockReturnValue( matterResult as any );
+
+			// Input data
+			const filePathsWithGithubUrl: Array<ChangesetPathsWithGithubUrl> = [
+				{
+					filePaths: [ changesetPath ],
+					gitHubUrl,
+					shouldSkipLinks: false,
+					cwd: '/test',
+					isRoot: false
+				}
+			];
+
+			// Execute the function
+			const result = await parseChangelogEntries( filePathsWithGithubUrl, true );
+
+			// Verify dateCreated is a Date (fallback to current date)
+			expect( result ).toHaveLength( 1 );
+			expect( result[ 0 ]?.dateCreated ).toBeInstanceOf( Date );
+		} );
+
+		it( 'should handle invalid date strings in filename', async () => {
+			// Mock data with filename that has invalid date
+			const changesetPath = '/path/to/99999999999999_invalid_date.md';
+			const gitHubUrl = 'https://github.com/test/repo';
+			const fileContent = 'file content';
+			const matterResult = {
+				content: 'parsed content',
+				data: { type: 'feature', scope: [] }
+			};
+
+			// Mock setup
+			vi.mocked( fs.readFile ).mockResolvedValue( fileContent as any );
+			vi.mocked( matter ).mockReturnValue( matterResult as any );
+
+			// Input data
+			const filePathsWithGithubUrl: Array<ChangesetPathsWithGithubUrl> = [
+				{
+					filePaths: [ changesetPath ],
+					gitHubUrl,
+					shouldSkipLinks: false,
+					cwd: '/test',
+					isRoot: false
+				}
+			];
+
+			// Execute the function
+			const result = await parseChangelogEntries( filePathsWithGithubUrl, true );
+
+			// Verify dateCreated is a Date (fallback to current date)
+			expect( result ).toHaveLength( 1 );
+			expect( result[ 0 ]?.dateCreated ).toBeInstanceOf( Date );
+		} );
+
+		it( 'should handle empty changeset path', async () => {
+			// Mock data with empty changeset path
+			const changesetPath = '';
+			const gitHubUrl = 'https://github.com/test/repo';
+			const fileContent = 'file content';
+			const matterResult = {
+				content: 'parsed content',
+				data: { type: 'feature', scope: [] }
+			};
+
+			// Mock setup
+			vi.mocked( fs.readFile ).mockResolvedValue( fileContent as any );
+			vi.mocked( matter ).mockReturnValue( matterResult as any );
+
+			// Input data
+			const filePathsWithGithubUrl: Array<ChangesetPathsWithGithubUrl> = [
+				{
+					filePaths: [ changesetPath ],
+					gitHubUrl,
+					shouldSkipLinks: false,
+					cwd: '/test',
+					isRoot: false
+				}
+			];
+
+			// Execute the function
+			const result = await parseChangelogEntries( filePathsWithGithubUrl, true );
+
+			// Verify dateCreated is a Date (fallback to current date)
+			expect( result ).toHaveLength( 1 );
+			expect( result[ 0 ]?.dateCreated ).toBeInstanceOf( Date );
+		} );
 	} );
 } );

--- a/packages/ckeditor5-dev-changelog/tests/utils/parsechangelogentries.ts
+++ b/packages/ckeditor5-dev-changelog/tests/utils/parsechangelogentries.ts
@@ -297,7 +297,7 @@ describe( 'parseChangelogEntries()', () => {
 		expect( matter ).not.toHaveBeenCalled();
 	} );
 
-	it( 'should call sortEntriesByScopeAndDate', async () => {
+	it( 'should sort entries', async () => {
 		// Mock data
 		const changesetPath = '/path/to/20240101120000_changeset.md';
 		const gitHubUrl = 'https://github.com/test/repo';
@@ -324,11 +324,12 @@ describe( 'parseChangelogEntries()', () => {
 
 		await parseChangelogEntries( filePathsWithGithubUrl, true );
 
-		// Verify sortEntriesByScopeAndDate is called with correct arguments structure
+		// Verify sortEntriesByScopeAndDate is called with the correct arguments structure.
 		expect( sortEntriesByScopeAndDate ).toHaveBeenCalledTimes( 1 );
-		const callArgs = vi.mocked( sortEntriesByScopeAndDate ).mock.calls[ 0 ]?.[ 0 ];
+		const callArgs = vi.mocked( sortEntriesByScopeAndDate ).mock.calls[ 0 ]![ 0 ];
+
 		expect( callArgs ).toHaveLength( 1 );
-		expect( callArgs?.[ 0 ] ).toMatchObject( {
+		expect( callArgs[ 0 ] ).toMatchObject( {
 			content: 'parsed content',
 			data: {
 				type: 'Feature',
@@ -342,12 +343,12 @@ describe( 'parseChangelogEntries()', () => {
 			changesetPath,
 			shouldSkipLinks: false
 		} );
-		expect( callArgs?.[ 0 ]?.createdAt ).toBeInstanceOf( Date );
+		expect( callArgs[ 0 ]!.createdAt ).toBeInstanceOf( Date );
 	} );
 
 	describe( 'date extraction from filename', () => {
 		it( 'should handle filenames without date pattern', async () => {
-			// Mock data with filename that doesn't match date pattern
+			// Mock data with filename that doesn't match a date pattern.
 			const changesetPath = '/path/to/invalid_filename.md';
 			const gitHubUrl = 'https://github.com/test/repo';
 			const fileContent = 'file content';

--- a/packages/ckeditor5-dev-changelog/tests/utils/parsechangelogentries.ts
+++ b/packages/ckeditor5-dev-changelog/tests/utils/parsechangelogentries.ts
@@ -107,7 +107,7 @@ describe( 'parseChangelogEntries()', () => {
 			language: 'md',
 			matter: ''
 		} );
-		expect( result[ 0 ]?.dateCreated ).toBeInstanceOf( Date );
+		expect( result[ 0 ]?.createdAt ).toBeInstanceOf( Date );
 
 		// Check second entry
 		expect( result[ 1 ] ).toMatchObject( {
@@ -127,7 +127,7 @@ describe( 'parseChangelogEntries()', () => {
 			language: 'md',
 			matter: ''
 		} );
-		expect( result[ 1 ]?.dateCreated ).toBeInstanceOf( Date );
+		expect( result[ 1 ]?.createdAt ).toBeInstanceOf( Date );
 
 		expect( fs.readFile ).toHaveBeenCalledTimes( 2 );
 		expect( fs.readFile ).toHaveBeenCalledWith( changesetPath1, 'utf-8' );
@@ -233,7 +233,7 @@ describe( 'parseChangelogEntries()', () => {
 			language: 'md',
 			matter: ''
 		} );
-		expect( result[ 0 ]?.dateCreated ).toBeInstanceOf( Date );
+		expect( result[ 0 ]?.createdAt ).toBeInstanceOf( Date );
 
 		// Check second entry
 		expect( result[ 1 ] ).toMatchObject( {
@@ -253,7 +253,7 @@ describe( 'parseChangelogEntries()', () => {
 			language: 'md',
 			matter: ''
 		} );
-		expect( result[ 1 ]?.dateCreated ).toBeInstanceOf( Date );
+		expect( result[ 1 ]?.createdAt ).toBeInstanceOf( Date );
 
 		expect( fs.readFile ).toHaveBeenCalledTimes( 2 );
 		expect( fs.readFile ).toHaveBeenCalledWith( changesetPath1, 'utf-8' );
@@ -342,7 +342,7 @@ describe( 'parseChangelogEntries()', () => {
 			changesetPath,
 			shouldSkipLinks: false
 		} );
-		expect( callArgs?.[ 0 ]?.dateCreated ).toBeInstanceOf( Date );
+		expect( callArgs?.[ 0 ]?.createdAt ).toBeInstanceOf( Date );
 	} );
 
 	describe( 'date extraction from filename', () => {
@@ -374,9 +374,9 @@ describe( 'parseChangelogEntries()', () => {
 			// Execute the function
 			const result = await parseChangelogEntries( filePathsWithGithubUrl, true );
 
-			// Verify dateCreated is a Date (fallback to current date)
+			// Verify createdAt is a Date (fallback to current date)
 			expect( result ).toHaveLength( 1 );
-			expect( result[ 0 ]?.dateCreated ).toBeInstanceOf( Date );
+			expect( result[ 0 ]?.createdAt ).toBeInstanceOf( Date );
 		} );
 
 		it( 'should handle invalid date strings in filename', async () => {
@@ -407,9 +407,9 @@ describe( 'parseChangelogEntries()', () => {
 			// Execute the function
 			const result = await parseChangelogEntries( filePathsWithGithubUrl, true );
 
-			// Verify dateCreated is a Date (fallback to current date)
+			// Verify createdAt is a Date (fallback to current date)
 			expect( result ).toHaveLength( 1 );
-			expect( result[ 0 ]?.dateCreated ).toBeInstanceOf( Date );
+			expect( result[ 0 ]?.createdAt ).toBeInstanceOf( Date );
 		} );
 
 		it( 'should handle empty changeset path', async () => {
@@ -440,9 +440,9 @@ describe( 'parseChangelogEntries()', () => {
 			// Execute the function
 			const result = await parseChangelogEntries( filePathsWithGithubUrl, true );
 
-			// Verify dateCreated is a Date (fallback to current date)
+			// Verify createdAt is a Date (fallback to current date)
 			expect( result ).toHaveLength( 1 );
-			expect( result[ 0 ]?.dateCreated ).toBeInstanceOf( Date );
+			expect( result[ 0 ]?.createdAt ).toBeInstanceOf( Date );
 		} );
 	} );
 } );

--- a/packages/ckeditor5-dev-changelog/tests/utils/sortentriesbyscopeanddate.ts
+++ b/packages/ckeditor5-dev-changelog/tests/utils/sortentriesbyscopeanddate.ts
@@ -9,7 +9,7 @@ import type { ParsedFile } from '../../src/types.js';
 
 function createMockEntry(
 	scope: Array<string>,
-	changesetPath: string,
+	dateCreated: Date,
 	content: string = 'Test content',
 	gitHubUrl: string = 'https://github.com/test/repo',
 	shouldSkipLinks: boolean = false
@@ -24,7 +24,8 @@ function createMockEntry(
 			communityCredits: [],
 			validations: []
 		},
-		changesetPath,
+		changesetPath: '',
+		dateCreated,
 		gitHubUrl,
 		shouldSkipLinks
 	};
@@ -33,59 +34,59 @@ function createMockEntry(
 describe( 'sortEntriesByScopeAndDate()', () => {
 	it( 'should sort entries with single scope alphabetically by scope name, then by date (older first)', () => {
 		const entries = [
-			createMockEntry( [ 'ui' ], 'path/20240102120000_feature.md' ),
-			createMockEntry( [ 'core' ], 'path/20240101120000_feature.md' ),
-			createMockEntry( [ 'ui' ], 'path/20240101120000_feature.md' ),
-			createMockEntry( [ 'engine' ], 'path/20240103120000_feature.md' )
+			createMockEntry( [ 'ui' ], new Date( 2025, 1, 1, 0, 0, 0, 0 ) ),
+			createMockEntry( [ 'core' ], new Date( 2025, 2, 1, 0, 0, 0, 0 ) ),
+			createMockEntry( [ 'ui' ], new Date( 2025, 3, 1, 0, 0, 0, 0 ) ),
+			createMockEntry( [ 'engine' ], new Date( 2025, 4, 1, 0, 0, 0, 0 ) )
 		];
 
 		const sorted = sortEntriesByScopeAndDate( entries );
 
 		expect( sorted[ 0 ]?.data.scope ).toEqual( [ 'core' ] );
-		expect( sorted[ 0 ]?.changesetPath ).toBe( 'path/20240101120000_feature.md' );
+		expect( sorted[ 0 ]?.dateCreated ).toEqual( new Date( 2025, 2, 1, 0, 0, 0, 0 ) );
 		expect( sorted[ 1 ]?.data.scope ).toEqual( [ 'engine' ] );
-		expect( sorted[ 1 ]?.changesetPath ).toBe( 'path/20240103120000_feature.md' );
+		expect( sorted[ 1 ]?.dateCreated ).toEqual( new Date( 2025, 4, 1, 0, 0, 0, 0 ) );
 		expect( sorted[ 2 ]?.data.scope ).toEqual( [ 'ui' ] );
-		expect( sorted[ 2 ]?.changesetPath ).toBe( 'path/20240101120000_feature.md' );
+		expect( sorted[ 2 ]?.dateCreated ).toEqual( new Date( 2025, 1, 1, 0, 0, 0, 0 ) );
 		expect( sorted[ 3 ]?.data.scope ).toEqual( [ 'ui' ] );
-		expect( sorted[ 3 ]?.changesetPath ).toBe( 'path/20240102120000_feature.md' );
+		expect( sorted[ 3 ]?.dateCreated ).toEqual( new Date( 2025, 3, 1, 0, 0, 0, 0 ) );
 	} );
 
 	it( 'should sort entries with same single scope by date (older first)', () => {
 		const entries = [
-			createMockEntry( [ 'core' ], 'path/20240103120000_feature.md' ),
-			createMockEntry( [ 'core' ], 'path/20240101120000_feature.md' ),
-			createMockEntry( [ 'core' ], 'path/20240102120000_feature.md' )
+			createMockEntry( [ 'core' ], new Date( 2025, 1, 1, 0, 0, 0, 0 ) ),
+			createMockEntry( [ 'core' ], new Date( 2025, 2, 1, 0, 0, 0, 0 ) ),
+			createMockEntry( [ 'core' ], new Date( 2025, 3, 1, 0, 0, 0, 0 ) )
 		];
 
 		const sorted = sortEntriesByScopeAndDate( entries );
 
 		expect( sorted ).toHaveLength( 3 );
-		expect( sorted[ 0 ]!.changesetPath ).toBe( 'path/20240101120000_feature.md' );
-		expect( sorted[ 1 ]!.changesetPath ).toBe( 'path/20240102120000_feature.md' );
-		expect( sorted[ 2 ]!.changesetPath ).toBe( 'path/20240103120000_feature.md' );
+		expect( sorted[ 0 ]!.dateCreated ).toEqual( new Date( 2025, 1, 1, 0, 0, 0, 0 ) );
+		expect( sorted[ 1 ]!.dateCreated ).toEqual( new Date( 2025, 2, 1, 0, 0, 0, 0 ) );
+		expect( sorted[ 2 ]!.dateCreated ).toEqual( new Date( 2025, 3, 1, 0, 0, 0, 0 ) );
 	} );
 
 	it( 'should sort entries with same number of scopes by date (older first)', () => {
 		const entries = [
-			createMockEntry( [ 'ui', 'engine' ], 'path/20240103120000_feature.md' ),
-			createMockEntry( [ 'core', 'utils' ], 'path/20240101120000_feature.md' ),
-			createMockEntry( [ 'widget', 'typing' ], 'path/20240102120000_feature.md' )
+			createMockEntry( [ 'ui', 'engine' ], new Date( 2025, 3, 1, 0, 0, 0, 0 ) ),
+			createMockEntry( [ 'core', 'utils' ], new Date( 2025, 2, 1, 0, 0, 0, 0 ) ),
+			createMockEntry( [ 'widget', 'typing' ], new Date( 2025, 1, 1, 0, 0, 0, 0 ) )
 		];
 
 		const sorted = sortEntriesByScopeAndDate( entries );
 
-		expect( sorted[ 0 ]!.changesetPath ).toBe( 'path/20240101120000_feature.md' );
-		expect( sorted[ 1 ]!.changesetPath ).toBe( 'path/20240102120000_feature.md' );
-		expect( sorted[ 2 ]!.changesetPath ).toBe( 'path/20240103120000_feature.md' );
+		expect( sorted[ 0 ]!.dateCreated ).toEqual( new Date( 2025, 1, 1, 0, 0, 0, 0 ) );
+		expect( sorted[ 1 ]!.dateCreated ).toEqual( new Date( 2025, 2, 1, 0, 0, 0, 0 ) );
+		expect( sorted[ 2 ]!.dateCreated ).toEqual( new Date( 2025, 3, 1, 0, 0, 0, 0 ) );
 	} );
 
 	it( 'should sort by number of scopes (more scopes first)', () => {
 		const entries = [
-			createMockEntry( [ 'core' ], 'path/20240101120000_feature.md' ),
-			createMockEntry( [ 'ui', 'engine', 'widget' ], 'path/20240101120000_feature.md' ),
-			createMockEntry( [ 'utils', 'typing' ], 'path/20240101120000_feature.md' ),
-			createMockEntry( [], 'path/20240101120000_feature.md' )
+			createMockEntry( [ 'core' ], new Date( 2025, 1, 1, 0, 0, 0, 0 ) ),
+			createMockEntry( [ 'ui', 'engine', 'widget' ], new Date( 2025, 2, 1, 0, 0, 0, 0 ) ),
+			createMockEntry( [ 'utils', 'typing' ], new Date( 2025, 3, 1, 0, 0, 0, 0 ) ),
+			createMockEntry( [], new Date( 2025, 4, 1, 0, 0, 0, 0 ) )
 		];
 
 		const sorted = sortEntriesByScopeAndDate( entries );
@@ -98,28 +99,22 @@ describe( 'sortEntriesByScopeAndDate()', () => {
 
 	it( 'should handle entries without scope', () => {
 		const entries = [
-			createMockEntry( [], 'path/20240103120000_feature.md' ),
-			createMockEntry( [], 'path/20240101120000_feature.md' ),
-			createMockEntry( [], 'path/20240102120000_feature.md' )
+			createMockEntry( [], new Date( 2025, 1, 1, 0, 0, 0, 0 ) ),
+			createMockEntry( [], new Date( 2025, 2, 1, 0, 0, 0, 0 ) ),
+			createMockEntry( [], new Date( 2025, 3, 1, 0, 0, 0, 0 ) )
 		];
 
 		const sorted = sortEntriesByScopeAndDate( entries );
 
-		expect( sorted[ 0 ]!.changesetPath ).toBe( 'path/20240101120000_feature.md' );
-		expect( sorted[ 1 ]!.changesetPath ).toBe( 'path/20240102120000_feature.md' );
-		expect( sorted[ 2 ]!.changesetPath ).toBe( 'path/20240103120000_feature.md' );
+		expect( sorted[ 0 ]!.dateCreated ).toEqual( new Date( 2025, 1, 1, 0, 0, 0, 0 ) );
+		expect( sorted[ 1 ]!.dateCreated ).toEqual( new Date( 2025, 2, 1, 0, 0, 0, 0 ) );
+		expect( sorted[ 2 ]!.dateCreated ).toEqual( new Date( 2025, 3, 1, 0, 0, 0, 0 ) );
 	} );
 
 	it( 'should handle entries with undefined scope as empty array', () => {
 		const entriesWithUndefinedScope = [
-			{
-				...createMockEntry( [ 'core' ], 'path/20240101120000_feature.md' ),
-				data: {
-					...createMockEntry( [ 'core' ], 'path/20240101120000_feature.md' ).data,
-					scope: undefined as any
-				}
-			},
-			createMockEntry( [ 'ui' ], 'path/20240101120000_feature.md' )
+			createMockEntry( undefined as any, new Date( 2025, 1, 1, 0, 0, 0, 0 ) ),
+			createMockEntry( [ 'ui' ], new Date( 2025, 2, 1, 0, 0, 0, 0 ) )
 		];
 
 		const sorted = sortEntriesByScopeAndDate( entriesWithUndefinedScope );
@@ -129,64 +124,13 @@ describe( 'sortEntriesByScopeAndDate()', () => {
 		expect( sorted[ 1 ]!.data.scope ).toBeUndefined();
 	} );
 
-	it( 'should handle filenames without date pattern (fallback to current date)', () => {
-		const entries = [
-			createMockEntry( [ 'core' ], 'path/invalid-filename.md' ),
-			createMockEntry( [ 'core' ], 'path/20240101120000_feature.md' )
-		];
-
-		const sorted = sortEntriesByScopeAndDate( entries );
-
-		// Entry with valid date should come first (older date)
-		expect( sorted[ 0 ]!.changesetPath ).toBe( 'path/20240101120000_feature.md' );
-		expect( sorted[ 1 ]!.changesetPath ).toBe( 'path/invalid-filename.md' );
-	} );
-
-	it( 'should handle filenames with invalid date format (fallback to current date)', () => {
-		const entries = [
-			createMockEntry( [ 'core' ], 'path/99999999999999_feature.md' ), // Invalid date
-			createMockEntry( [ 'core' ], 'path/20240101120000_feature.md' )
-		];
-
-		const sorted = sortEntriesByScopeAndDate( entries );
-
-		// Entry with valid date should come first (older date)
-		expect( sorted[ 0 ]!.changesetPath ).toBe( 'path/20240101120000_feature.md' );
-		expect( sorted[ 1 ]!.changesetPath ).toBe( 'path/99999999999999_feature.md' );
-	} );
-
-	it( 'should handle filenames without extension or path separators', () => {
-		const entries = [
-			createMockEntry( [ 'core' ], '20240102120000_feature.md' ),
-			createMockEntry( [ 'core' ], '20240101120000_feature.md' )
-		];
-
-		const sorted = sortEntriesByScopeAndDate( entries );
-
-		expect( sorted[ 0 ]!.changesetPath ).toBe( '20240101120000_feature.md' );
-		expect( sorted[ 1 ]!.changesetPath ).toBe( '20240102120000_feature.md' );
-	} );
-
-	it( 'should handle empty filename (fallback to current date)', () => {
-		const entries = [
-			createMockEntry( [ 'core' ], '' ),
-			createMockEntry( [ 'core' ], 'path/20240101120000_feature.md' )
-		];
-
-		const sorted = sortEntriesByScopeAndDate( entries );
-
-		// Entry with valid date should come first (older date)
-		expect( sorted[ 0 ]!.changesetPath ).toBe( 'path/20240101120000_feature.md' );
-		expect( sorted[ 1 ]!.changesetPath ).toBe( '' );
-	} );
-
 	it( 'should handle mixed scenarios with different scope counts and dates', () => {
 		const entries = [
-			createMockEntry( [ 'ui' ], 'path/20240103120000_feature.md' ),
-			createMockEntry( [ 'core', 'utils', 'engine' ], 'path/20240102120000_feature.md' ),
-			createMockEntry( [ 'core' ], 'path/20240101120000_feature.md' ),
-			createMockEntry( [ 'widget', 'typing' ], 'path/20240104120000_feature.md' ),
-			createMockEntry( [], 'path/20240105120000_feature.md' )
+			createMockEntry( [ 'ui' ], new Date( 2025, 1, 1, 0, 0, 0, 0 ) ),
+			createMockEntry( [ 'core', 'utils', 'engine' ], new Date( 2025, 2, 1, 0, 0, 0, 0 ) ),
+			createMockEntry( [ 'core' ], new Date( 2025, 3, 1, 0, 0, 0, 0 ) ),
+			createMockEntry( [ 'widget', 'typing' ], new Date( 2025, 4, 1, 0, 0, 0, 0 ) ),
+			createMockEntry( [], new Date( 2025, 5, 1, 0, 0, 0, 0 ) )
 		];
 
 		const sorted = sortEntriesByScopeAndDate( entries );
@@ -205,8 +149,8 @@ describe( 'sortEntriesByScopeAndDate()', () => {
 
 	it( 'should modify the original array (sort mutates)', () => {
 		const entries = [
-			createMockEntry( [ 'ui' ], 'path/20240102120000_feature.md' ),
-			createMockEntry( [ 'core' ], 'path/20240101120000_feature.md' )
+			createMockEntry( [ 'ui' ], new Date( 2025, 1, 1, 0, 0, 0, 0 ) ),
+			createMockEntry( [ 'core' ], new Date( 2025, 2, 1, 0, 0, 0, 0 ) )
 		];
 		const originalEntries = [ ...entries ];
 
@@ -229,7 +173,7 @@ describe( 'sortEntriesByScopeAndDate()', () => {
 
 	it( 'should handle single entry', () => {
 		const entries = [
-			createMockEntry( [ 'core' ], 'path/20240101120000_feature.md' )
+			createMockEntry( [ 'core' ], new Date( 2025, 1, 1, 0, 0, 0, 0 ) )
 		];
 
 		const sorted = sortEntriesByScopeAndDate( entries );
@@ -240,26 +184,14 @@ describe( 'sortEntriesByScopeAndDate()', () => {
 
 	it( 'should handle entries when all scopes are undefined', () => {
 		const entriesWithUndefinedScopes = [
-			{
-				...createMockEntry( [ 'test' ], 'path/20240102120000_feature.md' ),
-				data: {
-					...createMockEntry( [ 'test' ], 'path/20240102120000_feature.md' ).data,
-					scope: undefined as any
-				}
-			},
-			{
-				...createMockEntry( [ 'test' ], 'path/20240101120000_feature.md' ),
-				data: {
-					...createMockEntry( [ 'test' ], 'path/20240101120000_feature.md' ).data,
-					scope: undefined as any
-				}
-			}
+			createMockEntry( undefined as any, new Date( 2025, 1, 1, 0, 0, 0, 0 ) ),
+			createMockEntry( undefined as any, new Date( 2025, 2, 1, 0, 0, 0, 0 ) )
 		];
 
 		const sorted = sortEntriesByScopeAndDate( entriesWithUndefinedScopes );
 
 		// When both scopes are undefined, should fall back to date sorting (older first)
-		expect( sorted[ 0 ]!.changesetPath ).toBe( 'path/20240101120000_feature.md' );
-		expect( sorted[ 1 ]!.changesetPath ).toBe( 'path/20240102120000_feature.md' );
+		expect( sorted[ 0 ]!.dateCreated ).toEqual( new Date( 2025, 1, 1, 0, 0, 0, 0 ) );
+		expect( sorted[ 1 ]!.dateCreated ).toEqual( new Date( 2025, 2, 1, 0, 0, 0, 0 ) );
 	} );
 } );

--- a/packages/ckeditor5-dev-changelog/tests/utils/sortentriesbyscopeanddate.ts
+++ b/packages/ckeditor5-dev-changelog/tests/utils/sortentriesbyscopeanddate.ts
@@ -111,19 +111,6 @@ describe( 'sortEntriesByScopeAndDate()', () => {
 		expect( sorted[ 2 ]!.createdAt ).toEqual( new Date( 2025, 3, 1, 0, 0, 0, 0 ) );
 	} );
 
-	it( 'should handle entries with undefined scope as empty array', () => {
-		const entriesWithUndefinedScope = [
-			createMockEntry( undefined as any, new Date( 2025, 1, 1, 0, 0, 0, 0 ) ),
-			createMockEntry( [ 'ui' ], new Date( 2025, 2, 1, 0, 0, 0, 0 ) )
-		];
-
-		const sorted = sortEntriesByScopeAndDate( entriesWithUndefinedScope );
-
-		// Entry with undefined scope should be treated as having 0 scopes and come after entry with scope
-		expect( sorted[ 0 ]!.data.scope ).toEqual( [ 'ui' ] );
-		expect( sorted[ 1 ]!.data.scope ).toBeUndefined();
-	} );
-
 	it( 'should handle mixed scenarios with different scope counts and dates', () => {
 		const entries = [
 			createMockEntry( [ 'ui' ], new Date( 2025, 1, 1, 0, 0, 0, 0 ) ),
@@ -180,18 +167,5 @@ describe( 'sortEntriesByScopeAndDate()', () => {
 
 		expect( sorted ).toHaveLength( 1 );
 		expect( sorted[ 0 ]! ).toEqual( entries[ 0 ] );
-	} );
-
-	it( 'should handle entries when all scopes are undefined', () => {
-		const entriesWithUndefinedScopes = [
-			createMockEntry( undefined as any, new Date( 2025, 1, 1, 0, 0, 0, 0 ) ),
-			createMockEntry( undefined as any, new Date( 2025, 2, 1, 0, 0, 0, 0 ) )
-		];
-
-		const sorted = sortEntriesByScopeAndDate( entriesWithUndefinedScopes );
-
-		// When both scopes are undefined, should fall back to date sorting (older first)
-		expect( sorted[ 0 ]!.createdAt ).toEqual( new Date( 2025, 1, 1, 0, 0, 0, 0 ) );
-		expect( sorted[ 1 ]!.createdAt ).toEqual( new Date( 2025, 2, 1, 0, 0, 0, 0 ) );
 	} );
 } );

--- a/packages/ckeditor5-dev-changelog/tests/utils/sortentriesbyscopeanddate.ts
+++ b/packages/ckeditor5-dev-changelog/tests/utils/sortentriesbyscopeanddate.ts
@@ -1,0 +1,265 @@
+/**
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { sortEntriesByScopeAndDate } from '../../src/utils/sortentriesbyscopeanddate.js';
+import type { ParsedFile } from '../../src/types.js';
+
+function createMockEntry(
+	scope: Array<string>,
+	changesetPath: string,
+	content: string = 'Test content',
+	gitHubUrl: string = 'https://github.com/test/repo',
+	shouldSkipLinks: boolean = false
+): ParsedFile {
+	return {
+		content,
+		data: {
+			type: 'feat',
+			scope,
+			closes: [],
+			see: [],
+			communityCredits: [],
+			validations: []
+		},
+		changesetPath,
+		gitHubUrl,
+		shouldSkipLinks
+	};
+}
+
+describe( 'sortEntriesByScopeAndDate()', () => {
+	it( 'should sort entries with single scope alphabetically by scope name, then by date (older first)', () => {
+		const entries = [
+			createMockEntry( [ 'ui' ], 'path/20240102120000_feature.md' ),
+			createMockEntry( [ 'core' ], 'path/20240101120000_feature.md' ),
+			createMockEntry( [ 'ui' ], 'path/20240101120000_feature.md' ),
+			createMockEntry( [ 'engine' ], 'path/20240103120000_feature.md' )
+		];
+
+		const sorted = sortEntriesByScopeAndDate( entries );
+
+		expect( sorted[ 0 ]?.data.scope ).toEqual( [ 'core' ] );
+		expect( sorted[ 0 ]?.changesetPath ).toBe( 'path/20240101120000_feature.md' );
+		expect( sorted[ 1 ]?.data.scope ).toEqual( [ 'engine' ] );
+		expect( sorted[ 1 ]?.changesetPath ).toBe( 'path/20240103120000_feature.md' );
+		expect( sorted[ 2 ]?.data.scope ).toEqual( [ 'ui' ] );
+		expect( sorted[ 2 ]?.changesetPath ).toBe( 'path/20240101120000_feature.md' );
+		expect( sorted[ 3 ]?.data.scope ).toEqual( [ 'ui' ] );
+		expect( sorted[ 3 ]?.changesetPath ).toBe( 'path/20240102120000_feature.md' );
+	} );
+
+	it( 'should sort entries with same single scope by date (older first)', () => {
+		const entries = [
+			createMockEntry( [ 'core' ], 'path/20240103120000_feature.md' ),
+			createMockEntry( [ 'core' ], 'path/20240101120000_feature.md' ),
+			createMockEntry( [ 'core' ], 'path/20240102120000_feature.md' )
+		];
+
+		const sorted = sortEntriesByScopeAndDate( entries );
+
+		expect( sorted ).toHaveLength( 3 );
+		expect( sorted[ 0 ]!.changesetPath ).toBe( 'path/20240101120000_feature.md' );
+		expect( sorted[ 1 ]!.changesetPath ).toBe( 'path/20240102120000_feature.md' );
+		expect( sorted[ 2 ]!.changesetPath ).toBe( 'path/20240103120000_feature.md' );
+	} );
+
+	it( 'should sort entries with same number of scopes by date (older first)', () => {
+		const entries = [
+			createMockEntry( [ 'ui', 'engine' ], 'path/20240103120000_feature.md' ),
+			createMockEntry( [ 'core', 'utils' ], 'path/20240101120000_feature.md' ),
+			createMockEntry( [ 'widget', 'typing' ], 'path/20240102120000_feature.md' )
+		];
+
+		const sorted = sortEntriesByScopeAndDate( entries );
+
+		expect( sorted[ 0 ]!.changesetPath ).toBe( 'path/20240101120000_feature.md' );
+		expect( sorted[ 1 ]!.changesetPath ).toBe( 'path/20240102120000_feature.md' );
+		expect( sorted[ 2 ]!.changesetPath ).toBe( 'path/20240103120000_feature.md' );
+	} );
+
+	it( 'should sort by number of scopes (more scopes first)', () => {
+		const entries = [
+			createMockEntry( [ 'core' ], 'path/20240101120000_feature.md' ),
+			createMockEntry( [ 'ui', 'engine', 'widget' ], 'path/20240101120000_feature.md' ),
+			createMockEntry( [ 'utils', 'typing' ], 'path/20240101120000_feature.md' ),
+			createMockEntry( [], 'path/20240101120000_feature.md' )
+		];
+
+		const sorted = sortEntriesByScopeAndDate( entries );
+
+		expect( sorted[ 0 ]!.data.scope ).toEqual( [ 'ui', 'engine', 'widget' ] );
+		expect( sorted[ 1 ]!.data.scope ).toEqual( [ 'utils', 'typing' ] );
+		expect( sorted[ 2 ]!.data.scope ).toEqual( [ 'core' ] );
+		expect( sorted[ 3 ]!.data.scope ).toEqual( [] );
+	} );
+
+	it( 'should handle entries without scope', () => {
+		const entries = [
+			createMockEntry( [], 'path/20240103120000_feature.md' ),
+			createMockEntry( [], 'path/20240101120000_feature.md' ),
+			createMockEntry( [], 'path/20240102120000_feature.md' )
+		];
+
+		const sorted = sortEntriesByScopeAndDate( entries );
+
+		expect( sorted[ 0 ]!.changesetPath ).toBe( 'path/20240101120000_feature.md' );
+		expect( sorted[ 1 ]!.changesetPath ).toBe( 'path/20240102120000_feature.md' );
+		expect( sorted[ 2 ]!.changesetPath ).toBe( 'path/20240103120000_feature.md' );
+	} );
+
+	it( 'should handle entries with undefined scope as empty array', () => {
+		const entriesWithUndefinedScope = [
+			{
+				...createMockEntry( [ 'core' ], 'path/20240101120000_feature.md' ),
+				data: {
+					...createMockEntry( [ 'core' ], 'path/20240101120000_feature.md' ).data,
+					scope: undefined as any
+				}
+			},
+			createMockEntry( [ 'ui' ], 'path/20240101120000_feature.md' )
+		];
+
+		const sorted = sortEntriesByScopeAndDate( entriesWithUndefinedScope );
+
+		// Entry with undefined scope should be treated as having 0 scopes and come after entry with scope
+		expect( sorted[ 0 ]!.data.scope ).toEqual( [ 'ui' ] );
+		expect( sorted[ 1 ]!.data.scope ).toBeUndefined();
+	} );
+
+	it( 'should handle filenames without date pattern (fallback to current date)', () => {
+		const entries = [
+			createMockEntry( [ 'core' ], 'path/invalid-filename.md' ),
+			createMockEntry( [ 'core' ], 'path/20240101120000_feature.md' )
+		];
+
+		const sorted = sortEntriesByScopeAndDate( entries );
+
+		// Entry with valid date should come first (older date)
+		expect( sorted[ 0 ]!.changesetPath ).toBe( 'path/20240101120000_feature.md' );
+		expect( sorted[ 1 ]!.changesetPath ).toBe( 'path/invalid-filename.md' );
+	} );
+
+	it( 'should handle filenames with invalid date format (fallback to current date)', () => {
+		const entries = [
+			createMockEntry( [ 'core' ], 'path/99999999999999_feature.md' ), // Invalid date
+			createMockEntry( [ 'core' ], 'path/20240101120000_feature.md' )
+		];
+
+		const sorted = sortEntriesByScopeAndDate( entries );
+
+		// Entry with valid date should come first (older date)
+		expect( sorted[ 0 ]!.changesetPath ).toBe( 'path/20240101120000_feature.md' );
+		expect( sorted[ 1 ]!.changesetPath ).toBe( 'path/99999999999999_feature.md' );
+	} );
+
+	it( 'should handle filenames without extension or path separators', () => {
+		const entries = [
+			createMockEntry( [ 'core' ], '20240102120000_feature.md' ),
+			createMockEntry( [ 'core' ], '20240101120000_feature.md' )
+		];
+
+		const sorted = sortEntriesByScopeAndDate( entries );
+
+		expect( sorted[ 0 ]!.changesetPath ).toBe( '20240101120000_feature.md' );
+		expect( sorted[ 1 ]!.changesetPath ).toBe( '20240102120000_feature.md' );
+	} );
+
+	it( 'should handle empty filename (fallback to current date)', () => {
+		const entries = [
+			createMockEntry( [ 'core' ], '' ),
+			createMockEntry( [ 'core' ], 'path/20240101120000_feature.md' )
+		];
+
+		const sorted = sortEntriesByScopeAndDate( entries );
+
+		// Entry with valid date should come first (older date)
+		expect( sorted[ 0 ]!.changesetPath ).toBe( 'path/20240101120000_feature.md' );
+		expect( sorted[ 1 ]!.changesetPath ).toBe( '' );
+	} );
+
+	it( 'should handle mixed scenarios with different scope counts and dates', () => {
+		const entries = [
+			createMockEntry( [ 'ui' ], 'path/20240103120000_feature.md' ),
+			createMockEntry( [ 'core', 'utils', 'engine' ], 'path/20240102120000_feature.md' ),
+			createMockEntry( [ 'core' ], 'path/20240101120000_feature.md' ),
+			createMockEntry( [ 'widget', 'typing' ], 'path/20240104120000_feature.md' ),
+			createMockEntry( [], 'path/20240105120000_feature.md' )
+		];
+
+		const sorted = sortEntriesByScopeAndDate( entries );
+
+		// Order should be:
+		// 1. 3 scopes first
+		// 2. 2 scopes next
+		// 3. 1 scope entries by scope name (core, ui)
+		// 4. 0 scopes last
+		expect( sorted[ 0 ]!.data.scope ).toEqual( [ 'core', 'utils', 'engine' ] );
+		expect( sorted[ 1 ]!.data.scope ).toEqual( [ 'widget', 'typing' ] );
+		expect( sorted[ 2 ]!.data.scope ).toEqual( [ 'core' ] );
+		expect( sorted[ 3 ]!.data.scope ).toEqual( [ 'ui' ] );
+		expect( sorted[ 4 ]!.data.scope ).toEqual( [] );
+	} );
+
+	it( 'should modify the original array (sort mutates)', () => {
+		const entries = [
+			createMockEntry( [ 'ui' ], 'path/20240102120000_feature.md' ),
+			createMockEntry( [ 'core' ], 'path/20240101120000_feature.md' )
+		];
+		const originalEntries = [ ...entries ];
+
+		const sorted = sortEntriesByScopeAndDate( entries );
+
+		// Original array should be modified (Array.sort mutates)
+		expect( entries ).not.toEqual( originalEntries );
+		// Sorted array should be the same reference as original
+		expect( sorted ).toBe( entries );
+		expect( sorted[ 0 ]!.data.scope ).toEqual( [ 'core' ] );
+		expect( sorted[ 1 ]!.data.scope ).toEqual( [ 'ui' ] );
+	} );
+
+	it( 'should handle empty array', () => {
+		const entries: Array<ParsedFile> = [];
+		const sorted = sortEntriesByScopeAndDate( entries );
+
+		expect( sorted ).toEqual( [] );
+	} );
+
+	it( 'should handle single entry', () => {
+		const entries = [
+			createMockEntry( [ 'core' ], 'path/20240101120000_feature.md' )
+		];
+
+		const sorted = sortEntriesByScopeAndDate( entries );
+
+		expect( sorted ).toHaveLength( 1 );
+		expect( sorted[ 0 ]! ).toEqual( entries[ 0 ] );
+	} );
+
+	it( 'should handle entries when all scopes are undefined', () => {
+		const entriesWithUndefinedScopes = [
+			{
+				...createMockEntry( [ 'test' ], 'path/20240102120000_feature.md' ),
+				data: {
+					...createMockEntry( [ 'test' ], 'path/20240102120000_feature.md' ).data,
+					scope: undefined as any
+				}
+			},
+			{
+				...createMockEntry( [ 'test' ], 'path/20240101120000_feature.md' ),
+				data: {
+					...createMockEntry( [ 'test' ], 'path/20240101120000_feature.md' ).data,
+					scope: undefined as any
+				}
+			}
+		];
+
+		const sorted = sortEntriesByScopeAndDate( entriesWithUndefinedScopes );
+
+		// When both scopes are undefined, should fall back to date sorting (older first)
+		expect( sorted[ 0 ]!.changesetPath ).toBe( 'path/20240101120000_feature.md' );
+		expect( sorted[ 1 ]!.changesetPath ).toBe( 'path/20240102120000_feature.md' );
+	} );
+} );

--- a/packages/ckeditor5-dev-changelog/tests/utils/sortentriesbyscopeanddate.ts
+++ b/packages/ckeditor5-dev-changelog/tests/utils/sortentriesbyscopeanddate.ts
@@ -9,7 +9,7 @@ import type { ParsedFile } from '../../src/types.js';
 
 function createMockEntry(
 	scope: Array<string>,
-	dateCreated: Date,
+	createdAt: Date,
 	content: string = 'Test content',
 	gitHubUrl: string = 'https://github.com/test/repo',
 	shouldSkipLinks: boolean = false
@@ -25,7 +25,7 @@ function createMockEntry(
 			validations: []
 		},
 		changesetPath: '',
-		dateCreated,
+		createdAt,
 		gitHubUrl,
 		shouldSkipLinks
 	};
@@ -43,13 +43,13 @@ describe( 'sortEntriesByScopeAndDate()', () => {
 		const sorted = sortEntriesByScopeAndDate( entries );
 
 		expect( sorted[ 0 ]?.data.scope ).toEqual( [ 'core' ] );
-		expect( sorted[ 0 ]?.dateCreated ).toEqual( new Date( 2025, 2, 1, 0, 0, 0, 0 ) );
+		expect( sorted[ 0 ]?.createdAt ).toEqual( new Date( 2025, 2, 1, 0, 0, 0, 0 ) );
 		expect( sorted[ 1 ]?.data.scope ).toEqual( [ 'engine' ] );
-		expect( sorted[ 1 ]?.dateCreated ).toEqual( new Date( 2025, 4, 1, 0, 0, 0, 0 ) );
+		expect( sorted[ 1 ]?.createdAt ).toEqual( new Date( 2025, 4, 1, 0, 0, 0, 0 ) );
 		expect( sorted[ 2 ]?.data.scope ).toEqual( [ 'ui' ] );
-		expect( sorted[ 2 ]?.dateCreated ).toEqual( new Date( 2025, 1, 1, 0, 0, 0, 0 ) );
+		expect( sorted[ 2 ]?.createdAt ).toEqual( new Date( 2025, 1, 1, 0, 0, 0, 0 ) );
 		expect( sorted[ 3 ]?.data.scope ).toEqual( [ 'ui' ] );
-		expect( sorted[ 3 ]?.dateCreated ).toEqual( new Date( 2025, 3, 1, 0, 0, 0, 0 ) );
+		expect( sorted[ 3 ]?.createdAt ).toEqual( new Date( 2025, 3, 1, 0, 0, 0, 0 ) );
 	} );
 
 	it( 'should sort entries with same single scope by date (older first)', () => {
@@ -62,9 +62,9 @@ describe( 'sortEntriesByScopeAndDate()', () => {
 		const sorted = sortEntriesByScopeAndDate( entries );
 
 		expect( sorted ).toHaveLength( 3 );
-		expect( sorted[ 0 ]!.dateCreated ).toEqual( new Date( 2025, 1, 1, 0, 0, 0, 0 ) );
-		expect( sorted[ 1 ]!.dateCreated ).toEqual( new Date( 2025, 2, 1, 0, 0, 0, 0 ) );
-		expect( sorted[ 2 ]!.dateCreated ).toEqual( new Date( 2025, 3, 1, 0, 0, 0, 0 ) );
+		expect( sorted[ 0 ]!.createdAt ).toEqual( new Date( 2025, 1, 1, 0, 0, 0, 0 ) );
+		expect( sorted[ 1 ]!.createdAt ).toEqual( new Date( 2025, 2, 1, 0, 0, 0, 0 ) );
+		expect( sorted[ 2 ]!.createdAt ).toEqual( new Date( 2025, 3, 1, 0, 0, 0, 0 ) );
 	} );
 
 	it( 'should sort entries with same number of scopes by date (older first)', () => {
@@ -76,9 +76,9 @@ describe( 'sortEntriesByScopeAndDate()', () => {
 
 		const sorted = sortEntriesByScopeAndDate( entries );
 
-		expect( sorted[ 0 ]!.dateCreated ).toEqual( new Date( 2025, 1, 1, 0, 0, 0, 0 ) );
-		expect( sorted[ 1 ]!.dateCreated ).toEqual( new Date( 2025, 2, 1, 0, 0, 0, 0 ) );
-		expect( sorted[ 2 ]!.dateCreated ).toEqual( new Date( 2025, 3, 1, 0, 0, 0, 0 ) );
+		expect( sorted[ 0 ]!.createdAt ).toEqual( new Date( 2025, 1, 1, 0, 0, 0, 0 ) );
+		expect( sorted[ 1 ]!.createdAt ).toEqual( new Date( 2025, 2, 1, 0, 0, 0, 0 ) );
+		expect( sorted[ 2 ]!.createdAt ).toEqual( new Date( 2025, 3, 1, 0, 0, 0, 0 ) );
 	} );
 
 	it( 'should sort by number of scopes (more scopes first)', () => {
@@ -106,9 +106,9 @@ describe( 'sortEntriesByScopeAndDate()', () => {
 
 		const sorted = sortEntriesByScopeAndDate( entries );
 
-		expect( sorted[ 0 ]!.dateCreated ).toEqual( new Date( 2025, 1, 1, 0, 0, 0, 0 ) );
-		expect( sorted[ 1 ]!.dateCreated ).toEqual( new Date( 2025, 2, 1, 0, 0, 0, 0 ) );
-		expect( sorted[ 2 ]!.dateCreated ).toEqual( new Date( 2025, 3, 1, 0, 0, 0, 0 ) );
+		expect( sorted[ 0 ]!.createdAt ).toEqual( new Date( 2025, 1, 1, 0, 0, 0, 0 ) );
+		expect( sorted[ 1 ]!.createdAt ).toEqual( new Date( 2025, 2, 1, 0, 0, 0, 0 ) );
+		expect( sorted[ 2 ]!.createdAt ).toEqual( new Date( 2025, 3, 1, 0, 0, 0, 0 ) );
 	} );
 
 	it( 'should handle entries with undefined scope as empty array', () => {
@@ -191,7 +191,7 @@ describe( 'sortEntriesByScopeAndDate()', () => {
 		const sorted = sortEntriesByScopeAndDate( entriesWithUndefinedScopes );
 
 		// When both scopes are undefined, should fall back to date sorting (older first)
-		expect( sorted[ 0 ]!.dateCreated ).toEqual( new Date( 2025, 1, 1, 0, 0, 0, 0 ) );
-		expect( sorted[ 1 ]!.dateCreated ).toEqual( new Date( 2025, 2, 1, 0, 0, 0, 0 ) );
+		expect( sorted[ 0 ]!.createdAt ).toEqual( new Date( 2025, 1, 1, 0, 0, 0, 0 ) );
+		expect( sorted[ 1 ]!.createdAt ).toEqual( new Date( 2025, 2, 1, 0, 0, 0, 0 ) );
 	} );
 } );

--- a/packages/ckeditor5-dev-changelog/tests/utils/validateentry.ts
+++ b/packages/ckeditor5-dev-changelog/tests/utils/validateentry.ts
@@ -26,6 +26,7 @@ vi.mock( '../../src/utils/constants.js', () => {
 function createEntry( data: Record<string, any> ): ParsedFile {
 	return {
 		content: 'Test content',
+		createdAt: new Date(),
 		data: {
 			see: [],
 			closes: [],


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Added sorting entries by date and scope count. Closes ckeditor/ckeditor5#18534.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
