### PR TITLE
Added GitHub Actions Slack notification on the LTS line.

### DIFF
--- a/.changelog/20260522154014_i_4450_gh_actions_slack_notification.md
+++ b/.changelog/20260522154014_i_4450_gh_actions_slack_notification.md
@@ -1,0 +1,9 @@
+---
+type: Other
+scope:
+  - ckeditor5-dev-ci
+see:
+  - https://github.com/ckeditor/ckeditor5-internal/issues/4450
+---
+
+Added `ckeditor5-dev-ci-notify-github-actions-status`, a GitHub Actions equivalent of `ckeditor5-dev-ci-notify-circle-status` that posts a Slack notification summarizing a failed workflow.

--- a/packages/ckeditor5-dev-ci/README.md
+++ b/packages/ckeditor5-dev-ci/README.md
@@ -6,7 +6,7 @@ CKEditor 5 CI utilities
 
 Utils for [CKEditor 5](https://ckeditor.com) CI builds.
 
-Contains tools for sending Slack notifications by Circle CI.
+Contains tools for sending Slack notifications from Circle CI and GitHub Actions workflows.
 
 ## Available scripts
 
@@ -109,6 +109,31 @@ These commands accept a mix of environment variables and command line arguments.
   - `--pipeline-id` &mdash Value of Circle's `<< pipeline.number >>` parameter ([read more](https://circleci.com/docs/guides/orchestrate/pipeline-variables/#pipeline-values)).
   - `--trigger-repository-slug` &mdash; `<org>/<repo>` to construct the commit URL when provided with `--trigger-commit-hash`. Useful when a pipeline was triggered via a different repository.
   - `--trigger-commit-hash` &mdash; Commit SHA to construct the commit URL. Useful when a pipeline was triggered via a different repository.
+  - `--hide-author` &mdash; `"true"`/`"false"` to hide the author in Slack.
+
+- ⚙️ **`ckeditor5-dev-ci-notify-github-actions-status`**
+
+  Sends a Slack notification summarizing the current GitHub Actions workflow run.
+  Designed to be called from a step (or dedicated job) gated by `if: failure()`; the script does not check the workflow status before sending the notification.
+  Fetches the commit author and workflow run start time via the GitHub API (works with private repositories).
+
+  **Environment variables:**
+  - `CKE5_GITHUB_TOKEN` &mdash; GitHub token with the `repo` scope, used to fetch commit author and workflow run metadata.
+  - `CKE5_SLACK_WEBHOOK_URL` &mdash; Incoming Webhook URL for the Slack channel receiving notifications.
+
+  **GitHub-provided variables:**
+  - `GITHUB_REPOSITORY` &mdash; `<owner>/<repo>` of the current workflow.
+  - `GITHUB_REF_NAME` &mdash; Branch or tag name that triggered the workflow.
+  - `GITHUB_SHA` &mdash; Commit SHA of the current run.
+  - `GITHUB_RUN_ID` &mdash; ID of the current workflow run.
+  - `GITHUB_RUN_ATTEMPT` &mdash; *(Optional)* Run attempt number; included in the Slack message when greater than `1`.
+  - `GITHUB_WORKFLOW` &mdash; *(Optional)* Display name of the current workflow.
+  - `GITHUB_SERVER_URL` &mdash; *(Optional)* Server URL; defaults to `https://github.com`.
+  - `GITHUB_API_URL` &mdash; *(Optional)* API base URL; defaults to `https://api.github.com`.
+
+  **Parameters:**
+  - `--trigger-repository-slug` &mdash; `<org>/<repo>` to construct the commit URL when provided with `--trigger-commit-hash`. Useful when a workflow was triggered via a different repository.
+  - `--trigger-commit-hash` &mdash; Commit SHA to construct the commit URL. Useful when a workflow was triggered via a different repository.
   - `--hide-author` &mdash; `"true"`/`"false"` to hide the author in Slack.
 
 - ⚙️ **`ckeditor5-dev-ci-trigger-circle-build`**

--- a/packages/ckeditor5-dev-ci/bin/notify-github-actions-status.js
+++ b/packages/ckeditor5-dev-ci/bin/notify-github-actions-status.js
@@ -96,6 +96,7 @@ async function notifyGitHubActionsStatus() {
 		buildId: `#${ GITHUB_RUN_ID }${ runAttempt > 1 ? ` (attempt ${ runAttempt })` : '' }`,
 		githubToken: CKE5_GITHUB_TOKEN,
 		triggeringCommitUrl: getTriggeringCommitUrl( serverUrl ),
+		apiUrl,
 		startTime: startedAtIso ? Math.ceil( new Date( startedAtIso ).getTime() / 1000 ) : null,
 		endTime: Math.ceil( Date.now() / 1000 ),
 		shouldHideAuthor: isTrueLike( cliArguments[ 'hide-author' ] )

--- a/packages/ckeditor5-dev-ci/bin/notify-github-actions-status.js
+++ b/packages/ckeditor5-dev-ci/bin/notify-github-actions-status.js
@@ -76,8 +76,8 @@ notifyGitHubActionsStatus().catch( err => {
 async function notifyGitHubActionsStatus() {
 	assertRequiredEnvironmentVariables();
 
-	const serverUrl = GITHUB_SERVER_URL || 'https://github.com';
-	const apiUrl = GITHUB_API_URL || 'https://api.github.com';
+	const serverUrl = ( GITHUB_SERVER_URL || 'https://github.com' ).replace( /\/$/, '' );
+	const apiUrl = ( GITHUB_API_URL || 'https://api.github.com' ).replace( /\/$/, '' );
 	const [ repositoryOwner, repositoryName ] = GITHUB_REPOSITORY.split( '/' );
 	const runAttempt = GITHUB_RUN_ATTEMPT ? Number( GITHUB_RUN_ATTEMPT ) : 1;
 

--- a/packages/ckeditor5-dev-ci/bin/notify-github-actions-status.js
+++ b/packages/ckeditor5-dev-ci/bin/notify-github-actions-status.js
@@ -1,0 +1,158 @@
+#!/usr/bin/env node
+
+/**
+ * @license Copyright (c) 2003-2026, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+import { parseArgs } from 'node:util';
+import slackNotify from 'slack-notify';
+import formatMessage from '../lib/format-message.js';
+
+// This script assumes that it is being executed in a GitHub Actions runner.
+// The step using it should be conditional on the workflow having failed
+// (for example via `if: failure()` or a dedicated job depending on the failed one),
+// since the script itself does not check whether the workflow failed before sending
+// the notification.
+//
+// Described environment variables starting with "CKE5" must be added by the integrator.
+
+const {
+	/**
+	 * Required. Token to a GitHub account with the `repo` scope. It is required for obtaining
+	 * the author of the commit that triggered the failed workflow run. The repository can be
+	 * private, so the public, unauthenticated API cannot be used.
+	 */
+	CKE5_GITHUB_TOKEN,
+
+	/**
+	 * Required. Webhook URL of the Slack channel where the notification should be sent.
+	 */
+	CKE5_SLACK_WEBHOOK_URL,
+
+	// Variables that are available by default in the GitHub Actions environment.
+	// See: https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables.
+	GITHUB_REPOSITORY,
+	GITHUB_REF_NAME,
+	GITHUB_SHA,
+	GITHUB_RUN_ID,
+	GITHUB_RUN_ATTEMPT,
+	GITHUB_WORKFLOW,
+	GITHUB_SERVER_URL,
+	GITHUB_API_URL
+} = process.env;
+
+const { values: cliArguments } = parseArgs( {
+	options: {
+		/**
+		 * Optional. If both are defined, the script will use the URL as the commit URL.
+		 * Otherwise, the URL will be constructed using the current repository data.
+		 */
+		'trigger-repository-slug': {
+			type: 'string',
+			default: process.env.CKE5_TRIGGER_REPOSITORY_SLUG
+		},
+		'trigger-commit-hash': {
+			type: 'string',
+			default: process.env.CKE5_TRIGGER_COMMIT_HASH
+		},
+
+		/**
+		 * Optional. If set to "true" or "1", commit author will be hidden.
+		 * See: https://github.com/ckeditor/ckeditor5/issues/9252.
+		 */
+		'hide-author': {
+			type: 'string',
+			default: process.env.CKE5_SLACK_NOTIFY_HIDE_AUTHOR
+		}
+	}
+} );
+
+notifyGitHubActionsStatus().catch( err => {
+	console.error( err );
+	process.exit( 1 );
+} );
+
+async function notifyGitHubActionsStatus() {
+	assertRequiredEnvironmentVariables();
+
+	const serverUrl = GITHUB_SERVER_URL || 'https://github.com';
+	const apiUrl = GITHUB_API_URL || 'https://api.github.com';
+	const [ repositoryOwner, repositoryName ] = GITHUB_REPOSITORY.split( '/' );
+	const runAttempt = GITHUB_RUN_ATTEMPT ? Number( GITHUB_RUN_ATTEMPT ) : 1;
+
+	const runData = await getWorkflowRunData( { apiUrl, repositoryOwner, repositoryName } );
+	const buildUrl = [ serverUrl, GITHUB_REPOSITORY, 'actions', 'runs', GITHUB_RUN_ID, 'attempts', runAttempt ].join( '/' );
+	const startedAtIso = runData.run_started_at || runData.created_at;
+
+	const message = await formatMessage( {
+		slackMessageUsername: 'GitHub Actions',
+		iconUrl: 'https://avatars.githubusercontent.com/in/15368?s=80&v=4',
+		repositoryOwner,
+		repositoryName,
+		branch: GITHUB_REF_NAME,
+		buildTitle: GITHUB_WORKFLOW || 'Workflow run',
+		buildUrl,
+		buildId: `#${ GITHUB_RUN_ID }${ runAttempt > 1 ? ` (attempt ${ runAttempt })` : '' }`,
+		githubToken: CKE5_GITHUB_TOKEN,
+		triggeringCommitUrl: getTriggeringCommitUrl( serverUrl ),
+		startTime: startedAtIso ? Math.ceil( new Date( startedAtIso ).getTime() / 1000 ) : null,
+		endTime: Math.ceil( Date.now() / 1000 ),
+		shouldHideAuthor: isTrueLike( cliArguments[ 'hide-author' ] )
+	} );
+
+	return slackNotify( CKE5_SLACK_WEBHOOK_URL )
+		.send( message )
+		.catch( err => console.log( 'API error occurred:', err ) );
+}
+
+function assertRequiredEnvironmentVariables() {
+	const required = {
+		CKE5_GITHUB_TOKEN,
+		CKE5_SLACK_WEBHOOK_URL,
+		GITHUB_REPOSITORY,
+		GITHUB_REF_NAME,
+		GITHUB_SHA,
+		GITHUB_RUN_ID
+	};
+
+	for ( const [ name, value ] of Object.entries( required ) ) {
+		if ( !value ) {
+			throw new Error( `Missing environment variable: ${ name }` );
+		}
+	}
+}
+
+async function getWorkflowRunData( { apiUrl, repositoryOwner, repositoryName } ) {
+	const fetchUrl = [ apiUrl, 'repos', repositoryOwner, repositoryName, 'actions', 'runs', GITHUB_RUN_ID ].join( '/' );
+	const fetchOptions = {
+		method: 'GET',
+		headers: {
+			'Accept': 'application/vnd.github+json',
+			'Authorization': `Bearer ${ CKE5_GITHUB_TOKEN }`,
+			'X-GitHub-Api-Version': '2022-11-28'
+		}
+	};
+
+	const response = await fetch( fetchUrl, fetchOptions );
+
+	if ( !response.ok ) {
+		throw new Error( `Failed to fetch workflow run ${ GITHUB_RUN_ID }: HTTP ${ response.status }.` );
+	}
+
+	return response.json();
+}
+
+function getTriggeringCommitUrl( serverUrl ) {
+	const cliRepoSlug = cliArguments[ 'trigger-repository-slug' ];
+	const cliCommitHash = cliArguments[ 'trigger-commit-hash' ];
+
+	const repoSlug = cliRepoSlug && cliCommitHash ? cliRepoSlug.trim() : GITHUB_REPOSITORY;
+	const hash = cliRepoSlug && cliCommitHash ? cliCommitHash.trim() : GITHUB_SHA;
+
+	return [ serverUrl, repoSlug, 'commit', hash ].join( '/' );
+}
+
+function isTrueLike( value ) {
+	return value === true || value === 1 || value === '1' || value === 'true';
+}

--- a/packages/ckeditor5-dev-ci/lib/format-message.js
+++ b/packages/ckeditor5-dev-ci/lib/format-message.js
@@ -24,7 +24,8 @@ import { bots, members } from './data/index.js';
  */
 export default async function formatMessage( options ) {
 	const commitDetails = await getCommitDetails( options.triggeringCommitUrl, options.githubToken, options.apiUrl );
-	const repoUrl = `https://github.com/${ options.repositoryOwner }/${ options.repositoryName }`;
+	const serverUrl = new URL( options.triggeringCommitUrl ).origin;
+	const repoUrl = `${ serverUrl }/${ options.repositoryOwner }/${ options.repositoryName }`;
 
 	return {
 		username: options.slackMessageUsername,

--- a/packages/ckeditor5-dev-ci/lib/format-message.js
+++ b/packages/ckeditor5-dev-ci/lib/format-message.js
@@ -5,8 +5,6 @@
 
 import { bots, members } from './data/index.js';
 
-const REPOSITORY_REGEXP = /github\.com\/([^/]+)\/([^/]+)/;
-
 /**
  * @param {object} options
  * @param {string} options.slackMessageUsername
@@ -163,14 +161,16 @@ function getFormattedMessage( commitMessage, triggeringCommitUrl ) {
 		return '_Unavailable._';
 	}
 
-	const [ , repoOwner, repoName ] = triggeringCommitUrl.match( REPOSITORY_REGEXP );
+	const url = new URL( triggeringCommitUrl );
+	const serverUrl = url.origin;
+	const [ , repoOwner, repoName ] = url.pathname.split( '/' );
 
 	return commitMessage
 		.replace( / #(\d+)/g, ( _, issueId ) => {
-			return ` <https://github.com/${ repoOwner }/${ repoName }/issues/${ issueId }|#${ issueId }>`;
+			return ` <${ serverUrl }/${ repoOwner }/${ repoName }/issues/${ issueId }|#${ issueId }>`;
 		} )
 		.replace( /([\w-]+\/[\w-]+)#(\d+)/g, ( _, repoSlug, issueId ) => {
-			return `<https://github.com/${ repoSlug }/issues/${ issueId }|${ repoSlug }#${ issueId }>`;
+			return `<${ serverUrl }/${ repoSlug }/issues/${ issueId }|${ repoSlug }#${ issueId }>`;
 		} );
 }
 

--- a/packages/ckeditor5-dev-ci/lib/format-message.js
+++ b/packages/ckeditor5-dev-ci/lib/format-message.js
@@ -19,12 +19,13 @@ const REPOSITORY_REGEXP = /github\.com\/([^/]+)\/([^/]+)/;
  * @param {string} options.buildId
  * @param {string} options.githubToken
  * @param {string} options.triggeringCommitUrl
+ * @param {string} [options.apiUrl]
  * @param {number} options.startTime
  * @param {number} options.endTime
  * @param {boolean} options.shouldHideAuthor
  */
 export default async function formatMessage( options ) {
-	const commitDetails = await getCommitDetails( options.triggeringCommitUrl, options.githubToken );
+	const commitDetails = await getCommitDetails( options.triggeringCommitUrl, options.githubToken, options.apiUrl );
 	const repoUrl = `https://github.com/${ options.repositoryOwner }/${ options.repositoryName }`;
 
 	return {
@@ -178,10 +179,11 @@ function getFormattedMessage( commitMessage, triggeringCommitUrl ) {
  *
  * @param {string} triggeringCommitUrl The URL to the commit on GitHub.
  * @param {string} githubToken Github token used for authorization a request,
+ * @param {string} [apiUrl] Optional base URL of the GitHub API.
  * @returns {Promise.<object>}
  */
-function getCommitDetails( triggeringCommitUrl, githubToken ) {
-	const apiGithubUrlCommit = getGithubApiUrl( triggeringCommitUrl );
+function getCommitDetails( triggeringCommitUrl, githubToken, apiUrl ) {
+	const apiGithubUrlCommit = getGithubApiUrl( triggeringCommitUrl, apiUrl );
 	const options = {
 		method: 'GET',
 		credentials: 'include',
@@ -204,8 +206,15 @@ function getCommitDetails( triggeringCommitUrl, githubToken ) {
  * Returns a URL to GitHub API which returns details of the commit that caused the CI to fail its job.
  *
  * @param {string} triggeringCommitUrl The URL to the commit on GitHub.
+ * @param {string} [apiUrl] Optional base URL of the GitHub API.
  * @returns {string}
  */
-function getGithubApiUrl( triggeringCommitUrl ) {
+function getGithubApiUrl( triggeringCommitUrl, apiUrl ) {
+	if ( apiUrl ) {
+		const [ , owner, repo, , sha ] = new URL( triggeringCommitUrl ).pathname.split( '/' );
+
+		return `${ apiUrl.replace( /\/$/, '' ) }/repos/${ owner }/${ repo }/commits/${ sha }`;
+	}
+
 	return triggeringCommitUrl.replace( 'github.com/', 'api.github.com/repos/' ).replace( '/commit/', '/commits/' );
 }

--- a/packages/ckeditor5-dev-ci/package.json
+++ b/packages/ckeditor5-dev-ci/package.json
@@ -29,6 +29,7 @@
     "ckeditor5-dev-ci-is-job-triggered-by-member": "bin/is-job-triggered-by-member.js",
     "ckeditor5-dev-ci-is-workflow-restarted": "bin/is-workflow-restarted.js",
     "ckeditor5-dev-ci-notify-circle-status": "bin/notify-circle-status.js",
+    "ckeditor5-dev-ci-notify-github-actions-status": "bin/notify-github-actions-status.js",
     "ckeditor5-dev-ci-trigger-circle-build": "bin/trigger-circle-build.js",
     "ckeditor5-dev-ci-trigger-snyk-scan": "bin/trigger-snyk-scan.js"
   },

--- a/packages/ckeditor5-dev-ci/tests/format-message.js
+++ b/packages/ckeditor5-dev-ci/tests/format-message.js
@@ -339,5 +339,62 @@ describe( 'lib/format-message', () => {
 				expect( getCommitMessageField( message ) ).toEqual( '_Unavailable._' );
 			} );
 		} );
+
+		describe( 'Repository (branch) attachment field', () => {
+			const baseOptions = {
+				slackMessageUsername: 'Test',
+				iconUrl: 'https://avatars.githubusercontent.com/u/26329082?v=4',
+				branch: 'master',
+				buildTitle: 'Workflow',
+				buildUrl: 'https://...',
+				buildId: 1,
+				githubToken: 'secret-token',
+				startTime: 1,
+				endTime: 2,
+				shouldHideAuthor: false
+			};
+
+			beforeEach( () => {
+				fetchMock.mockResolvedValue( {
+					json: () => Promise.resolve( {
+						author: { login: 'ExampleNick' },
+						commit: { author: { name: 'Example Nick' }, message: '' },
+						sha: '35cbea88dc0b5c00406c9a5f0c357ad2a7195a19'
+					} )
+				} );
+			} );
+
+			function getRepositoryField( message ) {
+				return message.attachments[ 0 ].fields.find( field => field.title === 'Repository (branch)' ).value;
+			}
+
+			it( 'builds the repo + branch links from the public github.com host', async () => {
+				const message = await formatMessage( {
+					...baseOptions,
+					repositoryOwner: 'ckeditor',
+					repositoryName: 'ckeditor5-dev',
+					triggeringCommitUrl: 'https://github.com/ckeditor/ckeditor5-dev/commit/abc'
+				} );
+
+				expect( getRepositoryField( message ) ).toEqual(
+					'<https://github.com/ckeditor/ckeditor5-dev|ckeditor5-dev>' +
+					' (<https://github.com/ckeditor/ckeditor5-dev/tree/master|master>)'
+				);
+			} );
+
+			it( 'builds the repo + branch links from the GitHub Enterprise host', async () => {
+				const message = await formatMessage( {
+					...baseOptions,
+					repositoryOwner: 'owner',
+					repositoryName: 'repo',
+					triggeringCommitUrl: 'https://github.corp.example.com/owner/repo/commit/abc'
+				} );
+
+				expect( getRepositoryField( message ) ).toEqual(
+					'<https://github.corp.example.com/owner/repo|repo>' +
+					' (<https://github.corp.example.com/owner/repo/tree/master|master>)'
+				);
+			} );
+		} );
 	} );
 } );

--- a/packages/ckeditor5-dev-ci/tests/format-message.js
+++ b/packages/ckeditor5-dev-ci/tests/format-message.js
@@ -182,5 +182,162 @@ describe( 'lib/format-message', () => {
 			expect( message ).to.have.property( 'text' );
 			expect( message.text ).toEqual( '<@slackId>, could you take a look?' );
 		} );
+
+		describe( 'commit API URL resolution', () => {
+			const baseOptions = {
+				slackMessageUsername: 'Test',
+				iconUrl: 'https://avatars.githubusercontent.com/u/26329082?v=4',
+				repositoryOwner: 'ckeditor',
+				repositoryName: 'ckeditor5-dev',
+				branch: 'master',
+				buildTitle: 'Workflow',
+				buildUrl: 'https://...',
+				buildId: 1,
+				githubToken: 'secret-token',
+				startTime: 1,
+				endTime: 2,
+				shouldHideAuthor: false
+			};
+			const commitResponse = {
+				author: { login: 'ExampleNick' },
+				commit: { author: { name: 'Example Nick' }, message: 'An example message.' },
+				sha: '35cbea88dc0b5c00406c9a5f0c357ad2a7195a19'
+			};
+
+			beforeEach( () => {
+				fetchMock.mockResolvedValue( { json: () => Promise.resolve( commitResponse ) } );
+			} );
+
+			it( 'rewrites github.com → api.github.com when `apiUrl` is omitted (legacy path)', async () => {
+				await formatMessage( {
+					...baseOptions,
+					triggeringCommitUrl: 'https://github.com/ckeditor/ckeditor5-dev/commit/35cbea88dc0b5c00406c9a5f0c357ad2a7195a19'
+				} );
+
+				expect( fetchMock ).toHaveBeenCalledTimes( 1 );
+				expect( fetchMock.mock.calls[ 0 ][ 0 ] ).toEqual(
+					'https://api.github.com/repos/ckeditor/ckeditor5-dev/commits/35cbea88dc0b5c00406c9a5f0c357ad2a7195a19'
+				);
+			} );
+
+			it( 'uses `apiUrl` when provided for public github.com', async () => {
+				await formatMessage( {
+					...baseOptions,
+					triggeringCommitUrl: 'https://github.com/ckeditor/ckeditor5-dev/commit/35cbea88dc0b5c00406c9a5f0c357ad2a7195a19',
+					apiUrl: 'https://api.github.com'
+				} );
+
+				expect( fetchMock.mock.calls[ 0 ][ 0 ] ).toEqual(
+					'https://api.github.com/repos/ckeditor/ckeditor5-dev/commits/35cbea88dc0b5c00406c9a5f0c357ad2a7195a19'
+				);
+			} );
+
+			it( 'builds the GitHub Enterprise API URL from `apiUrl` regardless of the HTML host', async () => {
+				await formatMessage( {
+					...baseOptions,
+					triggeringCommitUrl: 'https://github.corp.example.com/owner/repo/commit/deadbeef',
+					apiUrl: 'https://github.corp.example.com/api/v3'
+				} );
+
+				expect( fetchMock.mock.calls[ 0 ][ 0 ] ).toEqual(
+					'https://github.corp.example.com/api/v3/repos/owner/repo/commits/deadbeef'
+				);
+			} );
+
+			it( 'trims a trailing slash from `apiUrl`', async () => {
+				await formatMessage( {
+					...baseOptions,
+					triggeringCommitUrl: 'https://github.com/owner/repo/commit/xyz',
+					apiUrl: 'https://api.github.com/'
+				} );
+
+				expect( fetchMock.mock.calls[ 0 ][ 0 ] ).toEqual(
+					'https://api.github.com/repos/owner/repo/commits/xyz'
+				);
+			} );
+		} );
+
+		describe( 'commit message issue-reference rewriting', () => {
+			const baseOptions = {
+				slackMessageUsername: 'Test',
+				iconUrl: 'https://avatars.githubusercontent.com/u/26329082?v=4',
+				repositoryOwner: 'ckeditor',
+				repositoryName: 'ckeditor5-dev',
+				branch: 'master',
+				buildTitle: 'Workflow',
+				buildUrl: 'https://...',
+				buildId: 1,
+				githubToken: 'secret-token',
+				startTime: 1,
+				endTime: 2,
+				shouldHideAuthor: false
+			};
+
+			function mockCommit( message ) {
+				fetchMock.mockResolvedValue( {
+					json: () => Promise.resolve( {
+						author: { login: 'ExampleNick' },
+						commit: { author: { name: 'Example Nick' }, message },
+						sha: '35cbea88dc0b5c00406c9a5f0c357ad2a7195a19'
+					} )
+				} );
+			}
+
+			function getCommitMessageField( message ) {
+				return message.attachments[ 0 ].fields.find( field => field.title === 'Commit message' ).value;
+			}
+
+			it( 'rewrites ` #<id>` references against the public github.com host', async () => {
+				mockCommit( 'Fix bug #42 in the parser.' );
+
+				const message = await formatMessage( {
+					...baseOptions,
+					triggeringCommitUrl: 'https://github.com/ckeditor/ckeditor5-dev/commit/abc'
+				} );
+
+				expect( getCommitMessageField( message ) ).toContain(
+					'<https://github.com/ckeditor/ckeditor5-dev/issues/42|#42>'
+				);
+			} );
+
+			it( 'rewrites ` #<id>` references against the GitHub Enterprise host', async () => {
+				mockCommit( 'Fix bug #42 in the parser.' );
+
+				const message = await formatMessage( {
+					...baseOptions,
+					triggeringCommitUrl: 'https://github.corp.example.com/owner/repo/commit/abc',
+					apiUrl: 'https://github.corp.example.com/api/v3'
+				} );
+
+				expect( getCommitMessageField( message ) ).toContain(
+					'<https://github.corp.example.com/owner/repo/issues/42|#42>'
+				);
+			} );
+
+			it( 'rewrites cross-repo `owner/repo#<id>` references using the triggering server URL', async () => {
+				mockCommit( 'See ckeditor/ckeditor5#10000 for context.' );
+
+				const message = await formatMessage( {
+					...baseOptions,
+					triggeringCommitUrl: 'https://github.corp.example.com/owner/repo/commit/abc',
+					apiUrl: 'https://github.corp.example.com/api/v3'
+				} );
+
+				expect( getCommitMessageField( message ) ).toContain(
+					'<https://github.corp.example.com/ckeditor/ckeditor5/issues/10000|ckeditor/ckeditor5#10000>'
+				);
+			} );
+
+			it( 'returns `_Unavailable._` when the commit message is empty', async () => {
+				mockCommit( '' );
+
+				const message = await formatMessage( {
+					...baseOptions,
+					triggeringCommitUrl: 'https://github.com/ckeditor/ckeditor5-dev/commit/abc'
+				} );
+
+				expect( getCommitMessageField( message ) ).toEqual( '_Unavailable._' );
+			} );
+		} );
 	} );
 } );


### PR DESCRIPTION
<!--

This repository uses Markdown files to define changelog entries. If the changes in this pull request are **user-facing**, please create a changelog entry by running the following command:

    pnpm run nice

This will generate a `*.md` file in the `.changelog/` directory for your description. You can create as many as you need.

**Note:**  
If your PR is internal-only (e.g., tests, tooling, docs), you can skip this step - just mention it below.

-->

### 🚀 Summary

Added `ckeditor5-dev-ci-notify-github-actions-status`, a GitHub Actions equivalent of `ckeditor5-dev-ci-notify-circle-status` that posts a Slack notification summarizing a failed workflow run (commit author, branch, run URL, duration). Intended to be invoked from a step or job gated by `if: failure()`.

---

### 📌 Related issues

<!--

Although changelog entries list connected issues, GitHub requires listing them here to automatically link and close them.

-->

* See ckeditor/ckeditor5-internal#4450

---

### 💡 Additional information

*Optional: Notes on decisions, edge cases, or anything helpful for reviewers.*
