### PR TITLE
Fix manual test catalog output path.

### DIFF
--- a/.changelog/20260611162049_ci_4530_fix_manual_catalog_build_path.md
+++ b/.changelog/20260611162049_ci_4530_fix_manual_catalog_build_path.md
@@ -1,0 +1,7 @@
+---
+type: Fix
+scope:
+  - ckeditor5-dev-manual-server
+---
+
+The Vite manual test build now emits the catalog page as `index.html` instead of using the catalog source path.

--- a/packages/ckeditor5-dev-manual-server/src/manual-test-plugin/plugin.ts
+++ b/packages/ckeditor5-dev-manual-server/src/manual-test-plugin/plugin.ts
@@ -59,10 +59,11 @@ export function manualTestsPlugin( manualTestPatterns: Array<string> ): Plugin {
 		return getManualPages().get( toPublicSpecifier( relative( workspaceRoot, filePath ) ) );
 	};
 	const getManualCatalogPublicPath = () => toPublicFilePath( MANUAL_CATALOG_FILE_PATH, workspaceRoot );
+	const getManualCatalogBuildInputFilePath = () => resolve( workspaceRoot, 'index.html' );
 	const getManualCatalogScriptPublicPath = () => toPublicFilePath( MANUAL_CATALOG_SCRIPT_FILE_PATH, workspaceRoot );
 	const getManualShellScriptPublicPath = () => toPublicFilePath( MANUAL_SHELL_SCRIPT_FILE_PATH, workspaceRoot );
 	const getManualBuildInputs = () => [
-		MANUAL_CATALOG_FILE_PATH,
+		getManualCatalogBuildInputFilePath(),
 		...[ ...getManualPages().values() ].map( entry => resolve( workspaceRoot, entry.htmlFilePath.slice( 1 ) ) )
 	];
 	const resolvedVirtualModuleId = `\0${ MANUAL_ENTRIES_VIRTUAL_ID }`;
@@ -111,12 +112,20 @@ export function manualTestsPlugin( manualTestPatterns: Array<string> ): Plugin {
 				return resolvedVirtualModuleId;
 			}
 
+			if ( isManualCatalogBuildInputSpecifier( source, getManualCatalogBuildInputFilePath(), workspaceRoot ) ) {
+				return getManualCatalogBuildInputFilePath();
+			}
+
 			return null;
 		},
 
 		load( id ) {
 			if ( id == resolvedVirtualModuleId ) {
 				return `export const manualTestEntries = ${ getManualEntriesJson() };`;
+			}
+
+			if ( toPosixPath( id ) == toPosixPath( getManualCatalogBuildInputFilePath() ) ) {
+				return readFileSync( MANUAL_CATALOG_FILE_PATH, 'utf8' );
 			}
 
 			return null;
@@ -136,7 +145,7 @@ export function manualTestsPlugin( manualTestPatterns: Array<string> ): Plugin {
 			order: 'pre',
 
 			handler( html, context ) {
-				if ( toPosixPath( context.filename ) == toPosixPath( MANUAL_CATALOG_FILE_PATH ) ) {
+				if ( isManualCatalogHtmlFile( context.filename, getManualCatalogBuildInputFilePath() ) ) {
 					return html.replace( './catalog.ts', getManualCatalogScriptPublicPath() );
 				}
 
@@ -224,6 +233,17 @@ function toManualPagePattern( pattern: string ): string {
 	}
 
 	return `${ pattern }.{html,js,md,ts}`;
+}
+
+function isManualCatalogHtmlFile( filePath: string, catalogBuildInputFilePath: string ): boolean {
+	const normalizedFilePath = toPosixPath( filePath );
+
+	return normalizedFilePath == toPosixPath( MANUAL_CATALOG_FILE_PATH ) ||
+		normalizedFilePath == toPosixPath( catalogBuildInputFilePath );
+}
+
+function isManualCatalogBuildInputSpecifier( source: string, catalogBuildInputFilePath: string, workspaceRoot: string ): boolean {
+	return toPosixPath( resolve( workspaceRoot, source ) ) == toPosixPath( catalogBuildInputFilePath );
 }
 
 function mergeBundledAssetTags(

--- a/packages/ckeditor5-dev-manual-server/tests/manual-test-plugin/plugin.test.ts
+++ b/packages/ckeditor5-dev-manual-server/tests/manual-test-plugin/plugin.test.ts
@@ -32,6 +32,7 @@ type TransformIndexHtmlHook = {
 };
 type GenerateBundleHook = ( this: { emitFile: ReturnType<typeof vi.fn> } ) => void;
 type LoadHook = ( id: string ) => string | null;
+type ResolveIdHook = ( id: string ) => string | null;
 type MemoryFile = { etag?: string; source: string | Uint8Array };
 type MemoryFilesGetMock = Mock<( filePath: string ) => MemoryFile | undefined>;
 type TestServer = {
@@ -218,6 +219,23 @@ describe( 'manualTestsPlugin()', () => {
 			fileName: 'packages/ckeditor5-foo/tests/manual/assets/image.png',
 			source: Buffer.from( 'image' )
 		} );
+	} );
+
+	test( 'registers the catalog HTML as the build index page', () => {
+		const plugin = manualTestsPlugin( [] );
+		const config = ( plugin.config as ConfigHook )();
+		const catalogBuildInputFilePath = join( workspaceRoot, 'index.html' );
+
+		expect( config.build.rolldownOptions.input ).to.include( catalogBuildInputFilePath );
+
+		( plugin.configResolved as ConfigResolvedHook )( {
+			root: workspaceRoot,
+			build: config.build
+		} );
+
+		expect( ( plugin.resolveId as ResolveIdHook )( 'index.html' ) ).to.equal( catalogBuildInputFilePath );
+		expect( ( plugin.load as LoadHook )( catalogBuildInputFilePath ) )
+			.to.contain( '<script type="module" src="./catalog.ts"></script>' );
 	} );
 
 	test( 'updates bundled manual HTML from current source in dev server', async () => {
@@ -421,6 +439,23 @@ describe( 'manualTestsPlugin()', () => {
 		expect( transformIndexHtml.handler(
 			'<script type="module" src="./catalog.ts"></script>',
 			{ filename: catalogFilePath.replace( /\//g, '\\' ) }
+		) ).to.equal( `<script type="module" src="/@fs/${ catalogScriptFilePath }"></script>` );
+	} );
+
+	test( 'rewrites the catalog script for the synthetic build index page', () => {
+		const plugin = manualTestsPlugin( [] );
+		const config = ( plugin.config as ConfigHook )();
+		const transformIndexHtml = plugin.transformIndexHtml as TransformIndexHtmlHook;
+		const catalogScriptFilePath = resolve( import.meta.dirname, '../../theme/catalog.ts' ).replace( /\\/g, '/' );
+
+		( plugin.configResolved as ConfigResolvedHook )( {
+			root: workspaceRoot,
+			build: config.build
+		} );
+
+		expect( transformIndexHtml.handler(
+			'<script type="module" src="./catalog.ts"></script>',
+			{ filename: join( workspaceRoot, 'index.html' ) }
 		) ).to.equal( `<script type="module" src="/@fs/${ catalogScriptFilePath }"></script>` );
 	} );
 


### PR DESCRIPTION
### 🚀 Summary

Registers the Vite manual test catalog as the build landing page so it is emitted as `index.html`.

---

### 📌 Related issues

* Closes https://github.com/ckeditor/ckeditor5-internal/issues/4530

---

### 💡 Additional information

N/A
