### PR TITLE
Fix changelog entry generation

### DIFF
--- a/.changelog/20250611114035_ck_18665_fix_changelog_generation.md
+++ b/.changelog/20250611114035_ck_18665_fix_changelog_generation.md
@@ -26,4 +26,4 @@ closes:
   - https://github.com/ckeditor/ckeditor5/issues/18665
 ---
 
-Fix changelog entry generation on published version of `dev-changelog` package.
+The template file for the changelog entries generator is included in the published package to avoid issues when using the `ckeditor5-dev-changelog-create-entry` binary script.

--- a/.changelog/20250611114035_ck_18665_fix_changelog_generation.md
+++ b/.changelog/20250611114035_ck_18665_fix_changelog_generation.md
@@ -1,0 +1,29 @@
+---
+# Required: Type of change.
+# Allowed values:
+# - Feature
+# - Fix
+# - Other
+# - Major breaking change
+# - Minor breaking change
+#
+# For guidance on breaking changes, see:
+# https://ckeditor.com/docs/ckeditor5/latest/updating/versioning-policy.html#major-and-minor-breaking-changes
+type: Fix
+
+# Optional: Affected package(s), using short names.
+# Can be skipped when processing a non-mono-repository.
+# Example: ckeditor5-core
+scope:
+  - ckeditor5-dev-changelog
+
+# Optional: Issues this change closes.
+# Format:
+# - {issue-number}
+# - {repo-owner}/{repo-name}#{issue-number}
+# - Full GitHub URL
+closes:
+  - https://github.com/ckeditor/ckeditor5/issues/18665
+---
+
+Fix changelog entry generation on published version of `dev-changelog` package.

--- a/packages/ckeditor5-dev-changelog/package.json
+++ b/packages/ckeditor5-dev-changelog/package.json
@@ -21,7 +21,8 @@
   "types": "dist/index.d.ts",
   "files": [
     "bin",
-    "dist"
+    "dist",
+    "template"
   ],
   "bin": {
     "ckeditor5-dev-changelog-create-entry": "bin/generate-template.js"


### PR DESCRIPTION
### 🚀 Summary

The template file for the changelog entries generator is included in the published package to avoid issues when using the `ckeditor5-dev-changelog-create-entry` binary script.

---

### 📌 Related issues

* Closes ckeditor/ckeditor5#18665.