### PR TITLE
Using `workspace:*` for dependencies in `checkVersionMatch` function.

### DIFF
--- a/.changelog/20251003145641_cc_8556_use_workspace_as_version.md
+++ b/.changelog/20251003145641_cc_8556_use_workspace_as_version.md
@@ -2,8 +2,6 @@
 type: Feature
 scope:
   - ckeditor5-dev-dependency-checker
-see:
-  - ckeditor/ckeditor5-commercial#8556
 ---
 
 Updated the `checkVersionMatch()` function to support the [`workspace:*`](https://pnpm.io/workspaces) protocol for dependencies.

--- a/.changelog/20251003145641_cc_8556_use_workspace_as_version.md
+++ b/.changelog/20251003145641_cc_8556_use_workspace_as_version.md
@@ -7,5 +7,6 @@ see:
 ---
 
 Using `workspace:*` for dependencies in `checkVersionMatch` function.
+Added `useWorkspace` property to verify if packages should use `workspace:*` as version.
 Dependencies that pass the `devDependenciesFilter` are now expected to use `workspace:*` instead of specific version numbers.
 This change supports pnpm workspace dependencies and ensures consistent versioning across workspace packages.

--- a/.changelog/20251003145641_cc_8556_use_workspace_as_version.md
+++ b/.changelog/20251003145641_cc_8556_use_workspace_as_version.md
@@ -1,0 +1,11 @@
+---
+type: Feature
+scope:
+  - ckeditor5-dev-dependency-checker
+see:
+  - ckeditor/ckeditor5-commercial#8556
+---
+
+Using `workspace:*` for dependencies in `checkVersionMatch` function.
+Dependencies that pass the `devDependenciesFilter` are now expected to use `workspace:*` instead of specific version numbers.
+This change supports pnpm workspace dependencies and ensures consistent versioning across workspace packages.

--- a/.changelog/20251003145641_cc_8556_use_workspace_as_version.md
+++ b/.changelog/20251003145641_cc_8556_use_workspace_as_version.md
@@ -6,4 +6,4 @@ scope:
 
 Updated the `checkVersionMatch()` function to support the [`workspace:*`](https://pnpm.io/workspaces) protocol for dependencies.
 
-Added a `useWorkspace` option that enforces using `workspace:*` instead of specific version numbers. Both `dependencies` and `devDependencies` (for packages matching `devDependenciesFilter`) are now validated to ensure consistent workspace versioning with pnpm.
+Added a `workspacePackages` option that specify the list of packages that should use `workspace:*` instead of specific version numbers. Both `dependencies` and `devDependencies` are validated to ensure consistent workspace versioning with pnpm.

--- a/.changelog/20251003145641_cc_8556_use_workspace_as_version.md
+++ b/.changelog/20251003145641_cc_8556_use_workspace_as_version.md
@@ -6,7 +6,6 @@ see:
   - ckeditor/ckeditor5-commercial#8556
 ---
 
-Using `workspace:*` for dependencies in `checkVersionMatch` function.
-Added `useWorkspace` property to verify if packages should use `workspace:*` as version.
-Dependencies that pass the `devDependenciesFilter` are now expected to use `workspace:*` instead of specific version numbers.
-This change supports pnpm workspace dependencies and ensures consistent versioning across workspace packages.
+Updated the `checkVersionMatch()` function to support the [`workspace:*`](https://pnpm.io/workspaces) protocol for dependencies.
+
+Added a `useWorkspace` option that enforces using `workspace:*` instead of specific version numbers. Both `dependencies` and `devDependencies` (for packages matching `devDependenciesFilter`) are now validated to ensure consistent workspace versioning with pnpm.

--- a/packages/ckeditor5-dev-changelog/package.json
+++ b/packages/ckeditor5-dev-changelog/package.json
@@ -28,7 +28,7 @@
     "ckeditor5-dev-changelog-create-entry": "bin/generate-template.js"
   },
   "dependencies": {
-    "@ckeditor/ckeditor5-dev-utils": "^53.2.0",
+    "@ckeditor/ckeditor5-dev-utils": "workspace:*",
     "chalk": "^5.0.0",
     "date-fns": "^4.0.0",
     "fs-extra": "^11.0.0",

--- a/packages/ckeditor5-dev-dependency-checker/lib/checkversionmatch.js
+++ b/packages/ckeditor5-dev-dependency-checker/lib/checkversionmatch.js
@@ -11,6 +11,8 @@ import semver from 'semver';
 import { globSync } from 'glob';
 import { execSync } from 'child_process';
 
+const PNPM_WORKSPACE_VERSION = 'workspace:*';
+
 const DEPENDENCY_TYPES = [
 	'dependencies',
 	'devDependencies'
@@ -160,6 +162,12 @@ function getExpectedDepsVersions( { packageJsons, devDependenciesFilter, version
 
 			Object.entries( packageJson[ dependencyType ] ).forEach( ( [ dependencyName, version ] ) => {
 				if ( dependencyType === 'devDependencies' && !devDependenciesFilter( dependencyName ) ) {
+					return;
+				}
+
+				if ( devDependenciesFilter( dependencyName ) ) {
+					expectedDependencies[ dependencyName ] = PNPM_WORKSPACE_VERSION;
+
 					return;
 				}
 

--- a/packages/ckeditor5-dev-dependency-checker/package.json
+++ b/packages/ckeditor5-dev-dependency-checker/package.json
@@ -26,7 +26,7 @@
     "ckeditor5-dev-dependency-checker": "bin/dependencychecker.js"
   },
   "dependencies": {
-    "@ckeditor/ckeditor5-dev-utils": "^53.2.0",
+    "@ckeditor/ckeditor5-dev-utils": "workspace:*",
     "chalk": "^5.0.0",
     "depcheck": "^1.3.1",
     "fs-extra": "^11.0.0",

--- a/packages/ckeditor5-dev-dependency-checker/tests/checkversionmatch.js
+++ b/packages/ckeditor5-dev-dependency-checker/tests/checkversionmatch.js
@@ -102,14 +102,6 @@ describe( 'checkVersionMatch()', () => {
 	} );
 
 	it( 'should log about dependencies being correct', () => {
-		// Set all dependencies to workspace:* to match the new expected behavior
-		files[ './package.json' ].dependencies.dep1 = 'workspace:*';
-		files[ './package.json' ].devDependencies.dep2 = 'workspace:*';
-		files[ './packages/foo/package.json' ].dependencies.dep1 = 'workspace:*';
-		files[ './packages/foo/package.json' ].devDependencies.dep2 = 'workspace:*';
-		files[ './packages/bar/package.json' ].dependencies.dep1 = 'workspace:*';
-		files[ './packages/bar/package.json' ].devDependencies.dep2 = 'workspace:*';
-
 		checkVersionMatch( options );
 
 		expect( consoleLogMock ).toHaveBeenCalledTimes( 2 );
@@ -135,12 +127,8 @@ describe( 'checkVersionMatch()', () => {
 			'❌  Errors found. Run this script with an argument: `--fix` to resolve the issues automatically:'
 		);
 		expect( consoleErrorMock ).toHaveBeenNthCalledWith( 2, [
-			'"dep1" in "rootPkg" in version "1.0.1" should be set to "workspace:*".',
-			'"dep2" in "rootPkg" in version "2.0.0" should be set to "workspace:*".',
-			'"dep1" in "fooPkg" in version "1.0.0" should be set to "workspace:*".',
-			'"dep2" in "fooPkg" in version "2.0.0" should be set to "workspace:*".',
-			'"dep1" in "barPkg" in version "1.0.0" should be set to "workspace:*".',
-			'"dep2" in "barPkg" in version "2.0.0" should be set to "workspace:*".'
+			'"dep1" in "fooPkg" in version "1.0.0" should be set to "1.0.1".',
+			'"dep1" in "barPkg" in version "1.0.0" should be set to "1.0.1".'
 		].join( '\n' ) );
 	} );
 
@@ -149,22 +137,20 @@ describe( 'checkVersionMatch()', () => {
 
 		checkVersionMatch( options );
 
-		expect( consoleLogMock ).toHaveBeenCalledTimes( 1 );
+		expect( consoleLogMock ).toHaveBeenCalledTimes( 2 );
 		expect( consoleErrorMock ).toHaveBeenCalledTimes( 2 );
 		expect( processExitMock ).toHaveBeenCalledTimes( 1 );
 
 		expect( consoleLogMock ).toHaveBeenNthCalledWith( 1, '🔍 Starting checking dependencies versions...' );
+		expect( consoleLogMock ).toHaveBeenNthCalledWith( 2, '⬇️ Downloading "dep1" versions from npm...' );
 
 		expect( consoleErrorMock ).toHaveBeenNthCalledWith( 1,
 			'❌  Errors found. Run this script with an argument: `--fix` to resolve the issues automatically:'
 		);
 		expect( consoleErrorMock ).toHaveBeenNthCalledWith( 2, [
-			'"dep1" in "rootPkg" in version "^1.0.0" should be set to "workspace:*".',
-			'"dep2" in "rootPkg" in version "2.0.0" should be set to "workspace:*".',
-			'"dep1" in "fooPkg" in version "1.0.0" should be set to "workspace:*".',
-			'"dep2" in "fooPkg" in version "2.0.0" should be set to "workspace:*".',
-			'"dep1" in "barPkg" in version "1.0.0" should be set to "workspace:*".',
-			'"dep2" in "barPkg" in version "2.0.0" should be set to "workspace:*".'
+			'"dep1" in "rootPkg" in version "^1.0.0" should be set to "1.0.1".',
+			'"dep1" in "fooPkg" in version "1.0.0" should be set to "1.0.1".',
+			'"dep1" in "barPkg" in version "1.0.0" should be set to "1.0.1".'
 		].join( '\n' ) );
 	} );
 
@@ -174,21 +160,19 @@ describe( 'checkVersionMatch()', () => {
 
 		checkVersionMatch( options );
 
-		expect( consoleLogMock ).toHaveBeenCalledTimes( 1 );
+		expect( consoleLogMock ).toHaveBeenCalledTimes( 2 );
 		expect( consoleErrorMock ).toHaveBeenCalledTimes( 2 );
 		expect( processExitMock ).toHaveBeenCalledTimes( 1 );
 
 		expect( consoleLogMock ).toHaveBeenNthCalledWith( 1, '🔍 Starting checking dependencies versions...' );
+		expect( consoleLogMock ).toHaveBeenNthCalledWith( 2, '⬇️ Downloading "dep1" versions from npm...' );
 
 		expect( consoleErrorMock ).toHaveBeenNthCalledWith( 1,
 			'❌  Errors found. Run this script with an argument: `--fix` to resolve the issues automatically:'
 		);
 		expect( consoleErrorMock ).toHaveBeenNthCalledWith( 2, [
-			'"dep1" in "rootPkg" in version "^1.0.0" should be set to "workspace:*".',
-			'"dep2" in "rootPkg" in version "2.0.0" should be set to "workspace:*".',
-			'"dep2" in "fooPkg" in version "2.0.0" should be set to "workspace:*".',
-			'"dep1" in "barPkg" in version "1.0.0" should be set to "workspace:*".',
-			'"dep2" in "barPkg" in version "2.0.0" should be set to "workspace:*".'
+			'"dep1" in "rootPkg" in version "^1.0.0" should be set to "1.0.1".',
+			'"dep1" in "barPkg" in version "1.0.0" should be set to "1.0.1".'
 		].join( '\n' ) );
 	} );
 
@@ -221,12 +205,8 @@ describe( 'checkVersionMatch()', () => {
 			'❌  Errors found. Run this script with an argument: `--fix` to resolve the issues automatically:'
 		);
 		expect( consoleErrorMock ).toHaveBeenNthCalledWith( 2, [
-			'"dep1" in "rootPkg" in version "1.0.0" should be set to "workspace:*".',
-			'"dep2" in "rootPkg" in version "2.0.1" should be set to "workspace:*".',
-			'"dep1" in "fooPkg" in version "1.0.0" should be set to "workspace:*".',
-			'"dep2" in "fooPkg" in version "2.0.0" should be set to "workspace:*".',
-			'"dep1" in "barPkg" in version "1.0.0" should be set to "workspace:*".',
-			'"dep2" in "barPkg" in version "2.0.0" should be set to "workspace:*".'
+			'"dep2" in "fooPkg" in version "2.0.0" should be set to "2.0.1".',
+			'"dep2" in "barPkg" in version "2.0.0" should be set to "2.0.1".'
 		].join( '\n' ) );
 	} );
 
@@ -235,22 +215,20 @@ describe( 'checkVersionMatch()', () => {
 
 		checkVersionMatch( options );
 
-		expect( consoleLogMock ).toHaveBeenCalledTimes( 1 );
+		expect( consoleLogMock ).toHaveBeenCalledTimes( 2 );
 		expect( consoleErrorMock ).toHaveBeenCalledTimes( 2 );
 		expect( processExitMock ).toHaveBeenCalledTimes( 1 );
 
 		expect( consoleLogMock ).toHaveBeenNthCalledWith( 1, '🔍 Starting checking dependencies versions...' );
+		expect( consoleLogMock ).toHaveBeenNthCalledWith( 2, '⬇️ Downloading "dep2" versions from npm...' );
 
 		expect( consoleErrorMock ).toHaveBeenNthCalledWith( 1,
 			'❌  Errors found. Run this script with an argument: `--fix` to resolve the issues automatically:'
 		);
 		expect( consoleErrorMock ).toHaveBeenNthCalledWith( 2, [
-			'"dep1" in "rootPkg" in version "1.0.0" should be set to "workspace:*".',
-			'"dep2" in "rootPkg" in version "^2.0.0" should be set to "workspace:*".',
-			'"dep1" in "fooPkg" in version "1.0.0" should be set to "workspace:*".',
-			'"dep2" in "fooPkg" in version "2.0.0" should be set to "workspace:*".',
-			'"dep1" in "barPkg" in version "1.0.0" should be set to "workspace:*".',
-			'"dep2" in "barPkg" in version "2.0.0" should be set to "workspace:*".'
+			'"dep2" in "rootPkg" in version "^2.0.0" should be set to "2.0.1".',
+			'"dep2" in "fooPkg" in version "2.0.0" should be set to "2.0.1".',
+			'"dep2" in "barPkg" in version "2.0.0" should be set to "2.0.1".'
 		].join( '\n' ) );
 	} );
 
@@ -270,12 +248,8 @@ describe( 'checkVersionMatch()', () => {
 			'❌  Errors found. Run this script with an argument: `--fix` to resolve the issues automatically:'
 		);
 		expect( consoleErrorMock ).toHaveBeenNthCalledWith( 2, [
-			'"dep1" in "rootPkg" in version "1.0.0" should be set to "workspace:*".',
-			'"dep2" in "rootPkg" in version "^2.0.0" should be set to "workspace:*".',
-			'"dep1" in "fooPkg" in version "1.0.0" should be set to "workspace:*".',
-			'"dep2" in "fooPkg" in version "2.0.0" should be set to "workspace:*".',
-			'"dep1" in "barPkg" in version "1.0.0" should be set to "workspace:*".',
-			'"dep2" in "barPkg" in version "2.0.0" should be set to "workspace:*".'
+			'"dep2" in "fooPkg" in version "2.0.0" should be set to "^2.0.0".',
+			'"dep2" in "barPkg" in version "2.0.0" should be set to "^2.0.0".'
 		].join( '\n' ) );
 	} );
 
@@ -285,38 +259,27 @@ describe( 'checkVersionMatch()', () => {
 
 		checkVersionMatch( options );
 
-		expect( consoleLogMock ).toHaveBeenCalledTimes( 1 );
+		expect( consoleLogMock ).toHaveBeenCalledTimes( 2 );
 		expect( consoleErrorMock ).toHaveBeenCalledTimes( 2 );
 		expect( processExitMock ).toHaveBeenCalledTimes( 1 );
 
 		expect( consoleLogMock ).toHaveBeenNthCalledWith( 1, '🔍 Starting checking dependencies versions...' );
+		expect( consoleLogMock ).toHaveBeenNthCalledWith( 2, '⬇️ Downloading "dep2" versions from npm...' );
 
 		expect( consoleErrorMock ).toHaveBeenNthCalledWith( 1,
 			'❌  Errors found. Run this script with an argument: `--fix` to resolve the issues automatically:'
 		);
 		expect( consoleErrorMock ).toHaveBeenNthCalledWith( 2, [
-			'"dep1" in "rootPkg" in version "1.0.0" should be set to "workspace:*".',
-			'"dep2" in "rootPkg" in version "^2.0.0" should be set to "workspace:*".',
-			'"dep1" in "fooPkg" in version "1.0.0" should be set to "workspace:*".',
-			'"dep1" in "barPkg" in version "1.0.0" should be set to "workspace:*".',
-			'"dep2" in "barPkg" in version "2.0.0" should be set to "workspace:*".'
+			'"dep2" in "rootPkg" in version "^2.0.0" should be set to "2.0.1".',
+			'"dep2" in "barPkg" in version "2.0.0" should be set to "2.0.1".'
 		].join( '\n' ) );
 	} );
 
 	it( 'should not log about dependencies using different version ranges when they are an exception', () => {
 		options.versionExceptions = { 'dep3': '^' };
-		// Use a filter that excludes dep3 so it uses the old logic with exceptions
-		options.devDependenciesFilter = depName => depName !== 'dep3';
 		files[ './package.json' ].dependencies.dep3 = '^3.0.2';
 		files[ './packages/foo/package.json' ].dependencies.dep3 = '^3.0.2';
 		files[ './packages/bar/package.json' ].dependencies.dep3 = '^3.0.2';
-		// Set all other dependencies to workspace:* to match the new expected behavior
-		files[ './package.json' ].dependencies.dep1 = 'workspace:*';
-		files[ './package.json' ].devDependencies.dep2 = 'workspace:*';
-		files[ './packages/foo/package.json' ].dependencies.dep1 = 'workspace:*';
-		files[ './packages/foo/package.json' ].devDependencies.dep2 = 'workspace:*';
-		files[ './packages/bar/package.json' ].dependencies.dep1 = 'workspace:*';
-		files[ './packages/bar/package.json' ].devDependencies.dep2 = 'workspace:*';
 
 		checkVersionMatch( options );
 
@@ -349,10 +312,10 @@ describe( 'checkVersionMatch()', () => {
 			{
 				name: 'rootPkg',
 				dependencies: {
-					dep1: 'workspace:*'
+					dep1: '1.0.1'
 				},
 				devDependencies: {
-					dep2: 'workspace:*'
+					dep2: '2.0.0'
 				}
 			},
 			{ 'spaces': 2 }
@@ -362,10 +325,10 @@ describe( 'checkVersionMatch()', () => {
 			{
 				name: 'fooPkg',
 				dependencies: {
-					dep1: 'workspace:*'
+					dep1: '1.0.1'
 				},
 				devDependencies: {
-					dep2: 'workspace:*'
+					dep2: '2.0.0'
 				}
 			},
 			{ 'spaces': 2 }
@@ -375,10 +338,10 @@ describe( 'checkVersionMatch()', () => {
 			{
 				name: 'barPkg',
 				dependencies: {
-					dep1: 'workspace:*'
+					dep1: '1.0.1'
 				},
 				devDependencies: {
-					dep2: 'workspace:*'
+					dep2: '2.0.0'
 				}
 			},
 			{ 'spaces': 2 }
@@ -407,10 +370,10 @@ describe( 'checkVersionMatch()', () => {
 			{
 				name: 'rootPkg',
 				dependencies: {
-					dep1: 'workspace:*'
+					dep1: '1.0.0'
 				},
 				devDependencies: {
-					dep2: 'workspace:*'
+					dep2: '2.0.1'
 				}
 			},
 			{ 'spaces': 2 }
@@ -420,7 +383,7 @@ describe( 'checkVersionMatch()', () => {
 			{
 				name: 'fooPkg',
 				devDependencies: {
-					dep2: 'workspace:*'
+					dep2: '2.0.1'
 				}
 			},
 			{ 'spaces': 2 }
@@ -430,18 +393,21 @@ describe( 'checkVersionMatch()', () => {
 			{
 				name: 'barPkg',
 				dependencies: {
-					dep1: 'workspace:*'
+					dep1: '1.0.0'
 				},
 				devDependencies: {
-					dep2: 'workspace:*'
+					dep2: '2.0.1'
 				}
 			},
 			{ 'spaces': 2 }
 		);
 	} );
 
-	it( 'should expect workspace:* for all dependencies when they are present in workspace', () => {
-		// Set all dependencies to workspace:* to match the new expected behavior
+	// TODO check
+
+	it( 'should expect workspace:* for all dependencies when useWorkspace is and not devDependenciesFilter is provided', () => {
+		options.useWorkspace = true;
+		// Set all dependencies to workspace:* to match the expected behavior
 		files[ './package.json' ].dependencies.dep1 = 'workspace:*';
 		files[ './package.json' ].devDependencies.dep2 = 'workspace:*';
 		files[ './packages/foo/package.json' ].dependencies.dep1 = 'workspace:*';
@@ -459,8 +425,8 @@ describe( 'checkVersionMatch()', () => {
 		expect( consoleLogMock ).toHaveBeenNthCalledWith( 2, '✅  All dependencies are correct!' );
 	} );
 
-	it( 'should expect workspace:* for dependencies that are not workspace:*', () => {
-		files[ './package.json' ].dependencies.dep1 = 'workspace:*';
+	it( 'should expect specific versions for dependencies that are not matching', () => {
+		files[ './package.json' ].dependencies.dep1 = '1.0.1';
 		files[ './packages/foo/package.json' ].dependencies.dep1 = '1.0.0';
 		files[ './packages/bar/package.json' ].dependencies.dep1 = '1.0.0';
 
@@ -476,11 +442,8 @@ describe( 'checkVersionMatch()', () => {
 			'❌  Errors found. Run this script with an argument: `--fix` to resolve the issues automatically:'
 		);
 		expect( consoleErrorMock ).toHaveBeenNthCalledWith( 2, [
-			'"dep2" in "rootPkg" in version "2.0.0" should be set to "workspace:*".',
-			'"dep1" in "fooPkg" in version "1.0.0" should be set to "workspace:*".',
-			'"dep2" in "fooPkg" in version "2.0.0" should be set to "workspace:*".',
-			'"dep1" in "barPkg" in version "1.0.0" should be set to "workspace:*".',
-			'"dep2" in "barPkg" in version "2.0.0" should be set to "workspace:*".'
+			'"dep1" in "fooPkg" in version "1.0.0" should be set to "1.0.1".',
+			'"dep1" in "barPkg" in version "1.0.0" should be set to "1.0.1".'
 		].join( '\n' ) );
 	} );
 
@@ -580,7 +543,94 @@ describe( 'checkVersionMatch()', () => {
 					dep1: 'workspace:*'
 				},
 				devDependencies: {
-					dep2: '2.0.1' // Should remain unchanged
+					dep2: '2.0.1' // Should remain unchanged due to filter
+				}
+			},
+			{ 'spaces': 2 }
+		);
+	} );
+
+	it( 'should expect workspace:* for dependencies that are not workspace:* when useWorkspace is true', () => {
+		options.useWorkspace = true;
+		files[ './package.json' ].dependencies.dep1 = 'workspace:*';
+		files[ './packages/foo/package.json' ].dependencies.dep1 = '1.0.0';
+		files[ './packages/bar/package.json' ].dependencies.dep1 = '1.0.0';
+
+		checkVersionMatch( options );
+
+		expect( consoleLogMock ).toHaveBeenCalledTimes( 1 );
+		expect( consoleErrorMock ).toHaveBeenCalledTimes( 2 );
+		expect( processExitMock ).toHaveBeenCalledTimes( 1 );
+
+		expect( consoleLogMock ).toHaveBeenNthCalledWith( 1, '🔍 Starting checking dependencies versions...' );
+
+		expect( consoleErrorMock ).toHaveBeenNthCalledWith( 1,
+			'❌  Errors found. Run this script with an argument: `--fix` to resolve the issues automatically:'
+		);
+		expect( consoleErrorMock ).toHaveBeenNthCalledWith( 2, [
+			'"dep2" in "rootPkg" in version "2.0.0" should be set to "workspace:*".',
+			'"dep1" in "fooPkg" in version "1.0.0" should be set to "workspace:*".',
+			'"dep2" in "fooPkg" in version "2.0.0" should be set to "workspace:*".',
+			'"dep1" in "barPkg" in version "1.0.0" should be set to "workspace:*".',
+			'"dep2" in "barPkg" in version "2.0.0" should be set to "workspace:*".'
+		].join( '\n' ) );
+	} );
+
+	it( 'should fix dependencies to workspace:* when useWorkspace is true', () => {
+		options.useWorkspace = true;
+		options.fix = true;
+		files[ './package.json' ].dependencies.dep1 = 'workspace:*';
+		files[ './packages/foo/package.json' ].dependencies.dep1 = '1.0.0';
+		files[ './packages/bar/package.json' ].dependencies.dep1 = '1.0.0';
+
+		checkVersionMatch( options );
+
+		expect( consoleLogMock ).toHaveBeenCalledTimes( 2 );
+		expect( consoleErrorMock ).toHaveBeenCalledTimes( 0 );
+		expect( processExitMock ).toHaveBeenCalledTimes( 0 );
+
+		expect( consoleLogMock ).toHaveBeenNthCalledWith( 1, '🔍 Starting checking dependencies versions...' );
+		expect( consoleLogMock ).toHaveBeenNthCalledWith( 2, '✅  All dependencies fixed!' );
+
+		expect( fs.writeJSONSync ).toHaveBeenCalledTimes( 3 );
+
+		expect( fs.writeJSONSync ).toHaveBeenNthCalledWith( 1,
+			'./package.json',
+			{
+				name: 'rootPkg',
+				dependencies: {
+					dep1: 'workspace:*'
+				},
+				devDependencies: {
+					dep2: 'workspace:*'
+				}
+			},
+			{ 'spaces': 2 }
+		);
+
+		expect( fs.writeJSONSync ).toHaveBeenNthCalledWith( 2,
+			'./packages/foo/package.json',
+			{
+				name: 'fooPkg',
+				dependencies: {
+					dep1: 'workspace:*'
+				},
+				devDependencies: {
+					dep2: 'workspace:*'
+				}
+			},
+			{ 'spaces': 2 }
+		);
+
+		expect( fs.writeJSONSync ).toHaveBeenNthCalledWith( 3,
+			'./packages/bar/package.json',
+			{
+				name: 'barPkg',
+				dependencies: {
+					dep1: 'workspace:*'
+				},
+				devDependencies: {
+					dep2: 'workspace:*'
 				}
 			},
 			{ 'spaces': 2 }

--- a/packages/ckeditor5-dev-dependency-checker/tests/checkversionmatch.js
+++ b/packages/ckeditor5-dev-dependency-checker/tests/checkversionmatch.js
@@ -14,7 +14,8 @@ const hoists = vi.hoisted( () => ( {
 	chalk: {
 		blue: vi.fn( input => input ),
 		green: vi.fn( input => input ),
-		red: vi.fn( input => input )
+		red: vi.fn( input => input ),
+		yellow: vi.fn( input => input )
 	}
 } ) );
 
@@ -464,7 +465,7 @@ describe( 'checkVersionMatch()', () => {
 
 		checkVersionMatch( options );
 
-		expect( consoleLogMock ).toHaveBeenCalledTimes( 1 );
+		expect( consoleLogMock ).toHaveBeenCalledTimes( 3 );
 		expect( consoleErrorMock ).toHaveBeenCalledTimes( 2 );
 		expect( processExitMock ).toHaveBeenCalledTimes( 1 );
 
@@ -474,8 +475,14 @@ describe( 'checkVersionMatch()', () => {
 			'❌  Errors found. Run this script with an argument: `--fix` to resolve the issues automatically:'
 		);
 		expect( consoleErrorMock ).toHaveBeenNthCalledWith( 2, [
+			'"dep1" in "rootPkg" in version "workspace:*" should be set to "1.0.1".',
 			'"dep3" in "rootPkg" in version "^3.0.1" should be set to "^3.0.2".',
-			'"dep3" in "barPkg" in version "^3.0.0" should be set to "^3.0.2".'
+			'"dep2" in "rootPkg" in version "workspace:*" should be set to "2.0.1".',
+			'"dep1" in "fooPkg" in version "workspace:*" should be set to "1.0.1".',
+			'"dep2" in "fooPkg" in version "workspace:*" should be set to "2.0.1".',
+			'"dep1" in "barPkg" in version "workspace:*" should be set to "1.0.1".',
+			'"dep3" in "barPkg" in version "^3.0.0" should be set to "^3.0.2".',
+			'"dep2" in "barPkg" in version "workspace:*" should be set to "2.0.1".'
 		].join( '\n' ) );
 	} );
 
@@ -495,20 +502,26 @@ describe( 'checkVersionMatch()', () => {
 
 		checkVersionMatch( options );
 
-		expect( consoleLogMock ).toHaveBeenCalledTimes( 2 );
+		expect( consoleLogMock ).toHaveBeenCalledTimes( 4 );
 		expect( consoleErrorMock ).toHaveBeenCalledTimes( 2 );
 		expect( processExitMock ).toHaveBeenCalledTimes( 1 );
 
 		expect( consoleLogMock ).toHaveBeenNthCalledWith( 1, '🔍 Starting checking dependencies versions...' );
-		expect( consoleLogMock ).toHaveBeenNthCalledWith( 2, '⬇️ Downloading "dep3" versions from npm...' );
+		expect( consoleLogMock ).toHaveBeenNthCalledWith( 2, '⬇️ Downloading "dep1" versions from npm...' );
 
 		expect( consoleErrorMock ).toHaveBeenNthCalledWith( 1,
 			'❌  Errors found. Run this script with an argument: `--fix` to resolve the issues automatically:'
 		);
 		expect( consoleErrorMock ).toHaveBeenNthCalledWith( 2, [
+			'"dep1" in "rootPkg" in version "workspace:*" should be set to "1.0.1".',
 			'"dep3" in "rootPkg" in version "^3.0.1" should be set to "3.0.2".',
+			'"dep2" in "rootPkg" in version "workspace:*" should be set to "2.0.1".',
+			'"dep1" in "fooPkg" in version "workspace:*" should be set to "1.0.1".',
 			'"dep3" in "fooPkg" in version "^3.0.2" should be set to "3.0.2".',
-			'"dep3" in "barPkg" in version "^3.0.0" should be set to "3.0.2".'
+			'"dep2" in "fooPkg" in version "workspace:*" should be set to "2.0.1".',
+			'"dep1" in "barPkg" in version "workspace:*" should be set to "1.0.1".',
+			'"dep3" in "barPkg" in version "^3.0.0" should be set to "3.0.2".',
+			'"dep2" in "barPkg" in version "workspace:*" should be set to "2.0.1".'
 		].join( '\n' ) );
 	} );
 
@@ -525,12 +538,12 @@ describe( 'checkVersionMatch()', () => {
 
 		checkVersionMatch( options );
 
-		expect( consoleLogMock ).toHaveBeenCalledTimes( 2 );
+		expect( consoleLogMock ).toHaveBeenCalledTimes( 3 );
 		expect( consoleErrorMock ).toHaveBeenCalledTimes( 0 );
 		expect( processExitMock ).toHaveBeenCalledTimes( 0 );
 
 		expect( consoleLogMock ).toHaveBeenNthCalledWith( 1, '🔍 Starting checking dependencies versions...' );
-		expect( consoleLogMock ).toHaveBeenNthCalledWith( 2, '✅  All dependencies fixed!' );
+		expect( consoleLogMock ).toHaveBeenNthCalledWith( 3, '✅  All dependencies fixed!' );
 
 		expect( fs.writeJSONSync ).toHaveBeenCalledTimes( 3 );
 
@@ -540,7 +553,7 @@ describe( 'checkVersionMatch()', () => {
 			{
 				name: 'rootPkg',
 				dependencies: {
-					dep1: 'workspace:*'
+					dep1: '1.0.1'
 				},
 				devDependencies: {
 					dep2: '2.0.1' // Should remain unchanged due to filter

--- a/packages/ckeditor5-dev-dependency-checker/tests/checkversionmatch.js
+++ b/packages/ckeditor5-dev-dependency-checker/tests/checkversionmatch.js
@@ -102,6 +102,14 @@ describe( 'checkVersionMatch()', () => {
 	} );
 
 	it( 'should log about dependencies being correct', () => {
+		// Set all dependencies to workspace:* to match the new expected behavior
+		files[ './package.json' ].dependencies.dep1 = 'workspace:*';
+		files[ './package.json' ].devDependencies.dep2 = 'workspace:*';
+		files[ './packages/foo/package.json' ].dependencies.dep1 = 'workspace:*';
+		files[ './packages/foo/package.json' ].devDependencies.dep2 = 'workspace:*';
+		files[ './packages/bar/package.json' ].dependencies.dep1 = 'workspace:*';
+		files[ './packages/bar/package.json' ].devDependencies.dep2 = 'workspace:*';
+
 		checkVersionMatch( options );
 
 		expect( consoleLogMock ).toHaveBeenCalledTimes( 2 );
@@ -127,8 +135,12 @@ describe( 'checkVersionMatch()', () => {
 			'❌  Errors found. Run this script with an argument: `--fix` to resolve the issues automatically:'
 		);
 		expect( consoleErrorMock ).toHaveBeenNthCalledWith( 2, [
-			'"dep1" in "fooPkg" in version "1.0.0" should be set to "1.0.1".',
-			'"dep1" in "barPkg" in version "1.0.0" should be set to "1.0.1".'
+			'"dep1" in "rootPkg" in version "1.0.1" should be set to "workspace:*".',
+			'"dep2" in "rootPkg" in version "2.0.0" should be set to "workspace:*".',
+			'"dep1" in "fooPkg" in version "1.0.0" should be set to "workspace:*".',
+			'"dep2" in "fooPkg" in version "2.0.0" should be set to "workspace:*".',
+			'"dep1" in "barPkg" in version "1.0.0" should be set to "workspace:*".',
+			'"dep2" in "barPkg" in version "2.0.0" should be set to "workspace:*".'
 		].join( '\n' ) );
 	} );
 
@@ -137,20 +149,22 @@ describe( 'checkVersionMatch()', () => {
 
 		checkVersionMatch( options );
 
-		expect( consoleLogMock ).toHaveBeenCalledTimes( 2 );
+		expect( consoleLogMock ).toHaveBeenCalledTimes( 1 );
 		expect( consoleErrorMock ).toHaveBeenCalledTimes( 2 );
 		expect( processExitMock ).toHaveBeenCalledTimes( 1 );
 
 		expect( consoleLogMock ).toHaveBeenNthCalledWith( 1, '🔍 Starting checking dependencies versions...' );
-		expect( consoleLogMock ).toHaveBeenNthCalledWith( 2, '⬇️ Downloading "dep1" versions from npm...' );
 
 		expect( consoleErrorMock ).toHaveBeenNthCalledWith( 1,
 			'❌  Errors found. Run this script with an argument: `--fix` to resolve the issues automatically:'
 		);
 		expect( consoleErrorMock ).toHaveBeenNthCalledWith( 2, [
-			'"dep1" in "rootPkg" in version "^1.0.0" should be set to "1.0.1".',
-			'"dep1" in "fooPkg" in version "1.0.0" should be set to "1.0.1".',
-			'"dep1" in "barPkg" in version "1.0.0" should be set to "1.0.1".'
+			'"dep1" in "rootPkg" in version "^1.0.0" should be set to "workspace:*".',
+			'"dep2" in "rootPkg" in version "2.0.0" should be set to "workspace:*".',
+			'"dep1" in "fooPkg" in version "1.0.0" should be set to "workspace:*".',
+			'"dep2" in "fooPkg" in version "2.0.0" should be set to "workspace:*".',
+			'"dep1" in "barPkg" in version "1.0.0" should be set to "workspace:*".',
+			'"dep2" in "barPkg" in version "2.0.0" should be set to "workspace:*".'
 		].join( '\n' ) );
 	} );
 
@@ -160,19 +174,21 @@ describe( 'checkVersionMatch()', () => {
 
 		checkVersionMatch( options );
 
-		expect( consoleLogMock ).toHaveBeenCalledTimes( 2 );
+		expect( consoleLogMock ).toHaveBeenCalledTimes( 1 );
 		expect( consoleErrorMock ).toHaveBeenCalledTimes( 2 );
 		expect( processExitMock ).toHaveBeenCalledTimes( 1 );
 
 		expect( consoleLogMock ).toHaveBeenNthCalledWith( 1, '🔍 Starting checking dependencies versions...' );
-		expect( consoleLogMock ).toHaveBeenNthCalledWith( 2, '⬇️ Downloading "dep1" versions from npm...' );
 
 		expect( consoleErrorMock ).toHaveBeenNthCalledWith( 1,
 			'❌  Errors found. Run this script with an argument: `--fix` to resolve the issues automatically:'
 		);
 		expect( consoleErrorMock ).toHaveBeenNthCalledWith( 2, [
-			'"dep1" in "rootPkg" in version "^1.0.0" should be set to "1.0.1".',
-			'"dep1" in "barPkg" in version "1.0.0" should be set to "1.0.1".'
+			'"dep1" in "rootPkg" in version "^1.0.0" should be set to "workspace:*".',
+			'"dep2" in "rootPkg" in version "2.0.0" should be set to "workspace:*".',
+			'"dep2" in "fooPkg" in version "2.0.0" should be set to "workspace:*".',
+			'"dep1" in "barPkg" in version "1.0.0" should be set to "workspace:*".',
+			'"dep2" in "barPkg" in version "2.0.0" should be set to "workspace:*".'
 		].join( '\n' ) );
 	} );
 
@@ -205,8 +221,12 @@ describe( 'checkVersionMatch()', () => {
 			'❌  Errors found. Run this script with an argument: `--fix` to resolve the issues automatically:'
 		);
 		expect( consoleErrorMock ).toHaveBeenNthCalledWith( 2, [
-			'"dep2" in "fooPkg" in version "2.0.0" should be set to "2.0.1".',
-			'"dep2" in "barPkg" in version "2.0.0" should be set to "2.0.1".'
+			'"dep1" in "rootPkg" in version "1.0.0" should be set to "workspace:*".',
+			'"dep2" in "rootPkg" in version "2.0.1" should be set to "workspace:*".',
+			'"dep1" in "fooPkg" in version "1.0.0" should be set to "workspace:*".',
+			'"dep2" in "fooPkg" in version "2.0.0" should be set to "workspace:*".',
+			'"dep1" in "barPkg" in version "1.0.0" should be set to "workspace:*".',
+			'"dep2" in "barPkg" in version "2.0.0" should be set to "workspace:*".'
 		].join( '\n' ) );
 	} );
 
@@ -215,20 +235,22 @@ describe( 'checkVersionMatch()', () => {
 
 		checkVersionMatch( options );
 
-		expect( consoleLogMock ).toHaveBeenCalledTimes( 2 );
+		expect( consoleLogMock ).toHaveBeenCalledTimes( 1 );
 		expect( consoleErrorMock ).toHaveBeenCalledTimes( 2 );
 		expect( processExitMock ).toHaveBeenCalledTimes( 1 );
 
 		expect( consoleLogMock ).toHaveBeenNthCalledWith( 1, '🔍 Starting checking dependencies versions...' );
-		expect( consoleLogMock ).toHaveBeenNthCalledWith( 2, '⬇️ Downloading "dep2" versions from npm...' );
 
 		expect( consoleErrorMock ).toHaveBeenNthCalledWith( 1,
 			'❌  Errors found. Run this script with an argument: `--fix` to resolve the issues automatically:'
 		);
 		expect( consoleErrorMock ).toHaveBeenNthCalledWith( 2, [
-			'"dep2" in "rootPkg" in version "^2.0.0" should be set to "2.0.1".',
-			'"dep2" in "fooPkg" in version "2.0.0" should be set to "2.0.1".',
-			'"dep2" in "barPkg" in version "2.0.0" should be set to "2.0.1".'
+			'"dep1" in "rootPkg" in version "1.0.0" should be set to "workspace:*".',
+			'"dep2" in "rootPkg" in version "^2.0.0" should be set to "workspace:*".',
+			'"dep1" in "fooPkg" in version "1.0.0" should be set to "workspace:*".',
+			'"dep2" in "fooPkg" in version "2.0.0" should be set to "workspace:*".',
+			'"dep1" in "barPkg" in version "1.0.0" should be set to "workspace:*".',
+			'"dep2" in "barPkg" in version "2.0.0" should be set to "workspace:*".'
 		].join( '\n' ) );
 	} );
 
@@ -248,8 +270,12 @@ describe( 'checkVersionMatch()', () => {
 			'❌  Errors found. Run this script with an argument: `--fix` to resolve the issues automatically:'
 		);
 		expect( consoleErrorMock ).toHaveBeenNthCalledWith( 2, [
-			'"dep2" in "fooPkg" in version "2.0.0" should be set to "^2.0.0".',
-			'"dep2" in "barPkg" in version "2.0.0" should be set to "^2.0.0".'
+			'"dep1" in "rootPkg" in version "1.0.0" should be set to "workspace:*".',
+			'"dep2" in "rootPkg" in version "^2.0.0" should be set to "workspace:*".',
+			'"dep1" in "fooPkg" in version "1.0.0" should be set to "workspace:*".',
+			'"dep2" in "fooPkg" in version "2.0.0" should be set to "workspace:*".',
+			'"dep1" in "barPkg" in version "1.0.0" should be set to "workspace:*".',
+			'"dep2" in "barPkg" in version "2.0.0" should be set to "workspace:*".'
 		].join( '\n' ) );
 	} );
 
@@ -259,27 +285,38 @@ describe( 'checkVersionMatch()', () => {
 
 		checkVersionMatch( options );
 
-		expect( consoleLogMock ).toHaveBeenCalledTimes( 2 );
+		expect( consoleLogMock ).toHaveBeenCalledTimes( 1 );
 		expect( consoleErrorMock ).toHaveBeenCalledTimes( 2 );
 		expect( processExitMock ).toHaveBeenCalledTimes( 1 );
 
 		expect( consoleLogMock ).toHaveBeenNthCalledWith( 1, '🔍 Starting checking dependencies versions...' );
-		expect( consoleLogMock ).toHaveBeenNthCalledWith( 2, '⬇️ Downloading "dep2" versions from npm...' );
 
 		expect( consoleErrorMock ).toHaveBeenNthCalledWith( 1,
 			'❌  Errors found. Run this script with an argument: `--fix` to resolve the issues automatically:'
 		);
 		expect( consoleErrorMock ).toHaveBeenNthCalledWith( 2, [
-			'"dep2" in "rootPkg" in version "^2.0.0" should be set to "2.0.1".',
-			'"dep2" in "barPkg" in version "2.0.0" should be set to "2.0.1".'
+			'"dep1" in "rootPkg" in version "1.0.0" should be set to "workspace:*".',
+			'"dep2" in "rootPkg" in version "^2.0.0" should be set to "workspace:*".',
+			'"dep1" in "fooPkg" in version "1.0.0" should be set to "workspace:*".',
+			'"dep1" in "barPkg" in version "1.0.0" should be set to "workspace:*".',
+			'"dep2" in "barPkg" in version "2.0.0" should be set to "workspace:*".'
 		].join( '\n' ) );
 	} );
 
 	it( 'should not log about dependencies using different version ranges when they are an exception', () => {
 		options.versionExceptions = { 'dep3': '^' };
+		// Use a filter that excludes dep3 so it uses the old logic with exceptions
+		options.devDependenciesFilter = depName => depName !== 'dep3';
 		files[ './package.json' ].dependencies.dep3 = '^3.0.2';
 		files[ './packages/foo/package.json' ].dependencies.dep3 = '^3.0.2';
 		files[ './packages/bar/package.json' ].dependencies.dep3 = '^3.0.2';
+		// Set all other dependencies to workspace:* to match the new expected behavior
+		files[ './package.json' ].dependencies.dep1 = 'workspace:*';
+		files[ './package.json' ].devDependencies.dep2 = 'workspace:*';
+		files[ './packages/foo/package.json' ].dependencies.dep1 = 'workspace:*';
+		files[ './packages/foo/package.json' ].devDependencies.dep2 = 'workspace:*';
+		files[ './packages/bar/package.json' ].dependencies.dep1 = 'workspace:*';
+		files[ './packages/bar/package.json' ].devDependencies.dep2 = 'workspace:*';
 
 		checkVersionMatch( options );
 
@@ -312,10 +349,10 @@ describe( 'checkVersionMatch()', () => {
 			{
 				name: 'rootPkg',
 				dependencies: {
-					dep1: '1.0.1'
+					dep1: 'workspace:*'
 				},
 				devDependencies: {
-					dep2: '2.0.0'
+					dep2: 'workspace:*'
 				}
 			},
 			{ 'spaces': 2 }
@@ -325,10 +362,10 @@ describe( 'checkVersionMatch()', () => {
 			{
 				name: 'fooPkg',
 				dependencies: {
-					dep1: '1.0.1'
+					dep1: 'workspace:*'
 				},
 				devDependencies: {
-					dep2: '2.0.0'
+					dep2: 'workspace:*'
 				}
 			},
 			{ 'spaces': 2 }
@@ -338,10 +375,10 @@ describe( 'checkVersionMatch()', () => {
 			{
 				name: 'barPkg',
 				dependencies: {
-					dep1: '1.0.1'
+					dep1: 'workspace:*'
 				},
 				devDependencies: {
-					dep2: '2.0.0'
+					dep2: 'workspace:*'
 				}
 			},
 			{ 'spaces': 2 }
@@ -370,10 +407,10 @@ describe( 'checkVersionMatch()', () => {
 			{
 				name: 'rootPkg',
 				dependencies: {
-					dep1: '1.0.0'
+					dep1: 'workspace:*'
 				},
 				devDependencies: {
-					dep2: '2.0.1'
+					dep2: 'workspace:*'
 				}
 			},
 			{ 'spaces': 2 }
@@ -383,7 +420,7 @@ describe( 'checkVersionMatch()', () => {
 			{
 				name: 'fooPkg',
 				devDependencies: {
-					dep2: '2.0.1'
+					dep2: 'workspace:*'
 				}
 			},
 			{ 'spaces': 2 }
@@ -393,10 +430,157 @@ describe( 'checkVersionMatch()', () => {
 			{
 				name: 'barPkg',
 				dependencies: {
-					dep1: '1.0.0'
+					dep1: 'workspace:*'
 				},
 				devDependencies: {
-					dep2: '2.0.1'
+					dep2: 'workspace:*'
+				}
+			},
+			{ 'spaces': 2 }
+		);
+	} );
+
+	it( 'should expect workspace:* for all dependencies when they are present in workspace', () => {
+		// Set all dependencies to workspace:* to match the new expected behavior
+		files[ './package.json' ].dependencies.dep1 = 'workspace:*';
+		files[ './package.json' ].devDependencies.dep2 = 'workspace:*';
+		files[ './packages/foo/package.json' ].dependencies.dep1 = 'workspace:*';
+		files[ './packages/foo/package.json' ].devDependencies.dep2 = 'workspace:*';
+		files[ './packages/bar/package.json' ].dependencies.dep1 = 'workspace:*';
+		files[ './packages/bar/package.json' ].devDependencies.dep2 = 'workspace:*';
+
+		checkVersionMatch( options );
+
+		expect( consoleLogMock ).toHaveBeenCalledTimes( 2 );
+		expect( consoleErrorMock ).toHaveBeenCalledTimes( 0 );
+		expect( processExitMock ).toHaveBeenCalledTimes( 0 );
+
+		expect( consoleLogMock ).toHaveBeenNthCalledWith( 1, '🔍 Starting checking dependencies versions...' );
+		expect( consoleLogMock ).toHaveBeenNthCalledWith( 2, '✅  All dependencies are correct!' );
+	} );
+
+	it( 'should expect workspace:* for dependencies that are not workspace:*', () => {
+		files[ './package.json' ].dependencies.dep1 = 'workspace:*';
+		files[ './packages/foo/package.json' ].dependencies.dep1 = '1.0.0';
+		files[ './packages/bar/package.json' ].dependencies.dep1 = '1.0.0';
+
+		checkVersionMatch( options );
+
+		expect( consoleLogMock ).toHaveBeenCalledTimes( 1 );
+		expect( consoleErrorMock ).toHaveBeenCalledTimes( 2 );
+		expect( processExitMock ).toHaveBeenCalledTimes( 1 );
+
+		expect( consoleLogMock ).toHaveBeenNthCalledWith( 1, '🔍 Starting checking dependencies versions...' );
+
+		expect( consoleErrorMock ).toHaveBeenNthCalledWith( 1,
+			'❌  Errors found. Run this script with an argument: `--fix` to resolve the issues automatically:'
+		);
+		expect( consoleErrorMock ).toHaveBeenNthCalledWith( 2, [
+			'"dep2" in "rootPkg" in version "2.0.0" should be set to "workspace:*".',
+			'"dep1" in "fooPkg" in version "1.0.0" should be set to "workspace:*".',
+			'"dep2" in "fooPkg" in version "2.0.0" should be set to "workspace:*".',
+			'"dep1" in "barPkg" in version "1.0.0" should be set to "workspace:*".',
+			'"dep2" in "barPkg" in version "2.0.0" should be set to "workspace:*".'
+		].join( '\n' ) );
+	} );
+
+	it( 'should test allowRanges logic for dependencies not in workspace filter', () => {
+		// Use a filter that excludes dep3 so it uses the old logic with allowRanges
+		options.devDependenciesFilter = depName => depName !== 'dep3';
+		options.allowRanges = true;
+		files[ './package.json' ].dependencies.dep3 = '^3.0.1';
+		files[ './packages/foo/package.json' ].dependencies.dep3 = '^3.0.2';
+		files[ './packages/bar/package.json' ].dependencies.dep3 = '^3.0.0';
+		// Set all other dependencies to workspace:* to match the new expected behavior
+		files[ './package.json' ].dependencies.dep1 = 'workspace:*';
+		files[ './package.json' ].devDependencies.dep2 = 'workspace:*';
+		files[ './packages/foo/package.json' ].dependencies.dep1 = 'workspace:*';
+		files[ './packages/foo/package.json' ].devDependencies.dep2 = 'workspace:*';
+		files[ './packages/bar/package.json' ].dependencies.dep1 = 'workspace:*';
+		files[ './packages/bar/package.json' ].devDependencies.dep2 = 'workspace:*';
+
+		checkVersionMatch( options );
+
+		expect( consoleLogMock ).toHaveBeenCalledTimes( 1 );
+		expect( consoleErrorMock ).toHaveBeenCalledTimes( 2 );
+		expect( processExitMock ).toHaveBeenCalledTimes( 1 );
+
+		expect( consoleLogMock ).toHaveBeenNthCalledWith( 1, '🔍 Starting checking dependencies versions...' );
+
+		expect( consoleErrorMock ).toHaveBeenNthCalledWith( 1,
+			'❌  Errors found. Run this script with an argument: `--fix` to resolve the issues automatically:'
+		);
+		expect( consoleErrorMock ).toHaveBeenNthCalledWith( 2, [
+			'"dep3" in "rootPkg" in version "^3.0.1" should be set to "^3.0.2".',
+			'"dep3" in "barPkg" in version "^3.0.0" should be set to "^3.0.2".'
+		].join( '\n' ) );
+	} );
+
+	it( 'should test npm version downloading for dependencies not in workspace filter', () => {
+		// Use a filter that excludes dep3 so it uses the old logic and downloads from npm
+		options.devDependenciesFilter = depName => depName !== 'dep3';
+		files[ './package.json' ].dependencies.dep3 = '^3.0.1';
+		files[ './packages/foo/package.json' ].dependencies.dep3 = '^3.0.2';
+		files[ './packages/bar/package.json' ].dependencies.dep3 = '^3.0.0';
+		// Set all other dependencies to workspace:* to match the new expected behavior
+		files[ './package.json' ].dependencies.dep1 = 'workspace:*';
+		files[ './package.json' ].devDependencies.dep2 = 'workspace:*';
+		files[ './packages/foo/package.json' ].dependencies.dep1 = 'workspace:*';
+		files[ './packages/foo/package.json' ].devDependencies.dep2 = 'workspace:*';
+		files[ './packages/bar/package.json' ].dependencies.dep1 = 'workspace:*';
+		files[ './packages/bar/package.json' ].devDependencies.dep2 = 'workspace:*';
+
+		checkVersionMatch( options );
+
+		expect( consoleLogMock ).toHaveBeenCalledTimes( 2 );
+		expect( consoleErrorMock ).toHaveBeenCalledTimes( 2 );
+		expect( processExitMock ).toHaveBeenCalledTimes( 1 );
+
+		expect( consoleLogMock ).toHaveBeenNthCalledWith( 1, '🔍 Starting checking dependencies versions...' );
+		expect( consoleLogMock ).toHaveBeenNthCalledWith( 2, '⬇️ Downloading "dep3" versions from npm...' );
+
+		expect( consoleErrorMock ).toHaveBeenNthCalledWith( 1,
+			'❌  Errors found. Run this script with an argument: `--fix` to resolve the issues automatically:'
+		);
+		expect( consoleErrorMock ).toHaveBeenNthCalledWith( 2, [
+			'"dep3" in "rootPkg" in version "^3.0.1" should be set to "3.0.2".',
+			'"dep3" in "fooPkg" in version "^3.0.2" should be set to "3.0.2".',
+			'"dep3" in "barPkg" in version "^3.0.0" should be set to "3.0.2".'
+		].join( '\n' ) );
+	} );
+
+	it( 'should skip filtered devDependencies in fix mode', () => {
+		options.fix = true;
+		options.devDependenciesFilter = depName => depName !== 'dep2';
+		// Set all other dependencies to workspace:* to match the new expected behavior
+		files[ './package.json' ].dependencies.dep1 = 'workspace:*';
+		files[ './package.json' ].devDependencies.dep2 = '2.0.1'; // This should be skipped
+		files[ './packages/foo/package.json' ].dependencies.dep1 = 'workspace:*';
+		files[ './packages/foo/package.json' ].devDependencies.dep2 = '2.0.0'; // This should be skipped
+		files[ './packages/bar/package.json' ].dependencies.dep1 = 'workspace:*';
+		files[ './packages/bar/package.json' ].devDependencies.dep2 = '2.0.0'; // This should be skipped
+
+		checkVersionMatch( options );
+
+		expect( consoleLogMock ).toHaveBeenCalledTimes( 2 );
+		expect( consoleErrorMock ).toHaveBeenCalledTimes( 0 );
+		expect( processExitMock ).toHaveBeenCalledTimes( 0 );
+
+		expect( consoleLogMock ).toHaveBeenNthCalledWith( 1, '🔍 Starting checking dependencies versions...' );
+		expect( consoleLogMock ).toHaveBeenNthCalledWith( 2, '✅  All dependencies fixed!' );
+
+		expect( fs.writeJSONSync ).toHaveBeenCalledTimes( 3 );
+
+		// dep2 should remain unchanged since it's filtered out
+		expect( fs.writeJSONSync ).toHaveBeenNthCalledWith( 1,
+			'./package.json',
+			{
+				name: 'rootPkg',
+				dependencies: {
+					dep1: 'workspace:*'
+				},
+				devDependencies: {
+					dep2: '2.0.1' // Should remain unchanged
 				}
 			},
 			{ 'spaces': 2 }

--- a/packages/ckeditor5-dev-dependency-checker/tests/checkversionmatch.js
+++ b/packages/ckeditor5-dev-dependency-checker/tests/checkversionmatch.js
@@ -404,8 +404,6 @@ describe( 'checkVersionMatch()', () => {
 		);
 	} );
 
-	// TODO check
-
 	it( 'should expect workspace:* for all dependencies when useWorkspace is and not devDependenciesFilter is provided', () => {
 		options.useWorkspace = true;
 		// Set all dependencies to workspace:* to match the expected behavior

--- a/packages/ckeditor5-dev-dependency-checker/tests/checkversionmatch.js
+++ b/packages/ckeditor5-dev-dependency-checker/tests/checkversionmatch.js
@@ -14,8 +14,7 @@ const hoists = vi.hoisted( () => ( {
 	chalk: {
 		blue: vi.fn( input => input ),
 		green: vi.fn( input => input ),
-		red: vi.fn( input => input ),
-		yellow: vi.fn( input => input )
+		red: vi.fn( input => input )
 	}
 } ) );
 

--- a/packages/ckeditor5-dev-dependency-checker/tests/checkversionmatch.js
+++ b/packages/ckeditor5-dev-dependency-checker/tests/checkversionmatch.js
@@ -518,8 +518,8 @@ describe( 'checkVersionMatch()', () => {
 		);
 	} );
 
-	it( 'should expect workspace:* for dependencies that are not workspace:* when useWorkspace is true', () => {
-		options.useWorkspace = true;
+	it( 'should expect workspace:* for dependencies that are not workspace:* when workspacePackages are specified', () => {
+		options.workspacePackages = [ 'dep1', 'dep2', 'dep3' ];
 		files[ './package.json' ].dependencies.dep1 = 'workspace:*';
 		files[ './packages/foo/package.json' ].dependencies.dep1 = '1.0.0';
 		files[ './packages/bar/package.json' ].dependencies.dep1 = '1.0.0';
@@ -544,9 +544,8 @@ describe( 'checkVersionMatch()', () => {
 		].join( '\n' ) );
 	} );
 
-	it( 'should expect workspace:* for filtered dependencies that are not workspace:* when useWorkspace is true', () => {
-		options.useWorkspace = true;
-		options.devDependenciesFilter = depName => depName !== 'dep2';
+	it( 'should expect workspace:* for filtered dependencies that are not workspace:* when workspacePakcages are specified', () => {
+		options.workspacePackages = [ 'dep1', 'dep3' ];
 		files[ './package.json' ].dependencies.dep1 = 'workspace:*';
 		files[ './packages/foo/package.json' ].dependencies.dep1 = '1.0.0';
 		files[ './packages/bar/package.json' ].dependencies.dep1 = '1.0.0';
@@ -568,9 +567,9 @@ describe( 'checkVersionMatch()', () => {
 		].join( '\n' ) );
 	} );
 
-	it( 'should fix dependencies to workspace:* when useWorkspace is true', () => {
-		options.useWorkspace = true;
+	it( 'should fix dependencies to workspace:* when workspacePackages are specified', () => {
 		options.fix = true;
+		options.workspacePackages = [ 'dep1', 'dep2', 'dep3' ];
 		files[ './package.json' ].dependencies.dep1 = 'workspace:*';
 		files[ './packages/foo/package.json' ].dependencies.dep1 = '1.0.0';
 		files[ './packages/bar/package.json' ].dependencies.dep1 = '1.0.0';

--- a/packages/ckeditor5-dev-dependency-checker/tests/checkversionmatch.js
+++ b/packages/ckeditor5-dev-dependency-checker/tests/checkversionmatch.js
@@ -403,48 +403,6 @@ describe( 'checkVersionMatch()', () => {
 		);
 	} );
 
-	it( 'should expect workspace:* for all dependencies when useWorkspace is and not devDependenciesFilter is provided', () => {
-		options.useWorkspace = true;
-		// Set all dependencies to workspace:* to match the expected behavior
-		files[ './package.json' ].dependencies.dep1 = 'workspace:*';
-		files[ './package.json' ].devDependencies.dep2 = 'workspace:*';
-		files[ './packages/foo/package.json' ].dependencies.dep1 = 'workspace:*';
-		files[ './packages/foo/package.json' ].devDependencies.dep2 = 'workspace:*';
-		files[ './packages/bar/package.json' ].dependencies.dep1 = 'workspace:*';
-		files[ './packages/bar/package.json' ].devDependencies.dep2 = 'workspace:*';
-
-		checkVersionMatch( options );
-
-		expect( consoleLogMock ).toHaveBeenCalledTimes( 2 );
-		expect( consoleErrorMock ).toHaveBeenCalledTimes( 0 );
-		expect( processExitMock ).toHaveBeenCalledTimes( 0 );
-
-		expect( consoleLogMock ).toHaveBeenNthCalledWith( 1, '🔍 Starting checking dependencies versions...' );
-		expect( consoleLogMock ).toHaveBeenNthCalledWith( 2, '✅  All dependencies are correct!' );
-	} );
-
-	it( 'should expect specific versions for dependencies that are not matching', () => {
-		files[ './package.json' ].dependencies.dep1 = '1.0.1';
-		files[ './packages/foo/package.json' ].dependencies.dep1 = '1.0.0';
-		files[ './packages/bar/package.json' ].dependencies.dep1 = '1.0.0';
-
-		checkVersionMatch( options );
-
-		expect( consoleLogMock ).toHaveBeenCalledTimes( 1 );
-		expect( consoleErrorMock ).toHaveBeenCalledTimes( 2 );
-		expect( processExitMock ).toHaveBeenCalledTimes( 1 );
-
-		expect( consoleLogMock ).toHaveBeenNthCalledWith( 1, '🔍 Starting checking dependencies versions...' );
-
-		expect( consoleErrorMock ).toHaveBeenNthCalledWith( 1,
-			'❌  Errors found. Run this script with an argument: `--fix` to resolve the issues automatically:'
-		);
-		expect( consoleErrorMock ).toHaveBeenNthCalledWith( 2, [
-			'"dep1" in "fooPkg" in version "1.0.0" should be set to "1.0.1".',
-			'"dep1" in "barPkg" in version "1.0.0" should be set to "1.0.1".'
-		].join( '\n' ) );
-	} );
-
 	it( 'should test allowRanges logic for dependencies not in workspace filter', () => {
 		// Use a filter that excludes dep3 so it uses the old logic with allowRanges
 		options.devDependenciesFilter = depName => depName !== 'dep3';
@@ -583,6 +541,30 @@ describe( 'checkVersionMatch()', () => {
 			'"dep2" in "fooPkg" in version "2.0.0" should be set to "workspace:*".',
 			'"dep1" in "barPkg" in version "1.0.0" should be set to "workspace:*".',
 			'"dep2" in "barPkg" in version "2.0.0" should be set to "workspace:*".'
+		].join( '\n' ) );
+	} );
+
+	it( 'should expect workspace:* for filtered dependencies that are not workspace:* when useWorkspace is true', () => {
+		options.useWorkspace = true;
+		options.devDependenciesFilter = depName => depName !== 'dep2';
+		files[ './package.json' ].dependencies.dep1 = 'workspace:*';
+		files[ './packages/foo/package.json' ].dependencies.dep1 = '1.0.0';
+		files[ './packages/bar/package.json' ].dependencies.dep1 = '1.0.0';
+
+		checkVersionMatch( options );
+
+		expect( consoleLogMock ).toHaveBeenCalledTimes( 1 );
+		expect( consoleErrorMock ).toHaveBeenCalledTimes( 2 );
+		expect( processExitMock ).toHaveBeenCalledTimes( 1 );
+
+		expect( consoleLogMock ).toHaveBeenNthCalledWith( 1, '🔍 Starting checking dependencies versions...' );
+
+		expect( consoleErrorMock ).toHaveBeenNthCalledWith( 1,
+			'❌  Errors found. Run this script with an argument: `--fix` to resolve the issues automatically:'
+		);
+		expect( consoleErrorMock ).toHaveBeenNthCalledWith( 2, [
+			'"dep1" in "fooPkg" in version "1.0.0" should be set to "workspace:*".',
+			'"dep1" in "barPkg" in version "1.0.0" should be set to "workspace:*".'
 		].join( '\n' ) );
 	} );
 

--- a/packages/ckeditor5-dev-docs/package.json
+++ b/packages/ckeditor5-dev-docs/package.json
@@ -22,7 +22,7 @@
     "lib"
   ],
   "dependencies": {
-    "@ckeditor/typedoc-plugins": "^53.2.0",
+    "@ckeditor/typedoc-plugins": "workspace:*",
     "glob": "^11.0.2",
     "typedoc": "0.28.9",
     "typedoc-plugin-rename-defaults": "^0.7.3",

--- a/packages/ckeditor5-dev-release-tools/package.json
+++ b/packages/ckeditor5-dev-release-tools/package.json
@@ -22,7 +22,7 @@
     "lib"
   ],
   "dependencies": {
-    "@ckeditor/ckeditor5-dev-utils": "^53.2.0",
+    "@ckeditor/ckeditor5-dev-utils": "workspace:*",
     "@octokit/rest": "^22.0.0",
     "chalk": "^5.0.0",
     "cli-columns": "^4.0.0",

--- a/packages/ckeditor5-dev-stale-bot/package.json
+++ b/packages/ckeditor5-dev-stale-bot/package.json
@@ -25,7 +25,7 @@
     "ckeditor5-dev-stale-bot": "bin/stale-bot.js"
   },
   "dependencies": {
-    "@ckeditor/ckeditor5-dev-utils": "^53.2.0",
+    "@ckeditor/ckeditor5-dev-utils": "workspace:*",
     "chalk": "^5.0.0",
     "date-fns": "^4.0.0",
     "fs-extra": "^11.0.0",

--- a/packages/ckeditor5-dev-tests/package.json
+++ b/packages/ckeditor5-dev-tests/package.json
@@ -28,8 +28,8 @@
   },
   "dependencies": {
     "@babel/core": "^7.10.5",
-    "@ckeditor/ckeditor5-dev-translations": "^53.2.0",
-    "@ckeditor/ckeditor5-dev-utils": "^53.2.0",
+    "@ckeditor/ckeditor5-dev-translations": "workspace:*",
+    "@ckeditor/ckeditor5-dev-utils": "workspace:*",
     "@ckeditor/ckeditor5-inspector": "^5.0.0",
     "@types/chai": "^4.3.5",
     "@types/karma-sinon-chai": "^2.0.2",

--- a/packages/ckeditor5-dev-translations/package.json
+++ b/packages/ckeditor5-dev-translations/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@babel/parser": "^7.18.9",
     "@babel/traverse": "^7.18.9",
-    "@ckeditor/ckeditor5-dev-utils": "^53.2.0",
+    "@ckeditor/ckeditor5-dev-utils": "workspace:*",
     "chalk": "^5.0.0",
     "fs-extra": "^11.0.0",
     "glob": "^11.0.2",

--- a/packages/ckeditor5-dev-utils/package.json
+++ b/packages/ckeditor5-dev-utils/package.json
@@ -23,7 +23,7 @@
     "dist"
   ],
   "dependencies": {
-    "@ckeditor/ckeditor5-dev-translations": "^53.2.0",
+    "@ckeditor/ckeditor5-dev-translations": "workspace:*",
     "@types/postcss-import": "^14.0.3",
     "@types/through2": "^2.0.41",
     "chalk": "^5.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -172,7 +172,7 @@ importers:
   packages/ckeditor5-dev-changelog:
     dependencies:
       '@ckeditor/ckeditor5-dev-utils':
-        specifier: ^53.2.0
+        specifier: workspace:*
         version: link:../ckeditor5-dev-utils
       chalk:
         specifier: ^5.0.0
@@ -246,7 +246,7 @@ importers:
   packages/ckeditor5-dev-dependency-checker:
     dependencies:
       '@ckeditor/ckeditor5-dev-utils':
-        specifier: ^53.2.0
+        specifier: workspace:*
         version: link:../ckeditor5-dev-utils
       chalk:
         specifier: ^5.0.0
@@ -280,7 +280,7 @@ importers:
   packages/ckeditor5-dev-docs:
     dependencies:
       '@ckeditor/typedoc-plugins':
-        specifier: ^53.2.0
+        specifier: workspace:*
         version: link:../typedoc-plugins
       glob:
         specifier: ^11.0.2
@@ -308,7 +308,7 @@ importers:
   packages/ckeditor5-dev-release-tools:
     dependencies:
       '@ckeditor/ckeditor5-dev-utils':
-        specifier: ^53.2.0
+        specifier: workspace:*
         version: link:../ckeditor5-dev-utils
       '@octokit/rest':
         specifier: ^22.0.0
@@ -357,7 +357,7 @@ importers:
   packages/ckeditor5-dev-stale-bot:
     dependencies:
       '@ckeditor/ckeditor5-dev-utils':
-        specifier: ^53.2.0
+        specifier: workspace:*
         version: link:../ckeditor5-dev-utils
       chalk:
         specifier: ^5.0.0
@@ -394,10 +394,10 @@ importers:
         specifier: ^7.10.5
         version: 7.28.0
       '@ckeditor/ckeditor5-dev-translations':
-        specifier: ^53.2.0
+        specifier: workspace:*
         version: link:../ckeditor5-dev-translations
       '@ckeditor/ckeditor5-dev-utils':
-        specifier: ^53.2.0
+        specifier: workspace:*
         version: link:../ckeditor5-dev-utils
       '@ckeditor/ckeditor5-inspector':
         specifier: ^5.0.0
@@ -548,7 +548,7 @@ importers:
         specifier: ^7.18.9
         version: 7.28.0
       '@ckeditor/ckeditor5-dev-utils':
-        specifier: ^53.2.0
+        specifier: workspace:*
         version: link:../ckeditor5-dev-utils
       chalk:
         specifier: ^5.0.0
@@ -582,7 +582,7 @@ importers:
   packages/ckeditor5-dev-utils:
     dependencies:
       '@ckeditor/ckeditor5-dev-translations':
-        specifier: ^53.2.0
+        specifier: workspace:*
         version: link:../ckeditor5-dev-translations
       '@types/postcss-import':
         specifier: ^14.0.3

--- a/scripts/ci/check-dependencies-versions-match.mjs
+++ b/scripts/ci/check-dependencies-versions-match.mjs
@@ -4,14 +4,31 @@
  */
 
 import upath from 'upath';
+import { glob } from 'glob';
+import fs from 'fs-extra';
 import { checkVersionMatch } from '../../packages/ckeditor5-dev-dependency-checker/lib/index.js';
 
 const shouldFix = process.argv[ 2 ] === '--fix';
 
 const ROOT_DIRECTORY = upath.join( import.meta.dirname, '..', '..' );
 
+const PACKAGES_DIRECTORY = upath.join( ROOT_DIRECTORY, 'packages' );
+
+const allPathsToPackageJson = await glob( PACKAGES_DIRECTORY + '/*/package.json', {
+	cwd: ROOT_DIRECTORY,
+	nodir: true,
+	absolute: true
+} );
+
+const allPackageJson = await Promise.all(
+	allPathsToPackageJson.map( pathToPackageJson => fs.readJson( pathToPackageJson ) )
+);
+
+const allPackageNames = allPackageJson.map( packageJson => packageJson.name );
+
 checkVersionMatch( {
 	cwd: ROOT_DIRECTORY,
 	fix: shouldFix,
-	allowRanges: true
+	allowRanges: true,
+	workspacePackages: allPackageNames
 } );

--- a/scripts/preparepackages.js
+++ b/scripts/preparepackages.js
@@ -12,7 +12,6 @@ import { ListrInquirerPromptAdapter } from '@listr2/prompt-adapter-inquirer';
 import { confirm } from '@inquirer/prompts';
 import { globSync } from 'glob';
 import * as releaseTools from '@ckeditor/ckeditor5-dev-release-tools';
-import { tools } from '@ckeditor/ckeditor5-dev-utils';
 import parseArguments from './utils/parsearguments.js';
 import getListrOptions from './utils/getlistroptions.js';
 import runBuildCommand from './utils/runbuildcommand.js';
@@ -100,30 +99,6 @@ const tasks = new Listr( [
 		}
 	},
 	{
-		title: 'Updating dependencies.',
-		task: () => {
-			return releaseTools.updateDependencies( {
-				version: '^' + latestVersion,
-				packagesDirectory: PACKAGES_DIRECTORY,
-				shouldUpdateVersionCallback: packageName => {
-					return CKEDITOR5_DEV_PACKAGES.includes( packageName.split( '/' )[ 1 ] );
-				}
-			} );
-		},
-		skip: () => {
-			// When compiling the packages only, do not validate the release.
-			if ( cliArguments.compileOnly ) {
-				return true;
-			}
-
-			return false;
-		}
-	},
-	{
-		title: 'Updating `pnpm-lock.yaml` file.',
-		task: () => tools.shExec( 'pnpm install --lockfile-only', { async: true, verbosity: 'silent' } )
-	},
-	{
 		title: 'Run the "build" command in `ckeditor5-*` packages.',
 		task: ( ctx, task ) => {
 			return releaseTools.executeInParallel( {
@@ -141,6 +116,18 @@ const tasks = new Listr( [
 				outputDirectory: RELEASE_DIRECTORY,
 				packagesDirectory: PACKAGES_DIRECTORY,
 				packagesToCopy: cliArguments.packages
+			} );
+		}
+	},
+	{
+		title: 'Updating dependencies.',
+		task: () => {
+			return releaseTools.updateDependencies( {
+				version: '^' + latestVersion,
+				packagesDirectory: RELEASE_DIRECTORY,
+				shouldUpdateVersionCallback: packageName => {
+					return CKEDITOR5_DEV_PACKAGES.includes( packageName.split( '/' )[ 1 ] );
+				}
 			} );
 		}
 	},


### PR DESCRIPTION
<!--

This repository uses Markdown files to define changelog entries. If the changes in this pull request are **user-facing**, please create a changelog entry by running the following command:

    pnpm run nice

This will generate a `*.md` file in the `.changelog/` directory for your description. You can create as many as you need.

**Note:**  
If your PR is internal-only (e.g., tests, tooling, docs), you can skip this step - just mention it below.

-->

### 🚀 Summary

Updated the `checkVersionMatch()` function to support the [`workspace:*`](https://pnpm.io/workspaces) protocol for dependencies.

Added a `workspacePackages` option that specify the list of packages that should use `workspace:*` instead of specific version numbers. Both `dependencies` and `devDependencies` are validated to ensure consistent workspace versioning with pnpm.

Switched to using `workspace:*` in monorepo workspace, so that the lock file is not broken after a release.

---

### 📌 Related issues

<!--

Although changelog entries list connected issues, GitHub requires listing them here to automatically link and close them.

-->

* See ckeditor/ckeditor5-commercial#8556

---

### 💡 Additional information

*Optional: Notes on decisions, edge cases, or anything helpful for reviewers.*
