### PR TITLE
Add the typedoc-plugin-hierarchy-fixer plugin restoring the class hierarchy in API docs.

### DIFF
--- a/.changelog/20260804133745_umberto_1140_restore_subclasses_in_api_docs.md
+++ b/.changelog/20260804133745_umberto_1140_restore_subclasses_in_api_docs.md
@@ -1,0 +1,7 @@
+---
+type: Fix
+scope:
+  - typedoc-plugins
+---
+
+Restored the class hierarchy in the generated API documentation data for classes extending an intermediate mixin constant, for example `const ClassicEditorBase = ElementApiMixin( Editor )`. The new `typedoc-plugin-hierarchy-fixer` plugin replaces the unresolvable base class reference with the actual base class, restores the "Subclasses" relation on the base class page, and lists the mixin interfaces in the "Implements" section. References to reflections removed by the private API purge mechanism no longer leak into the documentation output.

--- a/.changelog/20260804133745_umberto_1140_restore_subclasses_in_api_docs.md
+++ b/.changelog/20260804133745_umberto_1140_restore_subclasses_in_api_docs.md
@@ -1,7 +1,7 @@
 ---
-type: Fix
+type: Feature
 scope:
   - typedoc-plugins
 ---
 
-Restored the class hierarchy in the generated API documentation data for classes extending an intermediate mixin constant, for example `const ClassicEditorBase = ElementApiMixin( Editor )`. The new `typedoc-plugin-hierarchy-fixer` plugin replaces the unresolvable base class reference with the actual base class, restores the "Subclasses" relation on the base class page, and lists the mixin interfaces in the "Implements" section. References to reflections removed by the private API purge mechanism no longer leak into the documentation output.
+Added the `typedoc-plugin-hierarchy-fixer` plugin that restores the class hierarchy in the generated API documentation data for classes extending an intermediate mixin constant, for example `const ClassicEditorBase = ElementApiMixin( Editor )`. The plugin replaces the unresolvable base class reference with the actual base class, restores the "Subclasses" relation on the base class page, and lists the mixin interfaces in the "Implements" section. It also prevents references to reflections removed by the private API purge mechanism from leaking into the documentation output.

--- a/packages/ckeditor5-dev-docs/lib/build.js
+++ b/packages/ckeditor5-dev-docs/lib/build.js
@@ -81,6 +81,7 @@ export default async function build( config ) {
 	plugins.typeDocTagObservable( app );
 	plugins.typeDocEventParamFixer( app );
 	plugins.typeDocEventInheritanceFixer( app );
+	plugins.typeDocHierarchyFixer( app );
 	plugins.typeDocInterfaceAugmentationFixer( app );
 	plugins.typeDocPurgePrivateApiDocs( app );
 	plugins.typeDocReferenceFixer( app );

--- a/packages/ckeditor5-dev-docs/tests/build.js
+++ b/packages/ckeditor5-dev-docs/tests/build.js
@@ -14,9 +14,12 @@ import {
 	typeDocTagObservable,
 	typeDocEventParamFixer,
 	typeDocEventInheritanceFixer,
+	typeDocHierarchyFixer,
 	typeDocInterfaceAugmentationFixer,
 	typeDocPurgePrivateApiDocs,
+	typeDocReferenceFixer,
 	typeDocRestoreProgramAfterConversion,
+	typeDocOutputCleanUp,
 	validate
 } from '@ckeditor/typedoc-plugins';
 
@@ -145,9 +148,12 @@ describe( 'lib/build()', () => {
 			typeDocTagObservable,
 			typeDocEventParamFixer,
 			typeDocEventInheritanceFixer,
+			typeDocHierarchyFixer,
 			typeDocInterfaceAugmentationFixer,
 			typeDocPurgePrivateApiDocs,
-			typeDocRestoreProgramAfterConversion
+			typeDocReferenceFixer,
+			typeDocRestoreProgramAfterConversion,
+			typeDocOutputCleanUp
 		];
 
 		plugins.forEach( plugin => {

--- a/packages/typedoc-plugins/README.md
+++ b/packages/typedoc-plugins/README.md
@@ -71,6 +71,12 @@ const conversionResult = await typeDoc.convert();
 
   The plugin takes care of inheriting events, which are created manually via the [`@eventName`](#tag-eventname) annotation.
 
+- **Hierarchy fixer** &mdash; `typeDocHierarchyFixer()`
+
+  The plugin restores the class hierarchy broken by extending an intermediate mixin constant, e.g. `const ClassicEditorBase = ElementApiMixin( Editor )`. It replaces the unresolvable base class reference with the actual base class, restores the "Subclasses" relation on the base class, and lists the mixin interfaces as implemented by the extending class. It also removes references pointing to reflections purged from private packages.
+
+  The plugin must be executed after `typeDocEventInheritanceFixer()`, because inheriting events resolves the original (broken) references replaced by this plugin.
+
 - **Purge private API** &mdash; `typeDocPurgePrivateApiDocs()`
 
   The plugin removes reflections collected from private packages (marked as `"private": true` in their `package.json`). To disable the mechanism, add the `@publicApi` annotation at the beginning of a file.

--- a/packages/typedoc-plugins/README.md
+++ b/packages/typedoc-plugins/README.md
@@ -95,6 +95,22 @@ const conversionResult = await typeDoc.convert();
 
   Adds support for creating CKEditor 5 events from properties marked as `@observable`.
 
+- **Restore program after conversion** &mdash; `typeDocRestoreProgramAfterConversion()`
+
+  The plugin restores the TypeScript program used for the source conversion. TypeDoc deletes the `context.program` property once the conversion is finished, which prevents other plugins listening to the `EVENT_END` event from using the TypeScript API.
+
+- **Reference fixer** &mdash; `typeDocReferenceFixer()`
+
+  The plugin fixes reflections that are re-exported from another file as a default export. In such a case TypeDoc adds the reflection declaration to the file containing the re-export, while the actual source file contains only a reference. The plugin moves the declarations back to their source locations.
+
+- **Output clean-up** &mdash; `typeDocOutputCleanUp()`
+
+  The plugin removes unnecessary properties from reflections to decrease the size of the generated output.
+
+- **Validators** &mdash; `validate()`
+
+  Validates the CKEditor 5 documentation. It verifies the `@see` and `@link` references and the events specified in the `@fires` annotation. Optionally, when the `enableOverloadValidator` option is enabled, it also verifies whether overloaded signatures use the `@label` annotation.
+
 ------------------------------------------------------------------------------------
 
 ## Changelog

--- a/packages/typedoc-plugins/src/hierarchy-fixer/index.ts
+++ b/packages/typedoc-plugins/src/hierarchy-fixer/index.ts
@@ -1,0 +1,190 @@
+/**
+ * @license Copyright (c) 2003-2026, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+import {
+	Converter,
+	ReferenceType,
+	ReflectionKind,
+	type Application,
+	type Context,
+	type DeclarationReflection,
+	type SomeType
+} from 'typedoc';
+import { getPluginPriority } from '../utils/getpluginpriority.js';
+
+/**
+ * The `typedoc-plugin-hierarchy-fixer` restores the class hierarchy broken by the mixin pattern:
+ *
+ * ```ts
+ * const ClassicEditorBase: ElementApiMixinConstructor<typeof Editor> = ElementApiMixin( Editor );
+ *
+ * export class ClassicEditor extends ClassicEditorBase {}
+ * ```
+ *
+ * The intermediate `*Base` constant is not exported, so TypeDoc does not document it. As a result, the class extends a reflection
+ * that does not exist in the project, and the actual base class does not list the class in its `extendedBy` collection. Rendered
+ * API pages lose the "Subclasses" entries and the hierarchy path between both classes.
+ *
+ * This plugin works as follows:
+ * - It searches for classes whose parent (an entry in `extendedTypes`) is a reference that cannot be resolved within the project.
+ * - Using the type checker, it reads the base types of such a class. For the mixin pattern, it is an intersection of the actual
+ *   base class and the interfaces implemented by mixins, e.g. `Editor & ElementApi`.
+ * - Base classes documented in the project replace the broken reference. The base class `extendedBy` collection is updated too,
+ *   so the processed class appears in its "Subclasses" section.
+ * - Interfaces documented in the project are added to `implementedTypes` of the processed class (and their `implementedBy`
+ *   collections are updated). It covers mixins that do not extend any class, e.g. `class Editor extends ObservableMixin()`.
+ * - When no part of the base type is documented in the project (e.g. a class extending the native `Error`), the reflection
+ *   is left as is.
+ *
+ * Additionally, once the `typedoc-plugin-purge-private-api-docs` plugin removes reflections collected from private packages,
+ * the `extendedBy` and `implementedBy` collections are filtered out of references pointing to the removed reflections. Otherwise,
+ * names of the private API classes would leak into the "Subclasses" sections of the public API pages.
+ *
+ * The plugin must run after the `typedoc-plugin-event-inheritance-fixer` plugin. Inheriting events resolves the original (broken)
+ * references to the mixin base classes, which are replaced by this plugin.
+ */
+export function typeDocHierarchyFixer( app: Application ): void {
+	app.converter.on( Converter.EVENT_END, onEventEnd, getPluginPriority( typeDocHierarchyFixer.name ) );
+	app.converter.on( Converter.EVENT_END, onEventEndCleanUp, getPluginPriority( 'typeDocHierarchyFixerCleanUp' ) );
+}
+
+function onEventEnd( context: Context ) {
+	const reflections = context.project.getReflectionsByKind( ReflectionKind.Class ) as Array<DeclarationReflection>;
+
+	for ( const reflection of reflections ) {
+		if ( !reflection.extendedTypes || !reflection.extendedTypes.some( isBrokenReference ) ) {
+			continue;
+		}
+
+		const { baseClasses, baseInterfaces } = getDocumentedBaseReflections( context, reflection );
+
+		// The entire base type is not documented in the project. Nothing to fix.
+		if ( !baseClasses.length && !baseInterfaces.length ) {
+			continue;
+		}
+
+		const fixedTypes = reflection.extendedTypes.flatMap( type => {
+			if ( !isBrokenReference( type ) ) {
+				return [ type ];
+			}
+
+			return baseClasses.map( baseClass => {
+				return ReferenceType.createResolvedReference( baseClass.name, baseClass, context.project );
+			} );
+		} );
+
+		// A mixin does not have to extend any class, e.g. `class Editor extends ObservableMixin()`. In such a case the broken
+		// reference is removed without a replacement, and the class becomes a root of its own hierarchy.
+		reflection.extendedTypes = fixedTypes.length ? fixedTypes : undefined;
+
+		for ( const baseClass of baseClasses ) {
+			addBackReference( context, baseClass, 'extendedBy', reflection );
+		}
+
+		for ( const baseInterface of baseInterfaces ) {
+			if ( !( reflection.implementedTypes || [] ).some( type => isReferenceTo( type, baseInterface ) ) ) {
+				reflection.implementedTypes = [
+					...reflection.implementedTypes || [],
+					ReferenceType.createResolvedReference( baseInterface.name, baseInterface, context.project )
+				];
+			}
+
+			addBackReference( context, baseInterface, 'implementedBy', reflection );
+		}
+	}
+}
+
+/**
+ * Removes references to reflections that no longer exist in the project from the `extendedBy` and `implementedBy` collections.
+ * References resolved by a symbol (pointing to types outside of the project) are kept.
+ */
+function onEventEndCleanUp( context: Context ) {
+	const reflections = context.project.getReflectionsByKind(
+		ReflectionKind.Class | ReflectionKind.Interface
+	) as Array<DeclarationReflection>;
+
+	for ( const reflection of reflections ) {
+		for ( const collection of [ 'extendedBy', 'implementedBy' ] as const ) {
+			if ( !reflection[ collection ] ) {
+				continue;
+			}
+
+			const filteredTypes = reflection[ collection ].filter( type => type.reflection || type.symbolId );
+
+			reflection[ collection ] = filteredTypes.length ? filteredTypes : undefined;
+		}
+	}
+}
+
+/**
+ * Collects reflections representing the base type of the given class, as seen by the type checker. For the mixin pattern,
+ * the base type is an intersection, e.g. `Editor & ElementApi`. Its members are resolved independently and grouped by their kind.
+ * Members that are not documented in the project (e.g. native types) are ignored.
+ */
+function getDocumentedBaseReflections( context: Context, reflection: DeclarationReflection ) {
+	const baseClasses: Array<DeclarationReflection> = [];
+	const baseInterfaces: Array<DeclarationReflection> = [];
+	const symbol = context.getSymbolFromReflection( reflection );
+
+	if ( symbol ) {
+		const instanceType = context.checker.getDeclaredTypeOfSymbol( symbol );
+		const baseTypes = instanceType.isClassOrInterface() ? context.checker.getBaseTypes( instanceType ) : [];
+
+		for ( const baseType of baseTypes ) {
+			const baseTypeParts = baseType.isIntersection() ? baseType.types : [ baseType ];
+
+			for ( const baseTypePart of baseTypeParts ) {
+				const partSymbol = baseTypePart.getSymbol();
+				const target = partSymbol ?
+					context.getReflectionFromSymbol( partSymbol ) as DeclarationReflection | undefined :
+					undefined;
+
+				if ( !target || target === reflection ) {
+					continue;
+				}
+
+				if ( target.kindOf( ReflectionKind.Class ) && !baseClasses.includes( target ) ) {
+					baseClasses.push( target );
+				} else if ( target.kindOf( ReflectionKind.Interface ) && !baseInterfaces.includes( target ) ) {
+					baseInterfaces.push( target );
+				}
+			}
+		}
+	}
+
+	return { baseClasses, baseInterfaces };
+}
+
+/**
+ * Adds the given class to the `extendedBy` or `implementedBy` collection of its base reflection, unless it is already there.
+ */
+function addBackReference(
+	context: Context,
+	target: DeclarationReflection,
+	collection: 'extendedBy' | 'implementedBy',
+	reflection: DeclarationReflection
+) {
+	if ( !( target[ collection ] || [] ).some( type => isReferenceTo( type, reflection ) ) ) {
+		target[ collection ] = [
+			...target[ collection ] || [],
+			ReferenceType.createResolvedReference( reflection.name, reflection, context.project )
+		];
+	}
+}
+
+/**
+ * Checks whether the given type is a reference that cannot be resolved within the project. TypeDoc creates such references
+ * when a class extends a symbol excluded from the documentation, e.g. a non-exported constant produced by a mixin.
+ */
+function isBrokenReference( type: SomeType ): boolean {
+	return type instanceof ReferenceType && !type.reflection;
+}
+
+/**
+ * Checks whether the given type is a reference resolved to the given reflection.
+ */
+function isReferenceTo( type: SomeType, reflection: DeclarationReflection ): boolean {
+	return type instanceof ReferenceType && type.reflection === reflection;
+}

--- a/packages/typedoc-plugins/src/hierarchy-fixer/index.ts
+++ b/packages/typedoc-plugins/src/hierarchy-fixer/index.ts
@@ -10,7 +10,8 @@ import {
 	type Application,
 	type Context,
 	type DeclarationReflection,
-	type SomeType
+	type SomeType,
+	type TypeScript
 } from 'typedoc';
 import { getPluginPriority } from '../utils/getpluginpriority.js';
 
@@ -65,19 +66,12 @@ function onEventEnd( context: Context ) {
 			continue;
 		}
 
-		const fixedTypes = reflection.extendedTypes.flatMap( type => {
-			if ( !isBrokenReference( type ) ) {
-				return [ type ];
-			}
-
-			return baseClasses.map( baseClass => {
-				return ReferenceType.createResolvedReference( baseClass.name, baseClass, context.project );
-			} );
-		} );
-
+		// A class always has a single `extends` entry, so the broken reference can be replaced with the entire collection.
 		// A mixin does not have to extend any class, e.g. `class Editor extends ObservableMixin()`. In such a case the broken
 		// reference is removed without a replacement, and the class becomes a root of its own hierarchy.
-		reflection.extendedTypes = fixedTypes.length ? fixedTypes : undefined;
+		reflection.extendedTypes = baseClasses.length ?
+			baseClasses.map( baseClass => ReferenceType.createResolvedReference( baseClass.name, baseClass, context.project ) ) :
+			undefined;
 
 		for ( const baseClass of baseClasses ) {
 			addBackReference( context, baseClass, 'extendedBy', reflection );
@@ -124,37 +118,37 @@ function onEventEndCleanUp( context: Context ) {
  * Members that are not documented in the project (e.g. native types) are ignored.
  */
 function getDocumentedBaseReflections( context: Context, reflection: DeclarationReflection ) {
-	const baseClasses: Array<DeclarationReflection> = [];
-	const baseInterfaces: Array<DeclarationReflection> = [];
-	const symbol = context.getSymbolFromReflection( reflection );
+	const baseClasses = new Set<DeclarationReflection>();
+	const baseInterfaces = new Set<DeclarationReflection>();
 
-	if ( symbol ) {
-		const instanceType = context.checker.getDeclaredTypeOfSymbol( symbol );
-		const baseTypes = instanceType.isClassOrInterface() ? context.checker.getBaseTypes( instanceType ) : [];
+	// Class reflections always originate from a symbol, and the declared type of a class symbol is always an interface type.
+	const symbol = context.getSymbolFromReflection( reflection )!;
+	const instanceType = context.checker.getDeclaredTypeOfSymbol( symbol ) as TypeScript.InterfaceType;
 
-		for ( const baseType of baseTypes ) {
-			const baseTypeParts = baseType.isIntersection() ? baseType.types : [ baseType ];
+	for ( const baseType of context.checker.getBaseTypes( instanceType ) ) {
+		const baseTypeParts = baseType.isIntersection() ? baseType.types : [ baseType ];
 
-			for ( const baseTypePart of baseTypeParts ) {
-				const partSymbol = baseTypePart.getSymbol();
-				const target = partSymbol ?
-					context.getReflectionFromSymbol( partSymbol ) as DeclarationReflection | undefined :
-					undefined;
+		for ( const baseTypePart of baseTypeParts ) {
+			const partSymbol = baseTypePart.getSymbol();
+			const target = partSymbol ?
+				context.getReflectionFromSymbol( partSymbol ) as DeclarationReflection | undefined :
+				undefined;
 
-				if ( !target || target === reflection ) {
-					continue;
-				}
+			if ( !target ) {
+				continue;
+			}
 
-				if ( target.kindOf( ReflectionKind.Class ) && !baseClasses.includes( target ) ) {
-					baseClasses.push( target );
-				} else if ( target.kindOf( ReflectionKind.Interface ) && !baseInterfaces.includes( target ) ) {
-					baseInterfaces.push( target );
-				}
+			if ( target.kindOf( ReflectionKind.Class ) ) {
+				baseClasses.add( target );
+			}
+
+			if ( target.kindOf( ReflectionKind.Interface ) ) {
+				baseInterfaces.add( target );
 			}
 		}
 	}
 
-	return { baseClasses, baseInterfaces };
+	return { baseClasses: [ ...baseClasses ], baseInterfaces: [ ...baseInterfaces ] };
 }
 
 /**

--- a/packages/typedoc-plugins/src/index.ts
+++ b/packages/typedoc-plugins/src/index.ts
@@ -10,6 +10,7 @@ export { typeDocTagEvent } from './tag-event/index.js';
 export { typeDocTagObservable } from './tag-observable/index.js';
 export { typeDocEventParamFixer } from './event-param-fixer/index.js';
 export { typeDocEventInheritanceFixer } from './event-inheritance-fixer/index.js';
+export { typeDocHierarchyFixer } from './hierarchy-fixer/index.js';
 export { typeDocInterfaceAugmentationFixer } from './interface-augmentation-fixer/index.js';
 export { typeDocPurgePrivateApiDocs } from './purge-private-api-docs/index.js';
 export { typeDocRestoreProgramAfterConversion } from './restore-program-after-conversion/index.js';

--- a/packages/typedoc-plugins/src/utils/getpluginpriority.ts
+++ b/packages/typedoc-plugins/src/utils/getpluginpriority.ts
@@ -24,7 +24,16 @@ const pluginGroups = [
 		'typeDocInterfaceAugmentationFixer'
 	],
 	[
+		// Must run after the event inheritance fixer, because inheriting events resolves the original (broken)
+		// references to the mixin base classes that are replaced by this plugin.
+		'typeDocHierarchyFixer'
+	],
+	[
 		'typeDocPurgePrivateApiDocs'
+	],
+	[
+		// Must run after purging the private API docs to clean up references to the removed reflections.
+		'typeDocHierarchyFixerCleanUp'
 	],
 	[
 		'validators'

--- a/packages/typedoc-plugins/tests/hierarchy-fixer/fixtures/classic-editor.ts
+++ b/packages/typedoc-plugins/tests/hierarchy-fixer/fixtures/classic-editor.ts
@@ -1,0 +1,15 @@
+/**
+ * @license Copyright (c) 2003-2026, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/**
+ * @module fixtures/classic-editor
+ */
+
+import { Editor } from './editor.js';
+import { ElementApiMixin, type ElementApiMixinConstructor } from './element-api-mixin.js';
+
+const ClassicEditorBase: ElementApiMixinConstructor<typeof Editor> = ElementApiMixin( Editor );
+
+export class ClassicEditor extends ClassicEditorBase {}

--- a/packages/typedoc-plugins/tests/hierarchy-fixer/fixtures/custom-error.ts
+++ b/packages/typedoc-plugins/tests/hierarchy-fixer/fixtures/custom-error.ts
@@ -1,0 +1,10 @@
+/**
+ * @license Copyright (c) 2003-2026, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/**
+ * @module fixtures/custom-error
+ */
+
+export class CustomError extends Error {}

--- a/packages/typedoc-plugins/tests/hierarchy-fixer/fixtures/double-emitter-editor.ts
+++ b/packages/typedoc-plugins/tests/hierarchy-fixer/fixtures/double-emitter-editor.ts
@@ -1,0 +1,15 @@
+/**
+ * @license Copyright (c) 2003-2026, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/**
+ * @module fixtures/double-emitter-editor
+ */
+
+import { Editor } from './editor.js';
+import { EmitterMixin } from './emitter-mixin.js';
+
+const DoubleEmitterEditorBase = EmitterMixin( EmitterMixin( Editor ) );
+
+export class DoubleEmitterEditor extends DoubleEmitterEditorBase {}

--- a/packages/typedoc-plugins/tests/hierarchy-fixer/fixtures/editor.ts
+++ b/packages/typedoc-plugins/tests/hierarchy-fixer/fixtures/editor.ts
@@ -1,0 +1,14 @@
+/**
+ * @license Copyright (c) 2003-2026, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/**
+ * @module fixtures/editor
+ */
+
+import { EmitterMixin, type EmitterMixinConstructor } from './emitter-mixin.js';
+
+const EditorBase: EmitterMixinConstructor = EmitterMixin();
+
+export class Editor extends EditorBase {}

--- a/packages/typedoc-plugins/tests/hierarchy-fixer/fixtures/element-api-mixin.ts
+++ b/packages/typedoc-plugins/tests/hierarchy-fixer/fixtures/element-api-mixin.ts
@@ -1,0 +1,26 @@
+/**
+ * @license Copyright (c) 2003-2026, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/**
+ * @module fixtures/element-api-mixin
+ */
+
+import type { Constructor, Mixed } from './mixin.js';
+
+export interface ElementApi {
+	updateSourceElement( data?: string ): void;
+}
+
+export type ElementApiMixinConstructor<Base extends Constructor> = Mixed<Base, ElementApi>;
+
+export function ElementApiMixin<Base extends Constructor>( base: Base ): ElementApiMixinConstructor<Base> {
+	abstract class Mixin extends base implements ElementApi {
+		public updateSourceElement( data?: string ): void {
+			console.log( data );
+		}
+	}
+
+	return Mixin as unknown as ElementApiMixinConstructor<Base>;
+}

--- a/packages/typedoc-plugins/tests/hierarchy-fixer/fixtures/emitter-mixin.ts
+++ b/packages/typedoc-plugins/tests/hierarchy-fixer/fixtures/emitter-mixin.ts
@@ -1,0 +1,45 @@
+/**
+ * @license Copyright (c) 2003-2026, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/**
+ * @module fixtures/emitter-mixin
+ */
+
+import type { Constructor, Mixed } from './mixin.js';
+
+export interface Emitter {
+	fire( eventName: string ): void;
+}
+
+export type EmitterMixinConstructor<Base extends Constructor | undefined = undefined> = Base extends Constructor ?
+	Mixed<Base, Emitter> :
+	{
+		new (): Emitter;
+		prototype: Emitter;
+	};
+
+export function EmitterMixin<Base extends Constructor>( base: Base ): EmitterMixinConstructor<Base>;
+
+export function EmitterMixin(): EmitterMixinConstructor;
+
+export function EmitterMixin( base?: Constructor ): unknown {
+	if ( !base ) {
+		abstract class EmitterMixin implements Emitter {
+			public fire( eventName: string ): void {
+				console.log( eventName );
+			}
+		}
+
+		return EmitterMixin;
+	}
+
+	abstract class EmitterMixin extends base implements Emitter {
+		public fire( eventName: string ): void {
+			console.log( eventName );
+		}
+	}
+
+	return EmitterMixin;
+}

--- a/packages/typedoc-plugins/tests/hierarchy-fixer/fixtures/manual-editor.ts
+++ b/packages/typedoc-plugins/tests/hierarchy-fixer/fixtures/manual-editor.ts
@@ -1,0 +1,15 @@
+/**
+ * @license Copyright (c) 2003-2026, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/**
+ * @module fixtures/manual-editor
+ */
+
+import { Editor } from './editor.js';
+import { ElementApiMixin, type ElementApi } from './element-api-mixin.js';
+
+const ManualEditorBase = ElementApiMixin( Editor );
+
+export class ManualEditor extends ManualEditorBase implements ElementApi {}

--- a/packages/typedoc-plugins/tests/hierarchy-fixer/fixtures/mixin.ts
+++ b/packages/typedoc-plugins/tests/hierarchy-fixer/fixtures/mixin.ts
@@ -1,0 +1,18 @@
+/**
+ * @license Copyright (c) 2003-2026, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/**
+ * @module fixtures/mixin
+ */
+
+export type Constructor<Instance = object> = abstract new ( ...args: Array<any> ) => Instance;
+
+export type Mixed<Base extends Constructor, Mixin extends object> = {
+	new ( ...args: ConstructorParameters<Base> ): Mixin & InstanceType<Base>;
+	prototype: Mixin & InstanceType<Base>;
+} & {
+	// Include all static fields from Base.
+	[ K in keyof Base ]: Base[ K ];
+};

--- a/packages/typedoc-plugins/tests/hierarchy-fixer/fixtures/nested-editor.ts
+++ b/packages/typedoc-plugins/tests/hierarchy-fixer/fixtures/nested-editor.ts
@@ -1,0 +1,16 @@
+/**
+ * @license Copyright (c) 2003-2026, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/**
+ * @module fixtures/nested-editor
+ */
+
+import { Editor } from './editor.js';
+import { EmitterMixin } from './emitter-mixin.js';
+import { ElementApiMixin } from './element-api-mixin.js';
+
+const NestedEditorBase = ElementApiMixin( EmitterMixin( Editor ) );
+
+export class NestedEditor extends NestedEditorBase {}

--- a/packages/typedoc-plugins/tests/hierarchy-fixer/fixtures/regular.ts
+++ b/packages/typedoc-plugins/tests/hierarchy-fixer/fixtures/regular.ts
@@ -1,0 +1,12 @@
+/**
+ * @license Copyright (c) 2003-2026, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/**
+ * @module fixtures/regular
+ */
+
+export class RegularBase {}
+
+export class RegularDerived extends RegularBase {}

--- a/packages/typedoc-plugins/tests/hierarchy-fixer/fixtures/tsconfig.test.json
+++ b/packages/typedoc-plugins/tests/hierarchy-fixer/fixtures/tsconfig.test.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.test.json"
+}

--- a/packages/typedoc-plugins/tests/hierarchy-fixer/index.ts
+++ b/packages/typedoc-plugins/tests/hierarchy-fixer/index.ts
@@ -1,0 +1,181 @@
+/**
+ * @license Copyright (c) 2003-2026, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+import { describe, it, beforeAll, expect } from 'vitest';
+import { glob } from 'glob';
+import upath from 'upath';
+import {
+	Application,
+	Converter,
+	ReferenceType,
+	ReflectionKind,
+	type Context,
+	type DeclarationReflection,
+	type ProjectReflection
+} from 'typedoc';
+
+import { ROOT_TEST_DIRECTORY } from '../utils.js';
+import { typeDocHierarchyFixer, typeDocRestoreProgramAfterConversion } from '../../src/index.js';
+import { getPluginPriority } from '../../src/utils/getpluginpriority.js';
+
+describe( 'typedoc-plugins/hierarchy-fixer', () => {
+	let conversionResult: ProjectReflection;
+
+	beforeAll( async () => {
+		const FIXTURES_PATH = upath.join( ROOT_TEST_DIRECTORY, 'hierarchy-fixer', 'fixtures' );
+
+		const sourceFilePatterns = [
+			upath.join( FIXTURES_PATH, '**', '*.ts' )
+		];
+
+		const files = ( await glob( sourceFilePatterns ) ).map( file => upath.normalize( file ) );
+		const typeDoc = await Application.bootstrapWithPlugins( {
+			logLevel: 'Error',
+			entryPoints: files,
+			tsconfig: upath.join( FIXTURES_PATH, 'tsconfig.test.json' )
+		} );
+
+		typeDocRestoreProgramAfterConversion( typeDoc );
+		typeDocHierarchyFixer( typeDoc );
+
+		expect( files ).to.not.lengthOf( 0 );
+
+		conversionResult = ( await typeDoc.convert() )!;
+
+		expect( conversionResult ).to.be.an( 'object' );
+	} );
+
+	function getReflection( name: string, kind: ReflectionKind = ReflectionKind.Class ): DeclarationReflection {
+		const reflection = conversionResult.getReflectionsByKind( kind )
+			.find( reflection => reflection.name === name ) as DeclarationReflection | undefined;
+
+		expect( reflection, `expected the "${ name }" reflection to exist` ).to.not.be.undefined;
+
+		return reflection!;
+	}
+
+	function getReferenceNames( types: Array<unknown> | undefined ): Array<string | undefined> {
+		return ( types || [] ).map( type => {
+			expect( type ).to.be.instanceOf( ReferenceType );
+
+			return ( type as ReferenceType ).reflection?.name;
+		} );
+	}
+
+	it( 'should replace a broken reference to a mixin base with the actual base class', () => {
+		const classicEditor = getReflection( 'ClassicEditor' );
+
+		expect( getReferenceNames( classicEditor.extendedTypes ) ).to.deep.equal( [ 'Editor' ] );
+	} );
+
+	it( 'should add a class extending a mixin base to the "extendedBy" collection of the actual base class', () => {
+		const editor = getReflection( 'Editor' );
+
+		expect( getReferenceNames( editor.extendedBy ) ).to.include.members( [ 'ClassicEditor', 'ManualEditor', 'NestedEditor' ] );
+	} );
+
+	it( 'should add an interface implemented by a mixin to the "implementedTypes" collection of the extending class', () => {
+		const classicEditor = getReflection( 'ClassicEditor' );
+		const elementApi = getReflection( 'ElementApi', ReflectionKind.Interface );
+
+		expect( getReferenceNames( classicEditor.implementedTypes ) ).to.deep.equal( [ 'ElementApi' ] );
+		expect( getReferenceNames( elementApi.implementedBy ) ).to.include.members( [ 'ClassicEditor' ] );
+	} );
+
+	it( 'should remove a broken reference to a mixin that does not extend any class', () => {
+		const editor = getReflection( 'Editor' );
+
+		expect( editor.extendedTypes ).to.be.undefined;
+		expect( getReferenceNames( editor.implementedTypes ) ).to.deep.equal( [ 'Emitter' ] );
+	} );
+
+	it( 'should resolve nested mixin calls to the actual base class and all mixin interfaces', () => {
+		const nestedEditor = getReflection( 'NestedEditor' );
+
+		expect( getReferenceNames( nestedEditor.extendedTypes ) ).to.deep.equal( [ 'Editor' ] );
+		expect( getReferenceNames( nestedEditor.implementedTypes ) ).to.have.members( [ 'ElementApi', 'Emitter' ] );
+	} );
+
+	it( 'should not duplicate an interface that the extending class already implements explicitly', () => {
+		const manualEditor = getReflection( 'ManualEditor' );
+
+		expect( getReferenceNames( manualEditor.extendedTypes ) ).to.deep.equal( [ 'Editor' ] );
+		expect( getReferenceNames( manualEditor.implementedTypes ) ).to.deep.equal( [ 'ElementApi' ] );
+	} );
+
+	it( 'should keep a class extending a type outside of the project as is', () => {
+		const customError = getReflection( 'CustomError' );
+
+		expect( customError.extendedTypes ).to.lengthOf( 1 );
+
+		const [ extendedType ] = customError.extendedTypes!;
+
+		expect( extendedType ).to.be.instanceOf( ReferenceType );
+		expect( ( extendedType as ReferenceType ).name ).to.equal( 'Error' );
+		expect( ( extendedType as ReferenceType ).reflection ).to.be.undefined;
+	} );
+
+	it( 'should not touch classes with an inheritance chain resolved by TypeDoc', () => {
+		const regularDerived = getReflection( 'RegularDerived' );
+		const regularBase = getReflection( 'RegularBase' );
+
+		expect( getReferenceNames( regularDerived.extendedTypes ) ).to.deep.equal( [ 'RegularBase' ] );
+		expect( getReferenceNames( regularBase.extendedBy ) ).to.deep.equal( [ 'RegularDerived' ] );
+		expect( regularDerived.implementedTypes ).to.be.undefined;
+	} );
+} );
+
+describe( 'typedoc-plugins/hierarchy-fixer (clean-up after removing reflections)', () => {
+	let conversionResult: ProjectReflection;
+
+	beforeAll( async () => {
+		const FIXTURES_PATH = upath.join( ROOT_TEST_DIRECTORY, 'hierarchy-fixer', 'fixtures' );
+
+		const sourceFilePatterns = [
+			upath.join( FIXTURES_PATH, '**', '*.ts' )
+		];
+
+		const files = ( await glob( sourceFilePatterns ) ).map( file => upath.normalize( file ) );
+		const typeDoc = await Application.bootstrapWithPlugins( {
+			logLevel: 'Error',
+			entryPoints: files,
+			tsconfig: upath.join( FIXTURES_PATH, 'tsconfig.test.json' )
+		} );
+
+		typeDocRestoreProgramAfterConversion( typeDoc );
+		typeDocHierarchyFixer( typeDoc );
+
+		// Simulate the `typedoc-plugin-purge-private-api-docs` plugin removing a private class after fixing the hierarchy.
+		typeDoc.converter.on( Converter.EVENT_END, ( context: Context ) => {
+			const nestedEditor = context.project.getReflectionsByKind( ReflectionKind.Class )
+				.find( reflection => reflection.name === 'NestedEditor' )!;
+
+			context.project.removeReflection( nestedEditor );
+		}, getPluginPriority( 'typeDocPurgePrivateApiDocs' ) );
+
+		conversionResult = ( await typeDoc.convert() )!;
+
+		expect( conversionResult ).to.be.an( 'object' );
+	} );
+
+	function getReflection( name: string, kind: ReflectionKind = ReflectionKind.Class ): DeclarationReflection {
+		const reflection = conversionResult.getReflectionsByKind( kind )
+			.find( reflection => reflection.name === name ) as DeclarationReflection | undefined;
+
+		expect( reflection, `expected the "${ name }" reflection to exist` ).to.not.be.undefined;
+
+		return reflection!;
+	}
+
+	it( 'should remove references to removed reflections from the "extendedBy" and "implementedBy" collections', () => {
+		const editor = getReflection( 'Editor' );
+		const elementApi = getReflection( 'ElementApi', ReflectionKind.Interface );
+
+		for ( const reference of [ ...editor.extendedBy!, ...elementApi.implementedBy! ] ) {
+			expect( reference.reflection, `expected the "${ reference.name }" reference to be resolved` ).to.not.be.undefined;
+			expect( reference.name ).to.not.equal( 'NestedEditor' );
+		}
+	} );
+} );

--- a/packages/typedoc-plugins/tests/hierarchy-fixer/index.ts
+++ b/packages/typedoc-plugins/tests/hierarchy-fixer/index.ts
@@ -98,6 +98,13 @@ describe( 'typedoc-plugins/hierarchy-fixer', () => {
 		expect( getReferenceNames( nestedEditor.implementedTypes ) ).to.have.members( [ 'ElementApi', 'Emitter' ] );
 	} );
 
+	it( 'should not duplicate a base class or an interface repeated in the base type', () => {
+		const doubleEmitterEditor = getReflection( 'DoubleEmitterEditor' );
+
+		expect( getReferenceNames( doubleEmitterEditor.extendedTypes ) ).to.deep.equal( [ 'Editor' ] );
+		expect( getReferenceNames( doubleEmitterEditor.implementedTypes ) ).to.deep.equal( [ 'Emitter' ] );
+	} );
+
 	it( 'should not duplicate an interface that the extending class already implements explicitly', () => {
 		const manualEditor = getReflection( 'ManualEditor' );
 
@@ -147,12 +154,15 @@ describe( 'typedoc-plugins/hierarchy-fixer (clean-up after removing reflections)
 		typeDocRestoreProgramAfterConversion( typeDoc );
 		typeDocHierarchyFixer( typeDoc );
 
-		// Simulate the `typedoc-plugin-purge-private-api-docs` plugin removing a private class after fixing the hierarchy.
+		// Simulate the `typedoc-plugin-purge-private-api-docs` plugin removing private classes after fixing the hierarchy.
+		// Removing all classes implementing the `ElementApi` interface empties its `implementedBy` collection entirely.
 		typeDoc.converter.on( Converter.EVENT_END, ( context: Context ) => {
-			const nestedEditor = context.project.getReflectionsByKind( ReflectionKind.Class )
-				.find( reflection => reflection.name === 'NestedEditor' )!;
+			const classesToRemove = context.project.getReflectionsByKind( ReflectionKind.Class )
+				.filter( reflection => [ 'ClassicEditor', 'NestedEditor', 'ManualEditor' ].includes( reflection.name ) );
 
-			context.project.removeReflection( nestedEditor );
+			for ( const reflection of classesToRemove ) {
+				context.project.removeReflection( reflection );
+			}
 		}, getPluginPriority( 'typeDocPurgePrivateApiDocs' ) );
 
 		conversionResult = ( await typeDoc.convert() )!;
@@ -171,11 +181,17 @@ describe( 'typedoc-plugins/hierarchy-fixer (clean-up after removing reflections)
 
 	it( 'should remove references to removed reflections from the "extendedBy" and "implementedBy" collections', () => {
 		const editor = getReflection( 'Editor' );
+
+		for ( const reference of editor.extendedBy! ) {
+			expect( reference.reflection, `expected the "${ reference.name }" reference to be resolved` ).to.not.be.undefined;
+		}
+
+		expect( editor.extendedBy!.map( reference => reference.name ) ).to.deep.equal( [ 'DoubleEmitterEditor' ] );
+	} );
+
+	it( 'should remove the "extendedBy" and "implementedBy" collections when all their references point to removed reflections', () => {
 		const elementApi = getReflection( 'ElementApi', ReflectionKind.Interface );
 
-		for ( const reference of [ ...editor.extendedBy!, ...elementApi.implementedBy! ] ) {
-			expect( reference.reflection, `expected the "${ reference.name }" reference to be resolved` ).to.not.be.undefined;
-			expect( reference.name ).to.not.equal( 'NestedEditor' );
-		}
+		expect( elementApi.implementedBy ).to.be.undefined;
 	} );
 } );

--- a/packages/typedoc-plugins/tests/utils/getpluginpriority.ts
+++ b/packages/typedoc-plugins/tests/utils/getpluginpriority.ts
@@ -15,11 +15,27 @@ describe( 'getPluginPriority', () => {
 		expect( getPluginPriority( 'typeDocModuleFixer' ) ).toBe( -1 );
 	} );
 
-	it( 'should return -5 for validators', () => {
-		expect( getPluginPriority( 'validators' ) ).toBe( -5 );
+	it( 'should return -3 for event-inheritance-fixer', () => {
+		expect( getPluginPriority( 'typeDocEventInheritanceFixer' ) ).toBe( -3 );
 	} );
 
-	it( 'should return -6 for an unknown plugin', () => {
-		expect( getPluginPriority( 'unknown-plugin' ) ).toBe( -6 );
+	it( 'should return -4 for hierarchy-fixer', () => {
+		expect( getPluginPriority( 'typeDocHierarchyFixer' ) ).toBe( -4 );
+	} );
+
+	it( 'should return -5 for purge-private-api-docs', () => {
+		expect( getPluginPriority( 'typeDocPurgePrivateApiDocs' ) ).toBe( -5 );
+	} );
+
+	it( 'should return -6 for the hierarchy-fixer cleanup', () => {
+		expect( getPluginPriority( 'typeDocHierarchyFixerCleanUp' ) ).toBe( -6 );
+	} );
+
+	it( 'should return -7 for validators', () => {
+		expect( getPluginPriority( 'validators' ) ).toBe( -7 );
+	} );
+
+	it( 'should return -8 for an unknown plugin', () => {
+		expect( getPluginPriority( 'unknown-plugin' ) ).toBe( -8 );
 	} );
 } );


### PR DESCRIPTION
### 🚀 Summary

Added the `typedoc-plugin-hierarchy-fixer` plugin. It fixes the API docs data for classes extending a mixin constant:

```ts
const ClassicEditorBase = ElementApiMixin( Editor );

export class ClassicEditor extends ClassicEditorBase {}
```

TypeDoc does not document the non-exported `*Base` constant, so the hierarchy breaks: `Editor` loses its "Subclasses", `ClassicEditor` shows a dead `ClassicEditorBase` entry, and mixin interfaces are missing from "Implements".

The plugin reads the real base type from the TypeScript checker (here: `Editor & ElementApi`) and:

* points `extendedTypes` at the actual base class and adds the class to its `extendedBy`,
* adds mixin interfaces to `implementedTypes`, also for base-less mixins like `class Plugin extends ObservableMixin()`,
* skips bases from outside the project, like `extends Error`,
* after the private API purge, removes dangling `extendedBy`/`implementedBy` references, so private class names do not leak into "Subclasses".

Ordering matters: the plugin must run after `typedoc-plugin-event-inheritance-fixer`, which resolves inherited events through the original (broken) references. Running it earlier strips the `set:{property}`/`change:{property}` events from classes like `Command`.

---

### 📌 Related issues

* Closes https://github.com/cksource/umberto/issues/1140

---

### 💡 Additional information

Verified on a full CKEditor 5 docs build: 69 of 72 broken references fixed. The remaining 3 are `extends Error`, left as is. `Editor` lists all five editors as subclasses, `ClassicEditor` renders `Editor → ClassicEditor`, and `Plugin` shows `Observable` in "Implements".
