### PR TITLE
Bump a major version when processing a single repo and BREAKING CHANGE

### DIFF
--- a/.changelog/20250702151707_ck_18772_bc_major.md
+++ b/.changelog/20250702151707_ck_18772_bc_major.md
@@ -1,0 +1,9 @@
+---
+type: Fix
+scope:
+  - ckeditor5-dev-changelog 
+closes:
+  - https://github.com/ckeditor/ckeditor5/issues/18772
+---
+
+The `generateChangelogForSingleRepository()` task suggests bumping the major version when detecting a "BREAKING CHANGE" entry.

--- a/packages/ckeditor5-dev-changelog/src/utils/determinenextversion.ts
+++ b/packages/ckeditor5-dev-changelog/src/utils/determinenextversion.ts
@@ -51,12 +51,10 @@ export async function determineNextVersion( options: DetermineNextVersionOptions
 
 	let bumpType: ReleaseType = 'patch';
 
-	if ( sections.minor.entries.length || sections.feature.entries.length ) {
-		bumpType = 'minor';
-	}
-
-	if ( sections.major.entries.length ) {
+	if ( sections.major.entries.length || sections.breaking.entries.length ) {
 		bumpType = 'major';
+	} else if ( sections.minor.entries.length || sections.feature.entries.length ) {
+		bumpType = 'minor';
 	}
 
 	const areErrorsPresent = !!sections.invalid.entries.length;

--- a/packages/ckeditor5-dev-changelog/tests/utils/determinenextversion.ts
+++ b/packages/ckeditor5-dev-changelog/tests/utils/determinenextversion.ts
@@ -78,7 +78,7 @@ describe( 'determineNextVersion()', () => {
 		expect( mockedLogInfo ).toHaveBeenCalledWith( `○ ${ chalk.cyan( 'Determining the new version...' ) }` );
 	} );
 
-	it( 'should return a patch version when there are no minor, major, or feature entries', async () => {
+	it( 'should return a patch bump version when there are no breaking changes or feature entries', async () => {
 		mockedProvideNewVersion.mockResolvedValueOnce( '1.0.1' );
 
 		const result = await determineNextVersion( options );
@@ -104,11 +104,11 @@ describe( 'determineNextVersion()', () => {
 		expect( mockedLogInfo ).toHaveBeenCalledWith( `○ ${ chalk.cyan( 'Determined the next version to be 50.0.0.' ) }` );
 	} );
 
-	it( 'should return a minor version when minor entries are present', async () => {
+	it( 'should return a minor bump version when "MINOR BREAKING CHANGE" entries are present', async () => {
 		mockedProvideNewVersion.mockResolvedValueOnce( '1.1.0' );
 
 		options.sections = createSectionsWithEntries(
-			{ minor: { entries: [ createEntry( 'Some minor change' ) ], title: 'Minor Breaking Changes' } }
+			{ minor: { entries: [ createEntry( 'Minor breaking change' ) ], title: 'Minor Breaking Changes' } }
 		);
 
 		const result = await determineNextVersion( options );
@@ -123,7 +123,7 @@ describe( 'determineNextVersion()', () => {
 		} );
 	} );
 
-	it( 'should return a minor version when Feature entries are present', async () => {
+	it( 'should return a minor bump version when Feature entries are present', async () => {
 		mockedProvideNewVersion.mockResolvedValueOnce( '1.1.0' );
 
 		options.sections = createSectionsWithEntries(
@@ -142,11 +142,11 @@ describe( 'determineNextVersion()', () => {
 		} );
 	} );
 
-	it( 'should return a major version when major entries are present', async () => {
+	it( 'should return a major bump version when "BREAKING CHANGE" entries are present', async () => {
 		mockedProvideNewVersion.mockResolvedValueOnce( '2.0.0' );
 
 		options.sections = createSectionsWithEntries(
-			{ major: { entries: [ createEntry( 'Breaking change' ) ], title: 'Major Breaking Changes' } }
+			{ breaking: { entries: [ createEntry( 'Breaking change' ) ], title: 'Major Breaking Changes' } }
 		);
 
 		const result = await determineNextVersion( options );
@@ -161,7 +161,26 @@ describe( 'determineNextVersion()', () => {
 		} );
 	} );
 
-	it( 'should prioritize major version even if minor and feature entries are present', async () => {
+	it( 'should return a major bump version when "MAJOR BREAKING CHANGE" entries are present', async () => {
+		mockedProvideNewVersion.mockResolvedValueOnce( '2.0.0' );
+
+		options.sections = createSectionsWithEntries(
+			{ major: { entries: [ createEntry( 'Major breaking change' ) ], title: 'Major Breaking Changes' } }
+		);
+
+		const result = await determineNextVersion( options );
+
+		expect( result.newVersion ).toBe( '2.0.0' );
+		expect( result.isInternal ).toBe( false );
+		expect( mockedProvideNewVersion ).toHaveBeenCalledWith( {
+			version: '1.0.0',
+			packageName: 'test-package',
+			bumpType: 'major',
+			displayValidationWarning: false
+		} );
+	} );
+
+	it( 'should prioritize "MAJOR BREAKING CHANGE" version even if "MINOR BREAKING CHANGES" and feature entries are present', async () => {
 		mockedProvideNewVersion.mockResolvedValueOnce( '2.0.0' );
 
 		options.sections = createSectionsWithEntries( {


### PR DESCRIPTION
<!--

This repository uses Markdown files to define changelog entries. If the changes in this pull request are **user-facing**, please create a changelog entry by running the following command:

    yarn nice

This will generate a `*.md` file in the `.changelog/` directory for your description. You can create as many as you need.

**Note:**  
If your PR is internal-only (e.g., tests, tooling, docs), you can skip this step - just mention it below.

-->

### 🚀 Summary

This PR improves the detection of an upcoming release version when processing a "Breaking change" entry within a single repository.

---

### 📌 Related issues

<!--

Although changelog entries list connected issues, GitHub requires listing them here to automatically link and close them.

-->

* Closes https://github.com/ckeditor/ckeditor5/issues/18772.

---

### 💡 Additional information

**I checked it on Umberto:**
	![image](https://github.com/user-attachments/assets/66b35ff0-8265-4c83-865e-cfa9105d52de)
	It works the same if an entry is specified as a major or minor breaking change.

**A mono-repo is not affected:**

* Type: `breaking change`
	![image](https://github.com/user-attachments/assets/e3ca5bfe-d00a-4737-b62f-11a53106ad70)

* Type `minor bc`
	![image](https://github.com/user-attachments/assets/1baf5b08-d843-4da2-a339-3ddb2476c2bc)

* Type `major bc`
	![image](https://github.com/user-attachments/assets/211e76f1-15f2-4f26-aa4f-60d59db2792f)
	
