### PR TITLE
Don't hardcode the path to the `@ckeditor/ckeditor5-theme-lark` package.

### DIFF
--- a/.changelog/20250813102923_internal_4083.md
+++ b/.changelog/20250813102923_internal_4083.md
@@ -1,0 +1,5 @@
+---
+type: Fix
+---
+
+Don't hardcode the path to the `@ckeditor/ckeditor5-theme-lark` package.

--- a/packages/ckeditor5-dev-tests/bin/testautomated.js
+++ b/packages/ckeditor5-dev-tests/bin/testautomated.js
@@ -5,8 +5,8 @@
  * For licensing, see LICENSE.md.
  */
 
+import { fileURLToPath } from 'url';
 import chalk from 'chalk';
-import path from 'path';
 import * as tests from '../lib/index.js';
 
 const options = tests.parseArguments( process.argv.slice( 2 ) );
@@ -20,7 +20,7 @@ if ( options.files.length === 0 ) {
 }
 
 // "Lark" is the default theme for tests.
-options.themePath = path.resolve( options.cwd, 'packages', 'ckeditor5-theme-lark', 'theme', 'theme.css' );
+options.themePath = fileURLToPath( import.meta.resolve( '@ckeditor/ckeditor5-theme-lark' ) );
 
 tests.runAutomatedTests( options )
 	.then( () => {

--- a/packages/ckeditor5-dev-tests/bin/testmanual.js
+++ b/packages/ckeditor5-dev-tests/bin/testmanual.js
@@ -5,8 +5,8 @@
  * For licensing, see LICENSE.md.
  */
 
+import { fileURLToPath } from 'url';
 import chalk from 'chalk';
-import path from 'path';
 import * as tests from '../lib/index.js';
 
 const options = tests.parseArguments( process.argv.slice( 2 ), { allowDefaultIdentityFile: true } );
@@ -17,7 +17,7 @@ const options = tests.parseArguments( process.argv.slice( 2 ), { allowDefaultIde
 options.disableWatch = process.argv.includes( '--disable-watch' );
 
 // "Lark" is the default theme for tests.
-options.themePath = path.resolve( options.cwd, 'packages', 'ckeditor5-theme-lark', 'theme', 'theme.css' );
+options.themePath = fileURLToPath( import.meta.resolve( '@ckeditor/ckeditor5-theme-lark' ) );
 
 tests.runManualTests( options )
 	.catch( error => {


### PR DESCRIPTION
### 🚀 Summary

Don't hardcode the path to the `@ckeditor/ckeditor5-theme-lark` package.

---

### 📌 Related issues

* See https://github.com/ckeditor/ckeditor5-internal/issues/4083.
