### PR TITLE
Fix local Rolldown builds.

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,7 @@
     "noImplicitOverride": true
   },
   "include": [
+    "packages/*/rolldown.config.ts",
     "packages/*/src/**/*.ts",
     "packages/*/tests/**/*.ts"
   ],


### PR DESCRIPTION
### 🚀 Summary

Fix local Rolldown builds.

---

### 📌 Related issues

N/A

---

### 💡 Additional information

The `rolldown.config.ts` files must be included in tsconfig. Otherwise, Rolldown fails because it can't find any tsconfig that includes this file.
