### PR TITLE
Remove `@internal` annotation from JSDoc example.

### DIFF
--- a/packages/ckeditor5-dev-build-tools/src/plugins/declarations.ts
+++ b/packages/ckeditor5-dev-build-tools/src/plugins/declarations.ts
@@ -16,7 +16,7 @@ export interface RolldownDeclarationOptions {
 	sourceDirectory: string;
 
 	/**
-	 * Whether to skip declarations for internal APIs (marked with `@internal` in the source code).
+	 * Whether to skip declarations for internal APIs.
 	 *
 	 * @default true
 	 */


### PR DESCRIPTION
### 🚀 Summary

Remove `@internal` annotation from JSDoc example.

---

### 📌 Related issues

N/A

---

### 💡 Additional information

This causes the `stripInternal` property to be removed from the generated `.d.ts` file.
