### PR TITLE
[dev-changelog] Top-level `linkFilter()` callback

### DIFF
--- a/.changelog/20250813120310_ck_18936.md
+++ b/.changelog/20250813120310_ck_18936.md
@@ -1,0 +1,45 @@
+---
+# Required: Type of change.
+# Allowed values:
+# - Feature
+# - Fix
+# - Other
+# - Major breaking change
+# - Minor breaking change
+#
+# For guidance on breaking changes, see:
+# https://ckeditor.com/docs/ckeditor5/latest/updating/versioning-policy.html#major-and-minor-breaking-changes
+type: Feature
+
+# Optional: Affected package(s), using short names.
+# Leave empty when used in a single-package repository.
+# Example: ckeditor5-core
+scope:
+  - ckeditor5-dev-changelog
+
+# Optional: Issues this change closes.
+# Format:
+# - {issue-number}
+# - {repo-owner}/{repo-name}#{issue-number}
+# - Full GitHub URL
+closes:
+  - ckeditor/ckeditor5#18936
+
+# Optional: Related issues.
+# Format:
+# - {issue-number}
+# - {repo-owner}/{repo-name}#{issue-number}
+# - Full GitHub URL
+see:
+  -
+
+# Optional: Community contributors.
+# Format:
+# - {github-username}
+communityCredits:
+  -
+
+# Before committing, consider removing all comments to reduce file size and enhance readability.
+---
+
+Added a top-level `linkFilter()` callback option for changelog generators that determines which issue links should be preserved in the generated changelog and which should be removed. If the `shouldSkipLinks` flag is also provided, the `shouldSkipLinks` flag takes precedence over the `linkFilter()` callback to maintain backward compatibility.

--- a/packages/ckeditor5-dev-changelog/src/tasks/generatechangelogformonorepository.ts
+++ b/packages/ckeditor5-dev-changelog/src/tasks/generatechangelogformonorepository.ts
@@ -20,6 +20,7 @@ export const generateChangelogForMonoRepository: GenerateChangelogEntryPoint<Mon
 		disableFilesystemOperations,
 		npmPackageToCheck,
 		packagesDirectory,
+		linkFilter,
 		shouldSkipLinks,
 		shouldIgnoreRootPackage,
 		transformScope
@@ -32,6 +33,7 @@ export const generateChangelogForMonoRepository: GenerateChangelogEntryPoint<Mon
 		externalRepositories,
 		transformScope,
 		date,
+		linkFilter,
 		shouldSkipLinks,
 		disableFilesystemOperations,
 		...(

--- a/packages/ckeditor5-dev-changelog/src/tasks/generatechangelogforsinglerepository.ts
+++ b/packages/ckeditor5-dev-changelog/src/tasks/generatechangelogforsinglerepository.ts
@@ -15,6 +15,7 @@ export const generateChangelogForSingleRepository: GenerateChangelogEntryPoint<S
 		externalRepositories,
 		nextVersion,
 		disableFilesystemOperations,
+		linkFilter,
 		shouldSkipLinks
 	} = options;
 
@@ -23,6 +24,7 @@ export const generateChangelogForSingleRepository: GenerateChangelogEntryPoint<S
 		cwd,
 		externalRepositories,
 		date,
+		linkFilter,
 		shouldSkipLinks,
 		disableFilesystemOperations,
 		isSinglePackage: true,

--- a/packages/ckeditor5-dev-changelog/src/types.ts
+++ b/packages/ckeditor5-dev-changelog/src/types.ts
@@ -55,6 +55,13 @@ export type RepositoryConfig = {
 	packagesDirectory: null | string;
 
 	/**
+	 * Function that decides whether to filter out a link in the changelog entry.
+	 * If `shouldSkipLinks` flag is set, the `shouldSkipLinks` flag takes precedence over the `linkFilter` function.
+	 * No links are skipped by default.
+	 */
+	linkFilter?: LinkFilter;
+
+	/**
 	 * Whether to skip links in the changelog entries. Defaults to false.
 	 */
 	shouldSkipLinks?: boolean;
@@ -93,7 +100,7 @@ export type ParsedFile<T = FileMetadata> = {
 	changesetPath: string;
 	createdAt: Date;
 	gitHubUrl: string;
-	shouldSkipLinks: boolean;
+	linkFilter: LinkFilter;
 };
 
 export type Section = {
@@ -119,7 +126,7 @@ export type TransformScope = ( name: string ) => {
 export type ChangesetPathsWithGithubUrl = {
 	filePaths: Array<string>;
 	gitHubUrl: string;
-	shouldSkipLinks: boolean;
+	linkFilter: LinkFilter;
 	cwd: string;
 	isRoot: boolean;
 };
@@ -133,6 +140,8 @@ type NpmPackageRequiredWhenSkipRootPackage = {
 };
 
 export type LinkObject = { displayName: string; link: string };
+
+export type LinkFilter = ( resourceUrl: string ) => boolean;
 
 export type FileMetadata = {
 	type: string;

--- a/packages/ckeditor5-dev-changelog/src/utils/generatechangelog.ts
+++ b/packages/ckeditor5-dev-changelog/src/utils/generatechangelog.ts
@@ -52,10 +52,11 @@ const main: GenerateChangelogEntryPoint<GenerateChangelogConfig> = async options
 		isSinglePackage,
 		transformScope,
 		npmPackageToCheck,
+		linkFilter,
+		shouldSkipLinks,
 		cwd = process.cwd(),
 		externalRepositories = [],
 		date = format( new Date(), 'yyyy-MM-dd' ),
-		shouldSkipLinks = false,
 		shouldIgnoreRootPackage = false,
 		disableFilesystemOperations = false
 	} = options;
@@ -74,6 +75,7 @@ const main: GenerateChangelogEntryPoint<GenerateChangelogConfig> = async options
 	const entryPaths = await findChangelogEntryPaths( {
 		cwd,
 		externalRepositories,
+		linkFilter,
 		shouldSkipLinks,
 		includeSubdirectories: releaseType === 'latest' || releaseType === 'prerelease-promote'
 	} );

--- a/packages/ckeditor5-dev-changelog/src/utils/groupentriesbysection.ts
+++ b/packages/ckeditor5-dev-changelog/src/utils/groupentriesbysection.ts
@@ -29,15 +29,19 @@ export function groupEntriesBySection( options: GroupEntriesBySectionOptions ): 
 		const { validatedEntry, isValid } = validateEntry( entry, packageNames, isSinglePackage );
 		const validatedData = validatedEntry.data;
 
+		const closesLinks = filterLinks( validatedData.closes, validatedEntry );
+		const closes = getIssuesLinks( closesLinks, 'Closes' );
+
+		const seeLinks = filterLinks( validatedData.see, validatedEntry );
+		const see = getIssuesLinks( seeLinks, 'See' );
+
 		const scope = isSinglePackage ? null : getScopesLinks( validatedData.scope, transformScope! );
-		const closes = getIssuesLinks( validatedData.closes, 'Closes', validatedEntry.gitHubUrl );
-		const see = getIssuesLinks( validatedData.see, 'See', validatedEntry.gitHubUrl );
 		const section = getSection( { entry: validatedEntry, isSinglePackage, isValid } );
 		const contentWithCommunityCredits = getContentWithCommunityCredits( validatedEntry.content, validatedData.communityCredits );
 		const content = linkToGitHubUser( contentWithCommunityCredits );
 		const [ mainContent, ...restContent ] = formatContent( content );
 
-		const changeMessage = getChangeMessage( { restContent, scope, mainContent, entry, see, closes } );
+		const changeMessage = getChangeMessage( { restContent, scope, mainContent, see, closes } );
 
 		const newEntry: Entry = {
 			message: changeMessage,
@@ -46,8 +50,8 @@ export function groupEntriesBySection( options: GroupEntriesBySectionOptions ): 
 				restContent,
 				type: validatedData.type,
 				scope: validatedData.scope,
-				see: validatedData.see.map( see => getIssueLinkObject( see, validatedEntry.gitHubUrl ) ),
-				closes: validatedData.closes.map( closes => getIssueLinkObject( closes, validatedEntry.gitHubUrl ) ),
+				see: seeLinks,
+				closes: closesLinks,
 				validations: validatedData.validations,
 				communityCredits: validatedData.communityCredits
 			},
@@ -67,19 +71,29 @@ export function groupEntriesBySection( options: GroupEntriesBySectionOptions ): 
 type GetChangeMessageOptions = {
 	mainContent: string | undefined;
 	restContent: Array<string> | undefined;
-	entry: ParsedFile;
 	scope: string | null;
 	see: string;
 	closes: string;
 };
 
-function getChangeMessage( { restContent, scope, mainContent, entry, see, closes }: GetChangeMessageOptions ) {
+type IssueLinkObject = {
+	displayName: string;
+	link: string;
+};
+
+function filterLinks( links: Array<string>, entry: ParsedFile ) {
+	return links
+		.map( link => getIssueLinkObject( link, entry.gitHubUrl ) )
+		.filter( ( { link } ) => entry.linkFilter( link ) );
+}
+
+function getChangeMessage( { restContent, scope, mainContent, see, closes }: GetChangeMessageOptions ) {
 	const messageFirstLine = [
 		'*',
 		scope ? `**${ scope }**:` : null,
 		mainContent,
-		!entry.shouldSkipLinks && see.length ? see : null,
-		!entry.shouldSkipLinks && closes.length ? closes : null
+		see.length ? see : null,
+		closes.length ? closes : null
 	].filter( Boolean ).join( ' ' );
 
 	if ( !restContent || !restContent.length ) {
@@ -138,7 +152,7 @@ function getScopesLinks( scope: Array<string>, transformScope: TransformScope ):
 		.join( ', ' );
 }
 
-function getIssueLinkObject( issue: string, gitHubUrl: string ) {
+function getIssueLinkObject( issue: string, gitHubUrl: string ): IssueLinkObject {
 	if ( issue.match( ISSUE_PATTERN ) ) {
 		return { displayName: `#${ issue }`, link: `${ gitHubUrl }/issues/${ issue }` };
 	}
@@ -166,16 +180,12 @@ function getIssueLinkObject( issue: string, gitHubUrl: string ) {
 	return { displayName: '', link: '' };
 }
 
-function getIssuesLinks( issues: Array<string>, prefix: string, gitHubUrl: string ): string {
+function getIssuesLinks( issues: Array<IssueLinkObject>, prefix: string ): string {
 	if ( !issues.length ) {
 		return '';
 	}
 
-	const links = issues.map( String ).map( issue => {
-		const { displayName, link } = getIssueLinkObject( issue, gitHubUrl );
-
-		return `[${ displayName }](${ link })`;
-	} );
+	const links = issues.map( issue => `[${ issue.displayName }](${ issue.link })` );
 
 	return `${ prefix } ${ links.join( ', ' ) }.`;
 }

--- a/packages/ckeditor5-dev-changelog/src/utils/parsechangelogentries.ts
+++ b/packages/ckeditor5-dev-changelog/src/utils/parsechangelogentries.ts
@@ -11,7 +11,7 @@ import { sortEntriesByScopeAndDate } from './sortentriesbyscopeanddate.js';
 import { normalizeEntry } from './normalizeentry.js';
 import type { ChangesetPathsWithGithubUrl, FileMetadata, ParsedFile } from '../types.js';
 
-type SimpleParsedFile = Pick<ParsedFile, 'changesetPath' | 'gitHubUrl' | 'shouldSkipLinks'>;
+type SimpleParsedFile = Pick<ParsedFile, 'changesetPath' | 'gitHubUrl' | 'linkFilter'>;
 
 /**
  * Reads and processes input files to extract changelog entries.
@@ -20,20 +20,20 @@ export function parseChangelogEntries(
 	entryPaths: Array<ChangesetPathsWithGithubUrl>,
 	isSinglePackage: boolean
 ): Promise<Array<ParsedFile>> {
-	const fileEntries = entryPaths.reduce<Array<SimpleParsedFile>>( ( acc, { filePaths, gitHubUrl, shouldSkipLinks } ) => {
+	const fileEntries = entryPaths.reduce<Array<SimpleParsedFile>>( ( acc, { filePaths, gitHubUrl, linkFilter } ) => {
 		for ( const changesetPath of filePaths ) {
-			acc.push( { changesetPath, gitHubUrl, shouldSkipLinks } );
+			acc.push( { changesetPath, gitHubUrl, linkFilter } );
 		}
 		return acc;
 	}, [] );
 
 	return AsyncArray
 		.from( Promise.resolve( fileEntries ) )
-		.map( async ( { changesetPath, gitHubUrl, shouldSkipLinks } ) => ( {
+		.map( async ( { changesetPath, gitHubUrl, linkFilter } ) => ( {
 			...( matter( await fs.readFile( changesetPath, 'utf-8' ) ) as unknown as { content: string; data: FileMetadata } ),
 			gitHubUrl,
 			changesetPath,
-			shouldSkipLinks,
+			linkFilter,
 			createdAt: extractDateFromFilename( changesetPath )
 		} ) )
 		.map( entry => normalizeEntry( entry, isSinglePackage ) )

--- a/packages/ckeditor5-dev-changelog/tests/tasks/generatechangelogformonorepository.ts
+++ b/packages/ckeditor5-dev-changelog/tests/tasks/generatechangelogformonorepository.ts
@@ -17,6 +17,7 @@ describe( 'generateChangelogForMonoRepository()', () => {
 		date: '2024-03-26',
 		externalRepositories: [],
 		shouldSkipLinks: false,
+		linkFilter: () => true,
 		disableFilesystemOperations: false,
 		transformScope: ( name: string ) => ( {
 			displayName: name,
@@ -41,6 +42,7 @@ describe( 'generateChangelogForMonoRepository()', () => {
 				transformScope: defaultOptions.transformScope,
 				date: '2024-03-26',
 				shouldSkipLinks: false,
+				linkFilter: defaultOptions.linkFilter,
 				disableFilesystemOperations: false,
 				shouldIgnoreRootPackage: false,
 				isSinglePackage: false
@@ -74,6 +76,7 @@ describe( 'generateChangelogForMonoRepository()', () => {
 				transformScope: customOptions.transformScope,
 				date: '2024-03-26',
 				shouldSkipLinks: true,
+				linkFilter: defaultOptions.linkFilter,
 				disableFilesystemOperations: true,
 				shouldIgnoreRootPackage: false,
 				isSinglePackage: false
@@ -235,6 +238,7 @@ describe( 'generateChangelogForMonoRepository()', () => {
 				externalRepositories: undefined,
 				date: undefined,
 				shouldSkipLinks: undefined,
+				linkFilter: undefined,
 				disableFilesystemOperations: undefined
 			} ) );
 		} );
@@ -356,6 +360,7 @@ describe( 'generateChangelogForMonoRepository()', () => {
 					npmUrl: `https://npm.com/${ name }`
 				} ),
 				shouldSkipLinks: false,
+				linkFilter: () => true,
 				shouldIgnoreRootPackage: true as const,
 				npmPackageToCheck: 'test-package',
 				disableFilesystemOperations: false

--- a/packages/ckeditor5-dev-changelog/tests/tasks/generatechangelogforsinglerepository.ts
+++ b/packages/ckeditor5-dev-changelog/tests/tasks/generatechangelogforsinglerepository.ts
@@ -16,6 +16,7 @@ describe( 'generateChangelogForSingleRepository()', () => {
 		date: '2024-03-26',
 		externalRepositories: [],
 		shouldSkipLinks: false,
+		linkFilter: () => true,
 		disableFilesystemOperations: false
 	};
 
@@ -34,6 +35,7 @@ describe( 'generateChangelogForSingleRepository()', () => {
 				externalRepositories: [],
 				date: '2024-03-26',
 				shouldSkipLinks: false,
+				linkFilter: defaultOptions.linkFilter,
 				disableFilesystemOperations: false,
 				isSinglePackage: true,
 				packagesDirectory: null
@@ -64,6 +66,7 @@ describe( 'generateChangelogForSingleRepository()', () => {
 				externalRepositories: customOptions.externalRepositories,
 				date: '2024-03-26',
 				shouldSkipLinks: true,
+				linkFilter: defaultOptions.linkFilter,
 				disableFilesystemOperations: true,
 				isSinglePackage: true,
 				packagesDirectory: null
@@ -147,6 +150,7 @@ describe( 'generateChangelogForSingleRepository()', () => {
 				externalRepositories: undefined,
 				date: undefined,
 				shouldSkipLinks: undefined,
+				linkFilter: undefined,
 				disableFilesystemOperations: undefined
 			} ) );
 		} );
@@ -321,6 +325,7 @@ describe( 'generateChangelogForSingleRepository()', () => {
 				date: '2024-01-01',
 				externalRepositories: [],
 				shouldSkipLinks: false,
+				linkFilter: () => true,
 				disableFilesystemOperations: false
 			};
 

--- a/packages/ckeditor5-dev-changelog/tests/utils/findchangelogentrypaths.ts
+++ b/packages/ckeditor5-dev-changelog/tests/utils/findchangelogentrypaths.ts
@@ -36,7 +36,7 @@ describe( 'findChangelogEntryPaths()', () => {
 	it( 'should return file paths from both local and external repositories', async () => {
 		const rootSkipLinks = true;
 		const cwd = '/mock/current';
-		const externalRepositories: Array<Required<RepositoryConfig>> = [
+		const externalRepositories: Array<RepositoryConfig> = [
 			{ cwd: '/mock/repo1', packagesDirectory: 'packages', shouldSkipLinks: true },
 			{ cwd: '/mock/repo2', packagesDirectory: 'packages', shouldSkipLinks: false }
 		];
@@ -67,21 +67,21 @@ describe( 'findChangelogEntryPaths()', () => {
 			{
 				filePaths: [ '/mock/current/changesets/file1.md', '/mock/current/changesets/file2.md' ],
 				gitHubUrl: 'https://github.com/ckeditor/current',
-				shouldSkipLinks: true,
+				linkFilter: expect.any( Function ),
 				isRoot: true,
 				cwd: '/mock/current'
 			},
 			{
 				filePaths: [ '/mock/repo1/changesets/file3.md' ],
 				gitHubUrl: 'https://github.com/ckeditor/repo1',
-				shouldSkipLinks: true,
+				linkFilter: expect.any( Function ),
 				isRoot: false,
 				cwd: '/mock/repo1'
 			},
 			{
 				filePaths: [ '/mock/repo2/changesets/file4.md' ],
 				gitHubUrl: 'https://github.com/ckeditor/repo2',
-				shouldSkipLinks: false,
+				linkFilter: expect.any( Function ),
 				isRoot: false,
 				cwd: '/mock/repo2'
 			}
@@ -96,7 +96,7 @@ describe( 'findChangelogEntryPaths()', () => {
 	it( 'should return only local changeset files if there are no external repositories', async () => {
 		const rootSkipLinks = false;
 		const cwd = '/mock/current';
-		const externalRepositories: Array<Required<RepositoryConfig>> = [];
+		const externalRepositories: Array<RepositoryConfig> = [];
 
 		vi.mocked( glob ).mockResolvedValue( [ '/mock/current/changesets/file1.md' ] );
 
@@ -110,7 +110,7 @@ describe( 'findChangelogEntryPaths()', () => {
 			{
 				filePaths: [ '/mock/current/changesets/file1.md' ],
 				gitHubUrl: 'https://github.com/ckeditor/current',
-				shouldSkipLinks: false,
+				linkFilter: expect.any( Function ),
 				isRoot: true,
 				cwd: '/mock/current'
 			}
@@ -123,7 +123,7 @@ describe( 'findChangelogEntryPaths()', () => {
 	it( 'should return only external changeset files if there are no local files', async () => {
 		const rootSkipLinks = false;
 		const cwd = '/mock/current';
-		const externalRepositories: Array<Required<RepositoryConfig>> = [
+		const externalRepositories: Array<RepositoryConfig> = [
 			{ cwd: '/mock/repo1', packagesDirectory: 'packages', shouldSkipLinks: false }
 		];
 
@@ -149,14 +149,14 @@ describe( 'findChangelogEntryPaths()', () => {
 			{
 				filePaths: [],
 				gitHubUrl: 'https://github.com/ckeditor/current',
-				shouldSkipLinks: false,
+				linkFilter: expect.any( Function ),
 				cwd: '/mock/current',
 				isRoot: true
 			},
 			{
 				filePaths: [ '/mock/repo1/changesets/file3.md' ],
 				gitHubUrl: 'https://github.com/ckeditor/repo1',
-				shouldSkipLinks: false,
+				linkFilter: expect.any( Function ),
 				cwd: '/mock/repo1',
 				isRoot: false
 			}
@@ -170,7 +170,7 @@ describe( 'findChangelogEntryPaths()', () => {
 	it( 'should return an empty array when no changeset files exist in any repository', async () => {
 		const rootSkipLinks = false;
 		const cwd = '/mock/current';
-		const externalRepositories: Array<Required<RepositoryConfig>> = [
+		const externalRepositories: Array<RepositoryConfig> = [
 			{ cwd: '/mock/repo1', packagesDirectory: 'packages', shouldSkipLinks: false }
 		];
 
@@ -186,14 +186,14 @@ describe( 'findChangelogEntryPaths()', () => {
 			{
 				filePaths: [],
 				gitHubUrl: 'https://github.com/ckeditor/current',
-				shouldSkipLinks: false,
+				linkFilter: expect.any( Function ),
 				isRoot: true,
 				cwd: '/mock/current'
 			},
 			{
 				filePaths: [],
 				gitHubUrl: 'https://github.com/ckeditor/repo1',
-				shouldSkipLinks: false,
+				linkFilter: expect.any( Function ),
 				isRoot: false,
 				cwd: '/mock/repo1'
 			}
@@ -205,7 +205,7 @@ describe( 'findChangelogEntryPaths()', () => {
 	it( 'should handle errors gracefully by rejecting the promise', async () => {
 		const rootSkipLinks = false;
 		const cwd = '/mock/current';
-		const externalRepositories: Array<Required<RepositoryConfig>> = [
+		const externalRepositories: Array<RepositoryConfig> = [
 			{ cwd: '/mock/repo1', packagesDirectory: 'packages', shouldSkipLinks: false }
 		];
 
@@ -219,7 +219,7 @@ describe( 'findChangelogEntryPaths()', () => {
 	it( 'should normalize paths from Windows-style to POSIX format', async () => {
 		const rootSkipLinks = false;
 		const cwd = '/mock/current';
-		const externalRepositories: Array<Required<RepositoryConfig>> = [];
+		const externalRepositories: Array<RepositoryConfig> = [];
 
 		// Simulate Windows paths with backslashes
 		vi.mocked( glob ).mockResolvedValue( [
@@ -241,7 +241,7 @@ describe( 'findChangelogEntryPaths()', () => {
 					'C:/mock/current/changesets/subfolder/file2.md'
 				],
 				gitHubUrl: 'https://github.com/ckeditor/current',
-				shouldSkipLinks: false,
+				linkFilter: expect.any( Function ),
 				isRoot: true,
 				cwd: '/mock/current'
 			}
@@ -253,7 +253,7 @@ describe( 'findChangelogEntryPaths()', () => {
 	it( 'should use nested directory pattern when includeAllChannels is true', async () => {
 		const rootSkipLinks = false;
 		const cwd = '/mock/current';
-		const externalRepositories: Array<Required<RepositoryConfig>> = [];
+		const externalRepositories: Array<RepositoryConfig> = [];
 
 		vi.mocked( glob ).mockResolvedValue( [
 			'/mock/current/changesets/file1.md',
@@ -276,7 +276,7 @@ describe( 'findChangelogEntryPaths()', () => {
 					'/mock/current/changesets/beta/file3.md'
 				],
 				gitHubUrl: 'https://github.com/ckeditor/current',
-				shouldSkipLinks: false,
+				linkFilter: expect.any( Function ),
 				isRoot: true,
 				cwd: '/mock/current'
 			}
@@ -288,7 +288,7 @@ describe( 'findChangelogEntryPaths()', () => {
 	it( 'should use *.md glob pattern when includeAllChannels is false', async () => {
 		const rootSkipLinks = false;
 		const cwd = '/mock/current';
-		const externalRepositories: Array<Required<RepositoryConfig>> = [
+		const externalRepositories: Array<RepositoryConfig> = [
 			{ cwd: '/mock/repo1', packagesDirectory: 'packages', shouldSkipLinks: false }
 		];
 
@@ -313,14 +313,14 @@ describe( 'findChangelogEntryPaths()', () => {
 			{
 				filePaths: [ '/mock/current/changesets/file1.md' ],
 				gitHubUrl: 'https://github.com/ckeditor/current',
-				shouldSkipLinks: false,
+				linkFilter: expect.any( Function ),
 				isRoot: true,
 				cwd: '/mock/current'
 			},
 			{
 				filePaths: [ '/mock/repo1/changesets/file2.md' ],
 				gitHubUrl: 'https://github.com/ckeditor/repo1',
-				shouldSkipLinks: false,
+				linkFilter: expect.any( Function ),
 				isRoot: false,
 				cwd: '/mock/repo1'
 			}
@@ -328,5 +328,127 @@ describe( 'findChangelogEntryPaths()', () => {
 
 		expect( glob ).toHaveBeenCalledWith( '*.md', { cwd: '/mock/current/.changelog', absolute: true } );
 		expect( glob ).toHaveBeenCalledWith( '*.md', { cwd: '/mock/repo1/.changelog', absolute: true } );
+	} );
+
+	describe( 'linkFilter callback', () => {
+		beforeEach( () => {
+			vi.mocked( glob ).mockResolvedValue( [] );
+		} );
+
+		it( 'should return true if shouldSkipLinks is false', async () => {
+			const cwd = '/mock/current';
+			const externalRepositories: Array<RepositoryConfig> = [
+				{ cwd: '/mock/repo1', packagesDirectory: 'packages', shouldSkipLinks: false }
+			];
+
+			const result = await findChangelogEntryPaths( {
+				cwd,
+				externalRepositories,
+				shouldSkipLinks: false
+			} );
+
+			const linkFilterRootRepo = result.find( item => item.cwd === '/mock/current' )!.linkFilter;
+			const linkFilterExternalRepo = result.find( item => item.cwd === '/mock/repo1' )!.linkFilter;
+
+			expect( linkFilterRootRepo( 'https://github.com/ckeditor/current/issues/123' ) ).toEqual( true );
+			expect( linkFilterExternalRepo( 'https://github.com/ckeditor/current/issues/123' ) ).toEqual( true );
+		} );
+
+		it( 'should return false if shouldSkipLinks is true', async () => {
+			const cwd = '/mock/current';
+			const externalRepositories: Array<RepositoryConfig> = [
+				{ cwd: '/mock/repo1', packagesDirectory: 'packages', shouldSkipLinks: true }
+			];
+
+			const result = await findChangelogEntryPaths( {
+				cwd,
+				externalRepositories,
+				shouldSkipLinks: true
+			} );
+
+			const linkFilterRootRepo = result.find( item => item.cwd === '/mock/current' )!.linkFilter;
+			const linkFilterExternalRepo = result.find( item => item.cwd === '/mock/repo1' )!.linkFilter;
+
+			expect( linkFilterRootRepo( 'https://github.com/ckeditor/current/issues/123' ) ).toEqual( false );
+			expect( linkFilterExternalRepo( 'https://github.com/ckeditor/current/issues/123' ) ).toEqual( false );
+		} );
+
+		it( 'should use linkFilter function if it is set', async () => {
+			const cwd = '/mock/current';
+			const externalRepositories: Array<RepositoryConfig> = [
+				{ cwd: '/mock/repo1', packagesDirectory: 'packages', linkFilter: () => false }
+			];
+
+			const result = await findChangelogEntryPaths( {
+				cwd,
+				externalRepositories,
+				linkFilter: () => false
+			} );
+
+			const linkFilterRootRepo = result.find( item => item.cwd === '/mock/current' )!.linkFilter;
+			const linkFilterExternalRepo = result.find( item => item.cwd === '/mock/repo1' )!.linkFilter;
+
+			expect( linkFilterRootRepo( 'https://github.com/ckeditor/current/issues/123' ) ).toEqual( false );
+			expect( linkFilterExternalRepo( 'https://github.com/ckeditor/current/issues/123' ) ).toEqual( false );
+		} );
+
+		it( 'should use default linkFilter function if it is not set', async () => {
+			const cwd = '/mock/current';
+			const externalRepositories: Array<RepositoryConfig> = [
+				{ cwd: '/mock/repo1', packagesDirectory: 'packages' }
+			];
+
+			const result = await findChangelogEntryPaths( {
+				cwd,
+				externalRepositories
+			} );
+
+			const linkFilterRootRepo = result.find( item => item.cwd === '/mock/current' )!.linkFilter;
+			const linkFilterExternalRepo = result.find( item => item.cwd === '/mock/repo1' )!.linkFilter;
+
+			expect( linkFilterRootRepo( 'https://github.com/ckeditor/current/issues/123' ) ).toEqual( true );
+			expect( linkFilterExternalRepo( 'https://github.com/ckeditor/current/issues/123' ) ).toEqual( true );
+		} );
+
+		it( 'should use shouldSkipLinks if both shouldSkipLinks and linkFilter are set', async () => {
+			const cwd = '/mock/current';
+			const externalRepositories: Array<RepositoryConfig> = [
+				{ cwd: '/mock/repo1', packagesDirectory: 'packages', shouldSkipLinks: false, linkFilter: () => false }
+			];
+
+			const result = await findChangelogEntryPaths( {
+				cwd,
+				externalRepositories,
+				shouldSkipLinks: false,
+				linkFilter: () => false
+			} );
+
+			const linkFilterRootRepo = result.find( item => item.cwd === '/mock/current' )!.linkFilter;
+			const linkFilterExternalRepo = result.find( item => item.cwd === '/mock/repo1' )!.linkFilter;
+
+			expect( linkFilterRootRepo( 'https://github.com/ckeditor/current/issues/123' ) ).toEqual( true );
+			expect( linkFilterExternalRepo( 'https://github.com/ckeditor/current/issues/123' ) ).toEqual( true );
+		} );
+
+		it( 'should allow defining custom logic for root and external repositories', async () => {
+			const cwd = '/mock/current';
+			const externalRepositories: Array<RepositoryConfig> = [
+				{ cwd: '/mock/repo1', packagesDirectory: 'packages', linkFilter: () => false }
+			];
+
+			const result = await findChangelogEntryPaths( {
+				cwd,
+				externalRepositories,
+				linkFilter: resourceUrl => resourceUrl.endsWith( '123' )
+			} );
+
+			const linkFilterRootRepo = result.find( item => item.cwd === '/mock/current' )!.linkFilter;
+			const linkFilterExternalRepo = result.find( item => item.cwd === '/mock/repo1' )!.linkFilter;
+
+			expect( linkFilterRootRepo( 'https://github.com/ckeditor/current/issues/123' ) ).toEqual( true );
+			expect( linkFilterRootRepo( 'https://github.com/ckeditor/current/issues/999' ) ).toEqual( false );
+			expect( linkFilterExternalRepo( 'https://github.com/ckeditor/current/issues/123' ) ).toEqual( false );
+			expect( linkFilterExternalRepo( 'https://github.com/ckeditor/current/issues/999' ) ).toEqual( false );
+		} );
 	} );
 } );

--- a/packages/ckeditor5-dev-changelog/tests/utils/generatechangelog.ts
+++ b/packages/ckeditor5-dev-changelog/tests/utils/generatechangelog.ts
@@ -75,7 +75,7 @@ describe( 'generateChangelog()', () => {
 			{
 				filePaths: [ '/home/ckeditor/.changelog/changeset-1.md' ],
 				gitHubUrl: 'https://github.com/ckeditor/ckeditor5',
-				shouldSkipLinks: false,
+				linkFilter: () => true,
 				isRoot: true,
 				cwd: '/home/ckeditor'
 			}
@@ -94,7 +94,7 @@ describe( 'generateChangelog()', () => {
 				createdAt: new Date(),
 				changesetPath: '/home/ckeditor/.changelog/changeset-1.md',
 				gitHubUrl: 'https://github.com/ckeditor/ckeditor5',
-				shouldSkipLinks: false
+				linkFilter: () => true
 			}
 		] ) );
 		vi.mocked( groupEntriesBySection ).mockReturnValue( {
@@ -310,7 +310,7 @@ describe( 'generateChangelog()', () => {
 			{
 				filePaths: [ '/home/ckeditor/.changelog/changeset-1.md' ],
 				gitHubUrl: 'https://github.com/ckeditor/ckeditor5',
-				shouldSkipLinks: false,
+				linkFilter: expect.any( Function ),
 				isRoot: true,
 				cwd: '/home/ckeditor'
 			}
@@ -342,6 +342,8 @@ describe( 'generateChangelog()', () => {
 	} );
 
 	it( 'allows defining the external repositories', async () => {
+		const linkFilter = () => true;
+
 		const externalRepositories = [ {
 			cwd: '/external/repo',
 			packagesDirectory: 'packages',
@@ -351,6 +353,7 @@ describe( 'generateChangelog()', () => {
 		await generateChangelog( {
 			...defaultOptions,
 			shouldSkipLinks: true,
+			linkFilter,
 			externalRepositories
 		} );
 
@@ -362,7 +365,8 @@ describe( 'generateChangelog()', () => {
 		expect( findChangelogEntryPaths ).toHaveBeenCalledWith( expect.objectContaining( {
 			cwd: '/home/ckeditor',
 			externalRepositories,
-			shouldSkipLinks: true
+			shouldSkipLinks: true,
+			linkFilter
 		} ) );
 	} );
 
@@ -496,14 +500,14 @@ describe( 'generateChangelog()', () => {
 			{
 				filePaths: [ '/home/ckeditor/.changelog/changeset-1.md' ],
 				gitHubUrl: 'https://github.com/ckeditor/ckeditor5',
-				shouldSkipLinks: false,
+				linkFilter: () => true,
 				isRoot: true,
 				cwd: '/home/ckeditor'
 			},
 			{
 				filePaths: [ '/home/ckeditor5/external/ckeditor5-dev/.changelog/changeset-1.md' ],
 				gitHubUrl: 'https://github.com/ckeditor/ckeditor5-dev',
-				shouldSkipLinks: false,
+				linkFilter: () => true,
 				cwd: '/home/ckeditor5/external/ckeditor5-dev',
 				isRoot: false
 			}
@@ -586,7 +590,7 @@ describe( 'generateChangelog()', () => {
 				{
 					filePaths: [ '/home/ckeditor/.changelog/changeset-1.md' ],
 					gitHubUrl: 'https://github.com/ckeditor/ckeditor5',
-					shouldSkipLinks: false,
+					linkFilter: expect.any( Function ),
 					isRoot: true,
 					cwd: '/home/ckeditor'
 				}
@@ -604,7 +608,7 @@ describe( 'generateChangelog()', () => {
 				{
 					filePaths: [ '/home/ckeditor/.changelog/changeset-1.md' ],
 					gitHubUrl: 'https://github.com/ckeditor/ckeditor5',
-					shouldSkipLinks: false,
+					linkFilter: expect.any( Function ),
 					isRoot: true,
 					cwd: '/home/ckeditor'
 				}
@@ -639,7 +643,7 @@ describe( 'generateChangelog()', () => {
 						'/home/ckeditor/.changelog/changeset-1.md'
 					],
 					gitHubUrl: 'https://github.com/ckeditor/ckeditor5',
-					shouldSkipLinks: false,
+					linkFilter: () => true,
 					isRoot: true,
 					cwd: '/home/ckeditor'
 				}

--- a/packages/ckeditor5-dev-changelog/tests/utils/movechangelogentryfiles.ts
+++ b/packages/ckeditor5-dev-changelog/tests/utils/movechangelogentryfiles.ts
@@ -23,14 +23,14 @@ describe( 'moveChangelogEntryFiles()', () => {
 		{
 			filePaths: [ '/repo1/.changelog/file1.md', '/repo1/.changelog/file2.md' ],
 			gitHubUrl: 'https://github.com/ckeditor/repo1',
-			shouldSkipLinks: false,
+			linkFilter: () => true,
 			cwd: '/repo1',
 			isRoot: true
 		},
 		{
 			filePaths: [ '/repo2/.changelog/file3.md' ],
 			gitHubUrl: 'https://github.com/ckeditor/repo2',
-			shouldSkipLinks: true,
+			linkFilter: () => true,
 			cwd: '/repo2',
 			isRoot: false
 		}
@@ -108,7 +108,7 @@ describe( 'moveChangelogEntryFiles()', () => {
 			{
 				filePaths: [ '/repo1/.changelog/file1.md' ],
 				gitHubUrl: 'https://github.com/ckeditor/repo1',
-				shouldSkipLinks: false,
+				linkFilter: () => true,
 				cwd: '/repo1',
 				isRoot: true
 			}
@@ -131,7 +131,7 @@ describe( 'moveChangelogEntryFiles()', () => {
 			{
 				filePaths: [],
 				gitHubUrl: 'https://github.com/ckeditor/repo1',
-				shouldSkipLinks: false,
+				linkFilter: () => true,
 				cwd: '/repo1',
 				isRoot: true
 			}
@@ -165,7 +165,7 @@ describe( 'moveChangelogEntryFiles()', () => {
 			{
 				filePaths: [ '/repo1/.changelog/2025111200_feature-branch.md', '/repo1/.changelog/20250111300_fix-bug-123.md' ],
 				gitHubUrl: 'https://github.com/ckeditor/repo1',
-				shouldSkipLinks: false,
+				linkFilter: () => true,
 				cwd: '/repo1',
 				isRoot: true
 			}

--- a/packages/ckeditor5-dev-changelog/tests/utils/normalizeentry.ts
+++ b/packages/ckeditor5-dev-changelog/tests/utils/normalizeentry.ts
@@ -15,7 +15,7 @@ function wrapInput(
 		content: '',
 		changesetPath: '',
 		gitHubUrl: '',
-		shouldSkipLinks: false,
+		linkFilter: () => true,
 		data: partialData
 	};
 }

--- a/packages/ckeditor5-dev-changelog/tests/utils/parsechangelogentries.ts
+++ b/packages/ckeditor5-dev-changelog/tests/utils/parsechangelogentries.ts
@@ -26,6 +26,7 @@ describe( 'parseChangelogEntries()', () => {
 		const gitHubUrl = 'https://github.com/ckeditor/ckeditor5';
 		const fileContent1 = 'File content 1';
 		const fileContent2 = 'File content 2';
+		const linkFilter = () => false;
 
 		const matterResult1: GrayMatterFile<string> = {
 			content: 'Parsed content 1',
@@ -77,7 +78,7 @@ describe( 'parseChangelogEntries()', () => {
 			{
 				filePaths: [ changesetPath1, changesetPath2 ],
 				gitHubUrl,
-				shouldSkipLinks: false,
+				linkFilter,
 				cwd: '/changeset-path',
 				isRoot: false
 			}
@@ -102,7 +103,7 @@ describe( 'parseChangelogEntries()', () => {
 			},
 			gitHubUrl,
 			changesetPath: changesetPath1,
-			shouldSkipLinks: false,
+			linkFilter,
 			orig: fileContent1,
 			language: 'md',
 			matter: ''
@@ -122,7 +123,7 @@ describe( 'parseChangelogEntries()', () => {
 			},
 			gitHubUrl,
 			changesetPath: changesetPath2,
-			shouldSkipLinks: false,
+			linkFilter,
 			orig: fileContent2,
 			language: 'md',
 			matter: ''
@@ -137,7 +138,7 @@ describe( 'parseChangelogEntries()', () => {
 		expect( matter ).toHaveBeenCalledWith( fileContent2 );
 	} );
 
-	it( 'should handle multiple repositories with different skipLinks values', async () => {
+	it( 'should handle multiple repositories with different linkFilter values', async () => {
 		// Mock data
 		const changesetPath1 = '/path/to/repo1/20240101120000_changeset.md';
 		const changesetPath2 = '/path/to/repo2/20240101120001_changeset.md';
@@ -145,6 +146,8 @@ describe( 'parseChangelogEntries()', () => {
 		const gitHubUrl2 = 'https://github.com/ckeditor/ckeditor5-dev';
 		const fileContent1 = 'File content 1';
 		const fileContent2 = 'File content 2';
+		const linkFilter1 = () => true;
+		const linkFilter2 = () => false;
 
 		const matterResult1: GrayMatterFile<string> = {
 			content: 'Parsed content 1',
@@ -196,14 +199,14 @@ describe( 'parseChangelogEntries()', () => {
 			{
 				filePaths: [ changesetPath1 ],
 				gitHubUrl: gitHubUrl1,
-				shouldSkipLinks: false,
+				linkFilter: linkFilter1,
 				cwd: '/changeset-path-1',
 				isRoot: false
 			},
 			{
 				filePaths: [ changesetPath2 ],
 				gitHubUrl: gitHubUrl2,
-				shouldSkipLinks: true,
+				linkFilter: linkFilter2,
 				cwd: '/changeset-path-2',
 				isRoot: false
 			}
@@ -228,7 +231,7 @@ describe( 'parseChangelogEntries()', () => {
 			},
 			gitHubUrl: gitHubUrl1,
 			changesetPath: changesetPath1,
-			shouldSkipLinks: false,
+			linkFilter: linkFilter1,
 			orig: fileContent1,
 			language: 'md',
 			matter: ''
@@ -248,7 +251,7 @@ describe( 'parseChangelogEntries()', () => {
 			},
 			gitHubUrl: gitHubUrl2,
 			changesetPath: changesetPath2,
-			shouldSkipLinks: true,
+			linkFilter: linkFilter2,
 			orig: fileContent2,
 			language: 'md',
 			matter: ''
@@ -264,12 +267,15 @@ describe( 'parseChangelogEntries()', () => {
 	} );
 
 	it( 'should handle empty changeset paths array', async () => {
+		// Mock data
+		const linkFilter = () => false;
+
 		// Input data
 		const filePathsWithGithubUrl: Array<ChangesetPathsWithGithubUrl> = [
 			{
 				filePaths: [],
 				gitHubUrl: 'https://github.com/ckeditor/ckeditor5',
-				shouldSkipLinks: false,
+				linkFilter,
 				cwd: '/changeset-path-1',
 				isRoot: false
 			}
@@ -302,6 +308,7 @@ describe( 'parseChangelogEntries()', () => {
 		const changesetPath = '/path/to/20240101120000_changeset.md';
 		const gitHubUrl = 'https://github.com/test/repo';
 		const fileContent = 'file content';
+		const linkFilter = () => false;
 		const matterResult = {
 			content: 'parsed content',
 			data: { type: 'feature', scope: [ 'ui' ] }
@@ -316,7 +323,7 @@ describe( 'parseChangelogEntries()', () => {
 			{
 				filePaths: [ changesetPath ],
 				gitHubUrl,
-				shouldSkipLinks: false,
+				linkFilter,
 				cwd: '/test',
 				isRoot: false
 			}
@@ -341,7 +348,7 @@ describe( 'parseChangelogEntries()', () => {
 			},
 			gitHubUrl,
 			changesetPath,
-			shouldSkipLinks: false
+			linkFilter
 		} );
 		expect( callArgs[ 0 ]!.createdAt ).toBeInstanceOf( Date );
 	} );
@@ -352,6 +359,7 @@ describe( 'parseChangelogEntries()', () => {
 			const changesetPath = '/path/to/invalid_filename.md';
 			const gitHubUrl = 'https://github.com/test/repo';
 			const fileContent = 'file content';
+			const linkFilter = () => false;
 			const matterResult = {
 				content: 'parsed content',
 				data: { type: 'feature', scope: [] }
@@ -366,7 +374,7 @@ describe( 'parseChangelogEntries()', () => {
 				{
 					filePaths: [ changesetPath ],
 					gitHubUrl,
-					shouldSkipLinks: false,
+					linkFilter,
 					cwd: '/test',
 					isRoot: false
 				}
@@ -385,6 +393,7 @@ describe( 'parseChangelogEntries()', () => {
 			const changesetPath = '/path/to/99999999999999_invalid_date.md';
 			const gitHubUrl = 'https://github.com/test/repo';
 			const fileContent = 'file content';
+			const linkFilter = () => false;
 			const matterResult = {
 				content: 'parsed content',
 				data: { type: 'feature', scope: [] }
@@ -399,7 +408,7 @@ describe( 'parseChangelogEntries()', () => {
 				{
 					filePaths: [ changesetPath ],
 					gitHubUrl,
-					shouldSkipLinks: false,
+					linkFilter,
 					cwd: '/test',
 					isRoot: false
 				}
@@ -418,6 +427,7 @@ describe( 'parseChangelogEntries()', () => {
 			const changesetPath = '';
 			const gitHubUrl = 'https://github.com/test/repo';
 			const fileContent = 'file content';
+			const linkFilter = () => false;
 			const matterResult = {
 				content: 'parsed content',
 				data: { type: 'feature', scope: [] }
@@ -432,7 +442,7 @@ describe( 'parseChangelogEntries()', () => {
 				{
 					filePaths: [ changesetPath ],
 					gitHubUrl,
-					shouldSkipLinks: false,
+					linkFilter,
 					cwd: '/test',
 					isRoot: false
 				}

--- a/packages/ckeditor5-dev-changelog/tests/utils/removechangelogentryfiles.ts
+++ b/packages/ckeditor5-dev-changelog/tests/utils/removechangelogentryfiles.ts
@@ -22,14 +22,14 @@ describe( 'removeChangelogEntryFiles()', () => {
 		{
 			filePaths: [ '/repo/changelog/changeset-1.md' ],
 			gitHubUrl: 'https://github.com/repo/changelog/changeset-1',
-			shouldSkipLinks: false,
+			linkFilter: () => true,
 			cwd: '/changeset-path-1',
 			isRoot: true
 		},
 		{
 			filePaths: [ '/repo/changelog/changeset-2.md' ],
 			gitHubUrl: 'https://github.com/repo/changelog/changeset-2',
-			shouldSkipLinks: false,
+			linkFilter: () => true,
 			cwd: '/changeset-path-2',
 			isRoot: false
 		}

--- a/packages/ckeditor5-dev-changelog/tests/utils/sortentriesbyscopeanddate.ts
+++ b/packages/ckeditor5-dev-changelog/tests/utils/sortentriesbyscopeanddate.ts
@@ -5,14 +5,14 @@
 
 import { describe, it, expect } from 'vitest';
 import { sortEntriesByScopeAndDate } from '../../src/utils/sortentriesbyscopeanddate.js';
-import type { ParsedFile } from '../../src/types.js';
+import type { LinkFilter, ParsedFile } from '../../src/types.js';
 
 function createMockEntry(
 	scope: Array<string>,
 	createdAt: Date,
 	content: string = 'Test content',
 	gitHubUrl: string = 'https://github.com/test/repo',
-	shouldSkipLinks: boolean = false
+	linkFilter: LinkFilter = () => true
 ): ParsedFile {
 	return {
 		content,
@@ -27,7 +27,7 @@ function createMockEntry(
 		changesetPath: '',
 		createdAt,
 		gitHubUrl,
-		shouldSkipLinks
+		linkFilter
 	};
 }
 

--- a/packages/ckeditor5-dev-changelog/tests/utils/validateentry.ts
+++ b/packages/ckeditor5-dev-changelog/tests/utils/validateentry.ts
@@ -38,7 +38,7 @@ function createEntry( data: Record<string, any> ): ParsedFile {
 		} as any,
 		changesetPath: 'path/to/changeset',
 		gitHubUrl: 'https://github.com/ckeditor/ckeditor5',
-		shouldSkipLinks: false
+		linkFilter: () => true
 	};
 }
 


### PR DESCRIPTION
<!--

This repository uses Markdown files to define changelog entries. If the changes in this pull request are **user-facing**, please create a changelog entry by running the following command:

    yarn nice

This will generate a `*.md` file in the `.changelog/` directory for your description. You can create as many as you need.

**Note:**  
If your PR is internal-only (e.g., tests, tooling, docs), you can skip this step - just mention it below.

-->

### 🚀 Summary

Added a top-level `linkFilter()` callback option for changelog generators that determines which issue links should be preserved in the generated changelog and which should be removed. If the `shouldSkipLinks` flag is also provided, the `shouldSkipLinks` flag takes precedence over the `linkFilter()` callback to maintain backward compatibility.

---

### 📌 Related issues

<!--

Although changelog entries list connected issues, GitHub requires listing them here to automatically link and close them.

-->

* Closes https://github.com/ckeditor/ckeditor5/issues/18936.

---

### 💡 Additional information

When this PR is released, we can merge https://github.com/ckeditor/ckeditor5/pull/18964.

#### Tests

1. Switch to `ck/18936` branch in `ckeditor5-dev` repository. We are going to check if link to `ckeditor/ckeditor5#18936` is **skipped** or **preserved** in the changelog output.
2. Execute `yarn release:prepare-changelog --dry-run`.
   - Expected result: link is **preserved**.
3. Update `changelogOptions` in `scripts/preparechangelog.js` and then execute `yarn release:prepare-changelog --dry-run`:
   - Add `shouldSkipLinks: true`.  Expected result: link is **skipped**.
   - Add `shouldSkipLinks: false`. Expected result: link is **preserved**.
   - Add `linkFilter: () => false`. Expected result: link is **skipped**.
   - Add `linkFilter: () => true`. Expected result: link is **preserved**.
   - Add `linkFilter: () => true` and `shouldSkipLinks: true`. Expected result: link is **skipped**.
   - Add `linkFilter: () => false` and `shouldSkipLinks: false`. Expected result: link is **preserved**.
   - Add `linkFilter: url => url.endsWith( '18936' )`. Expected result: link is **preserved**.
   - Add `linkFilter: url => url.endsWith( '11111' )`. Expected result: link is **skipped**.