### PR TITLE
Add support for importing raw file content by appending `?raw` query parameter to the import path.

### DIFF
--- a/.changelog/20250625125147_ck_18745_add_support_for_raw_query_params_master.md
+++ b/.changelog/20250625125147_ck_18745_add_support_for_raw_query_params_master.md
@@ -1,0 +1,11 @@
+---
+type: Feature
+
+scope:
+  - ckeditor5-dev-build-tools
+
+see:
+  - https://github.com/ckeditor/ckeditor5/issues/18745
+---
+
+Add support for importing raw file content by appending `?raw` query parameter to import path.

--- a/packages/ckeditor5-dev-build-tools/src/config.ts
+++ b/packages/ckeditor5-dev-build-tools/src/config.ts
@@ -23,6 +23,7 @@ import typescriptPlugin from '@rollup/plugin-typescript';
 import { nodeResolve } from '@rollup/plugin-node-resolve';
 import { addBanner } from './plugins/banner.js';
 import { emitCss } from './plugins/emitCss.js';
+import { rawImport } from './plugins/rawImport.js';
 import { replaceImports } from './plugins/replace.js';
 import { splitCss } from './plugins/splitCss.js';
 import { loadTypeScriptSources } from './plugins/loadSources.js';
@@ -117,6 +118,11 @@ export async function getRollupConfig( options: BuildOptions ): Promise<RollupOp
 		},
 
 		plugins: [
+			/**
+			 * Allows importing raw file content using the `?raw` query parameter in the import path.
+			 */
+			rawImport(),
+
 			/**
 			 * Ensures that `.ts` files are loaded over `.js` files if both exist.
 			 */

--- a/packages/ckeditor5-dev-build-tools/src/index.ts
+++ b/packages/ckeditor5-dev-build-tools/src/index.ts
@@ -8,6 +8,7 @@ export { addBanner, type RollupBannerOptions } from './plugins/banner.js';
 export { emitCss, type RollupEmitCssOptions } from './plugins/emitCss.js';
 export { loadSourcemaps } from './plugins/loadSourcemaps.js';
 export { loadTypeScriptSources } from './plugins/loadSources.js';
+export { rawImport } from './plugins/rawImport.js';
 export { replaceImports, type RollupReplaceOptions } from './plugins/replace.js';
 export { splitCss, type RollupSplitCssOptions } from './plugins/splitCss.js';
 export { translations, type RollupTranslationsOptions } from './plugins/translations.js';

--- a/packages/ckeditor5-dev-build-tools/src/plugins/rawImport.ts
+++ b/packages/ckeditor5-dev-build-tools/src/plugins/rawImport.ts
@@ -1,0 +1,40 @@
+/**
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+import fs from 'fs';
+import { resolve, dirname } from 'path';
+import type { Plugin } from 'rollup';
+
+/**
+ * Allows importing raw file content using the `?raw` query parameter.
+ */
+export function rawImport(): Plugin {
+	const rawRE = /[?&]raw\b/;
+
+	return {
+		name: 'cke5-raw-import',
+
+		resolveId( source, importer ) {
+			if ( !importer || !rawRE.test( source ) ) {
+				return null;
+			}
+
+			const cleaned = source.replace( rawRE, '' );
+
+			return resolve( dirname( importer ), cleaned ) + '?raw';
+		},
+
+		load( id ) {
+			if ( !rawRE.test( id ) ) {
+				return null;
+			}
+
+			const [ path ] = id.split( '?' );
+			const content = fs.readFileSync( path!, 'utf-8' );
+
+			return `export default ${ JSON.stringify( content ) };`;
+		}
+	};
+}

--- a/packages/ckeditor5-dev-build-tools/tests/plugins/rawImport/fixtures/dependency.css
+++ b/packages/ckeditor5-dev-build-tools/tests/plugins/rawImport/fixtures/dependency.css
@@ -1,0 +1,8 @@
+/**
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+.ck {
+	color: red;
+}

--- a/packages/ckeditor5-dev-build-tools/tests/plugins/rawImport/fixtures/dependency.js
+++ b/packages/ckeditor5-dev-build-tools/tests/plugins/rawImport/fixtures/dependency.js
@@ -1,0 +1,6 @@
+/**
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+export const test = 123;

--- a/packages/ckeditor5-dev-build-tools/tests/plugins/rawImport/fixtures/dependency.txt
+++ b/packages/ckeditor5-dev-build-tools/tests/plugins/rawImport/fixtures/dependency.txt
@@ -1,0 +1,1 @@
+Hello World!

--- a/packages/ckeditor5-dev-build-tools/tests/plugins/rawImport/fixtures/input.js
+++ b/packages/ckeditor5-dev-build-tools/tests/plugins/rawImport/fixtures/input.js
@@ -1,0 +1,12 @@
+/**
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+import style from './dependency.css?raw';
+import script from './dependency.js?raw';
+import text from './dependency.txt?raw';
+
+console.log( style );
+console.log( script );
+console.log( text );

--- a/packages/ckeditor5-dev-build-tools/tests/plugins/rawImport/rawImport.test.ts
+++ b/packages/ckeditor5-dev-build-tools/tests/plugins/rawImport/rawImport.test.ts
@@ -1,0 +1,43 @@
+/**
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+import upath from 'upath';
+import { test } from 'vitest';
+import { rollup, type RollupOutput } from 'rollup';
+import { verifyChunk } from '../../_utils/utils.js';
+
+import { rawImport } from '../../../src/index.js';
+
+/**
+ * Helper function for creating a bundle that won't be written to the file system.
+ */
+async function generateBundle(): Promise<RollupOutput['output']> {
+	const bundle = await rollup( {
+		input: upath.join( import.meta.dirname, '/fixtures/input.js' ),
+		plugins: [
+			rawImport()
+		]
+	} );
+
+	const { output } = await bundle.generate( {
+		format: 'esm',
+		file: 'input.js'
+	} );
+
+	return output;
+}
+
+test( 'can import raw file content using the `?raw` query parameter', async () => {
+	const output = await generateBundle();
+
+	// Content from `dependency.css` file.
+	verifyChunk( output, 'input.js', 'color: red;' );
+
+	// Content from `dependency.js` file.
+	verifyChunk( output, 'input.js', 'const test = 123;' );
+
+	// Content from `dependency.txt` file.
+	verifyChunk( output, 'input.js', 'Hello World!' );
+} );


### PR DESCRIPTION
### 🚀 Summary

Add support for importing raw file content by appending `?raw` query parameter to the import path.

---

### 📌 Related issues

See https://github.com/ckeditor/ckeditor5/issues/18745