### PR TITLE
Added typeOnlyExportValidator.

### DIFF
--- a/.changelog/20260414175411_ck_18942.md
+++ b/.changelog/20260414175411_ck_18942.md
@@ -1,0 +1,9 @@
+---
+type: Feature
+scope:
+  - typedoc-plugins
+closes:
+  - ckeditor/ckeditor5#18942
+---
+
+Added a new TypeDoc validator that detects classes incorrectly exported as type-only exports (`export type { Foo }` or `export { type Foo }`). Type-only exports strip classes to their structural type, causing TypeDoc to render them as interfaces instead of classes in API documentation. Ambient `declare class` declarations are excluded from this check.

--- a/packages/typedoc-plugins/src/validators/index.ts
+++ b/packages/typedoc-plugins/src/validators/index.ts
@@ -15,6 +15,7 @@ import linkValidator from './link-validator/index.js';
 import firesValidator from './fires-validator/index.js';
 import moduleValidator from './module-validator/index.js';
 import overloadsValidator from './overloads-validator/index.js';
+import typeOnlyExportValidator from './type-only-export-validator/index.js';
 
 /**
  * Validates the CKEditor 5 documentation.
@@ -25,7 +26,8 @@ export function validate( app: Application, options: ValidatorOptions = {} ): vo
 			seeValidator,
 			linkValidator,
 			firesValidator,
-			moduleValidator
+			moduleValidator,
+			typeOnlyExportValidator
 		];
 
 		if ( options.enableOverloadValidator ) {

--- a/packages/typedoc-plugins/src/validators/type-only-export-validator/index.ts
+++ b/packages/typedoc-plugins/src/validators/type-only-export-validator/index.ts
@@ -1,0 +1,94 @@
+/**
+ * @license Copyright (c) 2003-2026, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+import { type Context, TypeScript } from 'typedoc';
+import { type ValidatorErrorCallback } from '../index.js';
+
+/**
+ * Validates that classes are not re-exported as type-only exports.
+ *
+ * A type-only export (`export type { Foo }` or `export { type Foo }`) strips the class to its structural type,
+ * causing TypeDoc to treat it as an interface instead of a class in the generated API documentation.
+ */
+export default function( context: Context, onError: ValidatorErrorCallback ): void {
+	const program = context.program;
+	const checker = program.getTypeChecker();
+
+	for ( const sourceFile of program.getSourceFiles() ) {
+		if ( sourceFile.isDeclarationFile ) {
+			continue;
+		}
+
+		TypeScript.forEachChild( sourceFile, node => {
+			if ( !TypeScript.isExportDeclaration( node ) ) {
+				return;
+			}
+
+			const exportDeclaration = node as TypeScript.ExportDeclaration;
+
+			if ( !exportDeclaration.exportClause || !TypeScript.isNamedExports( exportDeclaration.exportClause ) ) {
+				return;
+			}
+
+			for ( const specifier of exportDeclaration.exportClause.elements ) {
+				if ( !isTypeOnlyExportSpecifier( exportDeclaration, specifier ) ) {
+					continue;
+				}
+
+				const symbol = checker.getExportSpecifierLocalTargetSymbol( specifier );
+
+				if ( !symbol ) {
+					continue;
+				}
+
+				if ( !isClassSymbol( symbol, checker ) ) {
+					continue;
+				}
+
+				const exportedName = specifier.name.text;
+				const localName = specifier.propertyName?.text || exportedName;
+
+				const message = [
+					`Class "${ localName }"`,
+					localName !== exportedName && `(exported as "${ exportedName }")`,
+					'must not be exported as a type-only export.'
+				].filter( Boolean ).join( ' ' );
+
+				onError( message, specifier as unknown as TypeScript.Declaration );
+			}
+		} );
+	}
+}
+
+function isTypeOnlyExportSpecifier(
+	exportDeclaration: TypeScript.ExportDeclaration,
+	specifier: TypeScript.ExportSpecifier
+): boolean {
+	// `export type { Foo }` — the entire declaration is type-only.
+	if ( exportDeclaration.isTypeOnly ) {
+		return true;
+	}
+
+	// `export { type Foo }` — per-specifier type-only modifier.
+	if ( specifier.isTypeOnly ) {
+		return true;
+	}
+
+	return false;
+}
+
+function isClassSymbol( symbol: TypeScript.Symbol, checker: TypeScript.TypeChecker ): boolean {
+	// Resolve aliases (e.g., `export type { Foo } from './foo'` where Foo is re-exported through intermediaries).
+	const resolvedSymbol = symbol.flags & TypeScript.SymbolFlags.Alias ? checker.getAliasedSymbol( symbol ) : symbol;
+
+	if ( !resolvedSymbol.declarations ) {
+		return false;
+	}
+
+	return resolvedSymbol.declarations.some( declaration =>
+		TypeScript.isClassDeclaration( declaration ) &&
+		!( TypeScript.getCombinedModifierFlags( declaration ) & TypeScript.ModifierFlags.Ambient )
+	);
+}

--- a/packages/typedoc-plugins/tests/validators/type-only-export-validator/fixtures/ckeditor5-example/src/definitions.ts
+++ b/packages/typedoc-plugins/tests/validators/type-only-export-validator/fixtures/ckeditor5-example/src/definitions.ts
@@ -1,0 +1,52 @@
+/**
+ * @license Copyright (c) 2003-2026, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/**
+ * @module example/definitions
+ */
+
+// Invalid: class — must not be type-only exported.
+export class MyClass {
+	public value = 1;
+}
+
+// Invalid: class — must not be type-only exported.
+export class AnotherClass {
+	public name = 'test';
+}
+
+// Invalid: class — must not be type-only exported (aliased re-export).
+export class AliasedClass {
+	public id = 0;
+}
+
+// Valid: interface — type-only export is fine.
+export interface MyInterface {
+	foo: string;
+}
+
+// Valid: type alias — type-only export is fine.
+export type MyTypeAlias = {
+	bar: number;
+};
+
+// Valid: function — value export.
+export function myFunction(): void {
+	// noop
+}
+
+// Valid: constant — value export.
+export const myConst = 42;
+
+// Invalid: class — must not be type-only exported (mixed export).
+export class MixedClass {
+	public data = true;
+}
+
+// Valid: declare class — ambient declaration, no runtime value.
+export declare class DeclareClass {
+	public disableSomething(): void;
+	public enableSomething(): void;
+}

--- a/packages/typedoc-plugins/tests/validators/type-only-export-validator/fixtures/ckeditor5-example/src/index.ts
+++ b/packages/typedoc-plugins/tests/validators/type-only-export-validator/fixtures/ckeditor5-example/src/index.ts
@@ -1,0 +1,32 @@
+/**
+ * @license Copyright (c) 2003-2026, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/**
+ * @module example
+ */
+
+// Invalid: class exported as type-only declaration.
+export type { MyClass } from './definitions.js';
+
+// Invalid: class exported as per-specifier type-only.
+export { type AnotherClass } from './definitions.js';
+
+// Invalid: class with alias exported as type-only.
+export type { AliasedClass as RenamedClass } from './definitions.js';
+
+// Invalid: class exported as per-specifier type-only in a mixed export.
+export { type MixedClass, myConst } from './definitions.js';
+
+// Valid: interface exported as type-only is fine.
+export type { MyInterface } from './definitions.js';
+
+// Valid: type alias exported as type-only is fine.
+export type { MyTypeAlias } from './definitions.js';
+
+// Valid: function as value export is fine.
+export { myFunction } from './definitions.js';
+
+// Valid: declare class exported as type-only is fine (ambient declaration).
+export type { DeclareClass } from './definitions.js';

--- a/packages/typedoc-plugins/tests/validators/type-only-export-validator/fixtures/ckeditor5-example/src/index.ts
+++ b/packages/typedoc-plugins/tests/validators/type-only-export-validator/fixtures/ckeditor5-example/src/index.ts
@@ -30,3 +30,6 @@ export { myFunction } from './definitions.js';
 
 // Valid: declare class exported as type-only is fine (ambient declaration).
 export type { DeclareClass } from './definitions.js';
+
+// Valid: namespace (star) re-export is ignored by the validator.
+export * from './definitions.js';

--- a/packages/typedoc-plugins/tests/validators/type-only-export-validator/fixtures/tsconfig.json
+++ b/packages/typedoc-plugins/tests/validators/type-only-export-validator/fixtures/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../../tsconfig.json"
+}

--- a/packages/typedoc-plugins/tests/validators/type-only-export-validator/index.ts
+++ b/packages/typedoc-plugins/tests/validators/type-only-export-validator/index.ts
@@ -1,0 +1,96 @@
+/**
+ * @license Copyright (c) 2003-2026, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+import { beforeAll, describe, it, vi } from 'vitest';
+import { glob } from 'glob';
+import upath from 'upath';
+import { Application, Converter, type Context } from 'typedoc';
+
+import {
+	typeDocEventInheritanceFixer,
+	typeDocEventParamFixer,
+	typeDocInterfaceAugmentationFixer,
+	typeDocModuleFixer,
+	typeDocPurgePrivateApiDocs,
+	typeDocRestoreProgramAfterConversion,
+	typeDocSymbolFixer,
+	typeDocTagError,
+	typeDocTagEvent,
+	typeDocTagObservable
+} from '../../../src/index.js';
+
+import { assertCalls, ROOT_TEST_DIRECTORY } from '../../utils.js';
+import { getPluginPriority } from '../../../src/utils/getpluginpriority.js';
+import typeOnlyExportValidator from '../../../src/validators/type-only-export-validator/index.js';
+import { type ValidatorErrorCallback } from '../../../src/validators/index.js';
+
+describe( 'typedoc-plugins/validators/type-only-export-validator', () => {
+	const fixturesPath = upath.join( ROOT_TEST_DIRECTORY, 'validators', 'type-only-export-validator', 'fixtures' );
+	const sourceFilePattern = upath.join( fixturesPath, '**', '*.ts' );
+
+	let onError: ValidatorErrorCallback;
+
+	beforeAll( async () => {
+		const files = ( await glob( sourceFilePattern ) ).map( file => upath.normalize( file ) );
+		const app = await Application.bootstrapWithPlugins( {
+			logLevel: 'Error',
+			entryPoints: files,
+			tsconfig: upath.join( fixturesPath, 'tsconfig.json' )
+		} );
+
+		onError = vi.fn();
+
+		typeDocModuleFixer( app );
+		typeDocSymbolFixer( app );
+		typeDocTagError( app );
+		typeDocTagEvent( app );
+		typeDocTagObservable( app );
+		typeDocEventParamFixer( app );
+		typeDocEventInheritanceFixer( app );
+		typeDocInterfaceAugmentationFixer( app );
+		typeDocPurgePrivateApiDocs( app );
+		typeDocRestoreProgramAfterConversion( app );
+
+		// TODO: To resolve types.
+		// @ts-expect-error TS2339
+		// Property 'on' does not exist on type 'Converter'.
+		app.converter.on( Converter.EVENT_END, ( context: Context ) => {
+			typeOnlyExportValidator( context, onError );
+		}, getPluginPriority( 'validators' ) );
+
+		await app.convert();
+	} );
+
+	it( 'should warn when a class is exported as a type-only export', async () => {
+		const expectedErrors = [
+			{
+				identifier: 'MyClass',
+				source: 'ckeditor5-example/src/index.ts:11'
+			},
+			{
+				identifier: 'AnotherClass',
+				source: 'ckeditor5-example/src/index.ts:14'
+			},
+			{
+				identifier: 'AliasedClass',
+				aliasedName: 'RenamedClass',
+				source: 'ckeditor5-example/src/index.ts:17'
+			},
+			{
+				identifier: 'MixedClass',
+				source: 'ckeditor5-example/src/index.ts:20'
+			}
+		].map( error => ( {
+			message: 'aliasedName' in error && error.aliasedName ?
+				`Class "${ error.identifier }" (exported as "${ error.aliasedName }") must not be exported as a type-only export.` :
+				`Class "${ error.identifier }" must not be exported as a type-only export.`,
+			source: upath.join( fixturesPath, error.source )
+		} ) );
+
+		const errorCalls = vi.mocked( onError ).mock.calls;
+
+		assertCalls( errorCalls, expectedErrors );
+	} );
+} );


### PR DESCRIPTION
<!--

This repository uses Markdown files to define changelog entries. If the changes in this pull request are **user-facing**, please create a changelog entry by running the following command:

    pnpm run nice

This will generate a `*.md` file in the `.changelog/` directory for your description. You can create as many as you need.

**Note:**  
If your PR is internal-only (e.g., tests, tooling, docs), you can skip this step - just mention it below.

-->

### 🚀 Summary

*A brief summary of what this PR changes.*

---

### 📌 Related issues

<!--

Although changelog entries list connected issues, GitHub requires listing them here to automatically link and close them.

-->

* See https://github.com/ckeditor/ckeditor5/issues/18942.

---

### 💡 Additional information

Testing: link to `ckeditor5`. Run the `docs` script. Expect warnings such as:

```
./packages/ckeditor5-engine/src/index.ts:40:1 - [warning] Class "DowncastDispatcher" must not be exported as a type-only export.

40      DowncastDispatcher,

./packages/ckeditor5-engine/src/index.ts:55:1 - [warning] Class "UpcastDispatcher" must not be exported as a type-only export.

55      UpcastDispatcher,

./packages/ckeditor5-engine/src/index.ts:95:14 - [warning] Class "ModelConsumable" must not be exported as a type-only export.

95    export type { ModelConsumable } from './conversion/modelconsumable.js';

```
