### PR TITLE
Disable debug plugin unless `CK_DEBUG` env var is set

### DIFF
--- a/.changelog/20260701145301_ci_4536_disable_ck_debug_by_default.md
+++ b/.changelog/20260701145301_ci_4536_disable_ck_debug_by_default.md
@@ -1,0 +1,7 @@
+---
+type: Fix
+scope:
+  - ckeditor5-dev-manual-server
+---
+
+The debug plugin no longer enables debug code unless the `CK_DEBUG` environment variable is set.

--- a/packages/ckeditor5-dev-manual-server/src/debug-plugin/plugin.ts
+++ b/packages/ckeditor5-dev-manual-server/src/debug-plugin/plugin.ts
@@ -49,8 +49,8 @@ export function ckDebugPlugin(): Plugin {
 	};
 }
 
-function getDebugFlags( debugOption: string = '' ): Set<string> {
-	if ( debugOption === 'false' ) {
+function getDebugFlags( debugOption: string | undefined ): Set<string> {
+	if ( !debugOption || debugOption === 'false' ) {
 		return new Set();
 	}
 

--- a/packages/ckeditor5-dev-manual-server/tests/debug-plugin/plugin.test.ts
+++ b/packages/ckeditor5-dev-manual-server/tests/debug-plugin/plugin.test.ts
@@ -39,12 +39,11 @@ describe( 'ckDebugPlugin()', () => {
 		expect( transformCode( 'const value = 1;\n// @if CK_DEBUG // console.log( value );' ) ).to.equal( null );
 	} );
 
-	test( 'enables the base debug flag by default when CK_DEBUG is not set', () => {
+	test( 'does not enable debug flags when CK_DEBUG is not set', () => {
 		vi.stubEnv( 'CK_DEBUG', undefined );
 
-		expect( transformCode( '// @if CK_DEBUG // console.log( "debug" );' ) ).to.equal(
-			'/* @if CK_DEBUG */ console.log( "debug" );'
-		);
+		expect( ckDebugPlugin().transform ).to.equal( undefined );
+		expect( transformCode( '// @if CK_DEBUG // console.log( "debug" );' ) ).to.equal( null );
 		expect( transformCode( '// @if CK_DEBUG_ENGINE // console.log( "engine" );' ) ).to.equal( null );
 	} );
 


### PR DESCRIPTION
### 🚀 Summary

* Disable the debug plugin transform when the `CK_DEBUG` environment variable is not set.
* Keep `CK_DEBUG=true` and namespace values such as `CK_DEBUG=engine` enabled.

---

### 📌 Related issues

* https://github.com/ckeditor/ckeditor5-internal/issues/4536

---

### 💡 Additional information

The previous version skipped registering the transform hook only when `CK_DEBUG=false` was set, but we want it to skip the transform when:

- `CK_DEBUG` is not provided at all,
- an empty value is provided, for example `CK_DEBUG= pnpm run ...` (then `CK_DEBUG` equals `''`),
- `CK_DEBUG=false pnpm run ...` is provided.