### PR TITLE
Increase timeout in `ckeditor5-dev-web-crawler` from 15 to 30 seconds.

### DIFF
--- a/.changelog/20250909144153_core_19082_increase_timeout_in_web_crawler_to_30_s.md
+++ b/.changelog/20250909144153_core_19082_increase_timeout_in_web_crawler_to_30_s.md
@@ -1,0 +1,7 @@
+---
+type: Feature
+scope: ckeditor5-dev-web-crawler
+closes: https://github.com/ckeditor/ckeditor5/issues/19082
+---
+
+Increase timeout in `ckeditor5-dev-web-crawler` from 15 to 30 seconds.

--- a/packages/ckeditor5-dev-web-crawler/src/constants.ts
+++ b/packages/ckeditor5-dev-web-crawler/src/constants.ts
@@ -48,7 +48,7 @@ export const IGNORED_HOSTS = [
 
 export const DEFAULT_CONCURRENCY = Math.min( cpus().length, 16 );
 
-export const DEFAULT_TIMEOUT = 15 * 1000;
+export const DEFAULT_TIMEOUT = 30 * 1000;
 
 export const DEFAULT_RESPONSIVENESS_CHECK_TIMEOUT = 1000;
 


### PR DESCRIPTION
### 🚀 Summary

Increase timeout in `ckeditor5-dev-web-crawler` from 15 to 30 seconds.

---

### 📌 Related issues

* Closes https://github.com/ckeditor/ckeditor5/issues/19082

---

### 💡 Additional information

N/A
