### PR TITLE
Add CODEOWNERS file to define repository ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+/.github/                            @ckeditor/ckeditor-5-platform
+/.circleci/                          @ckeditor/ckeditor-5-platform
+/packages/                           @ckeditor/ckeditor-5-platform
+/scripts/                            @ckeditor/ckeditor-5-platform
+/package.json                        @ckeditor/ckeditor-5-platform
+/pnpm-lock.yaml                      @ckeditor/ckeditor-5-platform
+/pnpm-workspace.yaml                 @ckeditor/ckeditor-5-platform


### PR DESCRIPTION
<!--

This repository uses Markdown files to define changelog entries. If the changes in this pull request are **user-facing**, please create a changelog entry by running the following command:

    pnpm run nice

This will generate a `*.md` file in the `.changelog/` directory for your description. You can create as many as you need.

**Note:**  
If your PR is internal-only (e.g., tests, tooling, docs), you can skip this step - just mention it below.

-->

### 🚀 Summary

Added CODEOWNERS file to define repository ownership.

---

### 📌 Related issues

<!--

Although changelog entries list connected issues, GitHub requires listing them here to automatically link and close them.

-->

* Part of https://github.com/ckeditor/ckeditor5-internal/issues/4647.

---

### 💡 Additional information

- `@ckeditor/ckeditor-5-platform` with the `write` access is already added in this repository.
- _Require review from Code Owners_ already selected.
- Added `master` branch to the _Branch targeting criteria_ (previously only `master-v*` was configured).

    <img width="1161" height="287" alt="obraz" src="https://github.com/user-attachments/assets/9fb41bda-2e9f-4774-9bdc-eae4585f31ec" />

