### PR TITLE
Introduce the `useOidc` option in `publishPackages()` to support npm Trusted Publishing

### DIFF
--- a/.changelog/20260713130919_ci_4618_support_oidc_in_publish_packages.md
+++ b/.changelog/20260713130919_ci_4618_support_oidc_in_publish_packages.md
@@ -1,0 +1,7 @@
+---
+type: Feature
+scope:
+  - ckeditor5-dev-release-tools
+---
+
+Introduced the `useOidc` option in the `publishPackages()` task to support npm Trusted Publishing. When enabled, the task no longer verifies the npm account with `npm whoami` and the `npmOwner` option is not required. Instead, the task verifies that the `NPM_ID_TOKEN` environment variable is set, as npm exchanges the OIDC token only during supported operations, such as `npm publish`.

--- a/packages/ckeditor5-dev-release-tools/lib/tasks/publishpackages.js
+++ b/packages/ckeditor5-dev-release-tools/lib/tasks/publishpackages.js
@@ -19,7 +19,9 @@ import { workspaces, npm } from '@ckeditor/ckeditor5-dev-utils';
  *
  * The validation contains the following steps:
  *
- * - A user (a CLI session) must be logged to npm on the specified account (`npmOwner`).
+ * - A user (a CLI session) must be logged to npm on the specified account (`npmOwner`). When publishing via npm Trusted Publishing
+ *   (`useOidc`), this check is replaced by verifying that the `NPM_ID_TOKEN` environment variable is set, as `npm whoami` does not
+ *   reflect OIDC authentication.
  * - A package directory must contain `package.json` file.
  * - All files defined in the `optionalEntryPointPackages` option must exist in a package directory.
  * - An npm tag (dist-tag) must match the tag calculated from the package version.
@@ -33,7 +35,10 @@ import { workspaces, npm } from '@ckeditor/ckeditor5-dev-utils';
  *
  * @param {object} options
  * @param {string} options.packagesDirectory Relative path to a location of packages to release.
- * @param {string} options.npmOwner The account name on npm, which should be used to publish the packages.
+ * @param {string} [options.npmOwner] The account name on npm, which should be used to publish the packages.
+ * Required unless `useOidc` is enabled.
+ * @param {boolean} [options.useOidc=false] Whether to publish packages using npm Trusted Publishing (OIDC). When enabled,
+ * the `npm whoami` authorization check is skipped and the `NPM_ID_TOKEN` environment variable must be set instead.
  * @param {ListrTaskObject} [options.listrTask] An instance of `ListrTask`.
  * @param {AbortSignal|null} [options.signal=null] Signal to abort the asynchronous process.
  * @param {string} [options.npmTag='staging'] The npm distribution tag.
@@ -57,6 +62,7 @@ export default async function publishPackages( options ) {
 	const {
 		packagesDirectory,
 		npmOwner,
+		useOidc = false,
 		listrTask,
 		signal = null,
 		npmTag = 'staging',
@@ -70,7 +76,15 @@ export default async function publishPackages( options ) {
 		attempts = 5
 	} = options;
 
-	await assertNpmAuthorization( npmOwner );
+	if ( useOidc ) {
+		// npm exchanges the OIDC token only during supported operations, such as `npm publish`, and `npm whoami`
+		// does not reflect Trusted Publishing authentication. Hence, only the token presence can be verified upfront.
+		if ( !process.env.NPM_ID_TOKEN ) {
+			throw new Error( 'The "NPM_ID_TOKEN" environment variable is required when publishing using npm Trusted Publishing (OIDC).' );
+		}
+	} else {
+		await assertNpmAuthorization( npmOwner );
+	}
 
 	// Find packages that would be published...
 	const packagePaths = await workspaces.findPathsToPackages( cwd, packagesDirectory );

--- a/packages/ckeditor5-dev-release-tools/tests/tasks/publishpackages.js
+++ b/packages/ckeditor5-dev-release-tools/tests/tasks/publishpackages.js
@@ -118,6 +118,65 @@ describe( 'publishPackages()', () => {
 			expect( vi.mocked( assertNpmAuthorization ) ).toHaveBeenCalledExactlyOnceWith( 'fake-pepe' );
 		} );
 
+		it( 'should not verify npm authorization when publishing using OIDC (`useOidc=true`)', async () => {
+			vi.stubEnv( 'NPM_ID_TOKEN', 'oidc-token' );
+
+			const promise = publishPackages( {
+				packagesDirectory: 'packages',
+				useOidc: true,
+				listrTask: {}
+			} );
+
+			await vi.advanceTimersToNextTimerAsync();
+			await promise;
+
+			expect( vi.mocked( assertNpmAuthorization ) ).not.toHaveBeenCalled();
+			expect( vi.mocked( executeInParallel ) ).toHaveBeenCalledOnce();
+		} );
+
+		it( 'should throw when publishing using OIDC while the "NPM_ID_TOKEN" environment variable is not set', async () => {
+			vi.stubEnv( 'NPM_ID_TOKEN', undefined );
+
+			await expect( publishPackages( {
+				packagesDirectory: 'packages',
+				useOidc: true,
+				listrTask: {}
+			} ) ).rejects.toThrow(
+				'The "NPM_ID_TOKEN" environment variable is required when publishing using npm Trusted Publishing (OIDC).'
+			);
+
+			expect( vi.mocked( assertNpmAuthorization ) ).not.toHaveBeenCalled();
+			expect( vi.mocked( executeInParallel ) ).not.toHaveBeenCalled();
+		} );
+
+		it( 'should throw when publishing using OIDC while the "NPM_ID_TOKEN" environment variable is empty', async () => {
+			vi.stubEnv( 'NPM_ID_TOKEN', '' );
+
+			await expect( publishPackages( {
+				packagesDirectory: 'packages',
+				useOidc: true,
+				listrTask: {}
+			} ) ).rejects.toThrow(
+				'The "NPM_ID_TOKEN" environment variable is required when publishing using npm Trusted Publishing (OIDC).'
+			);
+
+			expect( vi.mocked( assertNpmAuthorization ) ).not.toHaveBeenCalled();
+			expect( vi.mocked( executeInParallel ) ).not.toHaveBeenCalled();
+		} );
+
+		it( 'should verify npm authorization when the `useOidc` option is disabled explicitly', async () => {
+			vi.mocked( workspaces.findPathsToPackages ).mockReset().mockResolvedValue( [] );
+
+			await publishPackages( {
+				packagesDirectory: 'packages',
+				npmOwner: 'pepe',
+				useOidc: false,
+				listrTask: {}
+			} );
+
+			expect( vi.mocked( assertNpmAuthorization ) ).toHaveBeenCalledExactlyOnceWith( 'pepe' );
+		} );
+
 		it( 'should assert that each found directory is a package', async () => {
 			const promise = publishPackages( {
 				packagesDirectory: 'packages',


### PR DESCRIPTION
### 🚀 Summary

Introduced the `useOidc` option in the `publishPackages()` task. When enabled, the task skips the `npm whoami` authorization check (which does not reflect OIDC authentication) and the `npmOwner` option is no longer required. Instead, the task verifies that the `NPM_ID_TOKEN` environment variable is set, failing fast with a clear error when it is missing.

---

### 📌 Related issues

* Closes https://github.com/ckeditor/ckeditor5-internal/issues/4618

---

### 💡 Additional information

* The OIDC support is an explicit opt-in (`useOidc: true`) rather than implicit detection of `NPM_ID_TOKEN`, so login-based flows keep their current behavior even if the variable happens to be present.
* `assertNpmAuthorization()` itself is untouched, so `reassignNpmTags()` still requires a regular npm login — OIDC does not authorize `npm dist-tag` operations.
* Follow-ups outside this PR: publish the updated package, pass `useOidc: true` in the Mrgit release configuration, and retry the v5.0.0 release.