### PR TITLE
Add missing Collaboration team members to members.json

### DIFF
--- a/.changelog/20260707093532_ci_4610_add_missing_members_to_members_json.md
+++ b/.changelog/20260707093532_ci_4610_add_missing_members_to_members_json.md
@@ -1,0 +1,7 @@
+---
+type: Other
+scope:
+  - ckeditor5-dev-ci
+---
+
+Added missing team members (`michnowak`, `tomaszdurka`, `Saddage`) to the `members.json` file used by the CI notification scripts.

--- a/packages/ckeditor5-dev-ci/lib/data/members.json
+++ b/packages/ckeditor5-dev-ci/lib/data/members.json
@@ -9,6 +9,7 @@
   "Mati365": "U06GGQ5G80K",
   "Mgsy": "U5A38S2PN",
   "Reinmar": "U03UQRP0C",
+  "Saddage": "U0BDD0QCJTZ",
   "Witoso": "U04S02SUZS5",
   "andrzejkala": "U07A7HAJX0S",
   "charlttsie": "U054YS7HUNT",
@@ -27,6 +28,7 @@
   "marburek": "U09FJ19EH2M",
   "marcelmroz": "U06CLB6AVFU",
   "martnpaneq": "U045B560E00",
+  "michnowak": "U0B78RRQZ2N",
   "mmotyczynska": "U02NSTQCTB8",
   "niegowski": "U01017YC7C7",
   "oleq": "U03UU2MNN",
@@ -36,5 +38,6 @@
   "pszczesniak": "U04167FKV88",
   "scofalik": "U05611ZMM",
   "themithy": "U0APT6TL16X",
+  "tomaszdurka": "U0B7AMBE1CZ",
   "wwalc": "U03UQQ8PY"
 }


### PR DESCRIPTION
### 🚀 Summary

Added missing team members (`michnowak`, `tomaszdurka`, `Saddage`) to the `members.json` file used by the CI notification scripts.

---

### 📌 Related issues

* Closes https://github.com/ckeditor/ckeditor5-internal/issues/4610

---

### 💡 Additional information

All three entries follow the existing format (GitHub handle as key, Slack member ID as value) and keep the file alphabetically sorted. Verified with the `ckeditor5-dev-ci` test suite and `pnpm run lint`.