### PR TITLE
Remove the `--disable-gpu` flag from the web crawler configuration

### DIFF
--- a/.changelog/20260526101915_ci_4486_improve_web_crawler_performance.md
+++ b/.changelog/20260526101915_ci_4486_improve_web_crawler_performance.md
@@ -1,0 +1,6 @@
+---
+type: Other
+scope: ckeditor5-dev-web-crawler
+---
+
+Remove the `--disable-gpu` flag from the web crawler configuration which causees performance issues on macOS.

--- a/.changelog/20260526101915_ci_4486_improve_web_crawler_performance.md
+++ b/.changelog/20260526101915_ci_4486_improve_web_crawler_performance.md
@@ -3,4 +3,4 @@ type: Other
 scope: ckeditor5-dev-web-crawler
 ---
 
-Remove the `--disable-gpu` flag from the web crawler configuration which causees performance issues on macOS.
+Remove the `--disable-gpu` flag from the web crawler configuration, which causes performance issues on macOS.

--- a/packages/ckeditor5-dev-web-crawler/src/crawler/create-cluster.ts
+++ b/packages/ckeditor5-dev-web-crawler/src/crawler/create-cluster.ts
@@ -78,7 +78,6 @@ function createPuppeteerOptions( {
 		args: [
 			'--disable-extensions', // Disables all browser extensions.
 			'--disable-plugins', // Disables all plugins.
-			'--disable-gpu', // Disables GPU hardware acceleration.
 			'--disable-software-rasterizer', // Disables software fallback for GPU rendering.
 			'--disable-renderer-backgrounding', // Prevents throttling of background tabs renderers.
 			'--disable-background-timer-throttling', // Stops throttling of JavaScript timers in background tabs.


### PR DESCRIPTION
### 🚀 Summary

Remove the `--disable-gpu` flag from the web crawler configuration, which causes performance issues on macOS.

---

### 📌 Related issues

* Closes https://github.com/ckeditor/ckeditor5-internal/issues/4486.

---

### 💡 Additional information

How to test in the CKE5 repository:

1. Run `pnpm run docs`.
2. Run `pnpm run docs:serve`.
3. In another terminal, run `pnpm run docs:verify`.
