### PR TITLE
Fix: Vitest CI hang on packages with multiple test files.

### DIFF
--- a/.changelog/20260529195249_ci_4495.md
+++ b/.changelog/20260529195249_ci_4495.md
@@ -1,5 +1,0 @@
----
-type: Other
----
-
-Readme simplification.

--- a/.changelog/20260611104708_cc_10462.md
+++ b/.changelog/20260611104708_cc_10462.md
@@ -1,0 +1,11 @@
+---
+type: Fix
+scope:
+  - ckeditor5-dev-tests
+closes:
+  - ckeditor/ckeditor5-commercial#10462
+---
+
+Spawn Vitest from each package's directory instead of going through the workspace `--project <name>` path.
+
+The workspace + browser-mode + per-file isolation combination hung the CI batch as soon as a project had more than one test file. Running per-package avoids that path. 

--- a/.changelog/20260611104708_cc_10462.md
+++ b/.changelog/20260611104708_cc_10462.md
@@ -2,8 +2,6 @@
 type: Fix
 scope:
   - ckeditor5-dev-tests
-closes:
-  - ckeditor/ckeditor5-commercial#10462
 ---
 
 Spawn Vitest from each package's directory instead of going through the workspace `--project <name>` path.

--- a/packages/ckeditor5-dev-tests/lib/tasks/runautomatedtests.js
+++ b/packages/ckeditor5-dev-tests/lib/tasks/runautomatedtests.js
@@ -36,7 +36,7 @@ export default async function runAutomatedTests( options ) {
 
 	const globPatterns = resolveTestGlobs( options.files );
 	const testFiles = collectTestFiles( globPatterns );
-	const { karmaFiles, vitestSelection } = partitionByRunner( testFiles );
+	const { karmaFiles, vitestSelection, vitestPackageRoots } = partitionByRunner( testFiles );
 
 	if ( !karmaFiles.length && !vitestSelection.length ) {
 		throw new Error( 'No test files found. Specified patterns are invalid.' );
@@ -68,7 +68,7 @@ export default async function runAutomatedTests( options ) {
 
 	if ( vitestSelection.length ) {
 		try {
-			await spawnVitest( options, vitestSelection );
+			await spawnVitest( options, vitestSelection, vitestPackageRoots );
 		} catch ( error ) {
 			errors.push( error );
 		}
@@ -129,6 +129,7 @@ function collectTestFiles( globPatterns ) {
 function partitionByRunner( testFiles ) {
 	const karmaFiles = [];
 	const vitestSelection = new Map();
+	const vitestPackageRoots = new Map();
 	const runnerCache = new Map();
 
 	for ( const filePath of testFiles ) {
@@ -144,12 +145,17 @@ function partitionByRunner( testFiles ) {
 			const files = vitestSelection.get( projectName ) || [];
 			files.push( filePath );
 			vitestSelection.set( projectName, files );
+			vitestPackageRoots.set( projectName, packageRoot );
 		} else {
 			karmaFiles.push( filePath );
 		}
 	}
 
-	return { karmaFiles, vitestSelection: [ ...vitestSelection.entries() ] };
+	return {
+		karmaFiles,
+		vitestSelection: [ ...vitestSelection.entries() ],
+		vitestPackageRoots
+	};
 }
 
 function getPackageRoot( filePath ) {
@@ -269,12 +275,12 @@ function startKarmaServer( options ) {
 
 // -- Vitest runner --------------------------------------------------------------------------------
 
-async function spawnVitest( options, vitestSelection ) {
+async function spawnVitest( options, vitestSelection, packageRoots ) {
 	const errors = [];
 
 	for ( const [ project, selectedFiles ] of vitestSelection ) {
 		try {
-			await spawnVitestProject( options, project, selectedFiles );
+			await spawnVitestProject( options, project, selectedFiles, packageRoots.get( project ) );
 		} catch ( error ) {
 			errors.push( error );
 		}
@@ -298,7 +304,13 @@ async function spawnVitest( options, vitestSelection ) {
 	}
 }
 
-function spawnVitestProject( options, project, selectedFiles ) {
+// Vitest runs from the package directory, so it loads the package-level config directly.
+// Using the workspace config with `--project <name>` hangs in browser mode when multiple
+// test files run, because per-file isolation does not tear down the browser context.
+// Running per-package avoids that path while keeping coverage compatible: reports still
+// go to the workspace `coverage-vitest/<project>/` directory via absolute
+// `--coverage.reportsDirectory`.
+function spawnVitestProject( options, project, selectedFiles, packageRoot ) {
 	return new Promise( ( resolve, reject ) => {
 		const args = [ 'vitest' ];
 
@@ -306,18 +318,27 @@ function spawnVitestProject( options, project, selectedFiles ) {
 
 		if ( options.coverage ) {
 			const coverageDir = upath.join( process.cwd(), 'coverage-vitest', project );
-			args.push( '--coverage.enabled', '--coverage.reportsDirectory', coverageDir );
+
+			args.push(
+				'--coverage.enabled',
+				'--coverage.reportsDirectory', coverageDir,
+				// Force the reporters the wrapper expects. The package's own `vitest.config.ts`
+				// defaults to `text`/`html` (developer-friendly); downstream coverage merging
+				// needs `json` (for nyc) and `lcovonly` (collected by
+				// `check-unit-tests-for-package.mjs`).
+				'--coverage.reporter', 'json',
+				'--coverage.reporter', 'lcovonly',
+				'--coverage.reporter', 'html'
+			);
 		}
 
-		args.push( '--project', project );
-
 		for ( const filePath of selectedFiles ) {
-			args.push( upath.relative( process.cwd(), filePath ) );
+			args.push( upath.relative( packageRoot, filePath ) );
 		}
 
 		const child = spawn( 'pnpm', args, {
 			stdio: 'inherit',
-			cwd: process.cwd(),
+			cwd: packageRoot,
 			shell: process.platform === 'win32'
 		} );
 

--- a/packages/ckeditor5-dev-tests/tests/tasks/runautomatedtests.js
+++ b/packages/ckeditor5-dev-tests/tests/tasks/runautomatedtests.js
@@ -545,11 +545,13 @@ describe( 'runAutomatedTests()', () => {
 			[
 				'vitest',
 				'--run',
-				'--project',
-				'engine',
-				'packages/ckeditor5-engine/tests/model/model.js'
+				'tests/model/model.js'
 			],
-			{ stdio: 'inherit', cwd: '/workspace', shell: process.platform === 'win32' }
+			{
+				stdio: 'inherit',
+				cwd: '/workspace/packages/ckeditor5-engine',
+				shell: process.platform === 'win32'
+			}
 		);
 		expect( vi.mocked( fs ).writeFileSync ).not.toHaveBeenCalledWith(
 			'/workspace/build/.automated-tests/entry-point.js',
@@ -588,11 +590,9 @@ describe( 'runAutomatedTests()', () => {
 			[
 				'vitest',
 				'--watch',
-				'--project',
-				'engine',
-				'packages/ckeditor5-engine/tests/model/model.js'
+				'tests/model/model.js'
 			],
-			expect.any( Object )
+			expect.objectContaining( { cwd: '/workspace/packages/ckeditor5-engine' } )
 		);
 	} );
 
@@ -630,7 +630,7 @@ describe( 'runAutomatedTests()', () => {
 
 		await promise;
 
-		// Vitest was called with per-project coverage directory.
+		// Vitest was called with per-project coverage directory and forced reporters.
 		expect( stubs.spawn.call ).toHaveBeenNthCalledWith(
 			1,
 			'pnpm',
@@ -640,11 +640,15 @@ describe( 'runAutomatedTests()', () => {
 				'--coverage.enabled',
 				'--coverage.reportsDirectory',
 				'/workspace/coverage-vitest/engine',
-				'--project',
-				'engine',
-				'packages/ckeditor5-engine/tests/model/model.js'
+				'--coverage.reporter',
+				'json',
+				'--coverage.reporter',
+				'lcovonly',
+				'--coverage.reporter',
+				'html',
+				'tests/model/model.js'
 			],
-			expect.any( Object )
+			expect.objectContaining( { cwd: '/workspace/packages/ckeditor5-engine' } )
 		);
 
 		// coverage-final.json was copied into .nyc_output.
@@ -703,6 +707,97 @@ describe( 'runAutomatedTests()', () => {
 		await expect( promise ).rejects.toThrow( 'Vitest finished with "1" code.' );
 	} );
 
+	// Regression: ckeditor/ckeditor5-commercial#10462. Going through the workspace config with
+	// `--project <name>` triggers a hang in Vitest browser mode whenever more than one test file
+	// runs. Spawning per-package (cwd = package root, no --project flag) side-steps that path.
+	it( 'should spawn Vitest with cwd set to the package root and no --project flag', async () => {
+		const options = {
+			files: [ 'engine' ],
+			production: true,
+			watch: false,
+			coverage: false
+		};
+
+		vi.mocked( transformFileOptionToTestGlob ).mockReturnValue( [
+			'/workspace/packages/ckeditor5-engine/tests/**/*.js'
+		] );
+		vi.mocked( globSync ).mockReturnValue( [
+			'/workspace/packages/ckeditor5-engine/tests/model/model.js',
+			'/workspace/packages/ckeditor5-engine/tests/view/view.js'
+		] );
+		vi.mocked( fs ).readFileSync.mockReturnValue( JSON.stringify( {
+			scripts: { test: 'vitest --run' }
+		} ) );
+
+		const promise = runAutomatedTests( options );
+		await new Promise( resolve => setTimeout( resolve ) );
+
+		const [ subprocess ] = vi.mocked( spawn ).mock.results.map( result => result.value );
+		subprocess.emit( 'close', 0 );
+
+		await promise;
+
+		const [ [ command, args, spawnOptions ] ] = stubs.spawn.call.mock.calls;
+
+		expect( command ).to.equal( 'pnpm' );
+		expect( spawnOptions ).toEqual( expect.objectContaining( {
+			cwd: '/workspace/packages/ckeditor5-engine'
+		} ) );
+		expect( args ).not.toContain( '--project' );
+		// File paths are passed relative to the package root, not the workspace root.
+		expect( args ).toEqual( expect.arrayContaining( [
+			'tests/model/model.js',
+			'tests/view/view.js'
+		] ) );
+		expect( args ).not.toEqual( expect.arrayContaining( [
+			expect.stringMatching( /^packages\// )
+		] ) );
+	} );
+
+	// Regression: ckeditor/ckeditor5-commercial#10462. Running per-package means the package's
+	// own `vitest.config.ts` wins, and its `text`/`html` reporters are not enough for the CI
+	// merge step — so the wrapper forces `json` (nyc) and `lcovonly` (lcov collation) on top.
+	it( 'should force json, lcovonly and html reporters when coverage is enabled', async () => {
+		const options = {
+			files: [ 'engine' ],
+			production: true,
+			watch: false,
+			coverage: true
+		};
+
+		vi.mocked( transformFileOptionToTestGlob ).mockReturnValue( [
+			'/workspace/packages/ckeditor5-engine/tests/**/*.js'
+		] );
+		vi.mocked( globSync ).mockReturnValue( [
+			'/workspace/packages/ckeditor5-engine/tests/model/model.js'
+		] );
+		vi.mocked( fs ).readFileSync.mockReturnValue( JSON.stringify( {
+			scripts: { test: 'vitest --run' }
+		} ) );
+		vi.mocked( fs ).existsSync.mockReturnValue( false );
+
+		const promise = runAutomatedTests( options );
+		await new Promise( resolve => setTimeout( resolve ) );
+
+		const [ vitestProcess ] = vi.mocked( spawn ).mock.results.map( r => r.value );
+		vitestProcess.emit( 'close', 0 );
+
+		await new Promise( resolve => setTimeout( resolve ) );
+
+		const [ , nycProcess ] = vi.mocked( spawn ).mock.results.map( r => r.value );
+		nycProcess.emit( 'close', 0 );
+
+		await promise;
+
+		const [ [ , args ] ] = stubs.spawn.call.mock.calls;
+
+		expect( args ).toEqual( expect.arrayContaining( [
+			'--coverage.reporter', 'json',
+			'--coverage.reporter', 'lcovonly',
+			'--coverage.reporter', 'html'
+		] ) );
+	} );
+
 	// -- Mixed Karma + Vitest tests ---------------------------------------------------------------
 
 	it( 'should route mixed package selection to Karma and Vitest', async () => {
@@ -752,8 +847,12 @@ describe( 'runAutomatedTests()', () => {
 		expect( stubs.karma.server.constructor ).toHaveBeenCalledOnce();
 		expect( stubs.spawn.call ).toHaveBeenCalledExactlyOnceWith(
 			'pnpm',
-			[ 'vitest', '--run', '--project', 'utils', 'packages/ckeditor5-utils/tests/first.js' ],
-			{ stdio: 'inherit', cwd: '/workspace', shell: process.platform === 'win32' }
+			[ 'vitest', '--run', 'tests/first.js' ],
+			{
+				stdio: 'inherit',
+				cwd: '/workspace/packages/ckeditor5-utils',
+				shell: process.platform === 'win32'
+			}
 		);
 	} );
 
@@ -916,11 +1015,13 @@ describe( 'runAutomatedTests()', () => {
 			[
 				'vitest',
 				'--run',
-				'--project',
-				'utils',
-				'external/ckeditor5/packages/ckeditor5-utils/tests/first.js'
+				'tests/first.js'
 			],
-			{ stdio: 'inherit', cwd: '/workspace', shell: process.platform === 'win32' }
+			{
+				stdio: 'inherit',
+				cwd: '/workspace/external/ckeditor5/packages/ckeditor5-utils',
+				shell: process.platform === 'win32'
+			}
 		);
 		expect( stubs.spawn.call ).toHaveBeenNthCalledWith(
 			2,
@@ -928,11 +1029,13 @@ describe( 'runAutomatedTests()', () => {
 			[
 				'vitest',
 				'--run',
-				'--project',
-				'engine',
-				'external/ckeditor5/packages/ckeditor5-engine/tests/model.js'
+				'tests/model.js'
 			],
-			{ stdio: 'inherit', cwd: '/workspace', shell: process.platform === 'win32' }
+			{
+				stdio: 'inherit',
+				cwd: '/workspace/external/ckeditor5/packages/ckeditor5-engine',
+				shell: process.platform === 'win32'
+			}
 		);
 	} );
 


### PR DESCRIPTION
### 🚀 Summary

CI batches using `ckeditor5-dev-tests` were hanging indefinitely for Vitest packages with multiple test files.

The wrapper now runs Vitest from each package directory instead of using the workspace `--project <name>` path, avoiding the broken iframe teardown and allowing CI batches to complete.

---

### 📌 Related issues

* See [ckeditor/ckeditor5-commercial#10462](https://github.com/ckeditor/ckeditor5-commercial/issues/10462)

---

### 💡 Additional information

Executing:

```
node scripts/ci/check-unit-tests-for-package.mjs --package-name ckeditor5-special-characters --check-coverage --coverage-file .out/combined_features_batch_3.info
```

with this fix:

```
> ckeditor5-root@48.2.0 test /Users/pomek/Projects/tmp/ckeditor5
> ckeditor5-dev-tests-run-automated --reporter=dots --production -b ChromeHeadless -f special-characters --coverage


 RUN  v4.1.8 /Users/pomek/Projects/tmp/ckeditor5/packages/ckeditor5-special-characters
      Coverage enabled with v8

 ✓  special-characters (chromium)  tests/specialcharacters.js (38 tests) 367ms
 ✓  special-characters (chromium)  tests/ui/charactergridview.js (13 tests) 62ms
 ✓  special-characters (chromium)  tests/ui/specialcharacterscategoriesview.js (12 tests) 24ms
 ✓  special-characters (chromium)  tests/specialcharacterslatin.js (6 tests) 20ms
 ✓  special-characters (chromium)  tests/specialcharacterscurrency.js (6 tests) 16ms
 ✓  special-characters (chromium)  tests/specialcharactersarrows.js (6 tests) 15ms
 ✓  special-characters (chromium)  tests/specialcharacterstext.js (6 tests) 16ms
 ✓  special-characters (chromium)  tests/specialcharactersmathematical.js (6 tests) 15ms
 ✓  special-characters (chromium)  tests/ui/specialcharactersview.js (5 tests) 11ms
 ✓  special-characters (chromium)  tests/ui/characterinfoview.js (6 tests) 2ms
 ✓  special-characters (chromium)  tests/specialcharactersessentials.js (4 tests) 0ms

 Test Files  11 passed (11)
      Tests  108 passed (108)
   Start at  10:44:42
   Duration  9.11s (transform 0ms, setup 13ms, import 1.12s, tests 547ms, environment 0ms)


=============================== Coverage summary ===============================
Statements   : 100% ( 203/203 )
Branches     : 100% ( 27/27 )
Functions    : 100% ( 68/68 )
Lines        : 100% ( 201/201 )
================================================================================
Combined Vitest coverage report saved in '/Users/pomek/Projects/tmp/ckeditor5/coverage-vitest'.
```

Without, CI hangs out.