### PR TITLE
Support triggering CircleCI GitHub App pipeline definitions in the trigger-circle-build script (master-v54)

### DIFF
--- a/.changelog/20260713112818_support_circleci_pipeline_definitions.md
+++ b/.changelog/20260713112818_support_circleci_pipeline_definitions.md
@@ -1,0 +1,7 @@
+---
+type: Feature
+scope:
+  - ckeditor5-dev-ci
+---
+
+Added support for triggering a specific CircleCI GitHub App pipeline definition using the `--pipeline-definition-id` option of the `ckeditor5-dev-ci-trigger-circle-build` command.

--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -167,7 +167,7 @@ jobs:
           command: pnpm ckeditor5-dev-ci-circle-disable-auto-cancel-builds --organization ckeditor --repository ckeditor5-dev
       - run:
           name: Trigger the release pipeline
-          command: pnpm ckeditor5-dev-ci-trigger-circle-build --slug ckeditor/ckeditor5-dev --release-branch master-v54
+          command: pnpm ckeditor5-dev-ci-trigger-circle-build --slug ckeditor/ckeditor5-dev --release-branch master-v54 --pipeline-definition-id 73d66b9b-677a-4100-bf5a-138833dbc4d5
       - run:
           name: Enable the redundant workflows option
           command: pnpm ckeditor5-dev-ci-circle-enable-auto-cancel-builds --organization ckeditor --repository ckeditor5-dev

--- a/packages/ckeditor5-dev-ci/README.md
+++ b/packages/ckeditor5-dev-ci/README.md
@@ -153,6 +153,8 @@ These commands accept a mix of environment variables and command line arguments.
   - `--trigger-repository-slug` &mdash; *(Optional)* Repository slug (`org/name`) that triggered the new pipeline.
     Can be omitted if it matches `--slug`.
   - `--release-branch` &mdash; *(Optional)* Branch that leads the release process.
+  - `--pipeline-definition-id` &mdash; *(Optional)* GitHub App pipeline definition ID. When provided, the specified pipeline
+    definition is triggered instead of the project's default OAuth pipeline.
 
 - ⚙️ **`ckeditor5-dev-ci-trigger-snyk-scan`**
 

--- a/packages/ckeditor5-dev-ci/bin/trigger-circle-build.js
+++ b/packages/ckeditor5-dev-ci/bin/trigger-circle-build.js
@@ -20,6 +20,7 @@ import triggerCircleBuild from '../lib/trigger-circle-build.js';
  *   - `--trigger-repository-slug` - (optional) a repository slug (org/name) that triggers a new pipeline.
  *     Can be skipped when overlaps with `--slug`.
  *   - `--release-branch` - (optional) define a branch that leads the release process.
+ *   - `--pipeline-definition-id` - (optional) define a GitHub App pipeline to trigger.
  *
  * Example usage:
  * CKE5_CIRCLE_TOKEN=... ckeditor5-dev-ci-trigger-circle-build
@@ -38,6 +39,9 @@ const { values: cliOptions } = parseArgs( {
 		'release-branch': {
 			type: 'string',
 			default: process.env.CKE5_GITHUB_RELEASE_BRANCH
+		},
+		'pipeline-definition-id': {
+			type: 'string'
 		}
 	}
 } );
@@ -46,6 +50,7 @@ const options = {
 	circleToken: process.env.CKE5_CIRCLE_TOKEN,
 	commit: process.env.CIRCLE_SHA1,
 	branch: process.env.CIRCLE_BRANCH,
+	pipelineDefinitionId: cliOptions[ 'pipeline-definition-id' ],
 	releaseBranch: cliOptions[ 'release-branch' ],
 	repositorySlug: cliOptions.slug
 };

--- a/packages/ckeditor5-dev-ci/lib/trigger-circle-build.js
+++ b/packages/ckeditor5-dev-ci/lib/trigger-circle-build.js
@@ -9,6 +9,7 @@
  * @param {string} options.commit
  * @param {string} options.branch
  * @param {string} options.repositorySlug A repository slug (org/name) where a new build will be started.
+ * @param {string|null} [options.pipelineDefinitionId=null] A pipeline definition to trigger.
  * @param {string|null} [options.releaseBranch=null] Define a branch that leads the release process.
  * @param {string|null} [options.triggerRepositorySlug=null] A repository slug (org/name) that triggers a new build.
  * @returns {Promise}
@@ -19,11 +20,15 @@ export default async function triggerCircleBuild( options ) {
 		commit,
 		branch,
 		repositorySlug,
+		pipelineDefinitionId = null,
 		releaseBranch = null,
 		triggerRepositorySlug = null
 	} = options;
 
-	const requestUrl = `https://circleci.com/api/v2/project/github/${ repositorySlug }/pipeline`;
+	// The new (GitHub App) endpoint accepts only the `gh` provider prefix, while the legacy one supports both.
+	const requestUrl = pipelineDefinitionId ?
+		`https://circleci.com/api/v2/project/gh/${ repositorySlug }/pipeline/run` :
+		`https://circleci.com/api/v2/project/github/${ repositorySlug }/pipeline`;
 
 	const parameters = {
 		triggerCommitHash: commit
@@ -37,6 +42,13 @@ export default async function triggerCircleBuild( options ) {
 		parameters.triggerRepositorySlug = triggerRepositorySlug;
 	}
 
+	const requestBody = pipelineDefinitionId ? {
+		definition_id: pipelineDefinitionId,
+		config: { branch },
+		checkout: { branch },
+		parameters
+	} : { branch, parameters };
+
 	const requestOptions = {
 		method: 'POST',
 		headers: {
@@ -44,7 +56,7 @@ export default async function triggerCircleBuild( options ) {
 			'Accept': 'application/json',
 			'Circle-Token': circleToken
 		},
-		body: JSON.stringify( { branch, parameters } )
+		body: JSON.stringify( requestBody )
 	};
 
 	return fetch( requestUrl, requestOptions )

--- a/packages/ckeditor5-dev-ci/tests/trigger-circle-build.js
+++ b/packages/ckeditor5-dev-ci/tests/trigger-circle-build.js
@@ -48,6 +48,49 @@ describe( 'lib/triggerCircleBuild', () => {
 		);
 	} );
 
+	it( 'should trigger a specified pipeline definition', async () => {
+		vi.mocked( fetchMock ).mockResolvedValue( {
+			json: () => Promise.resolve( {
+				error_message: null
+			} )
+		} );
+
+		await triggerCircleBuild( {
+			circleToken: 'circle-token',
+			commit: 'abcd1234',
+			branch: 'master',
+			repositorySlug: 'ckeditor/ckeditor5-dev',
+			pipelineDefinitionId: 'pipeline-definition-id',
+			releaseBranch: 'master'
+		} );
+
+		expect( vi.mocked( fetchMock ) ).toHaveBeenCalledTimes( 1 );
+		expect( vi.mocked( fetchMock ) ).toHaveBeenCalledWith(
+			'https://circleci.com/api/v2/project/gh/ckeditor/ckeditor5-dev/pipeline/run',
+			{
+				method: 'POST',
+				headers: {
+					Accept: 'application/json',
+					'Circle-Token': 'circle-token',
+					'Content-Type': 'application/json'
+				},
+				body: JSON.stringify( {
+					definition_id: 'pipeline-definition-id',
+					config: {
+						branch: 'master'
+					},
+					checkout: {
+						branch: 'master'
+					},
+					parameters: {
+						triggerCommitHash: 'abcd1234',
+						isRelease: true
+					}
+				} )
+			}
+		);
+	} );
+
 	it( 'should include the "isRelease=true" parameter when passing the `releaseBranch` option (the same release branch)', async () => {
 		vi.mocked( fetchMock ).mockResolvedValue( {
 			json: () => Promise.resolve( {


### PR DESCRIPTION
### 🚀 Summary

Port of #1423 to the `master-v54` LTS line. Added support for triggering a specific CircleCI GitHub App pipeline definition using the new, optional `--pipeline-definition-id` option of the `ckeditor5-dev-ci-trigger-circle-build` command. When the option is provided, the script calls the `POST /project/gh/{slug}/pipeline/run` endpoint with the given `definition_id` instead of the project's default OAuth pipeline. The release flow in `.circleci/template.yml` now uses the option when triggering the release pipeline.

---

### 📌 Related issues

* See #1423.

---

### 💡 Additional information

* One conflict in `.circleci/template.yml`: the release trigger command on this line uses `--release-branch master-v54`. Resolved by keeping `--release-branch master-v54` and adding `--pipeline-definition-id 73d66b9b-677a-4100-bf5a-138833dbc4d5` (the pipeline definition is project-level, the same as on `master` — please double-check this is the intended definition for the LTS release flow).
* `tests/trigger-circle-build.js` passes on this branch (7/7).