### PR TITLE
[build-tools] Add the `stripInternal` option

### DIFF
--- a/.changelog/20260601132901_cc_10227_add_strip_internal.md
+++ b/.changelog/20260601132901_cc_10227_add_strip_internal.md
@@ -1,0 +1,6 @@
+---
+type: Feature
+scope: ckeditor5-dev-build-tools
+---
+
+Added the `stripInternal` build option and the `--strip-internal` CLI flag for controlling whether declarations marked with `@internal` are omitted from generated declaration files. The option is enabled by default.

--- a/packages/ckeditor5-dev-build-tools/package.json
+++ b/packages/ckeditor5-dev-build-tools/package.json
@@ -34,6 +34,7 @@
     "glob": "^13.0.6",
     "lightningcss": "^1.32.0",
     "magic-string": "^0.30.21",
+    "oxc-transform": "^0.134.0",
     "pofile": "^1.1.4",
     "purgecss": "^8.0.0",
     "rolldown": "^1.0.3",

--- a/packages/ckeditor5-dev-build-tools/src/build.ts
+++ b/packages/ckeditor5-dev-build-tools/src/build.ts
@@ -90,7 +90,10 @@ function getCliArguments(): Partial<BuildOptions> {
 		args: process.argv.slice( 2 ),
 
 		// Fail when unknown argument is used.
-		strict: true
+		strict: true,
+
+		// Allows explicitly setting boolean options to `false` by prefixing the option name with `--no-`. Example: `--no-strip-internal`.
+		allowNegative: true
 	} );
 
 	return camelizeObjectKeys( values ) as Partial<BuildOptions>;

--- a/packages/ckeditor5-dev-build-tools/src/build.ts
+++ b/packages/ckeditor5-dev-build-tools/src/build.ts
@@ -23,6 +23,7 @@ export interface BuildOptions {
 	banner: string;
 	external: Array<string>;
 	declarations: boolean;
+	stripInternal: boolean;
 	translations: string;
 	sourceMap: boolean;
 	minify: boolean;
@@ -41,6 +42,7 @@ export const defaultOptions: BuildOptions = {
 	banner: '',
 	external: [],
 	declarations: false,
+	stripInternal: true,
 	translations: '',
 	sourceMap: false,
 	minify: false,
@@ -73,6 +75,7 @@ function getCliArguments(): Partial<BuildOptions> {
 			'banner': { type: 'string' },
 			'external': { type: 'string', multiple: true },
 			'declarations': { type: 'boolean' },
+			'strip-internal': { type: 'boolean' },
 			'translations': { type: 'string' },
 			'source-map': { type: 'boolean' },
 			'minify': { type: 'boolean' },

--- a/packages/ckeditor5-dev-build-tools/src/config.ts
+++ b/packages/ckeditor5-dev-build-tools/src/config.ts
@@ -27,6 +27,7 @@ export async function getRolldownConfig( options: BuildOptions ): Promise<Rolldo
 		banner,
 		external,
 		declarations,
+		stripInternal,
 		translations,
 		sourceMap,
 		minify,
@@ -178,7 +179,8 @@ export async function getRolldownConfig( options: BuildOptions ): Promise<Rolldo
 			getOptionalPlugin(
 				declarations && hasTsconfig,
 				declarationFiles( {
-					sourceDirectory: path.dirname( input )
+					sourceDirectory: path.dirname( input ),
+					stripInternal
 				} )
 			),
 

--- a/packages/ckeditor5-dev-build-tools/src/plugins/declarations.ts
+++ b/packages/ckeditor5-dev-build-tools/src/plugins/declarations.ts
@@ -5,7 +5,7 @@
 
 import { globSync, readFileSync } from 'node:fs';
 import path from 'upath';
-import { isolatedDeclaration } from 'rolldown/experimental';
+import { isolatedDeclaration } from 'oxc-transform';
 import type { Plugin } from 'rolldown';
 
 export interface RolldownDeclarationOptions {

--- a/packages/ckeditor5-dev-build-tools/src/plugins/declarations.ts
+++ b/packages/ckeditor5-dev-build-tools/src/plugins/declarations.ts
@@ -14,6 +14,13 @@ export interface RolldownDeclarationOptions {
 	 * Directory containing TypeScript source files.
 	 */
 	sourceDirectory: string;
+
+	/**
+	 * Whether to skip declarations for internal APIs (marked with `@internal` in the source code).
+	 *
+	 * @default true
+	 */
+	stripInternal?: boolean;
 }
 
 const declarationExtensions = new Set( [ '.mts', '.cts' ] );
@@ -44,18 +51,23 @@ function getDeclarationFileName( sourceFileName: string ): string {
  * Generates declaration files using isolated declarations.
  */
 export function declarationFiles( pluginOptions: RolldownDeclarationOptions ): Plugin {
+	const {
+		sourceDirectory,
+		stripInternal = true
+	} = pluginOptions;
+
 	return {
 		name: 'emit-declaration-files',
 
 		async generateBundle() {
-			const sourceFilePaths = getTypeScriptSourceFiles( pluginOptions.sourceDirectory );
+			const sourceFilePaths = getTypeScriptSourceFiles( sourceDirectory );
 
 			const declarationFiles = await Promise.all( sourceFilePaths.map( async sourceFilePath => {
-				const filename = path.relative( pluginOptions.sourceDirectory, sourceFilePath );
+				const filename = path.relative( sourceDirectory, sourceFilePath );
 				const source = readFileSync( sourceFilePath, 'utf8' );
 				const { errors, code } = await isolatedDeclaration( filename, source, {
 					sourcemap: false,
-					stripInternal: true
+					stripInternal
 				} );
 
 				return {

--- a/packages/ckeditor5-dev-build-tools/tests/build/arguments.test.ts
+++ b/packages/ckeditor5-dev-build-tools/tests/build/arguments.test.ts
@@ -155,6 +155,24 @@ test( '--declarations', async () => {
 	expect( spy ).toHaveBeenCalledWith( expect.objectContaining( { declarations: true } ) );
 } );
 
+test( '--strip-internal', async () => {
+	const spy = getConfigMock();
+
+	mockCliArgs( '--strip-internal' );
+	await build();
+
+	expect( spy ).toHaveBeenCalledWith( expect.objectContaining( { stripInternal: true } ) );
+} );
+
+test( '--no-strip-internal', async () => {
+	const spy = getConfigMock();
+
+	mockCliArgs( '--no-strip-internal' );
+	await build();
+
+	expect( spy ).toHaveBeenCalledWith( expect.objectContaining( { stripInternal: false } ) );
+} );
+
 test( '--translations', async () => {
 	const spy = getConfigMock();
 
@@ -258,6 +276,14 @@ test( '.declarations', async () => {
 	await build( { declarations: true } );
 
 	expect( spy ).toHaveBeenCalledWith( expect.objectContaining( { declarations: true } ) );
+} );
+
+test( '.stripInternal', async () => {
+	const spy = getConfigMock();
+
+	await build( { stripInternal: false } );
+
+	expect( spy ).toHaveBeenCalledWith( expect.objectContaining( { stripInternal: false } ) );
 } );
 
 test( '.translations', async () => {

--- a/packages/ckeditor5-dev-build-tools/tests/config/config.test.ts
+++ b/packages/ckeditor5-dev-build-tools/tests/config/config.test.ts
@@ -18,6 +18,7 @@ const defaults: Options = {
 	external: [],
 	globals: [],
 	declarations: false,
+	stripInternal: true,
 	translations: '',
 	sourceMap: false,
 	minify: false,

--- a/packages/ckeditor5-dev-build-tools/tests/plugins/declarations/declarations.test.ts
+++ b/packages/ckeditor5-dev-build-tools/tests/plugins/declarations/declarations.test.ts
@@ -8,7 +8,7 @@ import { expect, test, vi } from 'vitest';
 
 const isolatedDeclarationMock = vi.hoisted( () => vi.fn() );
 
-vi.mock( 'rolldown/experimental', () => ( {
+vi.mock( 'oxc-transform', () => ( {
 	isolatedDeclaration: isolatedDeclarationMock
 } ) );
 

--- a/packages/ckeditor5-dev-build-tools/tests/plugins/declarations/declarations.test.ts
+++ b/packages/ckeditor5-dev-build-tools/tests/plugins/declarations/declarations.test.ts
@@ -60,6 +60,38 @@ test( 'Emits declaration files for TypeScript source files', async () => {
 		fileName: 'common.d.cts',
 		source: 'export declare const value: string;'
 	} );
+	expect( isolatedDeclarationMock ).toHaveBeenCalledWith(
+		'valid.ts',
+		expect.any( String ),
+		{
+			sourcemap: false,
+			stripInternal: true
+		}
+	);
+} );
+
+test( 'Allows emitting internal APIs in declaration files', async () => {
+	isolatedDeclarationMock.mockResolvedValue( {
+		errors: [],
+		code: 'export declare const value: string;'
+	} );
+
+	const plugin = declarationFiles( {
+		sourceDirectory: join( import.meta.dirname, './fixtures' ),
+		stripInternal: false
+	} );
+	const context = createContext();
+
+	await runGenerateBundle( plugin, context );
+
+	expect( isolatedDeclarationMock ).toHaveBeenCalledWith(
+		'valid.ts',
+		expect.any( String ),
+		{
+			sourcemap: false,
+			stripInternal: false
+		}
+	);
 } );
 
 test( 'Throws formatted declaration generation errors', async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,6 +102,9 @@ importers:
       magic-string:
         specifier: ^0.30.21
         version: 0.30.21
+      oxc-transform:
+        specifier: ^0.134.0
+        version: 0.134.0
       pofile:
         specifier: ^1.1.4
         version: 1.1.4
@@ -1376,6 +1379,133 @@ packages:
 
   '@oxc-project/types@0.72.3':
     resolution: {integrity: sha512-CfAC4wrmMkUoISpQkFAIfMVvlPfQV3xg7ZlcqPXPOIMQhdKIId44G8W0mCPgtpWdFFAyJ+SFtiM+9vbyCkoVng==}
+
+  '@oxc-transform/binding-android-arm-eabi@0.134.0':
+    resolution: {integrity: sha512-0rKVNLLdMlAaVOYSGFyR+aWBBTyeAQTIgaqaFZ8sFiNuiKbuQTcqHI6ega/TDDXe9MyYbnvUGCrpcJd35eKqww==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxc-transform/binding-android-arm64@0.134.0':
+    resolution: {integrity: sha512-EI1CoPpYD4MJdvc4XtTgcd13vhy9ES9W+KK2D5TiZKtd6UJO8zIHxBDKe/jPMeCEbEqwIogSFukG+WBMOrAZbQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxc-transform/binding-darwin-arm64@0.134.0':
+    resolution: {integrity: sha512-ftTFOh0tyMhQFqQmHPlE+RTq5hQSR1YdBF0oXccwpa1DoCoUpqGVuEi5Z81R0yGONiUZ1y6CByyr5sfB+h+zug==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxc-transform/binding-darwin-x64@0.134.0':
+    resolution: {integrity: sha512-GGoMq5TL9nC9v8c9py6FJXGbFA9QfSjGGXk7crZxWMVdkL4sG1lTYgwdWAd7D9n3PaYUlEXjkntVPZQ00m2fLA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxc-transform/binding-freebsd-x64@0.134.0':
+    resolution: {integrity: sha512-s2M2Hj4TCGy0IgX4taXxIHCxhkoOPtoO8uA4chs37kv0j2tfvA+GyVdbCpJ8hPXoLcQcexlkZ5IIy9vFGEqyfg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxc-transform/binding-linux-arm-gnueabihf@0.134.0':
+    resolution: {integrity: sha512-WqdkEqjp/vTDMjNz3E8IIjPdxlI8OYMcrigwCMaUHccDtpvSgyqkp2xGbIXXPE7Gj4z24z47ZoNkbzqkS3rRZA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-transform/binding-linux-arm-musleabihf@0.134.0':
+    resolution: {integrity: sha512-9cyEJ/3s1PBO/WL3ayE7rosaQe1As31OFY0XWNSSUHPH0Ug3hdxqGqNqiZ6pZC6Yi+pEB9ji4mMmXgCFyAsMfA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-transform/binding-linux-arm64-gnu@0.134.0':
+    resolution: {integrity: sha512-jk//CVndbPtbd+hAe2nzGpf18Zk5kECg28WTq0dS3Li0Oba9bwcpLzYKxsOZIuSDTav/CFIbgB7yp9m9uGo9QA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-transform/binding-linux-arm64-musl@0.134.0':
+    resolution: {integrity: sha512-ZX6gntlu2D+i5ttgcJE4ZlifPpA/NgM5XQ7LpTqExAW/czS2ETLl1Z/pNEeHHJfX96M2+LEMwD8n/sP3+N4tnA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-transform/binding-linux-ppc64-gnu@0.134.0':
+    resolution: {integrity: sha512-E+t8OubTV0E3PzzGKVt7E++qmPmttutiuTX2xOJODLs7tslRlmFvlvVdegBYwHJjNboIvRMZv9ytsj0JL4xMDg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-transform/binding-linux-riscv64-gnu@0.134.0':
+    resolution: {integrity: sha512-BJyas48z0fB/AtBsr/79bhW0q/Su3nOZYqnAFaWpTsbxo5uj1VOEhzLuysIN6kiHJSZupR+u4JAb+G5DWuxOyw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-transform/binding-linux-riscv64-musl@0.134.0':
+    resolution: {integrity: sha512-R1bb4r5p05z9tjV/YqxQg0nOBBTZxDVnMkFViyzueJg/1pvFmjprsrSY8S3tkuYXtVe1X1Uv7ZGw2HmGZQcwKg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-transform/binding-linux-s390x-gnu@0.134.0':
+    resolution: {integrity: sha512-yR+b0TcvULHp6h9jyWAO5LODfySo+F9CilJTaw+ASRcvKYrdtEmFN1kU3Uf/Y5R+6lOYutBiRDkIuXyK+v7kJQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-transform/binding-linux-x64-gnu@0.134.0':
+    resolution: {integrity: sha512-Nh7HGNJtOfn/+yXi9PqhBh4DGuHfGOooqqXEDcM+TXBnmIJDZCbg6pldXdYZteVxUNT2r6L9AglHOn4qsqCI1g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-transform/binding-linux-x64-musl@0.134.0':
+    resolution: {integrity: sha512-naHDp/8xNXU56gUPQUNkDZ/bj0staup5omtgn6eU5OAamfCLpfaQe7/7nWC2NeVHWfPIbAZyweJQGM9bGabjbg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-transform/binding-openharmony-arm64@0.134.0':
+    resolution: {integrity: sha512-z7p2afAt1dafhGdzs0cCh4wCKwveN9AjziwhWCJn5fVLqK7VN9duCOmVTrhHq2ugUelqLnGFsjUbc+QoaHKIxA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxc-transform/binding-wasm32-wasi@0.134.0':
+    resolution: {integrity: sha512-k7WwCjSTZ87NijVvXmWeMYUe5lb84pgfjxG0qEHuksSQTJnd6vSRDrF2CgBjtFRg82iU6DIS6lUoGGmNGBGrPQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@oxc-transform/binding-win32-arm64-msvc@0.134.0':
+    resolution: {integrity: sha512-AgQMRFy4q72ISL+47xtK/KKhljqFkzY3ubVi7wbx0234hrdQBUBuTJAspCDxATYd92XO2Um618YCE6JGmAitWg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxc-transform/binding-win32-ia32-msvc@0.134.0':
+    resolution: {integrity: sha512-oCxVxV8WOK5F0NI1bQ96YgAztVwLNeb8MFB3JJamWa219IirZ7wGA6lU4qU0iGxDMt07ReJ+SG/KQC3gp262uA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@oxc-transform/binding-win32-x64-msvc@0.134.0':
+    resolution: {integrity: sha512-GE7NXT5BFQTnH4MN6NMnD6mbOJ6y78LDjbPedPFn6HyKWgLLG5fm3d/U97hIHv04ehcUhuXoi00dIpvQD4q5Ig==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -4277,6 +4407,10 @@ packages:
     resolution: {integrity: sha512-JYQeJKDcUTTZ/uTdJ+fZBGFjAjkLD1h0p3Tf44ZYXRcoMk+57d81paNPFAAwzrzzqhZmkGvKKXDxwyhJXYZlpg==}
     engines: {node: '>=14.0.0'}
 
+  oxc-transform@0.134.0:
+    resolution: {integrity: sha512-dclrs9Q37YQ+cWjf/XO1MonMBQ1Yl66VauCyCmTMyDwvay5pJTwbPczAgTR2JWxX+OUZ7qmBquJriFf0+SoCNA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+
   oxc-walker@0.3.0:
     resolution: {integrity: sha512-mGGgl9dmYHUX7Z3bxXhibwarI0fJVj2E64FNIOZQWUDvEeIPyJTe5ElyJmp4nmDdfdnrlG0bhdR+bR9D6DM/dA==}
     peerDependencies:
@@ -6251,6 +6385,70 @@ snapshots:
   '@oxc-project/types@0.133.0': {}
 
   '@oxc-project/types@0.72.3': {}
+
+  '@oxc-transform/binding-android-arm-eabi@0.134.0':
+    optional: true
+
+  '@oxc-transform/binding-android-arm64@0.134.0':
+    optional: true
+
+  '@oxc-transform/binding-darwin-arm64@0.134.0':
+    optional: true
+
+  '@oxc-transform/binding-darwin-x64@0.134.0':
+    optional: true
+
+  '@oxc-transform/binding-freebsd-x64@0.134.0':
+    optional: true
+
+  '@oxc-transform/binding-linux-arm-gnueabihf@0.134.0':
+    optional: true
+
+  '@oxc-transform/binding-linux-arm-musleabihf@0.134.0':
+    optional: true
+
+  '@oxc-transform/binding-linux-arm64-gnu@0.134.0':
+    optional: true
+
+  '@oxc-transform/binding-linux-arm64-musl@0.134.0':
+    optional: true
+
+  '@oxc-transform/binding-linux-ppc64-gnu@0.134.0':
+    optional: true
+
+  '@oxc-transform/binding-linux-riscv64-gnu@0.134.0':
+    optional: true
+
+  '@oxc-transform/binding-linux-riscv64-musl@0.134.0':
+    optional: true
+
+  '@oxc-transform/binding-linux-s390x-gnu@0.134.0':
+    optional: true
+
+  '@oxc-transform/binding-linux-x64-gnu@0.134.0':
+    optional: true
+
+  '@oxc-transform/binding-linux-x64-musl@0.134.0':
+    optional: true
+
+  '@oxc-transform/binding-openharmony-arm64@0.134.0':
+    optional: true
+
+  '@oxc-transform/binding-wasm32-wasi@0.134.0':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optional: true
+
+  '@oxc-transform/binding-win32-arm64-msvc@0.134.0':
+    optional: true
+
+  '@oxc-transform/binding-win32-ia32-msvc@0.134.0':
+    optional: true
+
+  '@oxc-transform/binding-win32-x64-msvc@0.134.0':
+    optional: true
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -9547,6 +9745,29 @@ snapshots:
       '@oxc-parser/binding-wasm32-wasi': 0.72.3
       '@oxc-parser/binding-win32-arm64-msvc': 0.72.3
       '@oxc-parser/binding-win32-x64-msvc': 0.72.3
+
+  oxc-transform@0.134.0:
+    optionalDependencies:
+      '@oxc-transform/binding-android-arm-eabi': 0.134.0
+      '@oxc-transform/binding-android-arm64': 0.134.0
+      '@oxc-transform/binding-darwin-arm64': 0.134.0
+      '@oxc-transform/binding-darwin-x64': 0.134.0
+      '@oxc-transform/binding-freebsd-x64': 0.134.0
+      '@oxc-transform/binding-linux-arm-gnueabihf': 0.134.0
+      '@oxc-transform/binding-linux-arm-musleabihf': 0.134.0
+      '@oxc-transform/binding-linux-arm64-gnu': 0.134.0
+      '@oxc-transform/binding-linux-arm64-musl': 0.134.0
+      '@oxc-transform/binding-linux-ppc64-gnu': 0.134.0
+      '@oxc-transform/binding-linux-riscv64-gnu': 0.134.0
+      '@oxc-transform/binding-linux-riscv64-musl': 0.134.0
+      '@oxc-transform/binding-linux-s390x-gnu': 0.134.0
+      '@oxc-transform/binding-linux-x64-gnu': 0.134.0
+      '@oxc-transform/binding-linux-x64-musl': 0.134.0
+      '@oxc-transform/binding-openharmony-arm64': 0.134.0
+      '@oxc-transform/binding-wasm32-wasi': 0.134.0
+      '@oxc-transform/binding-win32-arm64-msvc': 0.134.0
+      '@oxc-transform/binding-win32-ia32-msvc': 0.134.0
+      '@oxc-transform/binding-win32-x64-msvc': 0.134.0
 
   oxc-walker@0.3.0(oxc-parser@0.72.3):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -27,10 +27,9 @@ minimumReleaseAgeExclude:
   - '@cksource/*'
   - '*ckeditor5*'
 
-  # Remove after 2026-05-30
-  - 'rolldown'
-  - '@rolldown/*'
-  - '@oxc-project/*'
+  # Remove after 2026-06-34
+  - 'oxc-transform'
+  - '@oxc-transform/*'
 
 shellEmulator: true
 shamefullyHoist: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -27,7 +27,7 @@ minimumReleaseAgeExclude:
   - '@cksource/*'
   - '*ckeditor5*'
 
-  # Remove after 2026-06-34
+  # Remove after 2026-06-04
   - 'oxc-transform'
   - '@oxc-transform/*'
 


### PR DESCRIPTION
### 🚀 Summary

Add the `stripInternal` option for controlling whether declarations marked with `@internal` are omitted from generated declaration files.

---

### 📌 Related issues

* See https://github.com/ckeditor/ckeditor5-commercial/issues/10227.

---

### 💡 Additional information

*Optional: Notes on decisions, edge cases, or anything helpful for reviewers.*
