### PR TITLE
Fixed unavailable build time.

### DIFF
--- a/.changelog/20260424154037_ck_20081.md
+++ b/.changelog/20260424154037_ck_20081.md
@@ -1,0 +1,9 @@
+---
+type: Fix
+scope:
+  - ckeditor5-dev-ci
+closes:
+  - ckeditor/ckeditor5#20081
+---
+
+Fixed `ckeditor5-dev-ci-notify-circle-status` reporting "Build time: Unavailable." in Slack notifications. The CircleCI job API was called with a pipeline number instead of a job number, so the request did not return a valid `started_at` timestamp.

--- a/packages/ckeditor5-dev-ci/bin/notify-circle-status.js
+++ b/packages/ckeditor5-dev-ci/bin/notify-circle-status.js
@@ -33,6 +33,7 @@ const {
 
 	// Variables that are available by default in Circle environment.
 	CIRCLE_BRANCH,
+	CIRCLE_BUILD_NUM,
 	CIRCLE_PROJECT_REPONAME,
 	CIRCLE_PROJECT_USERNAME,
 	CIRCLE_SHA1,
@@ -126,7 +127,7 @@ async function getJobData() {
 		CIRCLE_PROJECT_USERNAME,
 		CIRCLE_PROJECT_REPONAME,
 		'job',
-		cliArguments[ 'pipeline-id' ]
+		CIRCLE_BUILD_NUM
 	].join( '/' );
 
 	const fetchOptions = {


### PR DESCRIPTION
<!--

This repository uses Markdown files to define changelog entries. If the changes in this pull request are **user-facing**, please create a changelog entry by running the following command:

    pnpm run nice

This will generate a `*.md` file in the `.changelog/` directory for your description. You can create as many as you need.

**Note:**  
If your PR is internal-only (e.g., tests, tooling, docs), you can skip this step - just mention it below.

-->

### 🚀 Summary

Fixed `ckeditor5-dev-ci-notify-circle-status` reporting "Build time: Unavailable." in Slack notifications. The CircleCI job API was called with a pipeline number instead of a job number, so the request did not return a valid `started_at` timestamp.

**Build time** is back: _(time shown is wrong due to running the script targeting old job)_

<img width="632" height="294" alt="image" src="https://github.com/user-attachments/assets/f91c891f-bbfb-4ac4-bd49-b8e62766ba81" />


---

### 📌 Related issues

<!--

Although changelog entries list connected issues, GitHub requires listing them here to automatically link and close them.

-->

* Closes https://github.com/ckeditor/ckeditor5/issues/20081.

---

### 💡 Testing

Fire `node packages/ckeditor5-dev-ci/bin/notify-circle-status.js` with proper args to test the script.
