### PR TITLE
[dev-changelog] Exit when no changelog entries exist

### DIFF
--- a/.changelog/20250616115503_master.md
+++ b/.changelog/20250616115503_master.md
@@ -1,0 +1,43 @@
+---
+# Required: Type of change.
+# Allowed values:
+# - Feature
+# - Fix
+# - Other
+# - Major breaking change
+# - Minor breaking change
+#
+# For guidance on breaking changes, see:
+# https://ckeditor.com/docs/ckeditor5/latest/updating/versioning-policy.html#major-and-minor-breaking-changes
+type: Other
+
+# Optional: Affected package(s), using short names.
+# Can be skipped when processing a non-mono-repository.
+# Example: ckeditor5-core
+scope:
+  - ckeditor5-dev-changelog
+
+# Optional: Issues this change closes.
+# Format:
+# - {issue-number}
+# - {repo-owner}/{repo-name}#{issue-number}
+# - Full GitHub URL
+closes:
+  - ckeditor/ckeditor5#18661
+
+# Optional: Related issues.
+# Format:
+# - {issue-number}
+# - {repo-owner}/{repo-name}#{issue-number}
+# - Full GitHub URL
+see:
+  -
+
+# Optional: Community contributors.
+# Format:
+# - {github-username}
+communityCredits:
+  -
+---
+
+When there are no changelog entries found, the changelog generator script informs about it in the terminal and exits.

--- a/packages/ckeditor5-dev-changelog/src/utils/generatechangelog.ts
+++ b/packages/ckeditor5-dev-changelog/src/utils/generatechangelog.ts
@@ -77,6 +77,14 @@ const main: GenerateChangelogEntryPoint<GenerateChangelogConfig> = async options
 		files: parsedChangesetFiles
 	} );
 
+	// Exit when no changelog entries exist.
+	if ( !parsedChangesetFiles.length ) {
+		logInfo( '' );
+		logInfo( chalk.bold( 'ℹ️  No changelog entries found, so there is nothing to prepare a changelog from.' ) );
+
+		return disableFilesystemOperations ? '' : undefined;
+	}
+
 	// Log changes in the console only when `nextVersion` is not provided.
 	if ( !nextVersion ) {
 		displayChanges( {
@@ -112,6 +120,7 @@ const main: GenerateChangelogEntryPoint<GenerateChangelogConfig> = async options
 		releasedPackagesInfo,
 		sections: filterVisibleSections( sectionsWithEntries )
 	} );
+
 	if ( disableFilesystemOperations ) {
 		return newChangelog as any;
 	}

--- a/packages/ckeditor5-dev-changelog/tests/utils/generatechangelog.ts
+++ b/packages/ckeditor5-dev-changelog/tests/utils/generatechangelog.ts
@@ -40,7 +40,8 @@ vi.mock( '../../src/utils/commitchanges.js' );
 vi.mock( 'chalk', () => ( {
 	default: {
 		green: ( text: string ) => text,
-		red: ( text: string ) => text
+		red: ( text: string ) => text,
+		bold: ( text: string ) => text
 	}
 } ) );
 
@@ -540,6 +541,17 @@ describe( 'generateChangelog()', () => {
 		] );
 	} );
 
+	it( 'displays info if no changelog entries exist and quits', async () => {
+		vi.mocked( parseChangelogEntries ).mockResolvedValue( [] );
+
+		await generateChangelog( defaultOptions );
+
+		expect( logInfo ).toHaveBeenCalledWith( 'ℹ️  No changelog entries found, so there is nothing to prepare a changelog from.' );
+
+		expect( modifyChangelog ).not.toHaveBeenCalled();
+		expect( commitChanges ).not.toHaveBeenCalled();
+	} );
+
 	describe( 'disableFilesystemOperations=true', () => {
 		it( 'returns the changelog instead of writing to a file when in `disableFilesystemOperations=true` mode', async () => {
 			await expect( generateChangelog( { ...defaultOptions, disableFilesystemOperations: true } ) )
@@ -553,6 +565,13 @@ describe( 'generateChangelog()', () => {
 			await generateChangelog( { ...defaultOptions, disableFilesystemOperations: true } );
 
 			expect( commitChanges ).toHaveBeenCalledTimes( 0 );
+		} );
+
+		it( 'returns empty string if no changelog entries exist in `disableFilesystemOperations=true` mode', async () => {
+			vi.mocked( parseChangelogEntries ).mockResolvedValue( [] );
+
+			await expect( generateChangelog( { ...defaultOptions, disableFilesystemOperations: true } ) )
+				.resolves.toEqual( '' );
 		} );
 	} );
 


### PR DESCRIPTION
<!--

This repository uses Markdown files to define changelog entries. If the changes in this pull request are **user-facing**, please create a changelog entry by running the following command:

    yarn nice

This will generate a `*.md` file in the `.changelog/` directory for your description. You can create as many as you need.

**Note:**  
If your PR is internal-only (e.g., tests, tooling, docs), you can skip this step - just mention it below.

-->

### 🚀 Summary

When there are no changelog entries found, the changelog generator script informs about it in the terminal and exits.

---

### 📌 Related issues

<!--

Although changelog entries list connected issues, GitHub requires listing them here to automatically link and close them.

-->

* Closes ckeditor/ckeditor5#18661

---

### 💡 Additional information

Output when there are no changelog entries:

```
$ yarn release:prepare-changelog
yarn run v1.22.22
$ node ./scripts/preparechangelog.js
(node:13012) ExperimentalWarning: Importing JSON modules is an experimental feature and might change at any time
(Use `node --trace-warnings ...` to show where the warning was created)

ℹ️  No changelog entries found, so there is nothing to prepare a changelog from.
Done in 2.19s.
```

Output when there is at least one changelog entry:

```
$ yarn release:prepare-changelog
yarn run v1.22.22
$ node ./scripts/preparechangelog.js
(node:12500) ExperimentalWarning: Importing JSON modules is an experimental feature and might change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
○ Listing the changes...
   ◌ Other changes:
      + changelog: When there are no changelog entries found, the changelog generator prints a message and exits.

   ◌ Legend:
      - Entries marked with + symbol are included in the changelog.
      - Entries marked with x symbol include invalid references (see and/or closes) or scope definitions. Please ensure that:
         * Reference entries match one of the following formats:
            1. An issue number (e.g., 1000)
            2. Repository-slug#id (e.g., org/repo#1000)
            3. A full issue link URL
         * A scope field consists of existing packages.

   Found 1 entries to parse.

○ Determining the new version...
? Type the new version (current: "50.1.1", suggested: "50.1.2", or "internal" for internal changes):
```
