### PR TITLE
Use `cimg/node:lts` Docker image instead of machine executor

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,8 @@ commands:
 
 jobs:
   generate_configuration:
-    machine: true
+    docker:
+      - image: cimg/node:lts
     steps:
       - checkout
       - install_ssh_keys_command


### PR DESCRIPTION
### 🚀 Summary

Use `cimg/node:lts` Docker image instead of machine executor

---

### 💡 Additional information

This change aims to fix the error `The engine "node" is incompatible with this module. Expected version "^20.19.0 || >=22.12.0". Got "22.11.0"`
