### PR TITLE
Fix manual preview links with relative base

### DIFF
--- a/.changelog/20260615130516_ci_4546_fix_manual_preview_relative_links.md
+++ b/.changelog/20260615130516_ci_4546_fix_manual_preview_relative_links.md
@@ -1,0 +1,7 @@
+---
+type: Fix
+scope:
+  - ckeditor5-dev-manual-server
+---
+
+The Vite manual test catalog and shell links now respect the configured base path when the manual test build is served from a nested directory.

--- a/packages/ckeditor5-dev-manual-server/src/manual-test-plugin/plugin.ts
+++ b/packages/ckeditor5-dev-manual-server/src/manual-test-plugin/plugin.ts
@@ -46,6 +46,7 @@ const MANUAL_SHELL_SCRIPT_FILE_PATH = resolve( MANUAL_THEME_ROOT, 'shell.ts' );
 
 export function manualTestsPlugin( manualTestPatterns: Array<string> ): Plugin {
 	let workspaceRoot = process.cwd();
+	let base = '/';
 	const manualPagePatterns = manualTestPatterns.map( toManualPagePattern );
 	const manualPagesCache = cacheValue( () => collectManualPages( manualPagePatterns, workspaceRoot ) );
 	const manualStaticAssetsCache = cacheValue( () => collectManualStaticAssets( manualTestPatterns, workspaceRoot ) );
@@ -62,6 +63,7 @@ export function manualTestsPlugin( manualTestPatterns: Array<string> ): Plugin {
 	const getManualCatalogBuildInputFilePath = () => resolve( workspaceRoot, 'index.html' );
 	const getManualCatalogScriptPublicPath = () => toPublicFilePath( MANUAL_CATALOG_SCRIPT_FILE_PATH, workspaceRoot );
 	const getManualShellScriptPublicPath = () => toPublicFilePath( MANUAL_SHELL_SCRIPT_FILE_PATH, workspaceRoot );
+	const getManualCatalogClientPath = ( entry: ManualPageEntry ) => toBaseCatalogPath( base, entry.htmlFilePath );
 	const getManualBuildInputs = () => [
 		getManualCatalogBuildInputFilePath(),
 		...[ ...getManualPages().values() ].map( entry => resolve( workspaceRoot, entry.htmlFilePath.slice( 1 ) ) )
@@ -69,7 +71,7 @@ export function manualTestsPlugin( manualTestPatterns: Array<string> ): Plugin {
 	const resolvedVirtualModuleId = `\0${ MANUAL_ENTRIES_VIRTUAL_ID }`;
 	const getClientEntries = (): Array<ManualTestClientEntry> => [ ...getManualPages().values() ].map( entry => ( {
 		displayName: entry.displayName,
-		href: entry.htmlFilePath,
+		href: toBasePublicPath( entry.htmlFilePath, base ),
 		packageName: entry.packageName,
 		slug: entry.slug
 	} ) );
@@ -90,6 +92,7 @@ export function manualTestsPlugin( manualTestPatterns: Array<string> ): Plugin {
 
 		configResolved( config ) {
 			workspaceRoot = config.root;
+			base = config.base || '/';
 
 			invalidateManualFileCaches();
 
@@ -100,11 +103,13 @@ export function manualTestsPlugin( manualTestPatterns: Array<string> ): Plugin {
 			const { memoryFiles } = server.environments.client as BundledDevClientEnvironment;
 
 			useManualTestMiddlewares( server, getManualCatalogPublicPath, getManualStaticAssets );
-			useBundledDevManualHtmlSource( memoryFiles, getManualPages, getManualShellScriptPublicPath, () => workspaceRoot );
-		},
-
-		configurePreviewServer( server ) {
-			useManualCatalogMiddleware( server, getManualCatalogPublicPath );
+			useBundledDevManualHtmlSource(
+				memoryFiles,
+				getManualPages,
+				getManualShellScriptPublicPath,
+				getManualCatalogClientPath,
+				() => workspaceRoot
+			);
 		},
 
 		resolveId( source ) {
@@ -156,6 +161,7 @@ export function manualTestsPlugin( manualTestPatterns: Array<string> ): Plugin {
 				}
 
 				return createManualShellHtml( {
+					catalogPublicPath: getManualCatalogClientPath( entry ),
 					entry,
 					html,
 					shellScriptPublicPath: getManualShellScriptPublicPath(),
@@ -191,6 +197,7 @@ function useBundledDevManualHtmlSource(
 	memoryFiles: ManualMemoryFilesLike | undefined,
 	getManualPages: () => Map<string, ManualPageEntry>,
 	getManualShellScriptPublicPath: () => string,
+	getManualCatalogClientPath: ( entry: ManualPageEntry ) => string,
 	getWorkspaceRoot: () => string
 ): void {
 	if ( !memoryFiles ) {
@@ -211,6 +218,7 @@ function useBundledDevManualHtmlSource(
 		const shellScriptPublicPath = getManualShellScriptPublicPath();
 		const bundledHtml = getFileSource( file );
 		const transformedSourceHtml = createManualShellHtml( {
+			catalogPublicPath: getManualCatalogClientPath( entry ),
 			entry,
 			html: readFileSync( resolve( workspaceRoot, stripLeadingSlash( entry.htmlFilePath ) ), 'utf8' ),
 			shellScriptPublicPath,
@@ -244,6 +252,22 @@ function isManualCatalogHtmlFile( filePath: string, catalogBuildInputFilePath: s
 
 function isManualCatalogBuildInputSpecifier( source: string, catalogBuildInputFilePath: string, workspaceRoot: string ): boolean {
 	return toPosixPath( resolve( workspaceRoot, source ) ) == toPosixPath( catalogBuildInputFilePath );
+}
+
+function toBasePublicPath( publicPath: string, base: string ): string {
+	if ( base == '' || base == './' ) {
+		return `.${ publicPath }`;
+	}
+
+	return `${ base.replace( /\/$/, '' ) }${ publicPath }`;
+}
+
+function toBaseCatalogPath( base: string, entryHtmlFilePath: string ): string {
+	if ( base == '' || base == './' ) {
+		return posix.relative( posix.dirname( stripLeadingSlash( entryHtmlFilePath ) ), 'index.html' );
+	}
+
+	return base;
 }
 
 function mergeBundledAssetTags(

--- a/packages/ckeditor5-dev-manual-server/src/manual-test-plugin/shell-html.ts
+++ b/packages/ckeditor5-dev-manual-server/src/manual-test-plugin/shell-html.ts
@@ -27,6 +27,7 @@ import { loadRenderedInstructions } from './parse-markdown.js';
 import type { ManualData, ManualPageEntry } from './types.js';
 
 export interface CreateManualShellHtmlOptions {
+	catalogPublicPath?: string;
 	entry: ManualPageEntry;
 	html: string;
 	shellScriptPublicPath: string;
@@ -35,6 +36,7 @@ export interface CreateManualShellHtmlOptions {
 }
 
 export function createManualShellHtml( {
+	catalogPublicPath = '/',
 	entry,
 	html,
 	shellScriptPublicPath,
@@ -42,7 +44,8 @@ export function createManualShellHtml( {
 	workspaceRoot
 }: CreateManualShellHtmlOptions ): string {
 	// Elements from shell template.
-	const shellHtml = readFileSync( shellTemplateFilePath, 'utf8' );
+	const shellHtml = readFileSync( shellTemplateFilePath, 'utf8' )
+		.replace( 'href="/" title="Back to test index"', `href="${ catalogPublicPath }" title="Back to test index"` );
 	const shellDocument = parse( shellHtml );
 	const shellHead = getRequiredElementByTagName( shellDocument, 'head' );
 	const shellBody = getRequiredElementByTagName( shellDocument, 'body' );

--- a/packages/ckeditor5-dev-manual-server/tests/manual-test-plugin/plugin.test.ts
+++ b/packages/ckeditor5-dev-manual-server/tests/manual-test-plugin/plugin.test.ts
@@ -21,6 +21,7 @@ type ConfigHook = () => {
 };
 type ConfigResolvedHook = ( config: {
 	root: string;
+	base?: string;
 	build: {
 		rolldownOptions: {
 			input: Array<string>;
@@ -108,6 +109,69 @@ describe( 'manualTestsPlugin()', () => {
 		expect( source ).to.contain( '/packages/ckeditor5-foo/tests/manual/foo.html' );
 	} );
 
+	test( 'exposes entry links relative to the catalog when using relative Vite base', async () => {
+		await Promise.all( [
+			createFile( workspaceRoot, 'packages/ckeditor5-foo/tests/manual/foo.html' ),
+			createFile( workspaceRoot, 'packages/ckeditor5-foo/tests/manual/foo.ts' )
+		] );
+
+		const plugin = manualTestsPlugin( [ 'packages/*/tests/manual/**/*' ] );
+		const config = ( plugin.config as ConfigHook )();
+
+		( plugin.configResolved as ConfigResolvedHook )( {
+			root: workspaceRoot,
+			base: './',
+			build: config.build
+		} );
+
+		const source = ( plugin.load as LoadHook )( '\0virtual:ckeditor5-manual-entries' )!;
+
+		expect( source ).to.contain( './packages/ckeditor5-foo/tests/manual/foo.html' );
+	} );
+
+	test( 'exposes entry links prefixed with the configured Vite base', async () => {
+		await Promise.all( [
+			createFile( workspaceRoot, 'packages/ckeditor5-foo/tests/manual/foo.html' ),
+			createFile( workspaceRoot, 'packages/ckeditor5-foo/tests/manual/foo.ts' )
+		] );
+
+		const plugin = manualTestsPlugin( [ 'packages/*/tests/manual/**/*' ] );
+		const config = ( plugin.config as ConfigHook )();
+
+		( plugin.configResolved as ConfigResolvedHook )( {
+			root: workspaceRoot,
+			base: '/manual/',
+			build: config.build
+		} );
+
+		const source = ( plugin.load as LoadHook )( '\0virtual:ckeditor5-manual-entries' )!;
+
+		expect( source ).to.contain( '/manual/packages/ckeditor5-foo/tests/manual/foo.html' );
+	} );
+
+	test( 'links wrapped manual pages back to the catalog when using relative Vite base', async () => {
+		await Promise.all( [
+			createFile( workspaceRoot, 'packages/ckeditor5-foo/tests/manual/foo.html' ),
+			createFile( workspaceRoot, 'packages/ckeditor5-foo/tests/manual/foo.ts' )
+		] );
+
+		const plugin = manualTestsPlugin( [ 'packages/*/tests/manual/**/*' ] );
+		const config = ( plugin.config as ConfigHook )();
+		const transformIndexHtml = plugin.transformIndexHtml as TransformIndexHtmlHook;
+
+		( plugin.configResolved as ConfigResolvedHook )( {
+			root: workspaceRoot,
+			base: './',
+			build: config.build
+		} );
+
+		const html = transformIndexHtml.handler( '<p>Manual test</p>', {
+			filename: join( workspaceRoot, 'packages/ckeditor5-foo/tests/manual/foo.html' )
+		} )!;
+
+		expect( html ).to.contain( 'href="../../../../index.html"' );
+	} );
+
 	test( 'uses the Vite root instead of the current working directory for page entries', async () => {
 		const currentWorkingDirectory = await createTemporaryDirectory( 'ckeditor5-manual-test-plugin-cwd-' );
 
@@ -190,16 +254,13 @@ describe( 'manualTestsPlugin()', () => {
 		expect( ( plugin.load as LoadHook )( '\u0000virtual:other' ) ).to.be.null;
 	} );
 
-	test( 'registers manual test middlewares for dev and preview servers', () => {
+	test( 'registers manual test middlewares for dev server', () => {
 		const plugin = manualTestsPlugin( [] );
 		const devServer = createMiddlewareServer();
-		const previewServer = createMiddlewareServer();
 
 		( plugin.configureServer as unknown as ServerHook )( devServer );
-		( plugin.configurePreviewServer as unknown as ServerHook )( previewServer );
 
 		expect( devServer.middlewares.use ).toHaveBeenCalledTimes( 2 );
-		expect( previewServer.middlewares.use ).toHaveBeenCalledTimes( 1 );
 	} );
 
 	test( 'emits manual static assets during build', async () => {

--- a/packages/ckeditor5-dev-manual-server/tests/manual-test-plugin/shell-html.test.ts
+++ b/packages/ckeditor5-dev-manual-server/tests/manual-test-plugin/shell-html.test.ts
@@ -61,6 +61,18 @@ describe( 'createManualShellHtml()', () => {
 		expect( getAttribute( body, 'data-test' ) ).to.equal( 'preserved' );
 	} );
 
+	test( 'sets the catalog link href', () => {
+		const html = createManualShellHtml( {
+			catalogPublicPath: '../../../../index.html',
+			entry,
+			html: '<p>Manual test</p>',
+			shellScriptPublicPath: '/theme/shell.ts',
+			shellTemplateFilePath,
+			workspaceRoot
+		} );
+		expect( html ).to.contain( 'href="../../../../index.html" title="Back to test index"' );
+	} );
+
 	test( 'keeps existing shell body attributes when manual body duplicates them', async () => {
 		const temporaryDirectory = await createTemporaryDirectory( 'ckeditor5-manual-shell-html-' );
 


### PR DESCRIPTION
### 🚀 Summary

* Fix manual test preview output so catalog links and the `All tests` back link respect Vite's configured base path.
* Remove the preview-server catalog rewrite because the built catalog is emitted as `index.html`.

---

### 📌 Related issues

* See https://github.com/ckeditor/ckeditor5-internal/issues/4546.

---

### 💡 Additional information

N/A