### PR TITLE
Bump TypeDoc to the latest version

### DIFF
--- a/packages/ckeditor5-dev-docs/package.json
+++ b/packages/ckeditor5-dev-docs/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@ckeditor/typedoc-plugins": "workspace:*",
     "glob": "^13.0.6",
-    "typedoc": "^0.28.18",
+    "typedoc": "^0.28.20",
     "typedoc-plugin-rename-defaults": "^0.7.3",
     "upath": "^2.0.1"
   },

--- a/packages/ckeditor5-dev-docs/tests/build.js
+++ b/packages/ckeditor5-dev-docs/tests/build.js
@@ -27,7 +27,16 @@ vi.stubGlobal( 'console', {
 } );
 
 vi.mock( 'glob' );
-vi.mock( 'typedoc' );
+vi.mock( 'typedoc', async importOriginal => {
+	const typedoc = await importOriginal();
+
+	return {
+		...typedoc,
+		Application: {
+			bootstrapWithPlugins: vi.fn()
+		}
+	};
+} );
 vi.mock( '@ckeditor/typedoc-plugins' );
 
 describe( 'lib/build()', () => {

--- a/packages/typedoc-plugins/package.json
+++ b/packages/typedoc-plugins/package.json
@@ -28,12 +28,12 @@
   "devDependencies": {
     "glob": "^13.0.6",
     "rolldown": "^1.1.2",
-    "typedoc": "^0.28.18",
+    "typedoc": "^0.28.20",
     "typedoc-plugin-rename-defaults": "^0.7.3",
     "vitest": "^4.1.2"
   },
   "peerDependencies": {
-    "typedoc": "^0.28.14"
+    "typedoc": "^0.28.20"
   },
   "scripts": {
     "build": "rolldown -c rolldown.config.ts",

--- a/packages/typedoc-plugins/tests/purge-private-api-docs/index.ts
+++ b/packages/typedoc-plugins/tests/purge-private-api-docs/index.ts
@@ -12,6 +12,7 @@ import {
 	ReflectionKind,
 	SourceReference,
 	DeclarationReflection,
+	normalizePath,
 	type Context,
 	type ProjectReflection
 } from 'typedoc';
@@ -33,7 +34,7 @@ function createInterface( name: string, isPrivate?: boolean ) {
 	const publicPath = '/fixtures/public-package/src/augmentedinterface.ts';
 	const fullFileName = upath.join( __dirname + ( isPrivate ? privatePath : publicPath ) );
 
-	const source = new SourceReference( fullFileName, 1, 1 );
+	const source = new SourceReference( normalizePath( fullFileName ), 1, 1 );
 	source.url = 'https://github.com/ckeditor/ckeditor5-dev/blob/hash/file.ts#L1';
 
 	const reflection = new DeclarationReflection( name, ReflectionKind.Interface );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -225,11 +225,11 @@ importers:
         specifier: ^13.0.6
         version: 13.0.6
       typedoc:
-        specifier: ^0.28.18
-        version: 0.28.19(typescript@5.5.4)
+        specifier: ^0.28.20
+        version: 0.28.20(typescript@5.5.4)
       typedoc-plugin-rename-defaults:
         specifier: ^0.7.3
-        version: 0.7.3(typedoc@0.28.19(typescript@5.5.4))
+        version: 0.7.3(typedoc@0.28.20(typescript@5.5.4))
       upath:
         specifier: ^2.0.1
         version: 2.0.1
@@ -468,11 +468,11 @@ importers:
         specifier: ^1.1.2
         version: 1.1.2
       typedoc:
-        specifier: ^0.28.18
-        version: 0.28.19(typescript@5.5.4)
+        specifier: ^0.28.20
+        version: 0.28.20(typescript@5.5.4)
       typedoc-plugin-rename-defaults:
         specifier: ^0.7.3
-        version: 0.7.3(typedoc@0.28.19(typescript@5.5.4))
+        version: 0.7.3(typedoc@0.28.20(typescript@5.5.4))
       vitest:
         specifier: ^4.1.2
         version: 4.1.7(@types/node@22.19.19)(@vitest/coverage-v8@4.1.7)(vite@8.1.0(@types/node@22.19.19)(esbuild@0.28.1)(terser@5.48.0)(yaml@2.9.0))
@@ -2879,8 +2879,8 @@ packages:
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
-  linkify-it@5.0.1:
-    resolution: {integrity: sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==}
+  linkify-it@5.0.2:
+    resolution: {integrity: sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==}
 
   lint-staged@16.4.0:
     resolution: {integrity: sha512-lBWt8hujh/Cjysw5GYVmZpFHXDCgZzhrOm8vbcUdobADZNOK/bRshr2kM3DfgrrtR1DQhfupW9gnIXOfiFi+bw==}
@@ -2953,8 +2953,8 @@ packages:
     resolution: {integrity: sha512-uCbIa8jWWmQZt4dSnEStkVC6gdakiinAm4PiGsywIkguF0eWMdcjDz0ECYhUolFU3pFLOev9VNPCEygydXnddg==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
-  markdown-it@14.2.0:
-    resolution: {integrity: sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==}
+  markdown-it@14.3.0:
+    resolution: {integrity: sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw==}
     hasBin: true
 
   markdown-table@3.0.4:
@@ -3961,8 +3961,8 @@ packages:
     peerDependencies:
       typedoc: '>=0.22.x <0.29.x'
 
-  typedoc@0.28.19:
-    resolution: {integrity: sha512-wKh+lhdmMFivMlc6vRRcMGXeGEHGU2g8a2CkPTJjJlwRf1iXbimWIPcFolCqe4E0d/FRtGszpIrsp3WLpDB8Pw==}
+  typedoc@0.28.20:
+    resolution: {integrity: sha512-uSKqkh8Cr48vllnEy+jdaAgOeR6Y+QCBW7usgUsKj7gJEfR7stw9U/fE49LBnj2tPRKPY0c0EBJSWe9Appmplg==}
     engines: {node: '>= 18', pnpm: '>= 10'}
     hasBin: true
     peerDependencies:
@@ -6545,7 +6545,7 @@ snapshots:
 
   lines-and-columns@1.2.4: {}
 
-  linkify-it@5.0.1:
+  linkify-it@5.0.2:
     dependencies:
       uc.micro: 2.1.0
 
@@ -6654,11 +6654,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  markdown-it@14.2.0:
+  markdown-it@14.3.0:
     dependencies:
       argparse: 2.0.1
       entities: 4.5.0
-      linkify-it: 5.0.1
+      linkify-it: 5.0.2
       mdurl: 2.0.0
       punycode.js: 2.3.1
       uc.micro: 2.1.0
@@ -7981,16 +7981,16 @@ snapshots:
 
   typed-query-selector@2.12.2: {}
 
-  typedoc-plugin-rename-defaults@0.7.3(typedoc@0.28.19(typescript@5.5.4)):
+  typedoc-plugin-rename-defaults@0.7.3(typedoc@0.28.20(typescript@5.5.4)):
     dependencies:
       camelcase: 8.0.0
-      typedoc: 0.28.19(typescript@5.5.4)
+      typedoc: 0.28.20(typescript@5.5.4)
 
-  typedoc@0.28.19(typescript@5.5.4):
+  typedoc@0.28.20(typescript@5.5.4):
     dependencies:
       '@gerrit0/mini-shiki': 3.23.0
       lunr: 2.3.9
-      markdown-it: 14.2.0
+      markdown-it: 14.3.0
       minimatch: 10.2.5
       typescript: 5.5.4
       yaml: 2.9.0


### PR DESCRIPTION
<!--

This repository uses Markdown files to define changelog entries. If the changes in this pull request are **user-facing**, please create a changelog entry by running the following command:

    pnpm run nice

This will generate a `*.md` file in the `.changelog/` directory for your description. You can create as many as you need.

**Note:**  
If your PR is internal-only (e.g., tests, tooling, docs), you can skip this step - just mention it below.

-->

### 🚀 Summary

Bump TypeDoc to the latest version: [v0.28.20](https://github.com/TypeStrong/typedoc/releases/tag/v0.28.20).

---

### 📌 Related issues

<!--

Although changelog entries list connected issues, GitHub requires listing them here to automatically link and close them.

-->

* Closes #000

---

### 💡 Additional information

TL;DR: No blockers, recommendation is **safe to bump**.

Also, I decided to keep TypeDoc in `@ckeditor/ckeditor5-dev-docs` as dependency (and not peer-only dependency). `@ckeditor/ckeditor5-dev-docs` imports and bootstraps TypeDoc directly, so TypeDoc is a runtime dependency of that package, not just a host-provided integration point like we have in `@ckeditor/typedoc-plugins`. IMHO, for a package that owns the TypeDoc bootstrap, a normal dependency is better contract.

---

I checked the TypeDoc bump in the `ckeditor5-commercial` repository by building and comparing two docs versions: first one used TypeDoc v0.28.19 and the second one used v0.28.20. After that, I compared differences in the following areas:

1. API findings in the produced `output.json`.

    - File size changed from 218,556,094 bytes to 218,471,524 bytes (-84,570 bytes).
    - Reflection count unchanged: 174,188.
    - Module count unchanged: 1,251.
    - Source entries unchanged: 106,816.
    - Structural diff after normalizing TypeDoc internal IDs: no module, signature, type, inheritance, overwrite or implementation-relation changes.

1. Rendered page findings.

    I checked what the following pages from the API docs actually look like after renedring, using both TypeDoc versions:
    
    - [`Collection`](https://ckeditor.com/docs/ckeditor5/latest/api/module_utils_collection-Collection.html)
    - [`CommandCollection`](https://ckeditor.com/docs/ckeditor5/latest/api/module_core_commandcollection-CommandCollection.html)
    - [`CommandsMap`](https://ckeditor.com/docs/ckeditor5/latest/api/module_core_commandcollection-CommandsMap.html)
    - [`PluginCollection`](https://ckeditor.com/docs/ckeditor5/latest/api/module_core_plugincollection-PluginCollection.html)
    - [`PluginsMap`](https://ckeditor.com/docs/ckeditor5/latest/api/module_core_plugincollection-PluginsMap.html)
    - [`Editor`](https://ckeditor.com/docs/ckeditor5/latest/api/module_core_editor_editor-Editor.html)
    - [`EditorConfig`](https://ckeditor.com/docs/ckeditor5/latest/api/module_core_editor_editorconfig-EditorConfig.html)
    
    Result: All seven pages returned HTTP 200, had zero text-length delta, zero screenshot-height delta, and zero changed pixels.

    Screenshots:
    
    <details>
    
    <summary><code>Collection</code></summary>
    
    - `v0.28.19`
    
        <img width="1440" height="4193" alt="collection" src="https://github.com/user-attachments/assets/b13509af-4fbe-492f-bec8-1b3dacb32f50" />
    
    - `v0.28.20`
    
        <img width="1440" height="4193" alt="collection" src="https://github.com/user-attachments/assets/e9eccc9c-1ede-4105-9808-1bc1ef1775f4" />
    
    - diff
    
        <img width="1440" height="4193" alt="collection" src="https://github.com/user-attachments/assets/d5d543ac-f72c-4d0e-8172-c62cab592bf5" />
    
    ---
    
    </details>
    
    <details>
    
    <summary><code>CommandCollection</code></summary>
    
    - `v0.28.19`
    
        <img width="1440" height="1700" alt="commandcollection" src="https://github.com/user-attachments/assets/c7b14819-7611-4c62-a520-3cbfd5a37c5b" />
    
    - `v0.28.20`
    
        <img width="1440" height="1700" alt="commandcollection" src="https://github.com/user-attachments/assets/ded739cd-e67f-47a8-9ed9-111ae3e87a7f" />
    
    - diff
    
        <img width="1440" height="1700" alt="commandcollection" src="https://github.com/user-attachments/assets/7f68908a-cb10-4034-b427-e4002467ea55" />
    
    ---
    
    </details>
    
    <details>
    
    <summary><code>CommandsMap</code></summary>
    
    - `v0.28.19`
    
        <img width="1440" height="16612" alt="commandsmap" src="https://github.com/user-attachments/assets/be1efc8f-fffa-4b38-ae88-31d4c1f43d6f" />
    
    - `v0.28.20`
    
        <img width="1440" height="16612" alt="commandsmap" src="https://github.com/user-attachments/assets/4d3da258-53aa-4cc8-af14-5dbebf8efaf1" />
    
    - diff
    
        <img width="1440" height="16612" alt="commandsmap" src="https://github.com/user-attachments/assets/19bc6908-a3a8-4fd4-ac01-f14c20cbf4a4" />
    
    ---
    
    </details>
    
    <details>
    
    <summary><code>PluginCollection</code></summary>
    
    - `v0.28.19`
    
        <img width="1440" height="2559" alt="plugincollection" src="https://github.com/user-attachments/assets/cb5b5796-d1b2-4575-8951-4d5b3d19e563" />
    
    - `v0.28.20`
    
        <img width="1440" height="2559" alt="plugincollection" src="https://github.com/user-attachments/assets/03c09ca6-adbe-41e9-87ad-5a7c148f1643" />
    
    - diff
    
        <img width="1440" height="2559" alt="plugincollection" src="https://github.com/user-attachments/assets/b4ac1b06-4ce5-440b-ab6b-8d080d64ebcf" />
    
    ---
    
    </details>
    
    <details>
    
    <summary><code>PluginsMap</code></summary>
    
    - `v0.28.19`
    
        <img width="1440" height="40232" alt="pluginsmap" src="https://github.com/user-attachments/assets/007bf970-d719-45e1-a7aa-f47f587468fa" />
    
    - `v0.28.20`
    
        <img width="1440" height="40232" alt="pluginsmap" src="https://github.com/user-attachments/assets/195ca392-8d02-48e9-bf58-692bb6f89e14" />
    
    - diff
    
        <img width="1440" height="40232" alt="pluginsmap" src="https://github.com/user-attachments/assets/5309d961-1a9d-474b-b472-55337c486e20" />
    
    ---
    
    </details>
    
    <details>
    
    <summary><code>Editor</code></summary>
    
    - `v0.28.19`
    
        <img width="1440" height="7704" alt="editor" src="https://github.com/user-attachments/assets/9283cad7-5b45-4668-86f4-543c6d9ff6a7" />
    
    - `v0.28.20`
    
        <img width="1440" height="7704" alt="editor" src="https://github.com/user-attachments/assets/38508688-ed2c-400d-811f-8707db1ea848" />
    
    - diff
    
        <img width="1440" height="7704" alt="editor" src="https://github.com/user-attachments/assets/bf94ddc2-8680-4c11-beee-e36d1a2bc890" />
    
    ---
    
    </details>
    
    <details>
    
    <summary><code>EditorConfig</code></summary>
    
    - `v0.28.19`
    
        <img width="1440" height="9153" alt="editorconfig" src="https://github.com/user-attachments/assets/314e36c5-bfd3-4282-b5ce-616f250382ac" />
    
    - `v0.28.20`
    
        <img width="1440" height="9153" alt="editorconfig" src="https://github.com/user-attachments/assets/90aefdfc-796e-4b10-9c7a-502df3adaec7" />
    
    - diff
    
        <img width="1440" height="9153" alt="editorconfig" src="https://github.com/user-attachments/assets/ec2592f9-594f-47bd-8c9d-1717665646f8" />
    
    ---
    
    </details>
