### PR TITLE
Ensure to exit the build process once Rollup is done

### DIFF
--- a/packages/ckeditor5-dev-build-tools/package.json
+++ b/packages/ckeditor5-dev-build-tools/package.json
@@ -63,7 +63,7 @@
     "vitest": "^3.1.1"
   },
   "scripts": {
-    "build": "rollup -c rollup.config.js",
+    "build": "rollup -c rollup.config.js --forceExit",
     "dev": "rollup -c rollup.config.js --watch",
     "test": "vitest run --config vitest.config.ts",
     "coverage": "vitest run --config vitest.config.ts --coverage",

--- a/packages/ckeditor5-dev-changelog/package.json
+++ b/packages/ckeditor5-dev-changelog/package.json
@@ -48,7 +48,7 @@
     "vitest": "^3.1.1"
   },
   "scripts": {
-    "build": "rollup -c rollup.config.js",
+    "build": "rollup -c rollup.config.js --forceExit",
     "dev": "rollup -c rollup.config.js --watch",
     "test": "vitest run --config vitest.config.ts",
     "coverage": "vitest run --config vitest.config.ts --coverage",

--- a/packages/ckeditor5-dev-utils/package.json
+++ b/packages/ckeditor5-dev-utils/package.json
@@ -63,7 +63,7 @@
     "vitest": "^3.1.1"
   },
   "scripts": {
-    "build": "rollup -c rollup.config.js",
+    "build": "rollup -c rollup.config.js --forceExit",
     "dev": "rollup -c rollup.config.js --watch",
     "test": "vitest run --config vitest.config.ts",
     "coverage": "vitest run --config vitest.config.ts --coverage",

--- a/packages/ckeditor5-dev-web-crawler/package.json
+++ b/packages/ckeditor5-dev-web-crawler/package.json
@@ -24,7 +24,7 @@
   ],
   "scripts": {
     "types": "tsc --noEmit",
-    "build": "rollup -c rollup.config.js",
+    "build": "rollup -c rollup.config.js --forceExit",
     "dev": "rollup -c rollup.config.js --watch"
   },
   "dependencies": {

--- a/packages/typedoc-plugins/package.json
+++ b/packages/typedoc-plugins/package.json
@@ -40,7 +40,7 @@
     "typedoc": "0.28.5"
   },
   "scripts": {
-    "build": "rollup -c rollup.config.js",
+    "build": "rollup -c rollup.config.js --forceExit",
     "dev": "rollup -c rollup.config.js --watch",
     "test": "vitest run --config vitest.config.ts",
     "coverage": "vitest run --config vitest.config.ts --coverage",


### PR DESCRIPTION
<!--

This repository uses Markdown files to define changelog entries. If the changes in this pull request are **user-facing**, please create a changelog entry by running the following command:

    yarn nice

This will generate a `*.md` file in the `.changelog/` directory for your description. You can create as many as you need.

**Note:**  
If your PR is internal-only (e.g., tests, tooling, docs), you can skip this step - just mention it below.

-->

### 🚀 Summary

Introduced a fix in all TypeScript packages to ensure to exit the build process once Rollup is done. Previously, building two dependent packages could end up hanging the build process.

---

### 📌 Related issues

<!--

Although changelog entries list connected issues, GitHub requires listing them here to automatically link and close them.

-->

* Closes ckeditor/ckeditor5#18668

---

### 💡 Additional information

I checked the generated `dist` directories in all TypeScript packages before and after this change. They all are the same so I assume `--forceExit` does not break or change the builds.
