### PR TITLE
Fix manual test pages missing package theme styles and the test header covering sticky editor UI

### DIFF
--- a/.changelog/20260729125700_cc_11139_fix_manual_test_server_issues.md
+++ b/.changelog/20260729125700_cc_11139_fix_manual_test_server_issues.md
@@ -6,4 +6,4 @@ scope:
 
 Manual tests now load the package theme stylesheets from `theme/index-editor.css` and `theme/index-content.css` instead of the removed `theme/index.css`, restoring package styles on manual test pages.
 
-The manual test header no longer covers sticky toolbars, menu bars, and balloons when the page is scrolled. Editors assigned to `window.editor` receive a viewport offset matching the header height.
+The manual test header no longer covers sticky toolbars, menu bars, and balloons when the page is scrolled. The header bar now stays in the normal document flow instead of being fixed to the viewport.

--- a/.changelog/20260729125700_cc_11139_fix_manual_test_server_issues.md
+++ b/.changelog/20260729125700_cc_11139_fix_manual_test_server_issues.md
@@ -1,0 +1,9 @@
+---
+type: Fix
+scope:
+  - ckeditor5-dev-manual-server
+---
+
+Manual tests now load the package theme stylesheets from `theme/index-editor.css` and `theme/index-content.css` instead of the removed `theme/index.css`, restoring package styles on manual test pages.
+
+The manual test header no longer covers sticky toolbars, menu bars, and balloons when the page is scrolled. Editors assigned to `window.editor` receive a viewport offset matching the header height.

--- a/packages/ckeditor5-dev-manual-server/src/manual-test-plugin/plugin.ts
+++ b/packages/ckeditor5-dev-manual-server/src/manual-test-plugin/plugin.ts
@@ -27,7 +27,7 @@ export interface ManualTestsPluginOptions {
 const MANUAL_HEADER_ELEMENT = 'ck-manual-header';
 const MANUAL_TEST_SUFFIX = '.manual.html';
 const MANUAL_TESTS_DIRECTORY = '/manual/';
-const THEME_ENTRY_FILE_PATH = 'theme/index.css';
+const THEME_ENTRY_FILE_PATHS = [ 'theme/index-editor.css', 'theme/index-content.css' ];
 const HEAD_CLOSE_TAG = '</head>';
 const MANUAL_ENTRIES_VIRTUAL_ID = 'virtual:ckeditor5-manual-entries';
 const MANUAL_THEME_ROOT = realpathSync( fileURLToPath( import.meta.resolve( '@ckeditor/ckeditor5-dev-manual-server/theme' ) ) );
@@ -53,12 +53,14 @@ export function manualTestsPlugin( options: ManualTestsPluginOptions ): Plugin {
 
 		return htmlSpecifier == scriptSpecifier ? undefined : getManualPages().get( htmlSpecifier );
 	};
-	const packageThemeEntryCache = new Map<string, boolean>();
-	const hasPackageThemeEntry = ( packageRootSpecifier: string ): boolean => {
+	const packageThemeEntryCache = new Map<string, Array<string>>();
+	const getPackageThemeEntries = ( packageRootSpecifier: string ): Array<string> => {
 		if ( !packageThemeEntryCache.has( packageRootSpecifier ) ) {
-			const themeEntryFilePath = resolve( workspaceRoot, stripLeadingSlash( packageRootSpecifier ), THEME_ENTRY_FILE_PATH );
+			const themeEntries = THEME_ENTRY_FILE_PATHS.filter( themeEntryFilePath =>
+				existsSync( resolve( workspaceRoot, stripLeadingSlash( packageRootSpecifier ), themeEntryFilePath ) )
+			);
 
-			packageThemeEntryCache.set( packageRootSpecifier, existsSync( themeEntryFilePath ) );
+			packageThemeEntryCache.set( packageRootSpecifier, themeEntries );
 		}
 
 		return packageThemeEntryCache.get( packageRootSpecifier )!;
@@ -142,7 +144,8 @@ export function manualTestsPlugin( options: ManualTestsPluginOptions ): Plugin {
 		transform: {
 			order: 'pre',
 
-			// Loads the package theme entry stylesheet (`theme/index.css`) in manual tests.
+			// Loads the package theme entry stylesheets (`theme/index-editor.css` and
+			// `theme/index-content.css`) in manual tests.
 			// Package stylesheets are imported by the package entry module (`src/index.ts`), not by
 			// individual source modules, and manual tests import source modules directly - without
 			// this they would render without the package's own styles. Stylesheets of other packages
@@ -162,18 +165,23 @@ export function manualTestsPlugin( options: ManualTestsPluginOptions ): Plugin {
 				}
 
 				const packageRootSpecifier = entry.htmlFilePath.slice( 0, entry.htmlFilePath.indexOf( MANUAL_TESTS_DIRECTORY ) );
+				const themeEntries = getPackageThemeEntries( packageRootSpecifier );
 
-				if ( !hasPackageThemeEntry( packageRootSpecifier ) ) {
+				if ( !themeEntries.length ) {
 					return;
 				}
 
-				const themeEntrySpecifier = posix.relative(
-					posix.dirname( scriptSpecifier ),
-					`${ packageRootSpecifier }/${ THEME_ENTRY_FILE_PATH }`
-				);
+				const themeEntryImports = themeEntries.map( themeEntryFilePath => {
+					const themeEntrySpecifier = posix.relative(
+						posix.dirname( scriptSpecifier ),
+						`${ packageRootSpecifier }/${ themeEntryFilePath }`
+					);
+
+					return `import '${ themeEntrySpecifier }';`;
+				} );
 
 				return {
-					code: `${ code }\nimport '${ themeEntrySpecifier }';\n`,
+					code: `${ code }\n${ themeEntryImports.join( '\n' ) }\n`,
 					map: null
 				};
 			}

--- a/packages/ckeditor5-dev-manual-server/tests/manual-test-plugin/plugin.test.ts
+++ b/packages/ckeditor5-dev-manual-server/tests/manual-test-plugin/plugin.test.ts
@@ -248,11 +248,12 @@ describe( 'manualTestsPlugin()', () => {
 		expect( result.tags[ 0 ]!.injectTo ).to.equal( 'head-prepend' );
 	} );
 
-	test( 'appends the package theme entry import to manual test entry scripts', async () => {
+	test( 'appends the package theme entry imports to manual test entry scripts', async () => {
 		await Promise.all( [
 			createFile( workspaceRoot, 'packages/ckeditor5-foo/manual/foo.manual.html' ),
 			createFile( workspaceRoot, 'packages/ckeditor5-foo/manual/foo.js', 'console.log( 1 );\n' ),
-			createFile( workspaceRoot, 'packages/ckeditor5-foo/theme/index.css' )
+			createFile( workspaceRoot, 'packages/ckeditor5-foo/theme/index-editor.css' ),
+			createFile( workspaceRoot, 'packages/ckeditor5-foo/theme/index-content.css' )
 		] );
 
 		const transform = createConfiguredTransformHook( { paths: [ 'packages/*' ] } );
@@ -260,46 +261,65 @@ describe( 'manualTestsPlugin()', () => {
 		const result = transform.handler( 'console.log( 1 );\n', scriptFilePath );
 
 		expect( transform.order ).to.equal( 'pre' );
-		expect( result!.code ).to.equal( 'console.log( 1 );\n\nimport \'../theme/index.css\';\n' );
+		expect( result!.code ).to.equal(
+			'console.log( 1 );\n\nimport \'../theme/index-editor.css\';\nimport \'../theme/index-content.css\';\n'
+		);
 		expect( result!.map ).to.equal( null );
 	} );
 
-	test( 'appends the theme entry import to nested and TypeScript manual test entry scripts', async () => {
+	test( 'appends only the theme entry stylesheets that exist in the package', async () => {
+		await Promise.all( [
+			createFile( workspaceRoot, 'packages/ckeditor5-foo/manual/foo.manual.html' ),
+			createFile( workspaceRoot, 'packages/ckeditor5-foo/manual/foo.js', 'console.log( 1 );\n' ),
+			createFile( workspaceRoot, 'packages/ckeditor5-foo/theme/index-editor.css' )
+		] );
+
+		const transform = createConfiguredTransformHook( { paths: [ 'packages/*' ] } );
+		const scriptFilePath = join( workspaceRoot, 'packages/ckeditor5-foo/manual/foo.js' );
+		const result = transform.handler( 'console.log( 1 );\n', scriptFilePath );
+
+		expect( result!.code ).to.contain( 'import \'../theme/index-editor.css\';' );
+		expect( result!.code ).to.not.contain( 'index-content.css' );
+	} );
+
+	test( 'appends the theme entry imports to nested and TypeScript manual test entry scripts', async () => {
 		await Promise.all( [
 			createFile( workspaceRoot, 'packages/ckeditor5-foo/manual/nested/bar.manual.html' ),
 			createFile( workspaceRoot, 'packages/ckeditor5-foo/manual/nested/bar.ts', 'console.log( 1 );\n' ),
-			createFile( workspaceRoot, 'packages/ckeditor5-foo/theme/index.css' )
+			createFile( workspaceRoot, 'packages/ckeditor5-foo/theme/index-editor.css' ),
+			createFile( workspaceRoot, 'packages/ckeditor5-foo/theme/index-content.css' )
 		] );
 
 		const transform = createConfiguredTransformHook( { paths: [ 'packages/*' ] } );
 		const scriptFilePath = join( workspaceRoot, 'packages/ckeditor5-foo/manual/nested/bar.ts' );
 		const result = transform.handler( 'console.log( 1 );\n', scriptFilePath );
 
-		expect( result!.code ).to.contain( 'import \'../../theme/index.css\';' );
+		expect( result!.code ).to.contain( 'import \'../../theme/index-editor.css\';' );
+		expect( result!.code ).to.contain( 'import \'../../theme/index-content.css\';' );
 	} );
 
 	test( 'ignores the query string when matching transformed manual test scripts', async () => {
 		await Promise.all( [
 			createFile( workspaceRoot, 'packages/ckeditor5-foo/manual/foo.manual.html' ),
 			createFile( workspaceRoot, 'packages/ckeditor5-foo/manual/foo.js', 'console.log( 1 );\n' ),
-			createFile( workspaceRoot, 'packages/ckeditor5-foo/theme/index.css' )
+			createFile( workspaceRoot, 'packages/ckeditor5-foo/theme/index-editor.css' )
 		] );
 
 		const transform = createConfiguredTransformHook( { paths: [ 'packages/*' ] } );
 		const scriptFilePath = join( workspaceRoot, 'packages/ckeditor5-foo/manual/foo.js' );
 		const result = transform.handler( 'console.log( 1 );\n', `${ scriptFilePath }?v=123` );
 
-		expect( result!.code ).to.contain( 'import \'../theme/index.css\';' );
+		expect( result!.code ).to.contain( 'import \'../theme/index-editor.css\';' );
 	} );
 
 	test( 'does not transform non-script modules', async () => {
 		await Promise.all( [
 			createFile( workspaceRoot, 'packages/ckeditor5-foo/manual/foo.manual.html' ),
-			createFile( workspaceRoot, 'packages/ckeditor5-foo/theme/index.css', '.ck {}' )
+			createFile( workspaceRoot, 'packages/ckeditor5-foo/theme/index-editor.css', '.ck {}' )
 		] );
 
 		const transform = createConfiguredTransformHook( { paths: [ 'packages/*' ] } );
-		const styleFilePath = join( workspaceRoot, 'packages/ckeditor5-foo/theme/index.css' );
+		const styleFilePath = join( workspaceRoot, 'packages/ckeditor5-foo/theme/index-editor.css' );
 
 		expect( transform.handler( '.ck {}', styleFilePath ) ).to.equal( undefined );
 	} );
@@ -310,7 +330,7 @@ describe( 'manualTestsPlugin()', () => {
 			createFile( workspaceRoot, 'packages/ckeditor5-foo/manual/foo.js', 'console.log( 1 );\n' ),
 			createFile( workspaceRoot, 'packages/ckeditor5-foo/manual/bar.manual.html' ),
 			createFile( workspaceRoot, 'packages/ckeditor5-foo/manual/bar.js', 'console.log( 2 );\n' ),
-			createFile( workspaceRoot, 'packages/ckeditor5-foo/theme/index.css' )
+			createFile( workspaceRoot, 'packages/ckeditor5-foo/theme/index-editor.css' )
 		] );
 
 		const transform = createConfiguredTransformHook( { paths: [ 'packages/*' ] } );
@@ -319,15 +339,15 @@ describe( 'manualTestsPlugin()', () => {
 		const fooResult = transform.handler( 'console.log( 1 );\n', fooFilePath );
 		const barResult = transform.handler( 'console.log( 2 );\n', barFilePath );
 
-		expect( fooResult!.code ).to.contain( 'import \'../theme/index.css\';' );
-		expect( barResult!.code ).to.contain( 'import \'../theme/index.css\';' );
+		expect( fooResult!.code ).to.contain( 'import \'../theme/index-editor.css\';' );
+		expect( barResult!.code ).to.contain( 'import \'../theme/index-editor.css\';' );
 	} );
 
 	test( 'does not transform helper modules without a sibling manual page', async () => {
 		await Promise.all( [
 			createFile( workspaceRoot, 'packages/ckeditor5-foo/manual/foo.manual.html' ),
 			createFile( workspaceRoot, 'packages/ckeditor5-foo/manual/_utils/helper.js', 'console.log( 1 );\n' ),
-			createFile( workspaceRoot, 'packages/ckeditor5-foo/theme/index.css' )
+			createFile( workspaceRoot, 'packages/ckeditor5-foo/theme/index-editor.css' )
 		] );
 
 		const transform = createConfiguredTransformHook( { paths: [ 'packages/*' ] } );
@@ -352,7 +372,7 @@ describe( 'manualTestsPlugin()', () => {
 		await Promise.all( [
 			createFile( workspaceRoot, 'packages/ckeditor5-foo/manual/foo.manual.html' ),
 			createFile( workspaceRoot, 'packages/ckeditor5-foo/manual/foo.js', 'console.log( 1 );\n' ),
-			createFile( workspaceRoot, 'packages/ckeditor5-foo/theme/index.css' )
+			createFile( workspaceRoot, 'packages/ckeditor5-foo/theme/index-editor.css' )
 		] );
 
 		const transform = createConfiguredTransformHook( { paths: [ 'packages/*' ], include: [ 'bar' ] } );

--- a/packages/ckeditor5-dev-manual-server/theme/manual-bootstrap.css
+++ b/packages/ckeditor5-dev-manual-server/theme/manual-bootstrap.css
@@ -7,7 +7,7 @@
 
 .refresh-prompt {
 	position: fixed;
-	top: calc( var( --ck-manual-header-height, 44px ) / 1.25 );
+	top: 16px;
 	left: 50%;
 	z-index: 100000;
 	box-sizing: border-box;
@@ -20,14 +20,14 @@
 	cursor: pointer;
 	opacity: 0;
 	pointer-events: none;
-	transform: translate(-50%, calc( -100% - var( --ck-manual-header-height, 44px ) ) );
+	transform: translate(-50%, calc( -100% - 16px ) );
 	transition: transform 0.18s ease-out, opacity 0.18s ease-out, background 0.1s;
 }
 
 .refresh-prompt--visible {
 	opacity: 1;
 	pointer-events: auto;
-	transform: translate(-50%, -50%);
+	transform: translate(-50%, 0);
 }
 
 .refresh-prompt:hover {

--- a/packages/ckeditor5-dev-manual-server/theme/manual-bootstrap.ts
+++ b/packages/ckeditor5-dev-manual-server/theme/manual-bootstrap.ts
@@ -23,6 +23,8 @@ const globalTarget = window as any;
  *
  * - sets the global license key so tests do not have to pass `licenseKey` explicitly;
  * - resets the `window.editor` named DOM property and auto-attaches the CKEditor inspector;
+ * - offsets the editor viewport below the fixed `<ck-manual-header>` bar (if the page has one),
+ *   so sticky toolbars, menu bars, and balloons are not covered by the test chrome when scrolling;
  * - renders the "source changed" refresh prompt driven by the dev server (`refreshPlugin`).
  *
  * The refresh prompt is part of the dev-server contract, not test chrome, so it belongs here.
@@ -53,12 +55,42 @@ function autoAttachInspector(): void {
 
 			if ( editor ) {
 				CKEditorInspector.attach( editor );
+				offsetViewportBelowManualHeader( editor );
 			}
 		},
 		get() {
 			return editor;
 		}
 	} );
+}
+
+const viewportOffsetEditors = new WeakSet<object>();
+
+/**
+ * Pushes the editor's viewport offset below the fixed `<ck-manual-header>` bar so sticky
+ * toolbars, menu bars, and balloon panels are not covered by the test chrome when the page
+ * is scrolled. Pages without the header chrome are left untouched, and an offset configured
+ * by the test itself is preserved (the header height is added on top of it).
+ */
+function offsetViewportBelowManualHeader( editor: any ): void {
+	const header = document.querySelector( 'ck-manual-header' );
+
+	if ( !header || !editor.ui || viewportOffsetEditors.has( editor ) ) {
+		return;
+	}
+
+	viewportOffsetEditors.add( editor );
+
+	// The visible chrome is the fixed `.bar` in the shadow DOM; the host itself has no height.
+	const headerHeight = header.shadowRoot?.querySelector( '.bar' )?.getBoundingClientRect().height ||
+		parseFloat( getComputedStyle( header ).getPropertyValue( '--ck-manual-header-height' ) ) ||
+		44;
+	const viewportOffset = editor.ui.viewportOffset || {};
+
+	editor.ui.viewportOffset = {
+		...viewportOffset,
+		top: ( viewportOffset.top || 0 ) + headerHeight
+	};
 }
 
 /**

--- a/packages/ckeditor5-dev-manual-server/theme/manual-bootstrap.ts
+++ b/packages/ckeditor5-dev-manual-server/theme/manual-bootstrap.ts
@@ -23,8 +23,6 @@ const globalTarget = window as any;
  *
  * - sets the global license key so tests do not have to pass `licenseKey` explicitly;
  * - resets the `window.editor` named DOM property and auto-attaches the CKEditor inspector;
- * - offsets the editor viewport below the fixed `<ck-manual-header>` bar (if the page has one),
- *   so sticky toolbars, menu bars, and balloons are not covered by the test chrome when scrolling;
  * - renders the "source changed" refresh prompt driven by the dev server (`refreshPlugin`).
  *
  * The refresh prompt is part of the dev-server contract, not test chrome, so it belongs here.
@@ -55,42 +53,12 @@ function autoAttachInspector(): void {
 
 			if ( editor ) {
 				CKEditorInspector.attach( editor );
-				offsetViewportBelowManualHeader( editor );
 			}
 		},
 		get() {
 			return editor;
 		}
 	} );
-}
-
-const viewportOffsetEditors = new WeakSet<object>();
-
-/**
- * Pushes the editor's viewport offset below the fixed `<ck-manual-header>` bar so sticky
- * toolbars, menu bars, and balloon panels are not covered by the test chrome when the page
- * is scrolled. Pages without the header chrome are left untouched, and an offset configured
- * by the test itself is preserved (the header height is added on top of it).
- */
-function offsetViewportBelowManualHeader( editor: any ): void {
-	const header = document.querySelector( 'ck-manual-header' );
-
-	if ( !header || !editor.ui || viewportOffsetEditors.has( editor ) ) {
-		return;
-	}
-
-	viewportOffsetEditors.add( editor );
-
-	// The visible chrome is the fixed `.bar` in the shadow DOM; the host itself has no height.
-	const headerHeight = header.shadowRoot?.querySelector( '.bar' )?.getBoundingClientRect().height ||
-		parseFloat( getComputedStyle( header ).getPropertyValue( '--ck-manual-header-height' ) ) ||
-		44;
-	const viewportOffset = editor.ui.viewportOffset || {};
-
-	editor.ui.viewportOffset = {
-		...viewportOffset,
-		top: ( viewportOffset.top || 0 ) + headerHeight
-	};
 }
 
 /**

--- a/packages/ckeditor5-dev-manual-server/theme/manual-header.css
+++ b/packages/ckeditor5-dev-manual-server/theme/manual-header.css
@@ -7,15 +7,9 @@
 
 :host {
 	display: block;
-	--ck-manual-header-height: 44px;
 }
 
 .bar {
-	position: fixed;
-	top: 0;
-	left: 0;
-	right: 0;
-	z-index: 99999;
 	display: flex;
 	align-items: stretch;
 	box-sizing: border-box;
@@ -142,7 +136,7 @@
 	--panel-transition-duration: 0.18s;
 
 	position: fixed;
-	top: var(--ck-manual-header-height);
+	top: 0;
 	right: 0;
 	bottom: 0;
 	z-index: 99998;

--- a/packages/ckeditor5-dev-manual-server/theme/manual-header.ts
+++ b/packages/ckeditor5-dev-manual-server/theme/manual-header.ts
@@ -56,8 +56,8 @@ const TEMPLATE = /* html */ `
 /* eslint-enable @stylistic/max-len */
 
 /**
- * `<ck-manual-header>` renders the manual test chrome: a fixed header bar with the test
- * name, package name, back-to-index link and favorite toggle, plus a collapsible instructions
+ * `<ck-manual-header>` renders the manual test chrome: a header bar with the test name,
+ * package name, back-to-index link and favorite toggle, plus a collapsible instructions
  * panel that projects the element's light-DOM children (default slot).
  *
  * The manual test server injects a `<meta name="ck-manual-header">` carrying the package

--- a/packages/ckeditor5-dev-manual-server/theme/manual-instructions.css
+++ b/packages/ckeditor5-dev-manual-server/theme/manual-instructions.css
@@ -11,12 +11,20 @@
  * reach nested nodes, so instruction typography is scoped here to `ck-manual-header` descendants.
  */
 
-/* Offset for the fixed header bar injected by the component. */
-body {
-	padding-top: var( --ck-manual-header-height, 44px );
+/*
+ * `:where()` keeps zero specificity so anything a test styles itself takes precedence.
+ */
+:where(*, *::before, *::after) {
+	box-sizing: border-box;
+}
+
+:where(body) {
+	margin: 0;
+	min-height: 100vh;
 }
 
 ck-manual-header {
+	margin-bottom: 12px;
 	font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
 	line-height: 1.6;
 	color: #0a0a0a;


### PR DESCRIPTION
### 🚀 Summary

Fixes two issues in the Vite-based manual test server:

* The manual test entry script transform now injects `theme/index-editor.css` and `theme/index-content.css` (each only when present), restoring package styles on manual test pages (broken style/table dropdowns, missing show-blocks outlines, unstyled pagination, minimap, code block labels, editor chrome, and more).
* The header bar now follows normal document flow instead of being fixed.

---

### 📌 Related issues

* https://github.com/ckeditor/ckeditor5-commercial/issues/11139

---

### 💡 Additional information

N/A