### PR TITLE
Export the formatMessage() helper from the ckeditor5-dev-ci package

### DIFF
--- a/.changelog/20260716112728_export_format_message.md
+++ b/.changelog/20260716112728_export_format_message.md
@@ -1,0 +1,7 @@
+---
+type: Feature
+scope:
+  - ckeditor5-dev-ci
+---
+
+Exported the `formatMessage()` helper from the package index. It builds the Slack notification payload for a failed CI build and can now be used by other tools, not only by the `ckeditor5-dev-ci-notify-circle-status` command.

--- a/packages/ckeditor5-dev-ci/lib/index.js
+++ b/packages/ckeditor5-dev-ci/lib/index.js
@@ -3,5 +3,6 @@
  * For licensing, see LICENSE.md.
  */
 
+export { default as formatMessage } from './format-message.js';
 export { default as getJobApprover } from './utils/get-job-approver.js';
 export { members } from './data/index.js';


### PR DESCRIPTION
## What is this?

This PR adds `formatMessage()` to the public exports of the `@ckeditor/ckeditor5-dev-ci` package.

The function builds the Slack notification payload for a failed CI build. Until now, only the `ckeditor5-dev-ci-notify-circle-status` command used it.

## Why?

DevHub will start sending CircleCI failure notifications itself, based on CircleCI webhooks. This will let us remove the `notify_ci_failure` polling jobs from CI workflows. DevHub needs to import `formatMessage()` to keep the Slack messages identical to the current ones.

See cksource/ckeditor5-devhub#419 for the full plan.

## Notes

- No behavior change. It is only a re-export.
- Tests for the package pass (87 tests).