### PR TITLE
Handle CircleCI jobs without the "dependencies" property in the workflow notifier.

### DIFF
--- a/.changelog/20260629121027_ci_4559_handle_undefined_job_dependencies.md
+++ b/.changelog/20260629121027_ci_4559_handle_undefined_job_dependencies.md
@@ -1,0 +1,7 @@
+---
+type: Fix
+scope:
+  - ckeditor5-dev-ci
+---
+
+The workflow notifier no longer throws when the CircleCI API returns a job without the `dependencies` property. Such a job is now treated as a job with no dependencies.

--- a/packages/ckeditor5-dev-ci/lib/process-job-statuses.js
+++ b/packages/ckeditor5-dev-ci/lib/process-job-statuses.js
@@ -25,7 +25,7 @@ export default function processJobStatuses( jobs ) {
 	const jobsToProcess = jobsClone
 		.filter( job => {
 			// Ignore job with no dependencies.
-			if ( !job.dependencies.length ) {
+			if ( !job.dependencies?.length ) {
 				return false;
 			}
 
@@ -92,5 +92,5 @@ function clone( obj ) {
  *
  * @property {'blocked'|'running'|'failed'|'canceled'|'failed_parent'|'success'|'skipped'} status
  *
- * @property {Array.<string>} dependencies
+ * @property {Array.<string>} [dependencies]
  */

--- a/packages/ckeditor5-dev-ci/tests/process-job-statuses.js
+++ b/packages/ckeditor5-dev-ci/tests/process-job-statuses.js
@@ -570,5 +570,88 @@ describe( 'lib/process-job-statuses', () => {
 				expect( processJobStatuses( jobs ) ).toEqual( expectedOutput );
 			} );
 		} );
+
+		// The CircleCI API may return job objects without the `dependencies` property.
+		// See: https://github.com/ckeditor/ckeditor5-internal/issues/4559.
+		describe( 'job without "dependencies"', () => {
+			// Workflow:
+			// ┌─────┐
+			// │Job A│
+			// └─────┘
+			it( 'should not throw and not modify a single job with missing "dependencies"', () => {
+				const jobs = [ {
+					id: 'id1',
+					status: 'success'
+				} ];
+
+				const expectedOutput = [ {
+					id: 'id1',
+					status: 'success'
+				} ];
+
+				expect( () => processJobStatuses( jobs ) ).to.not.throw();
+				expect( processJobStatuses( jobs ) ).toEqual( expectedOutput );
+			} );
+
+			// Workflow:
+			// ┌────┐     ┌────┐
+			// │Id 1├────►│Id 2│
+			// └────┘     └────┘
+			it( 'should treat a job with missing "dependencies" as a job with no dependencies', () => {
+				const jobs = [ {
+					id: 'id1',
+					status: 'failed',
+					dependencies: []
+				}, {
+					id: 'id2',
+					status: 'blocked'
+				} ];
+
+				const expectedOutput = [ {
+					id: 'id1',
+					status: 'failed',
+					dependencies: []
+				}, {
+					id: 'id2',
+					status: 'blocked'
+				} ];
+
+				expect( processJobStatuses( jobs ) ).toEqual( expectedOutput );
+			} );
+
+			// Workflow:
+			// ┌────┐     ┌────┐
+			// │Id 1├────►│Id 2│
+			// └────┘     └────┘
+			it( 'should still mark children of a failed job when an unrelated job is missing "dependencies"', () => {
+				const jobs = [ {
+					id: 'id1',
+					status: 'failed',
+					dependencies: []
+				}, {
+					id: 'id2',
+					status: 'blocked',
+					dependencies: [ 'id1' ]
+				}, {
+					id: 'id3',
+					status: 'running'
+				} ];
+
+				const expectedOutput = [ {
+					id: 'id1',
+					status: 'failed',
+					dependencies: []
+				}, {
+					id: 'id2',
+					status: 'failed_parent',
+					dependencies: [ 'id1' ]
+				}, {
+					id: 'id3',
+					status: 'running'
+				} ];
+
+				expect( processJobStatuses( jobs ) ).toEqual( expectedOutput );
+			} );
+		} );
 	} );
 } );


### PR DESCRIPTION
### 🚀 Summary

Handle CircleCI jobs without the `dependencies` property in the workflow notifier. The CircleCI API may return job objects without that property, which caused `processJobStatuses()` to throw. Such jobs are now treated as jobs with no dependencies.

---

### 📌 Related issues

* Closes https://github.com/ckeditor/ckeditor5-internal/issues/4559

---

### 💡 Additional information

The fix is a minimal optional-chaining guard (`!job.dependencies?.length`); the later dependency lookup is already gated behind that check. Added test coverage for jobs with a missing `dependencies` property.
