### PR TITLE
Add `kapa.ai` to the list of ignored hosts.

### DIFF
--- a/.changelog/20250904161709_ck_19064_add_kapa_ai_to_ignored_hosts.md
+++ b/.changelog/20250904161709_ck_19064_add_kapa_ai_to_ignored_hosts.md
@@ -1,0 +1,7 @@
+---
+type: Feature
+scope: ckeditor5-dev-web-crawler
+closes: https://github.com/ckeditor/ckeditor5/issues/19064
+---
+
+Add `kapa.ai` to the list of ignored hosts.

--- a/packages/ckeditor5-dev-web-crawler/src/constants.ts
+++ b/packages/ckeditor5-dev-web-crawler/src/constants.ts
@@ -40,6 +40,7 @@ export const IGNORED_HOSTS = [
 	'iframe.ly',
 	'jsfiddle.net',
 	'fonts.googleapis.com',
+	'kapa.ai',
 
 	// See: https://github.com/ckeditor/ckeditor5/issues/18519.
 	'if-cdn.com'


### PR DESCRIPTION
### 🚀 Summary

Add `kapa.ai` to the list of ignored hosts.

---

### 📌 Related issues

* Closes https://github.com/ckeditor/ckeditor5/issues/19064

---

### 💡 Additional information

The original issue is about blocking `csp.withgoogle.com`, as this was the domain shown by the crawler. However, the actual root cause is code being downloaded from `kapa.ai`.

Blocking requests to this domain reduces the crawl time for all ~4,000 pages from 9.5 minutes back to 5.1 minutes.
