### PR TITLE
Bumped TypeDoc to the latest version v0.28.9

### DIFF
--- a/.changelog/20250805131318_ck_18905.md
+++ b/.changelog/20250805131318_ck_18905.md
@@ -1,0 +1,46 @@
+---
+# Required: Type of change.
+# Allowed values:
+# - Feature
+# - Fix
+# - Other
+# - Major breaking change
+# - Minor breaking change
+#
+# For guidance on breaking changes, see:
+# https://ckeditor.com/docs/ckeditor5/latest/updating/versioning-policy.html#major-and-minor-breaking-changes
+type: Other
+
+# Optional: Affected package(s), using short names.
+# Leave empty when used in a single-package repository.
+# Example: ckeditor5-core
+scope:
+  - ckeditor5-dev-docs
+  - typedoc-plugins
+
+# Optional: Issues this change closes.
+# Format:
+# - {issue-number}
+# - {repo-owner}/{repo-name}#{issue-number}
+# - Full GitHub URL
+closes:
+  - https://github.com/ckeditor/ckeditor5/issues/18905
+
+# Optional: Related issues.
+# Format:
+# - {issue-number}
+# - {repo-owner}/{repo-name}#{issue-number}
+# - Full GitHub URL
+see:
+  -
+
+# Optional: Community contributors.
+# Format:
+# - {github-username}
+communityCredits:
+  -
+
+# Before committing, consider removing all comments to reduce file size and enhance readability.
+---
+
+Bumped TypeDoc to the latest version: v0.28.9.

--- a/packages/ckeditor5-dev-docs/package.json
+++ b/packages/ckeditor5-dev-docs/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@ckeditor/typedoc-plugins": "^50.3.1",
     "glob": "^11.0.2",
-    "typedoc": "0.28.5",
+    "typedoc": "0.28.9",
     "typedoc-plugin-rename-defaults": "^0.7.3",
     "upath": "^2.0.1"
   },

--- a/packages/typedoc-plugins/package.json
+++ b/packages/typedoc-plugins/package.json
@@ -31,13 +31,13 @@
     "@rollup/plugin-typescript": "12.1.2",
     "glob": "^11.0.2",
     "rollup": "^4.9.5",
-    "typedoc": "0.28.5",
+    "typedoc": "0.28.9",
     "typedoc-plugin-rename-defaults": "^0.7.3",
     "typescript": "5.0.4",
     "vitest": "^3.1.1"
   },
   "peerDependencies": {
-    "typedoc": "0.28.5"
+    "typedoc": "0.28.9"
   },
   "scripts": {
     "build": "rollup -c rollup.config.js --forceExit",


### PR DESCRIPTION
<!--

This repository uses Markdown files to define changelog entries. If the changes in this pull request are **user-facing**, please create a changelog entry by running the following command:

    yarn nice

This will generate a `*.md` file in the `.changelog/` directory for your description. You can create as many as you need.

**Note:**  
If your PR is internal-only (e.g., tests, tooling, docs), you can skip this step - just mention it below.

-->

### 🚀 Summary

Bumped TypeDoc to the latest version v0.28.9.

---

### 📌 Related issues

<!--

Although changelog entries list connected issues, GitHub requires listing them here to automatically link and close them.

-->

* This PR requires https://github.com/ckeditor/ckeditor5/pull/18941.
* Closes ckeditor/ckeditor5#18905.

---

### 💡 Additional information

1. The differences between the generated `output.json` in TypeDoc v0.28.5 and v0.28.9 shows that v0.28.9 adds more data (~150 KB). The changes are mostly related to:
- changed order of IDs,
- added `implementationOf` details for `Iterable.[iterator]`:

    ```diff
    "implementationOf": {
        "type": "reference",
    -   "target": -1,
    -   "name": "Iterable.[iterator]"
    +   "target": {
    +       "packageName": "typescript",
    +       "packagePath": "lib/lib.es2015.iterable.d.ts",
    +       "qualifiedName": "Iterable.[iterator]"
    +   },
    +   "name": "Iterable.[iterator]",
    +   "package": "typescript"
    }
    ```

- added more metadata:

    ```diff
    
    "overwrites": {
        "type": "reference",
    -   "name": "EmitterMixin( ModelPosition )._createAt"
    +   "name": "EmitterMixin( ModelPosition )._createAt",
    +   "package": "@ckeditor/ckeditor5-engine",
    +   "qualifiedName": "ModelPosition._createAt"
    }
    ```

2. Docs in `ckeditor5` repository are built correctly without errors using TypeDoc v0.28.9.
    I compared the docs with v0.28.5 on the API pages listed below. The differences in the navigation sidebar are made on purpose to indicate that two different pages - local vs. production - were compared.

- [`Collection` class](https://ckeditor.com/docs/ckeditor5/latest/api/module_utils_collection-Collection.html)

    <details><summary>Diff</summary><img width="1000" alt="Class Collection CKEditor 5 API docs DIFF" src="https://github.com/user-attachments/assets/7d44ccf3-7f74-4cca-909b-2d602256c0b4" /></details>

- [`CommandCollection` class](https://ckeditor.com/docs/ckeditor5/latest/api/module_core_commandcollection-CommandCollection.html)

    <details><summary>Diff</summary><img width="1000" alt="Class CommandCollection CKEditor 5 API docs DIFF" src="https://github.com/user-attachments/assets/7c0b1cb3-3fa2-4338-a60e-52c8806dcbed" /></details>

- [`CommandsMap` interface](https://ckeditor.com/docs/ckeditor5/latest/api/module_core_commandcollection-CommandsMap.html)

    <details><summary>Diff</summary><img width="1000" alt="Interface CommandsMap CKEditor 5 API docs DIFF" src="https://github.com/user-attachments/assets/cb7d2e47-b961-410e-b579-35e1d9acace8" /></details>

- [`PluginCollection` class](https://ckeditor.com/docs/ckeditor5/latest/api/module_core_plugincollection-PluginCollection.html)

    <details><summary>Diff</summary><img width="1000" alt="Class PluginCollection CKEditor 5 API docs DIFF" src="https://github.com/user-attachments/assets/186774cd-71c4-45a4-ad81-725ff27f9be4" /></details>

- [`PluginsMap` interface](https://ckeditor.com/docs/ckeditor5/latest/api/module_core_plugincollection-PluginsMap.html)

    <details><summary>Diff</summary><img width="1000" alt="Interface PluginsMap CKEditor 5 API docs DIFF" src="https://github.com/user-attachments/assets/e565334a-0219-4613-858f-d2b559b973e4" /></details>

- [`Editor` class](https://ckeditor.com/docs/ckeditor5/latest/api/module_core_editor_editor-Editor.html)

    <details><summary>Diff</summary><img width="1000" alt="Class Editor CKEditor 5 API docs DIFF" src="https://github.com/user-attachments/assets/a60fc5c3-9b45-4008-9a8c-aa912d21ebd3" /></details>

- [`EditorConfig` interface](https://ckeditor.com/docs/ckeditor5/latest/api/module_core_editor_editorconfig-EditorConfig.html)

    <details><summary>Diff</summary><img width="1000" alt="Interface EditorConfig CKEditor 5 API docs DIFF" src="https://github.com/user-attachments/assets/22222667-143e-44aa-a599-396483e508cb" /></details>

3. Uber docs are also built correctly without errors using TypeDoc v0.28.9. 
    I tested it by cloning `@ckeditor/ckeditor5-dev` on `ck/18905` branch into `external` directory. To make sure I'm using TypeDoc v0.28.9, I added a log that printed the TypeDoc version:

    ```
    [1/4] Why do we have the module "typedoc"...?
    [2/4] Initialising dependency graph...
    [3/4] Finding dependency...
    [4/4] Calculating file sizes...
    => Found "typedoc@0.28.9"
    info Reasons this module exists
       - "_project_#@ckeditor#ckeditor5-dev-docs" depends on it
       - Hoisted from "_project_#@ckeditor#ckeditor5-dev-docs#typedoc"
       - Hoisted from "_project_#@ckeditor#typedoc-plugins#typedoc"
    info Disk size without dependencies: "3.76MB"
    info Disk size with unique dependencies: "8.01MB"
    info Disk size with transitive dependencies: "21.1MB"
    info Number of shared dependencies: 19
    ```