### PR TITLE
Limit manual test reloads to affected clients

### DIFF
--- a/.changelog/20260715133303_cc_11045_limit_manual_test_reloads.md
+++ b/.changelog/20260715133303_cc_11045_limit_manual_test_reloads.md
@@ -1,0 +1,7 @@
+---
+type: Fix
+scope:
+  - ckeditor5-dev-manual-server
+---
+
+Fixed the manual test server to reload only affected pages after HTML or CSS changes.

--- a/packages/ckeditor5-dev-manual-server/src/refresh-plugin/plugin.ts
+++ b/packages/ckeditor5-dev-manual-server/src/refresh-plugin/plugin.ts
@@ -168,6 +168,10 @@ function ensureLatestBuildOutput( bundledDev: BundledDevInternals ): void {
 }
 
 function sendManualRefreshPayload( payload: HotPayload, send: ( payload: HotPayload ) => void ): void {
+	if ( payload.type == 'update' && !payload.updates.length ) {
+		return;
+	}
+
 	if ( shouldShowManualRefreshPrompt( payload ) ) {
 		send( {
 			type: 'custom',

--- a/packages/ckeditor5-dev-manual-server/src/refresh-plugin/plugin.ts
+++ b/packages/ckeditor5-dev-manual-server/src/refresh-plugin/plugin.ts
@@ -114,22 +114,23 @@ function wrapBundledDevFullReloads( bundledDev: BundledDevInternals, workspaceRo
 	const handleHmrOutput = bundledDev.handleHmrOutput.bind( bundledDev );
 
 	bundledDev.handleHmrOutput = ( client, files, hmrOutput, invalidateInformation ) => {
-		if ( hmrOutput.type == 'FullReload' ) {
-			if ( shouldShowManualRefreshPromptForFiles( files ) ) {
-				ensureLatestBuildOutput( bundledDev );
+		if ( hmrOutput.type != 'FullReload' ) {
+			return handleHmrOutput( client, files, hmrOutput, invalidateInformation );
+		}
 
-				client.send( {
-					type: 'custom',
-					event: MANUAL_REFRESH_EVENT_NAME
-				} );
-			} else {
-				reloadClientAfterLatestBuildOutput( bundledDev, client, files, workspaceRoot );
-			}
+		if ( !shouldShowManualRefreshPromptForFiles( files ) ) {
+			// Vite invokes this synchronous handler without awaiting its result.
+			reloadClientAfterLatestBuildOutput( bundledDev, client, files, workspaceRoot );
 
 			return;
 		}
 
-		return handleHmrOutput( client, files, hmrOutput, invalidateInformation );
+		ensureLatestBuildOutput( bundledDev );
+
+		client.send( {
+			type: 'custom',
+			event: MANUAL_REFRESH_EVENT_NAME
+		} );
 	};
 }
 

--- a/packages/ckeditor5-dev-manual-server/src/refresh-plugin/plugin.ts
+++ b/packages/ckeditor5-dev-manual-server/src/refresh-plugin/plugin.ts
@@ -26,7 +26,9 @@
 // Revisit this plugin (and delete the patches below) once Vite exposes HMR plugin
 // hooks for bundled dev.
 
+import { relative } from 'node:path';
 import type { Plugin, HotPayload } from 'vite';
+import { toPosixPath } from '../utils.js';
 
 export const MANUAL_REFRESH_EVENT_NAME = 'ckeditor5-manual:refresh-available';
 
@@ -78,7 +80,7 @@ export function refreshPlugin(): Plugin {
 			}
 
 			wrapBundledDevClientSend( bundledDev.clients );
-			wrapBundledDevFullReloads( bundledDev );
+			wrapBundledDevFullReloads( bundledDev, server.config.root );
 		}
 	};
 }
@@ -104,7 +106,7 @@ function wrapBundledDevClientSend( clients: BundledDevInternals[ 'clients' ] ): 
 	};
 }
 
-function wrapBundledDevFullReloads( bundledDev: BundledDevInternals ): void {
+function wrapBundledDevFullReloads( bundledDev: BundledDevInternals, workspaceRoot: string ): void {
 	if ( typeof bundledDev.handleHmrOutput != 'function' ) {
 		return;
 	}
@@ -112,19 +114,47 @@ function wrapBundledDevFullReloads( bundledDev: BundledDevInternals ): void {
 	const handleHmrOutput = bundledDev.handleHmrOutput.bind( bundledDev );
 
 	bundledDev.handleHmrOutput = ( client, files, hmrOutput, invalidateInformation ) => {
-		if ( hmrOutput.type == 'FullReload' && shouldShowManualRefreshPromptForFiles( files ) ) {
-			ensureLatestBuildOutput( bundledDev );
+		if ( hmrOutput.type == 'FullReload' ) {
+			if ( shouldShowManualRefreshPromptForFiles( files ) ) {
+				ensureLatestBuildOutput( bundledDev );
 
-			client.send( {
-				type: 'custom',
-				event: MANUAL_REFRESH_EVENT_NAME
-			} );
+				client.send( {
+					type: 'custom',
+					event: MANUAL_REFRESH_EVENT_NAME
+				} );
+			} else {
+				reloadClientAfterLatestBuildOutput( bundledDev, client, files, workspaceRoot );
+			}
 
 			return;
 		}
 
 		return handleHmrOutput( client, files, hmrOutput, invalidateInformation );
 	};
+}
+
+async function reloadClientAfterLatestBuildOutput(
+	bundledDev: BundledDevInternals,
+	client: BundledDevClient,
+	files: Array<string>,
+	workspaceRoot: string
+): Promise<void> {
+	try {
+		await bundledDev.devEngine?.ensureLatestBuildOutput();
+	} catch {
+		// Reload using the best output available instead of leaving the page stale.
+	}
+
+	client.send( {
+		type: 'full-reload',
+		path: getChangedHtmlPublicPath( files, workspaceRoot )
+	} );
+}
+
+function getChangedHtmlPublicPath( files: Array<string>, workspaceRoot: string ): string | undefined {
+	const htmlFile = files.find( file => file.endsWith( '.html' ) );
+
+	return htmlFile ? `/${ toPosixPath( relative( workspaceRoot, htmlFile ) ) }` : undefined;
 }
 
 function ensureLatestBuildOutput( bundledDev: BundledDevInternals ): void {

--- a/packages/ckeditor5-dev-manual-server/src/refresh-plugin/plugin.ts
+++ b/packages/ckeditor5-dev-manual-server/src/refresh-plugin/plugin.ts
@@ -26,9 +26,8 @@
 // Revisit this plugin (and delete the patches below) once Vite exposes HMR plugin
 // hooks for bundled dev.
 
-import { relative } from 'node:path';
 import type { Plugin, HotPayload } from 'vite';
-import { toPosixPath } from '../utils.js';
+import { toPublicFilePath } from '../utils.js';
 
 export const MANUAL_REFRESH_EVENT_NAME = 'ckeditor5-manual:refresh-available';
 
@@ -155,7 +154,7 @@ async function reloadClientAfterLatestBuildOutput(
 function getChangedHtmlPublicPath( files: Array<string>, workspaceRoot: string ): string | undefined {
 	const htmlFile = files.find( file => file.endsWith( '.html' ) );
 
-	return htmlFile ? `/${ toPosixPath( relative( workspaceRoot, htmlFile ) ) }` : undefined;
+	return htmlFile ? toPublicFilePath( htmlFile, workspaceRoot ) : undefined;
 }
 
 function ensureLatestBuildOutput( bundledDev: BundledDevInternals ): void {

--- a/packages/ckeditor5-dev-manual-server/tests/refresh-plugin/plugin.test.ts
+++ b/packages/ckeditor5-dev-manual-server/tests/refresh-plugin/plugin.test.ts
@@ -154,18 +154,64 @@ describe( 'refreshPlugin()', () => {
 		} ] );
 	} );
 
-	test( 'keeps bundled dev HTML full reloads', () => {
+	test( 'sends bundled dev HTML full reloads only to the affected client', async () => {
+		const clientPayloads: Array<HotPayload> = [];
+		const otherClientPayloads: Array<HotPayload> = [];
+		const handledFullReloads: Array<Array<string>> = [];
+		const server = createBundledDevServer( handledFullReloads );
+		const client = createBundledDevClient( clientPayloads );
+		const otherClient = createBundledDevClient( otherClientPayloads );
+
+		configureServer( server );
+		server.environments.client.bundledDev.clients.setupIfNeeded( client, 'client-1' );
+		server.environments.client.bundledDev.clients.setupIfNeeded( otherClient, 'client-2' );
+		server.environments.client.bundledDev.handleHmrOutput( client, [ '/workspace/article.html' ], { type: 'FullReload' } );
+		await vi.waitFor( () => expect( clientPayloads ).to.have.length( 1 ) );
+
+		expect( handledFullReloads ).to.deep.equal( [] );
+		expect( server.environments.client.bundledDev.devEngine.ensureLatestBuildOutput ).toHaveBeenCalledOnce();
+		expect( clientPayloads ).to.deep.equal( [ {
+			type: 'full-reload',
+			path: '/article.html'
+		} ] );
+		expect( otherClientPayloads ).to.deep.equal( [] );
+	} );
+
+	test( 'sends bundled dev CSS full reloads only to the affected client', async () => {
 		const clientPayloads: Array<HotPayload> = [];
 		const handledFullReloads: Array<Array<string>> = [];
 		const server = createBundledDevServer( handledFullReloads );
 		const client = createBundledDevClient( clientPayloads );
 
 		configureServer( server );
-		server.environments.client.bundledDev.handleHmrOutput( client, [ '/workspace/article.html' ], { type: 'FullReload' } );
+		server.environments.client.bundledDev.clients.setupIfNeeded( client, 'client-1' );
+		server.environments.client.bundledDev.handleHmrOutput( client, [ '/workspace/styles.css' ], { type: 'FullReload' } );
+		await vi.waitFor( () => expect( clientPayloads ).to.have.length( 1 ) );
 
-		expect( handledFullReloads ).to.deep.equal( [ [ '/workspace/article.html' ] ] );
-		expect( server.environments.client.bundledDev.devEngine.ensureLatestBuildOutput ).not.toHaveBeenCalled();
-		expect( clientPayloads ).to.deep.equal( [] );
+		expect( handledFullReloads ).to.deep.equal( [] );
+		expect( server.environments.client.bundledDev.devEngine.ensureLatestBuildOutput ).toHaveBeenCalledOnce();
+		expect( clientPayloads ).to.deep.equal( [ {
+			type: 'full-reload',
+			path: undefined
+		} ] );
+	} );
+
+	test( 'reloads the affected client when refreshing the build output fails', async () => {
+		const clientPayloads: Array<HotPayload> = [];
+		const server = createBundledDevServer();
+		const client = createBundledDevClient( clientPayloads );
+
+		server.environments.client.bundledDev.devEngine.ensureLatestBuildOutput =
+			vi.fn().mockRejectedValue( new Error( 'build output unavailable' ) );
+
+		configureServer( server );
+		server.environments.client.bundledDev.handleHmrOutput( client, [ '/workspace/article.html' ], { type: 'FullReload' } );
+		await vi.waitFor( () => expect( clientPayloads ).to.have.length( 1 ) );
+
+		expect( clientPayloads ).to.deep.equal( [ {
+			type: 'full-reload',
+			path: '/article.html'
+		} ] );
 	} );
 
 	test( 'does not crash when the bundled dev helper is unavailable', () => {
@@ -196,6 +242,9 @@ describe( 'refreshPlugin()', () => {
 	// exposed as `server.environments.client.bundledDev`.
 	function createBundledDevServer( handledFullReloads: Array<Array<string>> = [] ) {
 		return {
+			config: {
+				root: '/workspace'
+			},
 			environments: {
 				client: {
 					bundledDev: {

--- a/packages/ckeditor5-dev-manual-server/tests/refresh-plugin/plugin.test.ts
+++ b/packages/ckeditor5-dev-manual-server/tests/refresh-plugin/plugin.test.ts
@@ -214,6 +214,34 @@ describe( 'refreshPlugin()', () => {
 		} ] );
 	} );
 
+	test( 'keeps bundled dev output other than full reloads', () => {
+		const server = createBundledDevServer();
+		const client = createBundledDevClient( [] );
+		const handleHmrOutput = server.environments.client.bundledDev.handleHmrOutput;
+		const hmrOutput = { type: 'Patch' };
+		const invalidateInformation = {};
+
+		configureServer( server );
+		( server.environments.client.bundledDev.handleHmrOutput as (
+			client: unknown,
+			files: Array<string>,
+			hmrOutput: unknown,
+			invalidateInformation?: unknown
+		) => void )(
+			client,
+			[ '/workspace/article.css' ],
+			hmrOutput,
+			invalidateInformation
+		);
+
+		expect( handleHmrOutput ).toHaveBeenCalledExactlyOnceWith(
+			client,
+			[ '/workspace/article.css' ],
+			hmrOutput,
+			invalidateInformation
+		);
+	} );
+
 	test( 'does not crash when the bundled dev helper is unavailable', () => {
 		const server = createBundledDevServer();
 

--- a/packages/ckeditor5-dev-manual-server/tests/refresh-plugin/plugin.test.ts
+++ b/packages/ckeditor5-dev-manual-server/tests/refresh-plugin/plugin.test.ts
@@ -81,6 +81,21 @@ describe( 'refreshPlugin()', () => {
 		expect( clientPayloads ).to.deep.equal( [ payload ] );
 	} );
 
+	test( 'drops bundled dev empty HMR updates sent to clients unaffected by a change', () => {
+		const clientPayloads: Array<HotPayload> = [];
+		const server = createBundledDevServer();
+		const client = createBundledDevClient( clientPayloads );
+
+		configureServer( server );
+		server.environments.client.bundledDev.clients.setupIfNeeded( client, 'client-1' );
+		client.send( {
+			type: 'update',
+			updates: []
+		} );
+
+		expect( clientPayloads ).to.deep.equal( [] );
+	} );
+
 	test( 'keeps non-update payloads sent directly to clients', () => {
 		const clientPayloads: Array<HotPayload> = [];
 		const server = createBundledDevServer();


### PR DESCRIPTION
### 🚀 Summary

Scopes Vite bundled-dev HTML and CSS full reloads to the affected manual-test client instead of delegating them to the environment-wide reload path. JavaScript changes continue to use the existing manual refresh prompt.

---

### 📌 Related issues

* Closes https://github.com/ckeditor/ckeditor5-commercial/issues/11045

---

### 💡 Additional information

The plugin waits for the latest bundled output before reloading and falls back to the best available output if refreshing fails. Regression coverage verifies HTML client isolation, CSS full reloads, and build-output failures.
