### PR TITLE
Added validation to the version provided in the `nextVersion` property

### DIFF
--- a/.changelog/20250807101307_ck_18901.md
+++ b/.changelog/20250807101307_ck_18901.md
@@ -1,0 +1,45 @@
+---
+# Required: Type of change.
+# Allowed values:
+# - Feature
+# - Fix
+# - Other
+# - Major breaking change
+# - Minor breaking change
+#
+# For guidance on breaking changes, see:
+# https://ckeditor.com/docs/ckeditor5/latest/updating/versioning-policy.html#major-and-minor-breaking-changes
+type: Other
+
+# Optional: Affected package(s), using short names.
+# Leave empty when used in a single-package repository.
+# Example: ckeditor5-core
+scope:
+  - ckeditor5-dev-changelog
+
+# Optional: Issues this change closes.
+# Format:
+# - {issue-number}
+# - {repo-owner}/{repo-name}#{issue-number}
+# - Full GitHub URL
+closes:
+  - https://github.com/ckeditor/ckeditor5/issues/18901
+
+# Optional: Related issues.
+# Format:
+# - {issue-number}
+# - {repo-owner}/{repo-name}#{issue-number}
+# - Full GitHub URL
+see:
+  -
+
+# Optional: Community contributors.
+# Format:
+# - {github-username}
+communityCredits:
+  -
+
+# Before committing, consider removing all comments to reduce file size and enhance readability.
+---
+
+Added validation to the version provided in the `nextVersion` property. It must be a valid version in terms of the semantic versioning specification. The nightly version prefix `0.0.0-` is accepted without validation.

--- a/packages/ckeditor5-dev-changelog/src/utils/determinenextversion.ts
+++ b/packages/ckeditor5-dev-changelog/src/utils/determinenextversion.ts
@@ -22,7 +22,7 @@ export type DetermineNextVersionOptions = {
 
 /**
  * Determines the next version for a single package or a mono-repository setup based on
- * the change sections, * user input, and semantic versioning rules.
+ * the change sections, user input, and semantic versioning rules.
  *
  * The function handles:
  * * Automatic version bump calculation from categorized changelog sections (major, minor, patch).

--- a/packages/ckeditor5-dev-changelog/src/utils/determinenextversion.ts
+++ b/packages/ckeditor5-dev-changelog/src/utils/determinenextversion.ts
@@ -8,6 +8,8 @@ import { type ReleaseType } from 'semver';
 import { provideNewVersion } from './providenewversion.js';
 import { logInfo } from './loginfo.js';
 import { detectReleaseChannel } from './detectreleasechannel.js';
+import { validateInputVersion } from './validateinputversion.js';
+import { InternalError } from './internalerror.js';
 import type { ChangelogReleaseType, SectionsWithEntries } from '../types.js';
 
 export type DetermineNextVersionOptions = {
@@ -32,6 +34,24 @@ export async function determineNextVersion( options: DetermineNextVersionOptions
 
 	if ( nextVersion ) {
 		logInfo( `○ ${ chalk.cyan( `Determined the next version to be ${ nextVersion }.` ) }` );
+
+		const isNightlyVersion = nextVersion.startsWith( '0.0.0-' );
+
+		if ( isNightlyVersion ) {
+			return nextVersion;
+		}
+
+		const validationResult = await validateInputVersion( {
+			newVersion: nextVersion,
+			suggestedVersion: nextVersion,
+			version: currentVersion,
+			releaseType,
+			packageName
+		} );
+
+		if ( typeof validationResult === 'string' ) {
+			throw new InternalError( validationResult );
+		}
 
 		return nextVersion;
 	}

--- a/packages/ckeditor5-dev-changelog/tests/utils/determinenextversion.ts
+++ b/packages/ckeditor5-dev-changelog/tests/utils/determinenextversion.ts
@@ -7,19 +7,23 @@ import { determineNextVersion, type DetermineNextVersionOptions } from '../../sr
 import { provideNewVersion } from '../../src/utils/providenewversion.js';
 import { logInfo } from '../../src/utils/loginfo.js';
 import { detectReleaseChannel } from '../../src/utils/detectreleasechannel.js';
+import { validateInputVersion } from '../../src/utils/validateinputversion.js';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import chalk from 'chalk';
+import { InternalError } from '../../src/utils/internalerror.js';
 import type { Entry, SectionsWithEntries } from '../../src/types.js';
 
 vi.mock( '../../src/utils/providenewversion.js' );
 vi.mock( '../../src/utils/loginfo.js' );
 vi.mock( '../../src/utils/detectreleasechannel.js' );
+vi.mock( '../../src/utils/validateInputVersion.js' );
 
 describe( 'determineNextVersion()', () => {
 	let options: DetermineNextVersionOptions;
 	const mockedProvideNewVersion = vi.mocked( provideNewVersion );
 	const mockedLogInfo = vi.mocked( logInfo );
 	const mockedDetectReleaseChannel = vi.mocked( detectReleaseChannel );
+	const mockedValidateInputVersion = vi.mocked( validateInputVersion );
 
 	const createEntry = ( message: string ): Entry => ( {
 		message,
@@ -50,6 +54,7 @@ describe( 'determineNextVersion()', () => {
 
 	beforeEach( () => {
 		mockedDetectReleaseChannel.mockReturnValue( 'latest' );
+		mockedValidateInputVersion.mockResolvedValue( true );
 
 		options = {
 			sections: createSectionsWithEntries(),
@@ -85,15 +90,52 @@ describe( 'determineNextVersion()', () => {
 		expect( mockedDetectReleaseChannel ).toHaveBeenCalledWith( '1.0.0', false );
 	} );
 
-	it( 'should return provided version if it is not undefined', async () => {
+	it( 'should validate provided version if it is defined', async () => {
+		options.nextVersion = '50.0.0';
+
+		await determineNextVersion( options );
+
+		expect( mockedLogInfo ).toHaveBeenCalledWith( `○ ${ chalk.cyan( 'Determined the next version to be 50.0.0.' ) }` );
+		expect( mockedValidateInputVersion ).toHaveBeenCalledWith( expect.objectContaining( {
+			newVersion: '50.0.0',
+			suggestedVersion: '50.0.0'
+		} ) );
+	} );
+
+	it( 'should return provided version if it pass the validation', async () => {
 		options.nextVersion = '50.0.0';
 
 		const result = await determineNextVersion( options );
 
 		expect( result ).toBe( '50.0.0' );
 		expect( mockedProvideNewVersion ).not.toHaveBeenCalled();
-		expect( mockedLogInfo ).toHaveBeenCalledWith( `○ ${ chalk.cyan( 'Determined the next version to be 50.0.0.' ) }` );
 		expect( mockedDetectReleaseChannel ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should return provided nightly version without validation', async () => {
+		options.nextVersion = '0.0.0-nightly-20250806.0';
+
+		const result = await determineNextVersion( options );
+
+		expect( result ).toBe( '0.0.0-nightly-20250806.0' );
+		expect( mockedValidateInputVersion ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should throw an error if provided version does not pass the validation', async () => {
+		mockedValidateInputVersion.mockResolvedValue( 'Invalid version.' );
+
+		options.nextVersion = '50.0.0';
+
+		await determineNextVersion( options )
+			.then(
+				() => {
+					throw new Error( 'Expected to throw.' );
+				},
+				err => {
+					expect( err ).toBeInstanceOf( InternalError );
+					expect( err.message ).to.equal( 'Invalid version.' );
+				}
+			);
 	} );
 
 	it( 'should return a minor bump version when "MINOR BREAKING CHANGE" entries are present', async () => {


### PR DESCRIPTION
<!--

This repository uses Markdown files to define changelog entries. If the changes in this pull request are **user-facing**, please create a changelog entry by running the following command:

    yarn nice

This will generate a `*.md` file in the `.changelog/` directory for your description. You can create as many as you need.

**Note:**  
If your PR is internal-only (e.g., tests, tooling, docs), you can skip this step - just mention it below.

-->

### 🚀 Summary

Added validation to the version provided in the `nextVersion` property.

---

### 📌 Related issues

<!--

Although changelog entries list connected issues, GitHub requires listing them here to automatically link and close them.

-->

* Closes https://github.com/ckeditor/ckeditor5/issues/18901

---

### 💡 Additional information

#### Tests

In the `ckeditor5-dev` repository make the following changes and run `yarn release:prepare-changelog --dry-run`.

1. In `changelogOptions` in `scripts/preparechangelog.js` set `nextVersion: 'FOO'`.
    
    ✅ Rejected as expected:
    ```
    ○ Determined the next version to be FOO.
    Error: Please provide a valid version.
    ```

1. In `changelogOptions` in `scripts/preparechangelog.js` set `nextVersion: '1.2.3'`.
    
    ✅ Rejected as expected:
    ```
    ○ Determined the next version to be 1.2.3.
    Error: Provided version must be higher than "50.3.1".
    ```

1. In `changelogOptions` in `scripts/preparechangelog.js` set `nextVersion: '0.0.0-nightly-20250807.0'`.
    
    ✅ Accepted as expected:
    ```
    ○ Determined the next version to be 0.0.0-nightly-20250807.0.
    ```

1. In `changelogOptions` in `scripts/preparechangelog.js` set `nextVersion: '50.3.2'`.

    ✅ Accepted as expected:
    ```
    ○ Determined the next version to be 50.3.2.
    ```

1. In `package.json` set `"version": "51.0.0-alpha.0"` and in `changelogOptions` in `scripts/preparechangelog.js` set `nextVersion: '51.0.0-alpha.1'`.

    ✅ Accepted as expected:
    ```
    ○ Determined the next version to be 51.0.0-alpha.1.
    ```

1. In `package.json` set `"version": "51.0.0-alpha.0"` and in `changelogOptions` in `scripts/preparechangelog.js` set `nextVersion: '51.0.0-beta.0'`.

    ✅ Accepted as expected:
    ```
    ○ Determined the next version to be 51.0.0-beta.0.
    ```