### PR TITLE
Add the `timeout` configuration option to the `runCrawler` function

### DIFF
--- a/.changelog/20250627134956_commercial_7977_expose_timeout_option.md
+++ b/.changelog/20250627134956_commercial_7977_expose_timeout_option.md
@@ -1,0 +1,8 @@
+---
+type: Feature
+
+scope:
+  - ckeditor5-dev-web-crawler
+---
+
+Add `timeout` configuration option to the `runCrawler` function and export the `DEFAULT_TIMEOUT` variable.

--- a/.changelog/20250627134956_commercial_7977_expose_timeout_option.md
+++ b/.changelog/20250627134956_commercial_7977_expose_timeout_option.md
@@ -5,4 +5,4 @@ scope:
   - ckeditor5-dev-web-crawler
 ---
 
-Add `timeout` configuration option to the `runCrawler` function and export the `DEFAULT_TIMEOUT` variable.
+Add the `timeout` configuration option to the `runCrawler` function and export the `DEFAULT_TIMEOUT` variable.

--- a/packages/ckeditor5-dev-web-crawler/src/index.ts
+++ b/packages/ckeditor5-dev-web-crawler/src/index.ts
@@ -7,4 +7,4 @@
 
 export { default as runCrawler } from './runcrawler.js';
 export { getBaseUrl, isUrlValid, toArray } from './utils.js';
-export { DEFAULT_CONCURRENCY } from './constants.js';
+export { DEFAULT_CONCURRENCY, DEFAULT_TIMEOUT } from './constants.js';

--- a/packages/ckeditor5-dev-web-crawler/src/runcrawler.ts
+++ b/packages/ckeditor5-dev-web-crawler/src/runcrawler.ts
@@ -47,6 +47,13 @@ interface CrawlerOptions {
 	exclusions?: Array<string>;
 
 	/**
+	 * Timeout in milliseconds after which the crawler will stop crawling the page. 15 seconds by default.
+	 *
+	 * @default 15000
+	 */
+	timeout?: number;
+
+	/**
 	 * Number of concurrent pages (browser tabs) to be used during crawling. One by default.
 	 *
 	 * @default Half of the number of CPU cores.
@@ -102,6 +109,7 @@ export default async function runCrawler( options: CrawlerOptions ): Promise<voi
 		url,
 		depth = Infinity,
 		exclusions = [],
+		timeout = DEFAULT_TIMEOUT,
 		concurrency = DEFAULT_CONCURRENCY,
 		disableBrowserSandbox = false,
 		ignoreHTTPSErrors = false,
@@ -141,7 +149,7 @@ export default async function runCrawler( options: CrawlerOptions ): Promise<voi
 
 	const cluster: Cluster<QueueData, void> = await Cluster.launch( {
 		concurrency: Cluster.CONCURRENCY_PAGE,
-		timeout: DEFAULT_TIMEOUT,
+		timeout,
 		retryLimit: DEFAULT_REMAINING_ATTEMPTS,
 		maxConcurrency: concurrency,
 		puppeteerOptions,


### PR DESCRIPTION
### 🚀 Summary

Add the `timeout` configuration option to the `runCrawler` function and export the `DEFAULT_TIMEOUT` variable.

---

### 💡 Additional information

I'm testing whether we can use Docker executors instead of Machine executors in CircleCI, but I get timeouts on one of the heavy manual tests focused on testing performance. Currently, there is no way to override the default 15s timeout.
