### PR TITLE
Bump Node.js to v22 in `ckeditor5-dev-changelog`

### DIFF
--- a/.changelog/20250623122528_bump_node.md
+++ b/.changelog/20250623122528_bump_node.md
@@ -1,0 +1,43 @@
+---
+# Required: Type of change.
+# Allowed values:
+# - Feature
+# - Fix
+# - Other
+# - Major breaking change
+# - Minor breaking change
+#
+# For guidance on breaking changes, see:
+# https://ckeditor.com/docs/ckeditor5/latest/updating/versioning-policy.html#major-and-minor-breaking-changes
+type: Other
+
+# Optional: Affected package(s), using short names.
+# Can be skipped when processing a non-mono-repository.
+# Example: ckeditor5-core
+scope:
+  - ckeditor5-dev-changelog
+
+# Optional: Issues this change closes.
+# Format:
+# - {issue-number}
+# - {repo-owner}/{repo-name}#{issue-number}
+# - Full GitHub URL
+closes:
+  -
+
+# Optional: Related issues.
+# Format:
+# - {issue-number}
+# - {repo-owner}/{repo-name}#{issue-number}
+# - Full GitHub URL
+see:
+  - ckeditor/ckeditor5#18500
+
+# Optional: Community contributors.
+# Format:
+# - {github-username}
+communityCredits:
+  -
+---
+
+Corrected an inconsistency in supported Node.js versions and set the minimum Node.js version to 22.

--- a/packages/ckeditor5-dev-changelog/package.json
+++ b/packages/ckeditor5-dev-changelog/package.json
@@ -13,7 +13,7 @@
     "directory": "packages/ckeditor5-dev-changelog"
   },
   "engines": {
-    "node": ">=20.0.0",
+    "node": ">=22.0.0",
     "npm": ">=5.7.1"
   },
   "type": "module",


### PR DESCRIPTION
<!--

This repository uses Markdown files to define changelog entries. If the changes in this pull request are **user-facing**, please create a changelog entry by running the following command:

    yarn nice

This will generate a `*.md` file in the `.changelog/` directory for your description. You can create as many as you need.

**Note:**  
If your PR is internal-only (e.g., tests, tooling, docs), you can skip this step - just mention it below.

-->

### 🚀 Summary

Corrected an inconsistency in supported Node.js versions in `ckeditor5-dev` monorepo and set the minimum Node.js version to v22.

---

### 📌 Related issues

<!--

Although changelog entries list connected issues, GitHub requires listing them here to automatically link and close them.

-->

* See ckeditor/ckeditor5#18500.

---

### 💡 Additional information

*Optional: Notes on decisions, edge cases, or anything helpful for reviewers.*
