### PR TITLE
Downgrade `@rollup/plugin-typescript` to version `12.1.2` to fix failing builds

### DIFF
--- a/.changelog/20250618112811_ck_18731_downgrade_rollup_plugin_typescript.md
+++ b/.changelog/20250618112811_ck_18731_downgrade_rollup_plugin_typescript.md
@@ -1,0 +1,9 @@
+---
+type: Fix
+
+closes:
+  - https://github.com/ckeditor/ckeditor5/issues/18731
+
+---
+
+Downgrade `@rollup/plugin-typescript` to version `12.1.2` to fix failing builds.

--- a/packages/ckeditor5-dev-build-tools/package.json
+++ b/packages/ckeditor5-dev-build-tools/package.json
@@ -32,7 +32,7 @@
     "@rollup/plugin-node-resolve": "^16.0.1",
     "@rollup/plugin-swc": "^0.4.0",
     "@rollup/plugin-terser": "^0.4.4",
-    "@rollup/plugin-typescript": "^12.1.2",
+    "@rollup/plugin-typescript": "12.1.2",
     "@rollup/pluginutils": "^5.1.0",
     "@swc/core": "^1.4.8",
     "chalk": "^5.0.0",

--- a/packages/ckeditor5-dev-changelog/package.json
+++ b/packages/ckeditor5-dev-changelog/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^16.0.1",
-    "@rollup/plugin-typescript": "^12.1.2",
+    "@rollup/plugin-typescript": "12.1.2",
     "@types/fs-extra": "^11.0.4",
     "@vitest/coverage-v8": "^3.1.1",
     "rollup": "^4.9.5",

--- a/packages/ckeditor5-dev-utils/package.json
+++ b/packages/ckeditor5-dev-utils/package.json
@@ -53,7 +53,7 @@
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^16.0.1",
-    "@rollup/plugin-typescript": "^12.1.2",
+    "@rollup/plugin-typescript": "12.1.2",
     "@types/fs-extra": "^11.0.4",
     "@types/pacote": "^11.1.8",
     "@vitest/coverage-v8": "^3.1.1",

--- a/packages/ckeditor5-dev-web-crawler/package.json
+++ b/packages/ckeditor5-dev-web-crawler/package.json
@@ -35,7 +35,7 @@
   "devDependencies": {
     "@rollup/plugin-commonjs": "^28.0.3",
     "@rollup/plugin-node-resolve": "^16.0.1",
-    "@rollup/plugin-typescript": "^12.1.2",
+    "@rollup/plugin-typescript": "12.1.2",
     "rollup": "^4.9.5",
     "typescript": "5.0.4",
     "upath": "^2.0.1"

--- a/packages/typedoc-plugins/package.json
+++ b/packages/typedoc-plugins/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "@rollup/plugin-commonjs": "^28.0.3",
     "@rollup/plugin-node-resolve": "^16.0.1",
-    "@rollup/plugin-typescript": "^12.1.2",
+    "@rollup/plugin-typescript": "12.1.2",
     "glob": "^11.0.2",
     "rollup": "^4.9.5",
     "typedoc": "0.28.5",


### PR DESCRIPTION
### 📌 Related issues

* Closes ckeditor/ckeditor5#18731.
