### PR TITLE
Remove the notify_ci_failure job from the CircleCI configuration

### DIFF
--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -68,33 +68,6 @@ commands:
             git config --global tag.gpgSign true
 
 jobs:
-  notify_ci_failure:
-    docker:
-      - image: cimg/node:24.11.0
-    resource_class: small
-    parameters:
-      hideAuthor:
-        type: string
-        default: "false"
-    steps:
-      - checkout
-      - bootstrap_repository_command
-      - run:
-          # In the PRs that comes from forked repositories, we do not share secret variables.
-          # Hence, some of the scripts will not be executed.
-          name: 👤 Verify if the build was triggered by community - Check if the build should continue
-          command: |
-            #!/bin/bash
-
-            if [[ -z ${CODECOV_TOKEN} ]];
-            then
-              circleci-agent step halt
-            fi
-      - run:
-          name: Waiting for other jobs to finish and sending notification on failure
-          command: pnpm ckeditor5-dev-ci-circle-workflow-notifier --task "pnpm ckeditor5-dev-ci-notify-circle-status --pipeline-id << pipeline.number >> --hide-author << parameters.hideAuthor >>"
-          no_output_timeout: 1h
-
   validate_and_tests:
     docker:
       - image: cimg/node:24.11.0
@@ -265,11 +238,6 @@ workflows:
             branches:
               only:
                 - master-v54
-      - notify_ci_failure:
-          filters:
-            branches:
-              only:
-                - master-v54
 
   release:
     when:
@@ -290,9 +258,3 @@ workflows:
         - equal: [ false, << pipeline.parameters.isRelease >> ]
     jobs:
       - validate_and_tests
-      - notify_ci_failure:
-          hideAuthor: "true"
-          filters:
-            branches:
-              only:
-                - master-v54


### PR DESCRIPTION
### 🚀 Summary

CI failure notifications for this repository are now sent by DevHub. DevHub listens to the CircleCI `workflow-completed` webhook and posts the failure message to Slack. The `notify_ci_failure` job that polled the workflow status is no longer needed, so this PR removes it from the CircleCI configuration.

This PR is internal-only (CI configuration), so it does not add a changelog entry.

---

### 📌 Related issues

* See https://github.com/cksource/ckeditor5-devhub/issues/424.

---

### 💡 Additional information

Only the `.circleci/template.yml` file changes. The job definition and its two workflow usages (in the `main` and `nightly` workflows) are removed. The `packages/ckeditor5-dev-ci` source code is not touched.
