### PR TITLE
Add the `ckDebugPlugin()` Vite plugin to the manual server package

### DIFF
--- a/.changelog/20260626131355_ci_4437.md
+++ b/.changelog/20260626131355_ci_4437.md
@@ -1,0 +1,7 @@
+---
+type: Feature
+scope:
+  - ckeditor5-dev-manual-server
+---
+
+Added the `ckDebugPlugin()` Vite plugin to the manual server package. The plugin enables CKEditor debug comments in manual tests and uses Rolldown plugin hook filters to avoid unnecessary transform calls.

--- a/.changelog/20260626131355_ci_4437.md
+++ b/.changelog/20260626131355_ci_4437.md
@@ -1,7 +1,6 @@
 ---
 type: Feature
-scope:
-  - ckeditor5-dev-manual-server
+scope: ckeditor5-dev-manual-server
 ---
 
-Added the `ckDebugPlugin()` Vite plugin to the manual server package. The plugin enables CKEditor debug comments in manual tests and uses Rolldown plugin hook filters to avoid unnecessary transform calls.
+Added the `ckDebugPlugin()` Vite plugin to the manual server package.

--- a/.changelog/20260626135657_ci_4536_add_ck_debug_plugin.md
+++ b/.changelog/20260626135657_ci_4536_add_ck_debug_plugin.md
@@ -1,0 +1,6 @@
+---
+type: Fix
+scope: ckeditor5-dev-manual-server
+---
+
+Restored automatic CKEditor Inspector attachment for manual tests that expose their editor instance as `window.editor`, matching the behavior of the previous manual test server.

--- a/packages/ckeditor5-dev-manual-server/src/debug-plugin/plugin.ts
+++ b/packages/ckeditor5-dev-manual-server/src/debug-plugin/plugin.ts
@@ -1,0 +1,56 @@
+/**
+ * @license Copyright (c) 2003-2026, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+import type { Plugin } from 'vite';
+
+const SOURCE_FILE_REGEXP = /\.[cm]?[jt]sx?$/;
+
+export function ckDebugPlugin(): Plugin {
+	const debugFlags = getDebugFlags( process.env.CK_DEBUG );
+
+	return {
+		name: 'ck-debug',
+		enforce: 'pre',
+		transform: {
+			filter: {
+				id: {
+					include: SOURCE_FILE_REGEXP
+				}
+			},
+			handler( code ) {
+				if ( !code.includes( '// @if ' ) ) {
+					return null;
+				}
+
+				const transformedCode = code.replace(
+					/(^[ \t]*)\/\/ @if (!?[\w]+) \/\/(.*)$/gm,
+					( match, indentation: string, flagName: string, body: string ) => {
+						if ( !debugFlags.has( flagName ) ) {
+							return match;
+						}
+
+						return `${ indentation }/* @if ${ flagName } */${ body }`;
+					}
+				);
+
+				return transformedCode === code ? null : transformedCode;
+			}
+		}
+	};
+}
+
+function getDebugFlags( debugOption?: string ): Set<string> {
+	if ( !debugOption || debugOption === 'false' ) {
+		return new Set();
+	}
+
+	return new Set( [
+		'CK_DEBUG',
+		...debugOption.split( ',' )
+			.map( flag => flag.trim() )
+			.filter( Boolean )
+			.map( flag => `CK_DEBUG_${ flag.toUpperCase() }` )
+	] );
+}

--- a/packages/ckeditor5-dev-manual-server/src/debug-plugin/plugin.ts
+++ b/packages/ckeditor5-dev-manual-server/src/debug-plugin/plugin.ts
@@ -49,16 +49,18 @@ export function ckDebugPlugin(): Plugin {
 	};
 }
 
-function getDebugFlags( debugOption?: string ): Set<string> {
-	if ( !debugOption || debugOption === 'false' ) {
+function getDebugFlags( debugOption: string = '' ): Set<string> {
+	if ( debugOption === 'false' ) {
 		return new Set();
 	}
 
-	return new Set( [
-		'CK_DEBUG',
-		...debugOption.split( ',' )
-			.map( flag => flag.trim() )
-			.filter( Boolean )
-			.map( flag => `CK_DEBUG_${ flag.toUpperCase() }` )
-	] );
+	const flags = new Set( [ 'CK_DEBUG' ] );
+
+	debugOption
+		.split( ',' )
+		.map( flag => flag.trim() )
+		.filter( Boolean )
+		.forEach( flag => flags.add( `CK_DEBUG_${ flag.toUpperCase() }` ) );
+
+	return flags;
 }

--- a/packages/ckeditor5-dev-manual-server/src/debug-plugin/plugin.ts
+++ b/packages/ckeditor5-dev-manual-server/src/debug-plugin/plugin.ts
@@ -10,9 +10,17 @@ const SOURCE_FILE_REGEXP = /\.[cm]?[jt]sx?$/;
 export function ckDebugPlugin(): Plugin {
 	const debugFlags = getDebugFlags( process.env.CK_DEBUG );
 
-	return {
+	const plugin: Plugin = {
 		name: 'ck-debug',
-		enforce: 'pre',
+		enforce: 'pre'
+	};
+
+	if ( !debugFlags.size ) {
+		return plugin;
+	}
+
+	return {
+		...plugin,
 		transform: {
 			filter: {
 				id: {

--- a/packages/ckeditor5-dev-manual-server/src/index.ts
+++ b/packages/ckeditor5-dev-manual-server/src/index.ts
@@ -5,6 +5,7 @@
 
 export { manualTestsPlugin } from './manual-test-plugin/plugin.js';
 export type { ManualData, ManualTestsPluginOptions } from './manual-test-plugin/plugin.js';
+export { ckDebugPlugin } from './debug-plugin/plugin.js';
 export { refreshPlugin } from './refresh-plugin/plugin.js';
 export { rawHtmlPlugin } from './raw-plugin/plugin.js';
 export { stringifyValues } from './utils.js';

--- a/packages/ckeditor5-dev-manual-server/tests/debug-plugin/plugin.test.ts
+++ b/packages/ckeditor5-dev-manual-server/tests/debug-plugin/plugin.test.ts
@@ -22,6 +22,8 @@ describe( 'ckDebugPlugin()', () => {
 	} );
 
 	test( 'filters transform hook calls to JavaScript and TypeScript files', () => {
+		vi.stubEnv( 'CK_DEBUG', 'true' );
+
 		const transform = getTransformHook( ckDebugPlugin() );
 
 		expect( transform.filter.id.include ).to.be.instanceOf( RegExp );
@@ -30,9 +32,10 @@ describe( 'ckDebugPlugin()', () => {
 		expect( transform.filter.id.include.test( '/path/manual.css' ) ).to.equal( false );
 	} );
 
-	test( 'does not transform debug comments when the debug flag is disabled', () => {
+	test( 'does not register the transform hook when the debug flag is disabled', () => {
 		vi.stubEnv( 'CK_DEBUG', 'false' );
 
+		expect( ckDebugPlugin().transform ).to.equal( undefined );
 		expect( transformCode( 'const value = 1;\n// @if CK_DEBUG // console.log( value );' ) ).to.equal( null );
 	} );
 
@@ -58,7 +61,13 @@ describe( 'ckDebugPlugin()', () => {
 } );
 
 function transformCode( code: string ): string | null {
-	const result = getTransformHook( ckDebugPlugin() ).handler( code, '/path/manual.js' );
+	const plugin = ckDebugPlugin();
+
+	if ( !plugin.transform ) {
+		return null;
+	}
+
+	const result = getTransformHook( plugin ).handler( code, '/path/manual.js' );
 
 	if ( !result ) {
 		return null;

--- a/packages/ckeditor5-dev-manual-server/tests/debug-plugin/plugin.test.ts
+++ b/packages/ckeditor5-dev-manual-server/tests/debug-plugin/plugin.test.ts
@@ -47,6 +47,12 @@ describe( 'ckDebugPlugin()', () => {
 		);
 	} );
 
+	test( 'does not run debug replacement when source has no debug comments', () => {
+		vi.stubEnv( 'CK_DEBUG', 'true' );
+
+		expect( transformCode( 'const value = 1;\nconsole.log( value );' ) ).to.equal( null );
+	} );
+
 	test( 'transforms debug comments for selected debug namespaces', () => {
 		vi.stubEnv( 'CK_DEBUG', 'engine, ui' );
 

--- a/packages/ckeditor5-dev-manual-server/tests/debug-plugin/plugin.test.ts
+++ b/packages/ckeditor5-dev-manual-server/tests/debug-plugin/plugin.test.ts
@@ -1,0 +1,72 @@
+/**
+ * @license Copyright (c) 2003-2026, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+import { describe, expect, test, vi } from 'vitest';
+import type { Plugin } from 'vite';
+import { ckDebugPlugin } from '../../src/debug-plugin/plugin.js';
+
+type TransformHook = {
+	filter: {
+		id: {
+			include: RegExp;
+		};
+	};
+	handler: ( code: string, id: string ) => { code: string } | string | null;
+};
+
+describe( 'ckDebugPlugin()', () => {
+	test( 'runs before regular transforms', () => {
+		expect( ckDebugPlugin().enforce ).to.equal( 'pre' );
+	} );
+
+	test( 'filters transform hook calls to JavaScript and TypeScript files', () => {
+		const transform = getTransformHook( ckDebugPlugin() );
+
+		expect( transform.filter.id.include ).to.be.instanceOf( RegExp );
+		expect( transform.filter.id.include.test( '/path/manual.js' ) ).to.equal( true );
+		expect( transform.filter.id.include.test( '/path/manual.tsx' ) ).to.equal( true );
+		expect( transform.filter.id.include.test( '/path/manual.css' ) ).to.equal( false );
+	} );
+
+	test( 'does not transform debug comments when the debug flag is disabled', () => {
+		vi.stubEnv( 'CK_DEBUG', 'false' );
+
+		expect( transformCode( 'const value = 1;\n// @if CK_DEBUG // console.log( value );' ) ).to.equal( null );
+	} );
+
+	test( 'transforms debug comments when the global debug flag is enabled', () => {
+		vi.stubEnv( 'CK_DEBUG', 'true' );
+
+		expect( transformCode( 'const value = 1;\n\t// @if CK_DEBUG // console.log( value );' ) ).to.equal(
+			'const value = 1;\n\t/* @if CK_DEBUG */ console.log( value );'
+		);
+	} );
+
+	test( 'transforms debug comments for selected debug namespaces', () => {
+		vi.stubEnv( 'CK_DEBUG', 'engine, ui' );
+
+		expect( transformCode( '// @if CK_DEBUG_ENGINE // console.log( "engine" );' ) ).to.equal(
+			'/* @if CK_DEBUG_ENGINE */ console.log( "engine" );'
+		);
+		expect( transformCode( '// @if CK_DEBUG // console.log( "debug" );' ) ).to.equal(
+			'/* @if CK_DEBUG */ console.log( "debug" );'
+		);
+		expect( transformCode( '// @if CK_DEBUG_MODEL // console.log( "model" );' ) ).to.equal( null );
+	} );
+} );
+
+function transformCode( code: string ): string | null {
+	const result = getTransformHook( ckDebugPlugin() ).handler( code, '/path/manual.js' );
+
+	if ( !result ) {
+		return null;
+	}
+
+	return typeof result == 'string' ? result : result.code;
+}
+
+function getTransformHook( plugin: Plugin ): TransformHook {
+	return plugin.transform as TransformHook;
+}

--- a/packages/ckeditor5-dev-manual-server/tests/debug-plugin/plugin.test.ts
+++ b/packages/ckeditor5-dev-manual-server/tests/debug-plugin/plugin.test.ts
@@ -39,6 +39,15 @@ describe( 'ckDebugPlugin()', () => {
 		expect( transformCode( 'const value = 1;\n// @if CK_DEBUG // console.log( value );' ) ).to.equal( null );
 	} );
 
+	test( 'enables the base debug flag by default when CK_DEBUG is not set', () => {
+		vi.stubEnv( 'CK_DEBUG', undefined );
+
+		expect( transformCode( '// @if CK_DEBUG // console.log( "debug" );' ) ).to.equal(
+			'/* @if CK_DEBUG */ console.log( "debug" );'
+		);
+		expect( transformCode( '// @if CK_DEBUG_ENGINE // console.log( "engine" );' ) ).to.equal( null );
+	} );
+
 	test( 'transforms debug comments when the global debug flag is enabled', () => {
 		vi.stubEnv( 'CK_DEBUG', 'true' );
 

--- a/packages/ckeditor5-dev-manual-server/tests/index.test.ts
+++ b/packages/ckeditor5-dev-manual-server/tests/index.test.ts
@@ -4,10 +4,11 @@
  */
 
 import { describe, expect, test } from 'vitest';
-import { manualTestsPlugin, rawHtmlPlugin, refreshPlugin, stringifyValues } from '../src/index.js';
+import { ckDebugPlugin, manualTestsPlugin, rawHtmlPlugin, refreshPlugin, stringifyValues } from '../src/index.js';
 
 describe( 'package entry point', () => {
 	test( 'exports public plugin factories and utilities', () => {
+		expect( ckDebugPlugin ).to.be.a( 'function' );
 		expect( manualTestsPlugin ).to.be.a( 'function' );
 		expect( rawHtmlPlugin ).to.be.a( 'function' );
 		expect( refreshPlugin ).to.be.a( 'function' );

--- a/packages/ckeditor5-dev-manual-server/theme/shell.ts
+++ b/packages/ckeditor5-dev-manual-server/theme/shell.ts
@@ -35,6 +35,8 @@ if ( globalTarget.editor instanceof Element ) {
 globalTarget.CKEditorInspector ||= CKEditorInspector;
 globalTarget.CKEDITOR_GLOBAL_LICENSE_KEY ||= LICENSE_KEY;
 
+autoAttachInspector();
+
 /**
  * Clones the injected Shell template, fills it with current test metadata,
  * and prepends it to the page before the test content is wrapped.
@@ -102,6 +104,24 @@ function setupManualRefreshPrompt(): void {
 		button.removeAttribute( 'aria-hidden' );
 		button.removeAttribute( 'tabindex' );
 		button.classList.add( 'manual-refresh-prompt--visible' );
+	} );
+}
+
+function autoAttachInspector(): void {
+	let editor = globalTarget.editor;
+
+	Object.defineProperty( globalTarget, 'editor', {
+		configurable: true,
+		set( value ) {
+			editor = value;
+
+			if ( editor ) {
+				CKEditorInspector.attach( editor );
+			}
+		},
+		get() {
+			return editor;
+		}
 	} );
 }
 


### PR DESCRIPTION
### 🚀 Summary

* Add the `ckDebugPlugin()` Vite plugin to the manual server package.
* Auto attach inspector in Vite-based manual test server.

---

### 📌 Related issues

* See https://github.com/ckeditor/ckeditor5-internal/issues/4536.

---

### 💡 Additional information

N/A
