### PR TITLE
Fix production test bundling warnings. (master-v54)

### DIFF
--- a/.changelog/20260514150900_ci_4457.md
+++ b/.changelog/20260514150900_ci_4457.md
@@ -1,0 +1,7 @@
+---
+type: Fix
+scope:
+  - ckeditor5-dev-tests
+---
+
+Fixed `ckeditor5-dev-tests-run-automated` hanging in production mode when webpack warnings were treated as errors. The runner now emits generated bundles before failing the browser test run.

--- a/.changelog/20260514153200_ci_4457-protobuf.md
+++ b/.changelog/20260514153200_ci_4457-protobuf.md
@@ -1,0 +1,7 @@
+---
+type: Fix
+scope:
+  - ckeditor5-dev-tests
+---
+
+Fixed webpack warnings from `protobufjs` in automated and manual test runners. Test webpack configurations now handle dynamic optional `require()` calls from `@protobufjs/inquire` without reporting critical dependency warnings.

--- a/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getwebpackconfig.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/automated-tests/getwebpackconfig.js
@@ -7,6 +7,7 @@ import path from 'node:path';
 import webpack from 'webpack';
 import { loaders } from '@ckeditor/ckeditor5-dev-utils';
 import getDefinitionsFromFile from '../getdefinitionsfromfile.js';
+import getProtobufJsInquireWebpackRule from '../getprotobufjsinquirewebpackrule.js';
 import TreatWarningsAsErrorsWebpackPlugin from './treatwarningsaserrorswebpackplugin.js';
 
 /**
@@ -64,6 +65,8 @@ export default function getWebpackConfigForAutomatedTests( options ) {
 
 		module: {
 			rules: [
+				getProtobufJsInquireWebpackRule(),
+
 				options.coverage ? loaders.getCoverageLoader( { files: options.files } ) : null,
 
 				loaders.getIconsLoader(),

--- a/packages/ckeditor5-dev-tests/lib/utils/automated-tests/treatwarningsaserrorswebpackplugin.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/automated-tests/treatwarningsaserrorswebpackplugin.js
@@ -3,22 +3,52 @@
  * For licensing, see LICENSE.md.
  */
 
+const PLUGIN_NAME = 'TreatWarningsAsErrorsWebpackPlugin';
+
 /**
- * Webpack plugin that reassigns warnings as errors and stops the process if any errors or warnings detected.
+ * Webpack plugin that reassigns warnings as errors and makes the browser test run fail.
  */
 export default class TreatWarningsAsErrorsWebpackPlugin {
 	apply( compiler ) {
-		compiler.hooks.shouldEmit.tap( 'TreatWarningsAsErrorsWebpackPlugin', compilation => {
-			compilation.errors = [
-				...compilation.errors,
-				...compilation.warnings
-			];
+		compiler.hooks.thisCompilation.tap( PLUGIN_NAME, compilation => {
+			compilation.hooks.processAssets.tap( {
+				name: PLUGIN_NAME,
+				stage: compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONS
+			}, () => {
+				const warnings = compilation.warnings;
 
-			compilation.warnings = [];
+				if ( !warnings.length && !compilation.errors.length ) {
+					return;
+				}
 
-			if ( compilation.errors.length ) {
-				return false;
-			}
+				compilation.errors = [
+					...compilation.errors,
+					...warnings
+				];
+
+				compilation.warnings = [];
+
+				prependFailureToEntrypoints( compilation, compiler.webpack.sources.ConcatSource );
+			} );
 		} );
+	}
+}
+
+function prependFailureToEntrypoints( compilation, ConcatSource ) {
+	const files = new Set();
+
+	for ( const entrypoint of compilation.entrypoints.values() ) {
+		for ( const file of entrypoint.getFiles() ) {
+			if ( file.endsWith( '.js' ) ) {
+				files.add( file );
+			}
+		}
+	}
+
+	for ( const file of files ) {
+		compilation.updateAsset( file, source => new ConcatSource(
+			'throw new Error( "Webpack compilation failed. See terminal output for details." );\n',
+			source
+		) );
 	}
 }

--- a/packages/ckeditor5-dev-tests/lib/utils/getprotobufjsinquirewebpackrule.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/getprotobufjsinquirewebpackrule.js
@@ -1,0 +1,19 @@
+/**
+ * @license Copyright (c) 2003-2026, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/**
+ * `protobufjs` uses a dynamic `require()` wrapper for optional dependencies.
+ * The optional dependency probing is intentional, so webpack should not report it as a critical dependency.
+ *
+ * @returns {object}
+ */
+export default function getProtobufJsInquireWebpackRule() {
+	return {
+		test: /@protobufjs(?:\+|[\\/])inquire.*[\\/]index\.js$/,
+		parser: {
+			exprContextCritical: false
+		}
+	};
+}

--- a/packages/ckeditor5-dev-tests/lib/utils/manual-tests/getwebpackconfig.js
+++ b/packages/ckeditor5-dev-tests/lib/utils/manual-tests/getwebpackconfig.js
@@ -10,6 +10,7 @@ import { CKEditorTranslationsPlugin } from '@ckeditor/ckeditor5-dev-translations
 import { loaders } from '@ckeditor/ckeditor5-dev-utils';
 import WebpackNotifierPlugin from './webpacknotifierplugin.js';
 import getDefinitionsFromFile from '../getdefinitionsfromfile.js';
+import getProtobufJsInquireWebpackRule from '../getprotobufjsinquirewebpackrule.js';
 
 const require = createRequire( import.meta.url );
 
@@ -74,6 +75,8 @@ export default function getWebpackConfigForManualTests( options ) {
 
 		module: {
 			rules: [
+				getProtobufJsInquireWebpackRule(),
+
 				loaders.getIconsLoader( { matchExtensionOnly: true } ),
 
 				loaders.getStylesLoader( {
@@ -152,4 +155,3 @@ export default function getWebpackConfigForManualTests( options ) {
 
 	return webpackConfig;
 }
-

--- a/packages/ckeditor5-dev-tests/tests/utils/automated-tests/getwebpackconfig.js
+++ b/packages/ckeditor5-dev-tests/tests/utils/automated-tests/getwebpackconfig.js
@@ -9,13 +9,14 @@ import { loaders } from '@ckeditor/ckeditor5-dev-utils';
 import TreatWarningsAsErrorsWebpackPlugin from '../../../lib/utils/automated-tests/treatwarningsaserrorswebpackplugin.js';
 import getWebpackConfigForAutomatedTests from '../../../lib/utils/automated-tests/getwebpackconfig.js';
 import getDefinitionsFromFile from '../../../lib/utils/getdefinitionsfromfile.js';
+import getProtobufJsInquireWebpackRule from '../../../lib/utils/getprotobufjsinquirewebpackrule.js';
 
 vi.mock( '@ckeditor/ckeditor5-dev-utils' );
 vi.mock( '../../../lib/utils/getdefinitionsfromfile.js' );
+vi.mock( '../../../lib/utils/getprotobufjsinquirewebpackrule.js' );
 vi.mock( '../../../lib/utils/automated-tests/treatwarningsaserrorswebpackplugin', () => ( {
 	default: class TreatWarningsAsErrorsWebpackPlugin {}
 } ) );
-
 describe( 'getWebpackConfigForAutomatedTests()', () => {
 	it( 'should return basic webpack configuration object', () => {
 		const webpackConfig = getWebpackConfigForAutomatedTests( {
@@ -41,6 +42,12 @@ describe( 'getWebpackConfigForAutomatedTests()', () => {
 		expect( webpackConfig.resolveLoader.modules[ 0 ] ).to.equal( 'node_modules' );
 		expect( webpackConfig.devtool ).to.equal( undefined );
 		expect( webpackConfig.output ).to.have.property( 'devtoolModuleFilenameTemplate' );
+	} );
+
+	it( 'should add the @protobufjs/inquire webpack rule', () => {
+		getWebpackConfigForAutomatedTests( {} );
+
+		expect( vi.mocked( getProtobufJsInquireWebpackRule ) ).toHaveBeenCalledOnce();
 	} );
 
 	it( 'should aggregate events when running with the enabled watch mode', () => {

--- a/packages/ckeditor5-dev-tests/tests/utils/automated-tests/treatwarningsaserrorswebpackplugin.js
+++ b/packages/ckeditor5-dev-tests/tests/utils/automated-tests/treatwarningsaserrorswebpackplugin.js
@@ -5,11 +5,13 @@
 
 import { describe, expect, it } from 'vitest';
 import webpack from 'webpack';
+import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import TreatWarningsAsErrorsWebpackPlugin from '../../../lib/utils/automated-tests/treatwarningsaserrorswebpackplugin.js';
 
 describe( 'TreatWarningsAsErrorsWebpackPlugin', () => {
-	it( 'should reassign warnings to errors and not emit the code when errors are present', () => {
+	it( 'should reassign warnings to errors, emit the code and make the bundle fail', () => {
 		return new Promise( ( resolve, reject ) => {
 			runCompiler(
 				{
@@ -20,30 +22,29 @@ describe( 'TreatWarningsAsErrorsWebpackPlugin', () => {
 							apply( compiler ) {
 								compiler.hooks.make.tap( 'MakeCompilationWarning', compilation => {
 									compilation.errors.push( new Error( 'Compilation error 1' ) );
-									compilation.errors.push( new Error( 'Compilation error 2' ) );
 									compilation.warnings.push( new Error( 'Compilation warning 1' ) );
-									compilation.warnings.push( new Error( 'Compilation warning 2' ) );
 								} );
 							}
 						},
 						new TreatWarningsAsErrorsWebpackPlugin()
 					]
 				},
-				( err, stats ) => {
+				( err, stats, outputPath ) => {
 					if ( err ) {
 						return reject( err );
 					}
 
 					try {
 						const statsJson = stats.toJson( { errorDetails: false } );
+						const asset = statsJson.assets.find( asset => asset.name.endsWith( '.js' ) );
+						const assetContent = fs.readFileSync( path.join( outputPath, asset.name ), 'utf-8' );
 
-						expect( statsJson.errors.length ).to.equal( 4 );
+						expect( statsJson.errors.length ).to.equal( 2 );
 						expect( statsJson.warnings.length ).to.equal( 0 );
 						expect( statsJson.errors[ 0 ].message ).to.equal( 'Compilation error 1' );
-						expect( statsJson.errors[ 1 ].message ).to.equal( 'Compilation error 2' );
-						expect( statsJson.errors[ 2 ].message ).to.equal( 'Compilation warning 1' );
-						expect( statsJson.errors[ 3 ].message ).to.equal( 'Compilation warning 2' );
-						expect( statsJson.assets[ 0 ].emitted ).to.equal( false );
+						expect( statsJson.errors[ 1 ].message ).to.equal( 'Compilation warning 1' );
+						expect( asset.emitted ).to.equal( true );
+						expect( assetContent ).to.contain( 'Webpack compilation failed. See terminal output for details.' );
 						resolve();
 					} catch ( error ) {
 						reject( error );
@@ -55,12 +56,16 @@ describe( 'TreatWarningsAsErrorsWebpackPlugin', () => {
 
 function runCompiler( options, callback ) {
 	options.context = path.join( import.meta.dirname, '..', '..', 'fixtures' );
+	options.output = {
+		path: fs.mkdtempSync( path.join( os.tmpdir(), 'treat-warnings-as-errors-webpack-plugin-' ) )
+	};
 
 	const compiler = webpack( options );
 
-	compiler.outputFileSystem = {};
-
 	compiler.run( ( err, stats ) => {
-		callback( err, stats );
+		compiler.close( closeError => {
+			callback( err || closeError, stats, options.output.path );
+			fs.rmSync( options.output.path, { recursive: true, force: true } );
+		} );
 	} );
 }

--- a/packages/ckeditor5-dev-tests/tests/utils/getprotobufjsinquirewebpackrule.js
+++ b/packages/ckeditor5-dev-tests/tests/utils/getprotobufjsinquirewebpackrule.js
@@ -1,0 +1,21 @@
+/**
+ * @license Copyright (c) 2003-2026, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+import { describe, expect, it } from 'vitest';
+import getProtobufJsInquireWebpackRule from '../../lib/utils/getprotobufjsinquirewebpackrule.js';
+
+describe( 'getProtobufJsInquireWebpackRule()', () => {
+	it( 'should return parser configuration for @protobufjs/inquire', () => {
+		const rule = getProtobufJsInquireWebpackRule();
+
+		expect( '/node_modules/@protobufjs/inquire/index.js' ).to.match( rule.test );
+		expect( '/node_modules/.pnpm/@protobufjs+inquire@1.1.1/node_modules/@protobufjs/inquire/index.js' ).to.match( rule.test );
+		expect( '/node_modules/@protobufjs/base64/index.js' ).not.to.match( rule.test );
+
+		expect( rule.parser ).to.deep.equal( {
+			exprContextCritical: false
+		} );
+	} );
+} );

--- a/packages/ckeditor5-dev-tests/tests/utils/manual-tests/getwebpackconfig.js
+++ b/packages/ckeditor5-dev-tests/tests/utils/manual-tests/getwebpackconfig.js
@@ -6,6 +6,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { loaders } from '@ckeditor/ckeditor5-dev-utils';
 import getDefinitionsFromFile from '../../../lib/utils/getdefinitionsfromfile.js';
+import getProtobufJsInquireWebpackRule from '../../../lib/utils/getprotobufjsinquirewebpackrule.js';
 import getWebpackConfigForManualTests from '../../../lib/utils/manual-tests/getwebpackconfig.js';
 
 const stubs = vi.hoisted( () => ( {
@@ -32,6 +33,7 @@ vi.mock( '@ckeditor/ckeditor5-dev-translations', () => ( {
 	}
 } ) );
 vi.mock( '../../../lib/utils/getdefinitionsfromfile.js' );
+vi.mock( '../../../lib/utils/getprotobufjsinquirewebpackrule.js' );
 
 describe( 'getWebpackConfigForManualTests()', () => {
 	beforeEach( () => {
@@ -97,6 +99,12 @@ describe( 'getWebpackConfigForManualTests()', () => {
 
 		// The `devtool` property has been replaced by the `SourceMapDevToolPlugin()`.
 		expect( webpackConfig ).to.not.have.property( 'devtool' );
+	} );
+
+	it( 'should add the @protobufjs/inquire webpack rule', () => {
+		getWebpackConfigForManualTests( { disableWatch: true } );
+
+		expect( vi.mocked( getProtobufJsInquireWebpackRule ) ).toHaveBeenCalledOnce();
 	} );
 
 	it( 'should disable watcher mechanism when passing the "disableWatch" option', () => {


### PR DESCRIPTION
### 🚀 Summary

- Fixed `ckeditor5-dev-tests-run-automated` hanging in production mode when webpack warnings are treated as errors.
- Updated `TreatWarningsAsErrorsWebpackPlugin` to keep generated bundles emitted and fail the browser test run instead of blocking emission.
- Added a shared webpack parser rule for automated and manual test runners to avoid `@protobufjs/inquire` critical dependency warnings.

---

### 📌 Related issues

* Closes https://github.com/ckeditor/ckeditor5-internal/issues/4457.

---

### 💡 Additional information

Backport of #1360 to `master-v54`.

Tests:

- `pnpm exec vitest run --config vitest.config.js`
- `pnpm run test -f ckeditor5-collaboration-core --reporter=dots -b ChromeHeadless --production`