### PR TITLE
Added validation for a username provided in the community contributors section

### DIFF
--- a/.changelog/20250618122716_ck_18670.md
+++ b/.changelog/20250618122716_ck_18670.md
@@ -1,0 +1,43 @@
+---
+# Required: Type of change.
+# Allowed values:
+# - Feature
+# - Fix
+# - Other
+# - Major breaking change
+# - Minor breaking change
+#
+# For guidance on breaking changes, see:
+# https://ckeditor.com/docs/ckeditor5/latest/updating/versioning-policy.html#major-and-minor-breaking-changes
+type: Fix
+
+# Optional: Affected package(s), using short names.
+# Can be skipped when processing a non-mono-repository.
+# Example: ckeditor5-core
+scope:
+  - ckeditor5-dev-changelog
+
+# Optional: Issues this change closes.
+# Format:
+# - {issue-number}
+# - {repo-owner}/{repo-name}#{issue-number}
+# - Full GitHub URL
+closes:
+  - ckeditor/ckeditor5#18670
+
+# Optional: Related issues.
+# Format:
+# - {issue-number}
+# - {repo-owner}/{repo-name}#{issue-number}
+# - Full GitHub URL
+see:
+  -
+
+# Optional: Community contributors.
+# Format:
+# - {github-username}
+communityCredits:
+  -
+---
+
+Added validation for a username provided in the community contributors section.

--- a/packages/ckeditor5-dev-changelog/src/utils/constants.ts
+++ b/packages/ckeditor5-dev-changelog/src/utils/constants.ts
@@ -45,6 +45,8 @@ export const ISSUE_PATTERN = /^\d+$/;
 export const ISSUE_URL_PATTERN =
 	/^(?<base>https:\/\/github\.com)\/(?<owner>[a-z0-9.-]+)\/(?<repository>[a-z0-9.-]+)\/issues\/(?<number>\d+)$/;
 
+export const NICK_NAME_PATTERN = /^@[a-z0-9-_]+$/i;
+
 export const TYPES = [
 	{ name: 'Feature' },
 	{ name: 'Other' },

--- a/packages/ckeditor5-dev-changelog/src/utils/validateentry.ts
+++ b/packages/ckeditor5-dev-changelog/src/utils/validateentry.ts
@@ -4,7 +4,7 @@
  */
 
 import type { ParsedFile } from '../types.js';
-import { ISSUE_PATTERN, ISSUE_SLUG_PATTERN, ISSUE_URL_PATTERN, TYPES } from './constants.js';
+import { ISSUE_PATTERN, ISSUE_SLUG_PATTERN, ISSUE_URL_PATTERN, NICK_NAME_PATTERN, TYPES } from './constants.js';
 
 /**
  * Validates a changelog entry against expected types, scopes, and issue references.
@@ -99,6 +99,18 @@ export function validateEntry( entry: ParsedFile, packagesNames: Array<string>, 
 	}
 
 	data.closes = closesValidated;
+
+	const communityCreditsValidated = [];
+
+	for ( const nickName of data.communityCredits ) {
+		if ( !nickName.match( NICK_NAME_PATTERN ) ) {
+			validations.push( `Community username "${ nickName }" is not valid GitHub username.` );
+		} else {
+			communityCreditsValidated.push( nickName );
+		}
+	}
+
+	data.communityCredits = communityCreditsValidated;
 
 	const validatedEntry = {
 		...entry,


### PR DESCRIPTION
<!--

This repository uses Markdown files to define changelog entries. If the changes in this pull request are **user-facing**, please create a changelog entry by running the following command:

    yarn nice

This will generate a `*.md` file in the `.changelog/` directory for your description. You can create as many as you need.

**Note:**  
If your PR is internal-only (e.g., tests, tooling, docs), you can skip this step - just mention it below.

-->

### 🚀 Summary

Added validation for a username provided in the community contributors section.

If invalid username is detected, warning is printed in the terminal, but the changeset is still marked as valid. Invalid usernames are filtered out.

---

### 📌 Related issues

<!--

Although changelog entries list connected issues, GitHub requires listing them here to automatically link and close them.

-->

* Closes ckeditor/ckeditor5#18670.

---

### 💡 Additional information

GitHub defined some rules for valid usernames:
- Usernames for user accounts on GitHub can only contain alphanumeric characters and hyphen (`-`).
- Usernames cannot begin or end with a hyphen.
- Usernames cannot contain consecutive hyphens (i.e., `--`).
- Maximum length is 39 characters.

But:
- Even though the underscore `_` character is **not allowed**, [there are cases](https://docs.github.com/en/enterprise-cloud@latest/admin/managing-iam/iam-configuration-reference/username-considerations-for-external-authentication#examples-of-username-normalization) when it is used for a username.
- Also, it looks like there are some old accounts on GitHub that break these rules:
    - https://github.com/0----0
    - https://github.com/-Jerry-

Hence, I decided to simplify the logic that validates the usernames.