### PR TITLE
Fix external scripts in manual test server.

### DIFF
--- a/.changelog/20260611123428_fix_cdn_loading_in_manual_server.md
+++ b/.changelog/20260611123428_fix_cdn_loading_in_manual_server.md
@@ -6,4 +6,4 @@ scope:
 
 The manual test server no longer removes external scripts whose file names match a manual test entry script.
 
-This preserves CDN scripts, when wrapping and serving manual tests.
+This preserves CDN scripts when wrapping and serving manual tests.

--- a/.changelog/20260611123428_fix_cdn_loading_in_manual_server.md
+++ b/.changelog/20260611123428_fix_cdn_loading_in_manual_server.md
@@ -1,0 +1,9 @@
+---
+type: Fix
+scope:
+  - ckeditor5-dev-manual-server
+---
+
+The manual test server no longer removes external scripts whose file names match a manual test entry script.
+
+This preserves CDN scripts, when wrapping and serving manual tests.

--- a/.changelog/20260611125145_fix_cdn_loading_in_manual_server.md
+++ b/.changelog/20260611125145_fix_cdn_loading_in_manual_server.md
@@ -1,0 +1,9 @@
+---
+type: Fix
+scope:
+  - ckeditor5-dev-manual-server
+---
+
+The manual test server now serves CSS files linked from manual test HTML files.
+
+This preserves manual test stylesheets when wrapping and serving manual tests.

--- a/packages/ckeditor5-dev-manual-server/src/manual-test-plugin/plugin.ts
+++ b/packages/ckeditor5-dev-manual-server/src/manual-test-plugin/plugin.ts
@@ -267,7 +267,15 @@ function isSourceTestScript( node: Node, testScriptFileName: string ): boolean {
 		return false;
 	}
 
+	if ( isExternalScriptSource( source ) ) {
+		return false;
+	}
+
 	return posix.basename( source ) == testScriptFileName;
+}
+
+function isExternalScriptSource( source: string ): boolean {
+	return source.startsWith( 'http://' ) || source.startsWith( 'https://' ) || source.startsWith( '//' );
 }
 
 function isSourceShellScript( node: Node, shellScriptPublicPath: string ): boolean {

--- a/packages/ckeditor5-dev-manual-server/src/manual-test-plugin/shell-html.ts
+++ b/packages/ckeditor5-dev-manual-server/src/manual-test-plugin/shell-html.ts
@@ -163,9 +163,17 @@ function isManualTestScriptNode( node: Element, testScriptFileName: string ): bo
 		return false;
 	}
 
+	if ( isExternalScriptSource( source ) ) {
+		return false;
+	}
+
 	const sourceFileName = posix.basename( source.split( '?' )[ 0 ]!.split( '#' )[ 0 ]! );
 
 	return getScriptModuleName( sourceFileName ) == getScriptModuleName( testScriptFileName );
+}
+
+function isExternalScriptSource( source: string ): boolean {
+	return source.startsWith( 'http://' ) || source.startsWith( 'https://' ) || source.startsWith( '//' );
 }
 
 function getScriptModuleName( fileName: string ): string {

--- a/packages/ckeditor5-dev-manual-server/src/manual-test-plugin/static-assets.ts
+++ b/packages/ckeditor5-dev-manual-server/src/manual-test-plugin/static-assets.ts
@@ -8,7 +8,7 @@ import { globSync, statSync, createReadStream } from 'node:fs';
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import { toPublicSpecifier } from '../utils.js';
 
-const PROCESSED_MANUAL_TEST_EXTENSIONS = new Set( [ '.css', '.html', '.js', '.md', '.ts' ] );
+const PROCESSED_MANUAL_TEST_EXTENSIONS = new Set( [ '.html', '.js', '.md', '.ts' ] );
 const VITE_MODULE_QUERY_PARAMETERS = new Set( [
 	'import',
 	'raw',

--- a/packages/ckeditor5-dev-manual-server/tests/manual-test-plugin/plugin.test.ts
+++ b/packages/ckeditor5-dev-manual-server/tests/manual-test-plugin/plugin.test.ts
@@ -222,7 +222,11 @@ describe( 'manualTestsPlugin()', () => {
 
 	test( 'updates bundled manual HTML from current source in dev server', async () => {
 		await Promise.all( [
-			createFile( workspaceRoot, 'packages/ckeditor5-foo/tests/manual/foo.html', '<p>Fresh manual test</p>' ),
+			createFile(
+				workspaceRoot,
+				'packages/ckeditor5-foo/tests/manual/foo.html',
+				'<head><script src="https://cdn.example.com/foo.js"></script></head><p>Fresh manual test</p>'
+			),
 			createFile( workspaceRoot, 'packages/ckeditor5-foo/tests/manual/foo.js' )
 		] );
 
@@ -243,6 +247,7 @@ describe( 'manualTestsPlugin()', () => {
 		expect( file ).not.to.have.property( 'etag' );
 		expect( html ).to.contain( '<p>Fresh manual test</p>' );
 		expect( html ).to.contain( 'theme/shell.ts' );
+		expect( html ).to.contain( 'src="https://cdn.example.com/foo.js"' );
 		expect( html ).to.contain( 'src="/assets/foo.js"' );
 		expect( html ).to.contain( 'href="/assets/chunk.js"' );
 		expect( html ).not.to.contain( 'src="./foo.js"' );

--- a/packages/ckeditor5-dev-manual-server/tests/manual-test-plugin/shell-html.test.ts
+++ b/packages/ckeditor5-dev-manual-server/tests/manual-test-plugin/shell-html.test.ts
@@ -98,6 +98,7 @@ describe( 'createManualShellHtml()', () => {
 				'<head>',
 				'<script type="module" src="./iframe.js"></script>',
 				'<script>window.inline = true;</script>',
+				'<script src="https://cdn.example.com/iframe.js"></script>',
 				'<script type="module" src="./helper.js"></script>',
 				'</head>',
 				'<body>',
@@ -114,6 +115,7 @@ describe( 'createManualShellHtml()', () => {
 			.filter( ( source ): source is string => Boolean( source ) );
 
 		expect( scriptSources.filter( source => source == './iframe.js' ) ).to.have.length( 1 );
+		expect( scriptSources ).to.include( 'https://cdn.example.com/iframe.js' );
 		expect( scriptSources ).to.include( './helper.js' );
 		expect( html ).to.contain( '<script>window.inline = true;</script>' );
 	} );

--- a/packages/ckeditor5-dev-manual-server/tests/manual-test-plugin/static-assets.test.ts
+++ b/packages/ckeditor5-dev-manual-server/tests/manual-test-plugin/static-assets.test.ts
@@ -46,6 +46,10 @@ describe( 'manual static assets', () => {
 			[
 				'/packages/ckeditor5-foo/tests/manual/assets/image.png',
 				join( workspaceRoot, 'packages/ckeditor5-foo/tests/manual/assets/image.png' )
+			],
+			[
+				'/packages/ckeditor5-foo/tests/manual/styles.css',
+				join( workspaceRoot, 'packages/ckeditor5-foo/tests/manual/styles.css' )
 			]
 		] );
 	} );
@@ -104,26 +108,26 @@ describe( 'manual static assets', () => {
 	} );
 
 	test( 'serves collected static assets', async () => {
-		const filePath = await createFile( workspaceRoot, 'packages/ckeditor5-foo/tests/manual/assets/image.svg', '<svg></svg>' );
+		const filePath = await createFile( workspaceRoot, 'packages/ckeditor5-foo/tests/manual/styles.css', 'body { color: red; }' );
 		const response = createResponse();
 		const next = vi.fn();
 		const middleware = createManualStaticAssetsMiddleware( () => new Map( [
-			[ '/packages/ckeditor5-foo/tests/manual/assets/image.svg', filePath ]
+			[ '/packages/ckeditor5-foo/tests/manual/styles.css', filePath ]
 		] ) );
 		const finished = new Promise<void>( resolve => response.on( 'finish', resolve ) );
 
 		middleware( {
 			method: 'GET',
-			url: '/packages/ckeditor5-foo/tests/manual/assets/image.svg'
+			url: '/packages/ckeditor5-foo/tests/manual/styles.css'
 		} as never, response as never, next );
 
 		await finished;
 
 		expect( next ).not.toHaveBeenCalled();
 		expect( response.statusCode ).to.equal( 200 );
-		expect( response.setHeader ).toHaveBeenCalledWith( 'Content-Length', 11 );
-		expect( response.setHeader ).toHaveBeenCalledWith( 'Content-Type', 'image/svg+xml' );
-		expect( response.getBody() ).to.equal( '<svg></svg>' );
+		expect( response.setHeader ).toHaveBeenCalledWith( 'Content-Length', 20 );
+		expect( response.setHeader ).toHaveBeenCalledWith( 'Content-Type', 'text/css; charset=utf-8' );
+		expect( response.getBody() ).to.equal( 'body { color: red; }' );
 	} );
 
 	test( 'collects static assets when a candidate static asset is requested', async () => {
@@ -158,7 +162,7 @@ describe( 'manual static assets', () => {
 		const next = vi.fn();
 
 		middleware( { method: 'GET', url: '/packages/ckeditor5-foo/tests/manual/foo.html' } as never, response as never, next );
-		middleware( { method: 'GET', url: '/packages/ckeditor5-foo/tests/manual/foo.css' } as never, response as never, next );
+		middleware( { method: 'GET', url: '/packages/ckeditor5-foo/tests/manual/foo.css?import' } as never, response as never, next );
 		middleware( { method: 'GET', url: '/packages/ckeditor5-foo/tests/manual/foo.ts' } as never, response as never, next );
 		middleware( { method: 'GET', url: '/packages/ckeditor5-foo/tests/manual/image.png?url' } as never, response as never, next );
 		middleware( { method: 'POST', url: '/packages/ckeditor5-foo/tests/manual/image.png' } as never, response as never, next );


### PR DESCRIPTION
### 🚀 Summary

* Fix external scripts in the manual test server.
* Fix manual test server asset handling.

---

### 📌 Related issues

* See https://github.com/ckeditor/ckeditor5-internal/issues/4160.
* Follow-up to https://github.com/ckeditor/ckeditor5-dev/pull/1374.

---

### 💡 Additional information

N/A
