### PR TITLE
Add translation support to the manual test server

### DIFF
--- a/.changelog/20260812134956_ci_4538_support_manual_test_translations.md
+++ b/.changelog/20260812134956_ci_4538_support_manual_test_translations.md
@@ -1,0 +1,7 @@
+---
+type: Feature
+scope:
+  - ckeditor5-dev-manual-server
+---
+
+Added support for loading TypeScript translation sources and selecting the default editor language in the Vite manual test server.

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "semver": "^7.7.4",
     "typescript": "5.5.4",
     "upath": "^2.0.1",
-    "vite": "^8.2.0",
+    "vite": "^8.2.1",
     "vitest": "^4.1.2"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "semver": "^7.7.4",
     "typescript": "5.5.4",
     "upath": "^2.0.1",
-    "vite": "^8.1.0",
+    "vite": "^8.2.0",
     "vitest": "^4.1.2"
   },
   "scripts": {

--- a/packages/ckeditor5-dev-manual-server/README.md
+++ b/packages/ckeditor5-dev-manual-server/README.md
@@ -8,6 +8,21 @@ Used to extend Vite to create a manual test server for CKEditor 5.
 
 More information about development tools packages can be found at the following URL: <https://github.com/ckeditor/ckeditor5-dev>.
 
+## Loading translations
+
+Pass a language code to `manualTestsPlugin()` to load and combine that language's TypeScript translation files from the configured
+package paths. The selected language becomes the default UI and content language for editors and contexts created by manual tests.
+An explicit language in an editor or context configuration still takes precedence.
+
+```ts
+manualTestsPlugin( {
+	paths: [ 'packages/*' ],
+	language: process.env.CK_LANGUAGE || 'en'
+} )
+```
+
+For example, start the manual test server in Polish using `CK_LANGUAGE=pl pnpm manual`.
+
 ## Changelog
 
 See the [`CHANGELOG.md`](https://github.com/ckeditor/ckeditor5-dev/blob/master/packages/ckeditor5-dev-manual-server/CHANGELOG.md) file.

--- a/packages/ckeditor5-dev-manual-server/package.json
+++ b/packages/ckeditor5-dev-manual-server/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@ckeditor/ckeditor5-inspector": "^5.0.1",
-    "vite": "^8.2.0"
+    "vite": "^8.2.1"
   },
   "devDependencies": {
     "@vitest/coverage-v8": "^4.1.2",

--- a/packages/ckeditor5-dev-manual-server/package.json
+++ b/packages/ckeditor5-dev-manual-server/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@ckeditor/ckeditor5-inspector": "^5.0.1",
-    "vite": "^8.1.0"
+    "vite": "^8.2.0"
   },
   "devDependencies": {
     "@vitest/coverage-v8": "^4.1.2",

--- a/packages/ckeditor5-dev-manual-server/src/manual-test-plugin/plugin.ts
+++ b/packages/ckeditor5-dev-manual-server/src/manual-test-plugin/plugin.ts
@@ -92,13 +92,11 @@ export function manualTestsPlugin( options: ManualTestsPluginOptions ): Plugin {
 	return {
 		name: 'ckeditor5-manual-tests',
 
-		config() {
+		config( config = {} ) {
+			workspaceRoot = resolve( config.root || process.cwd() );
+
 			return {
-				build: {
-					rolldownOptions: {
-						input: getManualBuildInputs()
-					}
-				}
+				input: getManualBuildInputs()
 			};
 		},
 
@@ -108,8 +106,6 @@ export function manualTestsPlugin( options: ManualTestsPluginOptions ): Plugin {
 
 			manualPagesCache.invalidate();
 			packageThemeEntryCache.clear();
-
-			config.build.rolldownOptions.input = getManualBuildInputs();
 		},
 
 		configureServer( server ) {
@@ -119,9 +115,7 @@ export function manualTestsPlugin( options: ManualTestsPluginOptions ): Plugin {
 				next();
 			} );
 
-			const clientEnvironment = server.environments.client as typeof server.environments.client & BundledDevClientEnvironment;
-
-			keepManualHtmlSourceFresh( clientEnvironment.bundledDev?.memoryFiles, getManualPages, workspaceRoot );
+			keepManualHtmlSourceFresh( server.environments.client.bundledDev?.memoryFiles, getManualPages, workspaceRoot );
 		},
 
 		resolveId( source ) {
@@ -251,12 +245,6 @@ interface ManualMemoryFiles {
 	get( filePath: string ): ManualMemoryFile | undefined;
 }
 
-interface BundledDevClientEnvironment {
-	bundledDev?: {
-		memoryFiles?: ManualMemoryFiles;
-	};
-}
-
 /**
  * Keeps the served manual test HTML in sync with the source file while the dev server runs.
  *
@@ -264,7 +252,7 @@ interface BundledDevClientEnvironment {
  * produced by the rolldown dev engine. That engine emits the HTML output only during the initial
  * build and never regenerates it when the source `.html` changes: its bundle state reports no
  * stale output for HTML entries, `devEngine.invalidate()` throws on a non-JS module, and even a
- * forced full build leaves the HTML memory file untouched (verified against Vite 8.2). A `.html`
+ * forced full build leaves the HTML memory file untouched (verified against Vite 8.2.1). A `.html`
  * edit still triggers a full page reload, so without this the browser reloads into the same stale
  * HTML until the server is restarted.
  *

--- a/packages/ckeditor5-dev-manual-server/src/manual-test-plugin/plugin.ts
+++ b/packages/ckeditor5-dev-manual-server/src/manual-test-plugin/plugin.ts
@@ -7,6 +7,11 @@ import { existsSync, readFileSync, realpathSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { posix, resolve, relative } from 'node:path';
 import { collectManualPages } from './collect-pages.js';
+import {
+	createManualTranslationsModule,
+	MANUAL_TRANSLATIONS_VIRTUAL_ID,
+	RESOLVED_MANUAL_TRANSLATIONS_VIRTUAL_ID
+} from './translations.js';
 import { cacheValue, createPackageNameFilter, stripLeadingSlash, toPosixPath, toPublicFilePath, toPublicSpecifier } from '../utils.js';
 import type { Plugin, HtmlTagDescriptor } from 'vite';
 import type { ManualPageEntry } from './types.js';
@@ -20,6 +25,7 @@ interface ManualTestClientEntry {
 export interface ManualTestsPluginOptions {
 	paths: Array<string>;
 	include?: Array<string>;
+	language?: string;
 }
 
 // The custom element that opts a page into the test chrome. The component script and its data
@@ -81,6 +87,7 @@ export function manualTestsPlugin( options: ManualTestsPluginOptions ): Plugin {
 		slug: entry.slug
 	} ) );
 	const getManualEntriesJson = () => JSON.stringify( getClientEntries(), null, 2 );
+	const translationsModuleCode = options.language ? createManualTranslationsModule( options.paths, options.language ) : null;
 
 	return {
 		name: 'ckeditor5-manual-tests',
@@ -122,6 +129,10 @@ export function manualTestsPlugin( options: ManualTestsPluginOptions ): Plugin {
 				return resolvedVirtualModuleId;
 			}
 
+			if ( source == MANUAL_TRANSLATIONS_VIRTUAL_ID && translationsModuleCode ) {
+				return RESOLVED_MANUAL_TRANSLATIONS_VIRTUAL_ID;
+			}
+
 			if ( isManualCatalogBuildInputSpecifier( source, getManualCatalogBuildInputFilePath(), workspaceRoot ) ) {
 				return getManualCatalogBuildInputFilePath();
 			}
@@ -132,6 +143,10 @@ export function manualTestsPlugin( options: ManualTestsPluginOptions ): Plugin {
 		load( id ) {
 			if ( id == resolvedVirtualModuleId ) {
 				return `export const manualTestEntries = ${ getManualEntriesJson() };`;
+			}
+
+			if ( id == RESOLVED_MANUAL_TRANSLATIONS_VIRTUAL_ID ) {
+				return translationsModuleCode;
 			}
 
 			if ( toPosixPath( id ) == toPosixPath( getManualCatalogBuildInputFilePath() ) ) {
@@ -166,12 +181,7 @@ export function manualTestsPlugin( options: ManualTestsPluginOptions ): Plugin {
 
 				const packageRootSpecifier = entry.htmlFilePath.slice( 0, entry.htmlFilePath.indexOf( MANUAL_TESTS_DIRECTORY ) );
 				const themeEntries = getPackageThemeEntries( packageRootSpecifier );
-
-				if ( !themeEntries.length ) {
-					return;
-				}
-
-				const themeEntryImports = themeEntries.map( themeEntryFilePath => {
+				const imports = themeEntries.map( themeEntryFilePath => {
 					const themeEntrySpecifier = posix.relative(
 						posix.dirname( scriptSpecifier ),
 						`${ packageRootSpecifier }/${ themeEntryFilePath }`
@@ -180,8 +190,16 @@ export function manualTestsPlugin( options: ManualTestsPluginOptions ): Plugin {
 					return `import '${ themeEntrySpecifier }';`;
 				} );
 
+				if ( options.language ) {
+					imports.push( `import '${ MANUAL_TRANSLATIONS_VIRTUAL_ID }';` );
+				}
+
+				if ( !imports.length ) {
+					return;
+				}
+
 				return {
-					code: `${ code }\n${ themeEntryImports.join( '\n' ) }\n`,
+					code: `${ code }\n${ imports.join( '\n' ) }\n`,
 					map: null
 				};
 			}
@@ -246,7 +264,7 @@ interface BundledDevClientEnvironment {
  * produced by the rolldown dev engine. That engine emits the HTML output only during the initial
  * build and never regenerates it when the source `.html` changes: its bundle state reports no
  * stale output for HTML entries, `devEngine.invalidate()` throws on a non-JS module, and even a
- * forced full build leaves the HTML memory file untouched (verified against Vite 8.1.0). A `.html`
+ * forced full build leaves the HTML memory file untouched (verified against Vite 8.2). A `.html`
  * edit still triggers a full page reload, so without this the browser reloads into the same stale
  * HTML until the server is restarted.
  *

--- a/packages/ckeditor5-dev-manual-server/src/manual-test-plugin/translations.ts
+++ b/packages/ckeditor5-dev-manual-server/src/manual-test-plugin/translations.ts
@@ -1,0 +1,45 @@
+/**
+ * @license Copyright (c) 2003-2026, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+import { posix } from 'node:path';
+import { toPosixPath } from '../utils.js';
+
+export const MANUAL_TRANSLATIONS_VIRTUAL_ID: string = 'virtual:ckeditor5-manual-translations';
+export const RESOLVED_MANUAL_TRANSLATIONS_VIRTUAL_ID: string = `\0${ MANUAL_TRANSLATIONS_VIRTUAL_ID }`;
+
+/**
+ * Generates the virtual module that loads translations from every configured package root.
+ */
+export function createManualTranslationsModule( paths: Array<string>, language: string ): string {
+	const translationPatterns = paths.map( packagePath => {
+		return posix.join( '/', toPosixPath( packagePath ), `lang/translations/${ language }.ts` );
+	} );
+
+	return `
+import { add } from '@ckeditor/ckeditor5-utils';
+import { Context, Editor } from '@ckeditor/ckeditor5-core';
+
+const translationModules = import.meta.glob(
+	${ JSON.stringify( translationPatterns ) },
+	{ eager: true, import: 'default' }
+);
+const language = ${ JSON.stringify( language ) };
+const translations = Object.values( translationModules ).map( module => module[ language ] );
+
+if ( !translations.length ) {
+	throw new Error( \`No CKEditor 5 translations found for "\${ language }".\` );
+}
+
+if ( !translations.some( translation => translation.getPluralForm ) ) {
+	throw new Error( \`The ckeditor5-core translations for "\${ language }" were not loaded.\` );
+}
+
+for ( const translation of translations ) {
+	add( language, translation.dictionary, translation.getPluralForm );
+}
+
+Editor.defaultConfig = { ...Editor.defaultConfig, language: ${ JSON.stringify( language ) } };
+Context.defaultConfig = { ...Context.defaultConfig, language: ${ JSON.stringify( language ) } };`;
+}

--- a/packages/ckeditor5-dev-manual-server/src/refresh-plugin/plugin.ts
+++ b/packages/ckeditor5-dev-manual-server/src/refresh-plugin/plugin.ts
@@ -5,7 +5,7 @@
 
 // Why monkey-patch instead of using the documented `hotUpdate` plugin hook?
 //
-// Spike result (2026-07-02, Vite 8.1.0): under `experimental.bundledDev`, Vite's
+// Spike result (2026-08-12, Vite 8.2): under `experimental.bundledDev`, Vite's
 // `handleHMRUpdate()` early-returns on `config.experimental.bundledDev` BEFORE it
 // ever reaches the plugin hook loop, so `hotUpdate`/`handleHotUpdate` are never
 // invoked. Bundled dev HMR instead runs entirely on a separate rolldown dev-engine
@@ -15,7 +15,7 @@
 // this file only needs to reach for undocumented internals because `bundledDev`
 // must stay enabled.
 //
-// This plugin targets the Vite 8.1+ internals: the `BundledDev` helper exposed as
+// This plugin targets the Vite 8.2 internals: the `BundledDev` helper exposed as
 // `server.environments.client.bundledDev`, carrying `clients`, `handleHmrOutput`
 // and `devEngine`. Because these internals are undocumented, they move without
 // notice — in Vite 8.0.x the very same members lived directly on the client
@@ -35,7 +35,7 @@ const isManualRefreshWrappedClient = Symbol( 'isManualRefreshWrappedClient' );
 
 /**
  * The undocumented `BundledDev` internals this plugin patches, exposed as
- * `server.environments.client.bundledDev` in Vite 8.1+.
+ * `server.environments.client.bundledDev` in Vite 8.2.
  */
 interface BundledDevInternals {
 	clients?: {
@@ -47,8 +47,7 @@ interface BundledDevInternals {
 	handleHmrOutput?(
 		client: BundledDevClient,
 		files: Array<string>,
-		hmrOutput: BundledDevHmrOutput,
-		invalidateInformation?: unknown
+		hmrOutput: BundledDevHmrOutput
 	): unknown;
 }
 
@@ -112,9 +111,9 @@ function wrapBundledDevFullReloads( bundledDev: BundledDevInternals, workspaceRo
 
 	const handleHmrOutput = bundledDev.handleHmrOutput.bind( bundledDev );
 
-	bundledDev.handleHmrOutput = ( client, files, hmrOutput, invalidateInformation ) => {
+	bundledDev.handleHmrOutput = ( client, files, hmrOutput ) => {
 		if ( hmrOutput.type != 'FullReload' ) {
-			return handleHmrOutput( client, files, hmrOutput, invalidateInformation );
+			return handleHmrOutput( client, files, hmrOutput );
 		}
 
 		if ( !shouldShowManualRefreshPromptForFiles( files ) ) {
@@ -167,7 +166,7 @@ function ensureLatestBuildOutput( bundledDev: BundledDevInternals ): void {
 }
 
 function sendManualRefreshPayload( payload: HotPayload, send: ( payload: HotPayload ) => void ): void {
-	if ( payload.type == 'update' && !payload.updates.length ) {
+	if ( payload.type == 'bundled-dev-update' && !payload.changedIds.length ) {
 		return;
 	}
 
@@ -184,17 +183,11 @@ function sendManualRefreshPayload( payload: HotPayload, send: ( payload: HotPayl
 }
 
 function shouldShowManualRefreshPrompt( payload: HotPayload ): boolean {
-	if ( payload.type == 'update' ) {
-		return !isCssUpdatePayload( payload );
-	}
-
-	return false;
+	return payload.type == 'bundled-dev-update' && payload.changedIds.some( filePath => !isCssFile( filePath ) );
 }
 
-function isCssUpdatePayload( payload: HotPayload ): boolean {
-	return payload.type == 'update' && payload.updates.length > 0 && payload.updates.every( update => {
-		return update.type == 'css-update' || ( update.type == 'js-update' && update.acceptedPath.endsWith( '.css' ) );
-	} );
+function isCssFile( filePath: string ): boolean {
+	return filePath.split( '?', 1 )[ 0 ]!.endsWith( '.css' );
 }
 
 function shouldShowManualRefreshPromptForFiles( files: Array<string> ): boolean {

--- a/packages/ckeditor5-dev-manual-server/src/refresh-plugin/plugin.ts
+++ b/packages/ckeditor5-dev-manual-server/src/refresh-plugin/plugin.ts
@@ -3,66 +3,46 @@
  * For licensing, see LICENSE.md.
  */
 
-// Why monkey-patch instead of using the documented `hotUpdate` plugin hook?
+// Under `experimental.bundledDev` (Vite 8.2.1), HMR runs on the rolldown dev-engine
+// path (`onHmrUpdates` → `handleHmrOutput` → `client.send`): the server ships a patch,
+// the client walks its module graph, and on a missing HMR boundary (manual tests accept
+// no JS updates) it requests a rebuild and auto-reloads. This plugin turns that
+// auto-reload into the refresh prompt for JS/TS changes, while CSS updates pass through
+// (hot-update in place) and HTML updates pass through (auto-reload; the reloaded body
+// is kept fresh by the manual test plugin's HTML splicing).
 //
-// Spike result (2026-08-12, Vite 8.2): under `experimental.bundledDev`, Vite's
-// `handleHMRUpdate()` early-returns on `config.experimental.bundledDev` BEFORE it
-// ever reaches the plugin hook loop, so `hotUpdate`/`handleHotUpdate` are never
-// invoked. Bundled dev HMR instead runs entirely on a separate rolldown dev-engine
-// path (`onHmrUpdates` → `handleHmrOutput` → `client.send`) that has no plugin
-// extension point today. A control run with `bundledDev` disabled confirmed the
-// documented `hotUpdate` hook + suppression + custom events all work fine there —
-// this file only needs to reach for undocumented internals because `bundledDev`
-// must stay enabled.
+// The documented `hotUpdate` hook cannot implement the prompt: suppressing an update
+// there skips the engine's module re-fetch (stale output after the prompt's reload),
+// and letting it through auto-reloads (losing editor state). Hence the monkey-patch of
+// the last mile, the per-client `client.send`. `hotUpdate` is still used to force-ship
+// manual HTML edits, which the engine would otherwise drop as unchanged.
 //
-// This plugin targets the Vite 8.2 internals: the `BundledDev` helper exposed as
-// `server.environments.client.bundledDev`, carrying `clients`, `handleHmrOutput`
-// and `devEngine`. Because these internals are undocumented, they move without
-// notice — in Vite 8.0.x the very same members lived directly on the client
-// environment. When a Vite upgrade relocates them again, the patches below turn
-// into no-ops and manual tests regress to full page reloads on every JS edit
-// (losing editor state) instead of showing the refresh prompt.
-//
-// Revisit this plugin (and delete the patches below) once Vite exposes HMR plugin
-// hooks for bundled dev.
+// The patched internals (`server.environments.client.bundledDev` with `clients`,
+// `handleHmrOutput`, `devEngine`) are undocumented and move without notice; when a Vite
+// upgrade relocates them, `configureServer` throws at server startup — update this
+// plugin together with Vite. Delete the patches once Vite exposes an HMR plugin
+// extension point for the bundled dev client payloads.
 
-import type { Plugin, HotPayload } from 'vite';
+import type { Plugin, HotPayload, HotChannelClient } from 'vite';
 import { toPublicFilePath } from '../utils.js';
 
 export const MANUAL_REFRESH_EVENT_NAME = 'ckeditor5-manual:refresh-available';
 
-const isManualRefreshWrappedClient = Symbol( 'isManualRefreshWrappedClient' );
-
 /**
- * The undocumented `BundledDev` internals this plugin patches, exposed as
- * `server.environments.client.bundledDev` in Vite 8.2.
+ * The `BundledDev` members this plugin patches. They exist at runtime but are declared
+ * `private` in Vite's published types, so they are re-declared structurally here.
  */
 interface BundledDevInternals {
-	clients?: {
-		setupIfNeeded( client: BundledDevClient, clientId: string ): unknown;
+	clients: {
+		setupIfNeeded( client: HotChannelClient, clientId: string ): unknown;
 	};
-	devEngine?: {
+	devEngine: {
 		ensureLatestBuildOutput(): Promise<unknown>;
 	};
-	handleHmrOutput?(
-		client: BundledDevClient,
-		files: Array<string>,
-		hmrOutput: BundledDevHmrOutput
-	): unknown;
+	handleHmrOutput( client: HotChannelClient, files: Array<string>, hmrOutput: { type: string } ): unknown;
 }
 
-interface BundledDevClientEnvironment {
-	bundledDev?: BundledDevInternals;
-}
-
-interface BundledDevClient {
-	send( payload: HotPayload ): void;
-	[ isManualRefreshWrappedClient ]?: boolean;
-}
-
-interface BundledDevHmrOutput {
-	type: string;
-}
+const wrappedClients = new WeakSet<HotChannelClient>();
 
 export function refreshPlugin(): Plugin {
 	return {
@@ -70,34 +50,35 @@ export function refreshPlugin(): Plugin {
 		apply: 'serve',
 
 		configureServer( server ) {
-			const clientEnvironment = server.environments.client as unknown as BundledDevClientEnvironment;
-			const bundledDev = clientEnvironment.bundledDev;
+			const { bundledDev } = server.environments.client as unknown as { bundledDev: BundledDevInternals };
 
-			if ( !bundledDev ) {
-				return;
-			}
-
-			wrapBundledDevClientSend( bundledDev.clients );
+			wrapBundledDevClientSend( bundledDev );
 			wrapBundledDevFullReloads( bundledDev, server.config.root );
+		},
+
+		// The page body is not part of the HTML module's JS render, so body-only edits render
+		// byte-identical and the dev engine drops them without notifying any client. Returning
+		// the affected modules force-ships them, which ends in an automatic full reload.
+		hotUpdate( { file, modules } ) {
+			if ( file.endsWith( '.manual.html' ) ) {
+				return modules;
+			}
 		}
 	};
 }
 
-function wrapBundledDevClientSend( clients: BundledDevInternals[ 'clients' ] ): void {
-	if ( !clients || typeof clients.setupIfNeeded != 'function' ) {
-		return;
-	}
-
+function wrapBundledDevClientSend( bundledDev: BundledDevInternals ): void {
+	const clients = bundledDev.clients;
 	const setupIfNeeded = clients.setupIfNeeded.bind( clients );
 
-	clients.setupIfNeeded = ( client: BundledDevClient, clientId: string ) => {
-		if ( !client[ isManualRefreshWrappedClient ] ) {
+	clients.setupIfNeeded = ( client, clientId ) => {
+		if ( !wrappedClients.has( client ) ) {
 			const send = client.send.bind( client );
 
-			client.send = ( payload: HotPayload ) => {
-				sendManualRefreshPayload( payload, send );
+			client.send = payload => {
+				sendManualRefreshPayload( bundledDev, payload, send );
 			};
-			client[ isManualRefreshWrappedClient ] = true;
+			wrappedClients.add( client );
 		}
 
 		return setupIfNeeded( client, clientId );
@@ -105,10 +86,6 @@ function wrapBundledDevClientSend( clients: BundledDevInternals[ 'clients' ] ): 
 }
 
 function wrapBundledDevFullReloads( bundledDev: BundledDevInternals, workspaceRoot: string ): void {
-	if ( typeof bundledDev.handleHmrOutput != 'function' ) {
-		return;
-	}
-
 	const handleHmrOutput = bundledDev.handleHmrOutput.bind( bundledDev );
 
 	bundledDev.handleHmrOutput = ( client, files, hmrOutput ) => {
@@ -116,7 +93,7 @@ function wrapBundledDevFullReloads( bundledDev: BundledDevInternals, workspaceRo
 			return handleHmrOutput( client, files, hmrOutput );
 		}
 
-		if ( !shouldShowManualRefreshPromptForFiles( files ) ) {
+		if ( !shouldShowManualRefreshPrompt( files ) ) {
 			// Vite invokes this synchronous handler without awaiting its result.
 			reloadClientAfterLatestBuildOutput( bundledDev, client, files, workspaceRoot );
 
@@ -134,43 +111,52 @@ function wrapBundledDevFullReloads( bundledDev: BundledDevInternals, workspaceRo
 
 async function reloadClientAfterLatestBuildOutput(
 	bundledDev: BundledDevInternals,
-	client: BundledDevClient,
+	client: HotChannelClient,
 	files: Array<string>,
 	workspaceRoot: string
 ): Promise<void> {
 	try {
-		await bundledDev.devEngine?.ensureLatestBuildOutput();
+		await bundledDev.devEngine.ensureLatestBuildOutput();
 	} catch {
 		// Reload using the best output available instead of leaving the page stale.
 	}
 
+	const htmlFile = files.find( file => isHtmlFile( file ) );
+
 	client.send( {
 		type: 'full-reload',
-		path: getChangedHtmlPublicPath( files, workspaceRoot )
+		path: htmlFile ? toPublicFilePath( htmlFile, workspaceRoot ) : undefined
 	} );
-}
-
-function getChangedHtmlPublicPath( files: Array<string>, workspaceRoot: string ): string | undefined {
-	const htmlFile = files.find( file => file.endsWith( '.html' ) );
-
-	return htmlFile ? toPublicFilePath( htmlFile, workspaceRoot ) : undefined;
 }
 
 function ensureLatestBuildOutput( bundledDev: BundledDevInternals ): void {
 	try {
-		bundledDev.devEngine?.ensureLatestBuildOutput().catch( () => {} );
+		bundledDev.devEngine.ensureLatestBuildOutput().catch( () => {} );
 	} catch {
 		// The `devEngine` getter throws until initialized. An HMR update arriving before
 		// that is unlikely, but do not let it break the update handling.
 	}
 }
 
-function sendManualRefreshPayload( payload: HotPayload, send: ( payload: HotPayload ) => void ): void {
-	if ( payload.type == 'bundled-dev-update' && !payload.changedIds.length ) {
-		return;
-	}
+function sendManualRefreshPayload(
+	bundledDev: BundledDevInternals,
+	payload: HotPayload,
+	send: ( payload: HotPayload ) => void
+): void {
+	if ( payload.type == 'bundled-dev-update' && shouldShowManualRefreshPrompt( payload.changedIds ) ) {
+		// The client never sees the changed ids, so it never requests the rebuild it would
+		// normally trigger — refresh the bundle output up front so the prompt's reload is fresh.
+		ensureLatestBuildOutput( bundledDev );
 
-	if ( shouldShowManualRefreshPrompt( payload ) ) {
+		// Forward the update neutralized (no changed ids) instead of dropping it: the client
+		// no-ops on it but still records its `seq`. A dropped update would trip the client's
+		// sequence-gap safety on the next passed-through update (e.g. a CSS hot update) and
+		// force a full reload, losing the editor state the prompt exists to protect.
+		send( {
+			...payload,
+			changedIds: []
+		} );
+
 		send( {
 			type: 'custom',
 			event: MANUAL_REFRESH_EVENT_NAME
@@ -182,14 +168,16 @@ function sendManualRefreshPayload( payload: HotPayload, send: ( payload: HotPayl
 	send( payload );
 }
 
-function shouldShowManualRefreshPrompt( payload: HotPayload ): boolean {
-	return payload.type == 'bundled-dev-update' && payload.changedIds.some( filePath => !isCssFile( filePath ) );
+// CSS updates hot-update in place and HTML updates auto-reload through the client's
+// boundary walk, so only JS/TS changes are turned into the refresh prompt.
+function shouldShowManualRefreshPrompt( filePaths: Array<string> ): boolean {
+	return filePaths.some( filePath => !isCssFile( filePath ) && !isHtmlFile( filePath ) );
 }
 
 function isCssFile( filePath: string ): boolean {
 	return filePath.split( '?', 1 )[ 0 ]!.endsWith( '.css' );
 }
 
-function shouldShowManualRefreshPromptForFiles( files: Array<string> ): boolean {
-	return files.some( file => !file.endsWith( '.css' ) && !file.endsWith( '.html' ) );
+function isHtmlFile( filePath: string ): boolean {
+	return filePath.split( '?', 1 )[ 0 ]!.endsWith( '.html' );
 }

--- a/packages/ckeditor5-dev-manual-server/tests/_utils/vite.ts
+++ b/packages/ckeditor5-dev-manual-server/tests/_utils/vite.ts
@@ -4,18 +4,20 @@
  */
 
 import { expect, vi } from 'vitest';
-import { createServer, type AppType, type HotPayload, type Plugin, type ViteDevServer } from 'vite';
+import { createServer, type AppType, type HotPayload, type Plugin, type UserConfig, type ViteDevServer } from 'vite';
 import { createFile } from './files.js';
 
 export interface CreateTestServerOptions {
 	appType?: AppType;
 	plugins: Array<Plugin>;
+	resolve?: UserConfig[ 'resolve' ];
 	root: string;
 }
 
 export async function createTestServer( {
 	appType,
 	plugins,
+	resolve,
 	root
 }: CreateTestServerOptions ): Promise<ViteDevServer> {
 	return createServer( {
@@ -26,6 +28,7 @@ export async function createTestServer( {
 		server: {
 			middlewareMode: true
 		},
+		resolve,
 		plugins
 	} );
 }

--- a/packages/ckeditor5-dev-manual-server/tests/manual-test-plugin/plugin.ts
+++ b/packages/ckeditor5-dev-manual-server/tests/manual-test-plugin/plugin.ts
@@ -60,6 +60,7 @@ type TestServer = {
 
 const HEADER_PAGE = '<!DOCTYPE html><html><head><title>Foo</title></head>' +
 	'<body><ck-manual-header><p>Steps</p></ck-manual-header></body></html>';
+const MANUAL_TRANSLATIONS_VIRTUAL_ID = 'virtual:ckeditor5-manual-translations';
 
 describe( 'manualTestsPlugin()', () => {
 	let server: ViteDevServer | undefined;
@@ -265,6 +266,82 @@ describe( 'manualTestsPlugin()', () => {
 			'console.log( 1 );\n\nimport \'../theme/index-editor.css\';\nimport \'../theme/index-content.css\';\n'
 		);
 		expect( result!.map ).to.equal( null );
+	} );
+
+	it( 'injects the translations module only into discovered manual test entry scripts', async () => {
+		await Promise.all( [
+			createFile( workspaceRoot, 'packages/ckeditor5-foo/manual/foo.manual.html' ),
+			createFile( workspaceRoot, 'packages/ckeditor5-foo/manual/foo.js', 'console.log( 1 );\n' ),
+			createFile( workspaceRoot, 'packages/ckeditor5-foo/manual/_utils/helper.js', 'console.log( 2 );\n' ),
+			createFile( workspaceRoot, 'packages/ckeditor5-foo/theme/index-editor.css' )
+		] );
+
+		const transform = createConfiguredTransformHook( {
+			paths: [ 'packages/*' ],
+			language: 'pl'
+		} );
+		const entryFilePath = join( workspaceRoot, 'packages/ckeditor5-foo/manual/foo.js' );
+		const helperFilePath = join( workspaceRoot, 'packages/ckeditor5-foo/manual/_utils/helper.js' );
+
+		expect( transform.handler( 'console.log( 1 );\n', entryFilePath )!.code )
+			.to.contain( `import '${ MANUAL_TRANSLATIONS_VIRTUAL_ID }';` );
+		expect( transform.handler( 'console.log( 2 );\n', helperFilePath ) ).to.equal( undefined );
+	} );
+
+	it( 'generates the translations module for the selected language and configured package roots', async () => {
+		await Promise.all( [
+			createFile( workspaceRoot, 'packages/ckeditor5-foo/manual/foo.manual.html' ),
+			createFile( workspaceRoot, 'packages/ckeditor5-foo/lang/translations/pl.ts',
+				'export default { pl: { dictionary: { Cancel: \'Anuluj\' } } };\n' ),
+			createFile( workspaceRoot, 'packages/ckeditor5-bar/lang/translations/pl.ts',
+				'export default { pl: { dictionary: { Cancel: \'Annulla\' } } };\n' ),
+			createFile( workspaceRoot, 'packages/ckeditor5-foo/lang/translations/en.ts',
+				'export default { en: { dictionary: { Cancel: \'Cancel\' } } };\n' )
+		] );
+
+		server = await createManualTestServer( {
+			paths: [ 'packages/ckeditor5-foo' ],
+			language: 'pl'
+		} );
+		const resolvedId = await server.pluginContainer.resolveId( MANUAL_TRANSLATIONS_VIRTUAL_ID );
+		const source = getCode( await server.pluginContainer.load( resolvedId!.id ) );
+
+		expect( source ).to.contain( 'lang/translations/pl.ts' );
+		expect( source ).to.contain( 'packages/ckeditor5-foo' );
+		expect( source ).not.to.contain( 'packages/ckeditor5-bar' );
+		expect( source ).not.to.contain( 'lang/translations/en.ts' );
+	} );
+
+	it( 'expands the selected translation files through Vite', async () => {
+		await Promise.all( [
+			createFile( workspaceRoot, 'packages/ckeditor5-foo/manual/foo.manual.html' ),
+			createFile( workspaceRoot, 'packages/ckeditor5-foo/lang/translations/pl.ts',
+				'export default { pl: { dictionary: { Cancel: \'Anuluj\' } } };\n' ),
+			createFile( workspaceRoot, 'stubs/core.ts', 'export class Context {}\nexport class Editor {}\n' ),
+			createFile( workspaceRoot, 'stubs/utils.ts', 'export function add() {}\n' )
+		] );
+
+		server = await createTestServer( {
+			root: workspaceRoot,
+			appType: 'mpa',
+			resolve: {
+				alias: {
+					'@ckeditor/ckeditor5-core': join( workspaceRoot, 'stubs/core.ts' ),
+					'@ckeditor/ckeditor5-utils': join( workspaceRoot, 'stubs/utils.ts' )
+				}
+			},
+			plugins: [
+				manualTestsPlugin( {
+					paths: [ 'packages/ckeditor5-foo' ],
+					language: 'pl'
+				} )
+			]
+		} );
+		const resolvedId = await server.pluginContainer.resolveId( MANUAL_TRANSLATIONS_VIRTUAL_ID );
+		const transformed = await server.transformRequest( resolvedId!.id );
+
+		expect( transformed!.code ).to.contain( '/packages/ckeditor5-foo/lang/translations/pl.ts' );
+		expect( transformed!.code ).not.to.contain( 'import.meta.glob' );
 	} );
 
 	it( 'appends only the theme entry stylesheets that exist in the package', async () => {

--- a/packages/ckeditor5-dev-manual-server/tests/manual-test-plugin/plugin.ts
+++ b/packages/ckeditor5-dev-manual-server/tests/manual-test-plugin/plugin.ts
@@ -13,21 +13,12 @@ import { createFile, createTemporaryDirectory, removeDirectory } from '../_utils
 import { createTestServer, getCode } from '../_utils/vite.js';
 
 type ServerHook = ( server: TestServer ) => void;
-type ConfigHook = () => {
-	build: {
-		rolldownOptions: {
-			input: Array<string>;
-		};
-	};
+type ConfigHook = ( config?: { root?: string } ) => {
+	input: Array<string>;
 };
 type ConfigResolvedHook = ( config: {
 	root: string;
 	base?: string;
-	build: {
-		rolldownOptions: {
-			input: Array<string>;
-		};
-	};
 } ) => void;
 type TransformResult = string | undefined | { html: string; tags: Array<HtmlTagDescriptor> };
 type TransformIndexHtmlHook = {
@@ -87,7 +78,7 @@ describe( 'manualTestsPlugin()', () => {
 		server = await createManualTestServer( {
 			paths: [ 'packages/ckeditor5-foo' ]
 		} );
-		const input = server.config.build.rolldownOptions.input as Array<string>;
+		const input = server.config.input as Array<string>;
 
 		expect( input ).to.include( join( workspaceRoot, 'packages/ckeditor5-foo/manual/foo.manual.html' ) );
 		expect( input ).not.to.include( join( workspaceRoot, 'packages/ckeditor5-bar/manual/bar.manual.html' ) );
@@ -118,13 +109,13 @@ describe( 'manualTestsPlugin()', () => {
 		server = await createManualTestServer( {
 			paths: [ 'packages/*' ]
 		} );
-		const input = server.config.build.rolldownOptions.input as Array<string>;
+		const input = server.config.input as Array<string>;
 
 		expect( input ).to.include( join( workspaceRoot, 'packages/ckeditor5-foo/manual/foo.manual.html' ) );
 		expect( input ).not.to.include( join( workspaceRoot, 'packages/ckeditor5-foo/manual/fixture.html' ) );
 	} );
 
-	it( 'filters build inputs and catalog entries using included full package names', async () => {
+	it( 'filters inputs and catalog entries using included full package names', async () => {
 		await Promise.all( [
 			createFile( workspaceRoot, 'packages/ckeditor5-foo/manual/foo.manual.html' ),
 			createFile( workspaceRoot, 'packages/ckeditor5-bar/manual/bar.manual.html' )
@@ -134,7 +125,7 @@ describe( 'manualTestsPlugin()', () => {
 			paths: [ 'packages/*' ],
 			include: [ 'ckeditor5-bar' ]
 		} );
-		const input = server.config.build.rolldownOptions.input as Array<string>;
+		const input = server.config.input as Array<string>;
 		const resolvedId = await server.pluginContainer.resolveId( 'virtual:ckeditor5-manual-entries' );
 		const source = getCode( await server.pluginContainer.load( resolvedId!.id ) );
 
@@ -181,10 +172,10 @@ describe( 'manualTestsPlugin()', () => {
 		await createFile( workspaceRoot, 'packages/ckeditor5-foo/manual/foo.manual.html', HEADER_PAGE );
 
 		const plugin = manualTestsPlugin( { paths: [ 'packages/*' ] } );
-		const config = ( plugin.config as ConfigHook )();
+		( plugin.config as ConfigHook )();
 		const transformIndexHtml = plugin.transformIndexHtml as TransformIndexHtmlHook;
 
-		( plugin.configResolved as ConfigResolvedHook )( { root: workspaceRoot, base: './', build: config.build } );
+		( plugin.configResolved as ConfigResolvedHook )( { root: workspaceRoot, base: './' } );
 
 		const result = transformIndexHtml.handler( HEADER_PAGE, {
 			filename: join( workspaceRoot, 'packages/ckeditor5-foo/manual/foo.manual.html' )
@@ -215,10 +206,10 @@ describe( 'manualTestsPlugin()', () => {
 		await createFile( workspaceRoot, 'packages/ckeditor5-foo/manual/foo.manual.html', HEADER_PAGE );
 
 		const plugin = manualTestsPlugin( { paths: [ 'packages/*' ] } );
-		const config = ( plugin.config as ConfigHook )();
+		( plugin.config as ConfigHook )();
 		const transformIndexHtml = plugin.transformIndexHtml as TransformIndexHtmlHook;
 
-		( plugin.configResolved as ConfigResolvedHook )( { root: workspaceRoot, base: '/manual/', build: config.build } );
+		( plugin.configResolved as ConfigResolvedHook )( { root: workspaceRoot, base: '/manual/' } );
 
 		const result = transformIndexHtml.handler( HEADER_PAGE, {
 			filename: join( workspaceRoot, 'packages/ckeditor5-foo/manual/foo.manual.html' )
@@ -232,10 +223,10 @@ describe( 'manualTestsPlugin()', () => {
 		await createFile( workspaceRoot, 'packages/ckeditor5-foo/manual/foo.manual.html', '<p>No chrome</p>' );
 
 		const plugin = manualTestsPlugin( { paths: [ 'packages/*' ] } );
-		const config = ( plugin.config as ConfigHook )();
+		( plugin.config as ConfigHook )();
 		const transformIndexHtml = plugin.transformIndexHtml as TransformIndexHtmlHook;
 
-		( plugin.configResolved as ConfigResolvedHook )( { root: workspaceRoot, base: './', build: config.build } );
+		( plugin.configResolved as ConfigResolvedHook )( { root: workspaceRoot, base: './' } );
 
 		const result = transformIndexHtml.handler( '<p>No chrome</p>', {
 			filename: join( workspaceRoot, 'packages/ckeditor5-foo/manual/foo.manual.html' )
@@ -460,9 +451,9 @@ describe( 'manualTestsPlugin()', () => {
 
 	function createConfiguredTransformHook( options: ManualTestsPluginOptions ): TransformHook {
 		const plugin = manualTestsPlugin( options );
-		const config = ( plugin.config as ConfigHook )();
+		( plugin.config as ConfigHook )();
 
-		( plugin.configResolved as ConfigResolvedHook )( { root: workspaceRoot, base: './', build: config.build } );
+		( plugin.configResolved as ConfigResolvedHook )( { root: workspaceRoot, base: './' } );
 
 		return plugin.transform as unknown as TransformHook;
 	}
@@ -479,9 +470,12 @@ describe( 'manualTestsPlugin()', () => {
 			] );
 
 			server = await createManualTestServer( { paths: [ 'packages/*' ] } );
+			const input = server.config.input as Array<string>;
 			const resolvedId = await server.pluginContainer.resolveId( 'virtual:ckeditor5-manual-entries' );
 			const source = getCode( await server.pluginContainer.load( resolvedId!.id ) );
 
+			expect( input ).to.include( join( workspaceRoot, 'packages/ckeditor5-foo/manual/foo.manual.html' ) );
+			expect( input ).not.to.include( join( currentWorkingDirectory, 'packages/ckeditor5-bar/manual/bar.manual.html' ) );
 			expect( source ).to.contain( '/packages/ckeditor5-foo/manual/foo.manual.html' );
 			expect( source ).not.to.contain( '/packages/ckeditor5-bar/manual/bar.manual.html' );
 		} finally {
@@ -489,15 +483,13 @@ describe( 'manualTestsPlugin()', () => {
 		}
 	} );
 
-	it( 'uses current working directory for initial build inputs', async () => {
+	it( 'uses current working directory for initial inputs', async () => {
 		await createFile( workspaceRoot, 'packages/ckeditor5-foo/manual/foo.manual.html' );
 
 		const plugin = manualTestsPlugin( { paths: [ 'packages/*' ] } );
 		const config = ( plugin.config as ConfigHook )();
 
-		expect( config.build.rolldownOptions.input ).to.include(
-			join( workspaceRoot, 'packages/ckeditor5-foo/manual/foo.manual.html' )
-		);
+		expect( config.input ).to.include( join( workspaceRoot, 'packages/ckeditor5-foo/manual/foo.manual.html' ) );
 	} );
 
 	it( 'does not resolve unknown virtual module requests', async () => {
@@ -524,17 +516,16 @@ describe( 'manualTestsPlugin()', () => {
 	it( 'registers the catalog HTML as the build index page', () => {
 		const plugin = manualTestsPlugin( { paths: [] } );
 		const config = ( plugin.config as ConfigHook )();
-		const catalogBuildInputFilePath = join( workspaceRoot, 'index.html' );
+		const catalogInputFilePath = join( workspaceRoot, 'index.html' );
 
-		expect( config.build.rolldownOptions.input ).to.include( catalogBuildInputFilePath );
+		expect( config.input ).to.include( catalogInputFilePath );
 
 		( plugin.configResolved as ConfigResolvedHook )( {
-			root: workspaceRoot,
-			build: config.build
+			root: workspaceRoot
 		} );
 
-		expect( ( plugin.resolveId as ResolveIdHook )( 'index.html' ) ).to.equal( catalogBuildInputFilePath );
-		expect( ( plugin.load as LoadHook )( catalogBuildInputFilePath ) )
+		expect( ( plugin.resolveId as ResolveIdHook )( 'index.html' ) ).to.equal( catalogInputFilePath );
+		expect( ( plugin.load as LoadHook )( catalogInputFilePath ) )
 			.to.contain( '<script type="module" src="./catalog.ts"></script>' );
 	} );
 
@@ -598,13 +589,12 @@ describe( 'manualTestsPlugin()', () => {
 
 	it( 'rewrites the catalog script for the synthetic build index page', () => {
 		const plugin = manualTestsPlugin( { paths: [] } );
-		const config = ( plugin.config as ConfigHook )();
+		( plugin.config as ConfigHook )();
 		const transformIndexHtml = plugin.transformIndexHtml as TransformIndexHtmlHook;
 		const catalogScriptFilePath = resolve( import.meta.dirname, '../../theme/catalog.ts' ).replace( /\\/g, '/' );
 
 		( plugin.configResolved as ConfigResolvedHook )( {
-			root: workspaceRoot,
-			build: config.build
+			root: workspaceRoot
 		} );
 
 		expect( transformIndexHtml.handler(
@@ -751,31 +741,31 @@ describe( 'manualTestsPlugin()', () => {
 
 		it( 'does not wrap memory files when bundled dev is unavailable', () => {
 			const plugin = manualTestsPlugin( { paths: [ 'packages/*' ] } );
-			const config = ( plugin.config as ConfigHook )();
+			( plugin.config as ConfigHook )();
 			const server = createMiddlewareServer();
 
-			( plugin.configResolved as ConfigResolvedHook )( { root: workspaceRoot, base: './', build: config.build } );
+			( plugin.configResolved as ConfigResolvedHook )( { root: workspaceRoot, base: './' } );
 
 			expect( () => ( plugin.configureServer as unknown as ServerHook )( server ) ).not.to.throw();
 		} );
 
 		function configureFreshness( memoryFiles: MemoryFilesLike ): void {
 			const plugin = manualTestsPlugin( { paths: [ 'packages/*' ] } );
-			const config = ( plugin.config as ConfigHook )();
+			( plugin.config as ConfigHook )();
 			const server = createMiddlewareServer();
 
 			server.environments.client.bundledDev = { memoryFiles };
 
-			( plugin.configResolved as ConfigResolvedHook )( { root: workspaceRoot, base: './', build: config.build } );
+			( plugin.configResolved as ConfigResolvedHook )( { root: workspaceRoot, base: './' } );
 			( plugin.configureServer as unknown as ServerHook )( server );
 		}
 	} );
 
 	function loadEntries( options: ManualTestsPluginOptions, base: string ): string {
 		const plugin = manualTestsPlugin( options );
-		const config = ( plugin.config as ConfigHook )();
+		( plugin.config as ConfigHook )();
 
-		( plugin.configResolved as ConfigResolvedHook )( { root: workspaceRoot, base, build: config.build } );
+		( plugin.configResolved as ConfigResolvedHook )( { root: workspaceRoot, base } );
 
 		return ( plugin.load as LoadHook )( '\0virtual:ckeditor5-manual-entries' )!;
 	}

--- a/packages/ckeditor5-dev-manual-server/tests/manual-test-plugin/translations.ts
+++ b/packages/ckeditor5-dev-manual-server/tests/manual-test-plugin/translations.ts
@@ -1,0 +1,32 @@
+/**
+ * @license Copyright (c) 2003-2026, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { createManualTranslationsModule } from '../../src/manual-test-plugin/translations.js';
+
+describe( 'createManualTranslationsModule()', () => {
+	it( 'loads and registers translations from the configured package roots', () => {
+		const source = createManualTranslationsModule( [ './packages/*', 'external/ckeditor5/packages/*/' ], 'ar' );
+
+		expect( source ).to.contain( '"/packages/*/lang/translations/ar.ts"' );
+		expect( source ).to.contain( '"/external/ckeditor5/packages/*/lang/translations/ar.ts"' );
+		expect( source ).to.contain( 'Object.values( translationModules ).map( module => module[ language ] )' );
+		expect( source ).to.contain( 'add( language, translation.dictionary, translation.getPluralForm )' );
+	} );
+
+	it( 'requires translations and a plural form for the selected language', () => {
+		const source = createManualTranslationsModule( [ 'packages/*' ], 'pl' );
+
+		expect( source ).to.contain( 'No CKEditor 5 translations found' );
+		expect( source ).to.contain( 'The ckeditor5-core translations' );
+	} );
+
+	it( 'sets the default language for editors and contexts', () => {
+		const source = createManualTranslationsModule( [ 'packages/*' ], 'ar' );
+
+		expect( source ).to.contain( 'Editor.defaultConfig = { ...Editor.defaultConfig, language: "ar" }' );
+		expect( source ).to.contain( 'Context.defaultConfig = { ...Context.defaultConfig, language: "ar" }' );
+	} );
+} );

--- a/packages/ckeditor5-dev-manual-server/tests/refresh-plugin/plugin.ts
+++ b/packages/ckeditor5-dev-manual-server/tests/refresh-plugin/plugin.ts
@@ -16,7 +16,7 @@ describe( 'refreshPlugin()', () => {
 		expect( refreshPlugin().apply ).to.equal( 'serve' );
 	} );
 
-	it( 'replaces bundled dev JavaScript HMR updates sent directly to clients with the manual refresh prompt', () => {
+	it( 'replaces bundled dev translation updates with the manual refresh prompt', () => {
 		const clientPayloads: Array<HotPayload> = [];
 		const server = createBundledDevServer();
 		const client = createBundledDevClient( clientPayloads );
@@ -24,13 +24,10 @@ describe( 'refreshPlugin()', () => {
 		configureServer( server );
 		server.environments.client.bundledDev.clients.setupIfNeeded( client, 'client-1' );
 		client.send( {
-			type: 'update',
-			updates: [ {
-				type: 'js-update',
-				path: '/assets/article.js',
-				acceptedPath: '/assets/article.js',
-				timestamp: Date.now()
-			} ]
+			type: 'bundled-dev-update',
+			changedIds: [ '/packages/ckeditor5-foo/lang/translations/pl.ts' ],
+			url: '/assets/virtual-translations.js',
+			seq: 1
 		} );
 
 		expect( clientPayloads ).to.deep.equal( [ {
@@ -39,39 +36,15 @@ describe( 'refreshPlugin()', () => {
 		} ] );
 	} );
 
-	it( 'keeps bundled dev CSS HMR updates sent directly to clients', () => {
-		const clientPayloads: Array<HotPayload> = [];
-		const server = createBundledDevServer();
-		const client = createBundledDevClient( clientPayloads );
-
-		configureServer( server );
-		server.environments.client.bundledDev.clients.setupIfNeeded( client, 'client-1' );
-		client.send( {
-			type: 'update',
-			updates: [ {
-				type: 'css-update',
-				path: '/styles.css',
-				acceptedPath: '/styles.css',
-				timestamp: Date.now()
-			} ]
-		} );
-
-		expect( clientPayloads ).to.have.length( 1 );
-		expect( clientPayloads[ 0 ]!.type ).to.equal( 'update' );
-	} );
-
-	it( 'keeps bundled dev CSS patches sent as JavaScript HMR updates directly to clients', () => {
+	it( 'keeps bundled dev CSS updates sent directly to clients', () => {
 		const clientPayloads: Array<HotPayload> = [];
 		const server = createBundledDevServer();
 		const client = createBundledDevClient( clientPayloads );
 		const payload: HotPayload = {
-			type: 'update',
-			updates: [ {
-				type: 'js-update',
-				path: 'packages/foo/theme/foo.css',
-				acceptedPath: 'packages/foo/theme/foo.css',
-				timestamp: Date.now()
-			} ]
+			type: 'bundled-dev-update',
+			changedIds: [ '/packages/ckeditor5-foo/theme/foo.css?direct' ],
+			url: '/assets/foo.js',
+			seq: 1
 		};
 
 		configureServer( server );
@@ -81,7 +54,7 @@ describe( 'refreshPlugin()', () => {
 		expect( clientPayloads ).to.deep.equal( [ payload ] );
 	} );
 
-	it( 'drops bundled dev empty HMR updates sent to clients unaffected by a change', () => {
+	it( 'drops bundled dev empty update notifications sent to clients unaffected by a change', () => {
 		const clientPayloads: Array<HotPayload> = [];
 		const server = createBundledDevServer();
 		const client = createBundledDevClient( clientPayloads );
@@ -89,8 +62,10 @@ describe( 'refreshPlugin()', () => {
 		configureServer( server );
 		server.environments.client.bundledDev.clients.setupIfNeeded( client, 'client-1' );
 		client.send( {
-			type: 'update',
-			updates: []
+			type: 'bundled-dev-update',
+			changedIds: [],
+			url: '/assets/noop.js',
+			seq: 1
 		} );
 
 		expect( clientPayloads ).to.deep.equal( [] );
@@ -117,13 +92,10 @@ describe( 'refreshPlugin()', () => {
 		server.environments.client.bundledDev.clients.setupIfNeeded( client, 'client-1' );
 		server.environments.client.bundledDev.clients.setupIfNeeded( client, 'client-1' );
 		client.send( {
-			type: 'update',
-			updates: [ {
-				type: 'js-update',
-				path: '/assets/article.js',
-				acceptedPath: '/assets/article.js',
-				timestamp: Date.now()
-			} ]
+			type: 'bundled-dev-update',
+			changedIds: [ '/assets/article.js' ],
+			url: '/assets/article.js',
+			seq: 1
 		} );
 
 		expect( clientPayloads ).to.deep.equal( [ {
@@ -234,26 +206,18 @@ describe( 'refreshPlugin()', () => {
 		const client = createBundledDevClient( [] );
 		const handleHmrOutput = server.environments.client.bundledDev.handleHmrOutput;
 		const hmrOutput = { type: 'Patch' };
-		const invalidateInformation = {};
 
 		configureServer( server );
-		( server.environments.client.bundledDev.handleHmrOutput as (
-			client: unknown,
-			files: Array<string>,
-			hmrOutput: unknown,
-			invalidateInformation?: unknown
-		) => void )(
+		server.environments.client.bundledDev.handleHmrOutput(
 			client,
 			[ '/workspace/article.css' ],
-			hmrOutput,
-			invalidateInformation
+			hmrOutput
 		);
 
 		expect( handleHmrOutput ).toHaveBeenCalledExactlyOnceWith(
 			client,
 			[ '/workspace/article.css' ],
-			hmrOutput,
-			invalidateInformation
+			hmrOutput
 		);
 	} );
 
@@ -281,7 +245,7 @@ describe( 'refreshPlugin()', () => {
 		expect( () => configureServer( server ) ).not.to.throw();
 	} );
 
-	// Mirrors the Vite 8.1+ layout: the patched internals live on the `BundledDev` helper
+	// Mirrors the Vite 8.2 layout: the patched internals live on the `BundledDev` helper
 	// exposed as `server.environments.client.bundledDev`.
 	function createBundledDevServer( handledFullReloads: Array<Array<string>> = [] ) {
 		return {

--- a/packages/ckeditor5-dev-manual-server/tests/refresh-plugin/plugin.ts
+++ b/packages/ckeditor5-dev-manual-server/tests/refresh-plugin/plugin.ts
@@ -30,10 +30,52 @@ describe( 'refreshPlugin()', () => {
 			seq: 1
 		} );
 
-		expect( clientPayloads ).to.deep.equal( [ {
-			type: 'custom',
-			event: MANUAL_REFRESH_EVENT_NAME
-		} ] );
+		expect( clientPayloads ).to.deep.equal( [
+			{
+				type: 'bundled-dev-update',
+				changedIds: [],
+				url: '/assets/virtual-translations.js',
+				seq: 1
+			},
+			{
+				type: 'custom',
+				event: MANUAL_REFRESH_EVENT_NAME
+			}
+		] );
+	} );
+
+	it( 'refreshes the bundle output when showing the manual refresh prompt', () => {
+		const server = createBundledDevServer();
+		const client = createBundledDevClient( [] );
+
+		configureServer( server );
+		server.environments.client.bundledDev.clients.setupIfNeeded( client, 'client-1' );
+		client.send( {
+			type: 'bundled-dev-update',
+			changedIds: [ '/packages/ckeditor5-foo/src/foo.ts' ],
+			url: '/assets/foo.js',
+			seq: 1
+		} );
+
+		expect( server.environments.client.bundledDev.devEngine.ensureLatestBuildOutput ).toHaveBeenCalledOnce();
+	} );
+
+	it( 'keeps bundled dev HTML updates sent directly to clients', () => {
+		const clientPayloads: Array<HotPayload> = [];
+		const server = createBundledDevServer();
+		const client = createBundledDevClient( clientPayloads );
+		const payload: HotPayload = {
+			type: 'bundled-dev-update',
+			changedIds: [ 'packages/ckeditor5-foo/manual/foo.manual.html' ],
+			url: '/assets/foo.manual.js',
+			seq: 1
+		};
+
+		configureServer( server );
+		server.environments.client.bundledDev.clients.setupIfNeeded( client, 'client-1' );
+		client.send( payload );
+
+		expect( clientPayloads ).to.deep.equal( [ payload ] );
 	} );
 
 	it( 'keeps bundled dev CSS updates sent directly to clients', () => {
@@ -54,21 +96,24 @@ describe( 'refreshPlugin()', () => {
 		expect( clientPayloads ).to.deep.equal( [ payload ] );
 	} );
 
-	it( 'drops bundled dev empty update notifications sent to clients unaffected by a change', () => {
+	// Empty updates keep the client's update sequence numbering intact and no-op there,
+	// so they must pass through without triggering the refresh prompt.
+	it( 'keeps bundled dev empty update notifications sent to clients unaffected by a change', () => {
 		const clientPayloads: Array<HotPayload> = [];
 		const server = createBundledDevServer();
 		const client = createBundledDevClient( clientPayloads );
-
-		configureServer( server );
-		server.environments.client.bundledDev.clients.setupIfNeeded( client, 'client-1' );
-		client.send( {
+		const payload: HotPayload = {
 			type: 'bundled-dev-update',
 			changedIds: [],
 			url: '/assets/noop.js',
 			seq: 1
-		} );
+		};
 
-		expect( clientPayloads ).to.deep.equal( [] );
+		configureServer( server );
+		server.environments.client.bundledDev.clients.setupIfNeeded( client, 'client-1' );
+		client.send( payload );
+
+		expect( clientPayloads ).to.deep.equal( [ payload ] );
 	} );
 
 	it( 'keeps non-update payloads sent directly to clients', () => {
@@ -98,10 +143,18 @@ describe( 'refreshPlugin()', () => {
 			seq: 1
 		} );
 
-		expect( clientPayloads ).to.deep.equal( [ {
-			type: 'custom',
-			event: MANUAL_REFRESH_EVENT_NAME
-		} ] );
+		expect( clientPayloads ).to.deep.equal( [
+			{
+				type: 'bundled-dev-update',
+				changedIds: [],
+				url: '/assets/article.js',
+				seq: 1
+			},
+			{
+				type: 'custom',
+				event: MANUAL_REFRESH_EVENT_NAME
+			}
+		] );
 	} );
 
 	it( 'replaces bundled dev JavaScript full reloads with the manual refresh prompt', () => {
@@ -221,31 +274,29 @@ describe( 'refreshPlugin()', () => {
 		);
 	} );
 
-	it( 'does not crash when the bundled dev helper is unavailable', () => {
-		const server = createBundledDevServer();
+	it( 'force-ships manual test HTML modules from the hotUpdate hook', () => {
+		const modules = [ { id: 'packages/ckeditor5-foo/manual/foo.manual.html' } ];
 
-		delete ( server.environments.client as Partial<typeof server.environments.client> ).bundledDev;
-
-		expect( () => configureServer( server ) ).not.to.throw();
+		expect( callHotUpdate( '/workspace/packages/ckeditor5-foo/manual/foo.manual.html', modules ) )
+			.to.equal( modules );
 	} );
 
-	it( 'does not crash when bundled dev clients are unavailable', () => {
-		const server = createBundledDevServer();
-
-		delete ( server.environments.client.bundledDev as Partial<typeof server.environments.client.bundledDev> ).clients;
-
-		expect( () => configureServer( server ) ).not.to.throw();
+	it( 'keeps the default hotUpdate behavior for files other than manual test HTML', () => {
+		expect( callHotUpdate( '/workspace/packages/ckeditor5-foo/src/foo.ts', [ {} ] ) )
+			.to.equal( undefined );
+		expect( callHotUpdate( '/workspace/packages/ckeditor5-foo/manual/fixture.html', [ {} ] ) )
+			.to.equal( undefined );
 	} );
 
-	it( 'does not crash when bundled dev HMR handling is unavailable', () => {
-		const server = createBundledDevServer();
+	function callHotUpdate( file: string, modules: Array<unknown> ): Array<unknown> | undefined {
+		const hotUpdate = refreshPlugin().hotUpdate as unknown as (
+			options: { file: string; modules: Array<unknown> }
+		) => Array<unknown> | undefined;
 
-		delete ( server.environments.client.bundledDev as Partial<typeof server.environments.client.bundledDev> ).handleHmrOutput;
+		return hotUpdate( { file, modules } );
+	}
 
-		expect( () => configureServer( server ) ).not.to.throw();
-	} );
-
-	// Mirrors the Vite 8.2 layout: the patched internals live on the `BundledDev` helper
+	// Mirrors the Vite 8.2.1 layout: the patched internals live on the `BundledDev` helper
 	// exposed as `server.environments.client.bundledDev`.
 	function createBundledDevServer( handledFullReloads: Array<Array<string>> = [] ) {
 		return {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,7 +78,7 @@ importers:
         specifier: ^2.0.1
         version: 2.0.1
       vite:
-        specifier: ^8.2.0
+        specifier: ^8.2.1
         version: 8.2.1(@types/node@22.19.19)(esbuild@0.28.1)(terser@5.48.0)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.2
@@ -261,7 +261,7 @@ importers:
         specifier: ^5.0.1
         version: 5.0.1
       vite:
-        specifier: ^8.2.0
+        specifier: ^8.2.1
         version: 8.2.1(@types/node@22.19.19)(esbuild@0.28.1)(terser@5.48.0)(yaml@2.9.0)
     devDependencies:
       '@vitest/coverage-v8':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,11 +78,11 @@ importers:
         specifier: ^2.0.1
         version: 2.0.1
       vite:
-        specifier: ^8.1.0
-        version: 8.1.0(@types/node@22.19.19)(esbuild@0.28.1)(terser@5.48.0)(yaml@2.9.0)
+        specifier: ^8.2.0
+        version: 8.2.1(@types/node@22.19.19)(esbuild@0.28.1)(terser@5.48.0)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.2
-        version: 4.1.7(@types/node@22.19.19)(@vitest/coverage-v8@4.1.7)(vite@8.1.0(@types/node@22.19.19)(esbuild@0.28.1)(terser@5.48.0)(yaml@2.9.0))
+        version: 4.1.7(@types/node@22.19.19)(@vitest/coverage-v8@4.1.7)(vite@8.2.1(@types/node@22.19.19)(esbuild@0.28.1)(terser@5.48.0)(yaml@2.9.0))
 
   packages/ckeditor5-dev-build-tools:
     dependencies:
@@ -100,7 +100,7 @@ importers:
         version: 1.33.0
       rolldown:
         specifier: ^1.1.2
-        version: 1.1.2
+        version: 1.2.3
       source-map:
         specifier: ^0.7.6
         version: 0.7.6
@@ -119,7 +119,7 @@ importers:
         version: 4.41.0
       vitest:
         specifier: ^4.1.2
-        version: 4.1.7(@types/node@22.19.19)(@vitest/coverage-v8@4.1.7)(vite@8.1.0(@types/node@22.19.19)(esbuild@0.28.1)(terser@5.48.0)(yaml@2.9.0))
+        version: 4.1.7(@types/node@22.19.19)(@vitest/coverage-v8@4.1.7)(vite@8.2.1(@types/node@22.19.19)(esbuild@0.28.1)(terser@5.48.0)(yaml@2.9.0))
 
   packages/ckeditor5-dev-bump-year:
     dependencies:
@@ -162,10 +162,10 @@ importers:
         version: 4.1.7(vitest@4.1.7)
       rolldown:
         specifier: ^1.1.2
-        version: 1.1.2
+        version: 1.2.3
       vitest:
         specifier: ^4.1.2
-        version: 4.1.7(@types/node@22.19.19)(@vitest/coverage-v8@4.1.7)(vite@8.1.0(@types/node@22.19.19)(esbuild@0.28.1)(terser@5.48.0)(yaml@2.9.0))
+        version: 4.1.7(@types/node@22.19.19)(@vitest/coverage-v8@4.1.7)(vite@8.2.1(@types/node@22.19.19)(esbuild@0.28.1)(terser@5.48.0)(yaml@2.9.0))
 
   packages/ckeditor5-dev-ci:
     dependencies:
@@ -181,7 +181,7 @@ importers:
     devDependencies:
       vitest:
         specifier: ^4.1.2
-        version: 4.1.7(@types/node@22.19.19)(@vitest/coverage-v8@4.1.7)(vite@8.1.0(@types/node@22.19.19)(esbuild@0.28.1)(terser@5.48.0)(yaml@2.9.0))
+        version: 4.1.7(@types/node@22.19.19)(@vitest/coverage-v8@4.1.7)(vite@8.2.1(@types/node@22.19.19)(esbuild@0.28.1)(terser@5.48.0)(yaml@2.9.0))
 
   packages/ckeditor5-dev-dependency-checker:
     dependencies:
@@ -209,7 +209,7 @@ importers:
     devDependencies:
       vitest:
         specifier: ^4.1.2
-        version: 4.1.7(@types/node@22.19.19)(@vitest/coverage-v8@4.1.7)(vite@8.1.0(@types/node@22.19.19)(esbuild@0.28.1)(terser@5.48.0)(yaml@2.9.0))
+        version: 4.1.7(@types/node@22.19.19)(@vitest/coverage-v8@4.1.7)(vite@8.2.1(@types/node@22.19.19)(esbuild@0.28.1)(terser@5.48.0)(yaml@2.9.0))
 
   packages/ckeditor5-dev-docs:
     dependencies:
@@ -234,7 +234,7 @@ importers:
         version: 5.0.3
       vitest:
         specifier: ^4.1.2
-        version: 4.1.7(@types/node@22.19.19)(@vitest/coverage-v8@4.1.7)(vite@8.1.0(@types/node@22.19.19)(esbuild@0.28.1)(terser@5.48.0)(yaml@2.9.0))
+        version: 4.1.7(@types/node@22.19.19)(@vitest/coverage-v8@4.1.7)(vite@8.2.1(@types/node@22.19.19)(esbuild@0.28.1)(terser@5.48.0)(yaml@2.9.0))
 
   packages/ckeditor5-dev-license-checker:
     dependencies:
@@ -250,10 +250,10 @@ importers:
         version: 4.1.7(vitest@4.1.7)
       rolldown:
         specifier: ^1.1.2
-        version: 1.1.2
+        version: 1.2.3
       vitest:
         specifier: ^4.1.2
-        version: 4.1.7(@types/node@22.19.19)(@vitest/coverage-v8@4.1.7)(vite@8.1.0(@types/node@22.19.19)(esbuild@0.28.1)(terser@5.48.0)(yaml@2.9.0))
+        version: 4.1.7(@types/node@22.19.19)(@vitest/coverage-v8@4.1.7)(vite@8.2.1(@types/node@22.19.19)(esbuild@0.28.1)(terser@5.48.0)(yaml@2.9.0))
 
   packages/ckeditor5-dev-manual-server:
     dependencies:
@@ -261,18 +261,18 @@ importers:
         specifier: ^5.0.1
         version: 5.0.1
       vite:
-        specifier: ^8.1.0
-        version: 8.1.0(@types/node@22.19.19)(esbuild@0.28.1)(terser@5.48.0)(yaml@2.9.0)
+        specifier: ^8.2.0
+        version: 8.2.1(@types/node@22.19.19)(esbuild@0.28.1)(terser@5.48.0)(yaml@2.9.0)
     devDependencies:
       '@vitest/coverage-v8':
         specifier: ^4.1.2
         version: 4.1.7(vitest@4.1.7)
       rolldown:
         specifier: ^1.1.2
-        version: 1.1.2
+        version: 1.2.3
       vitest:
         specifier: ^4.1.2
-        version: 4.1.7(@types/node@22.19.19)(@vitest/coverage-v8@4.1.7)(vite@8.1.0(@types/node@22.19.19)(esbuild@0.28.1)(terser@5.48.0)(yaml@2.9.0))
+        version: 4.1.7(@types/node@22.19.19)(@vitest/coverage-v8@4.1.7)(vite@8.2.1(@types/node@22.19.19)(esbuild@0.28.1)(terser@5.48.0)(yaml@2.9.0))
 
   packages/ckeditor5-dev-release-tools:
     dependencies:
@@ -315,7 +315,7 @@ importers:
         version: 5.5.0
       vitest:
         specifier: ^4.1.2
-        version: 4.1.7(@types/node@22.19.19)(@vitest/coverage-v8@4.1.7)(vite@8.1.0(@types/node@22.19.19)(esbuild@0.28.1)(terser@5.48.0)(yaml@2.9.0))
+        version: 4.1.7(@types/node@22.19.19)(@vitest/coverage-v8@4.1.7)(vite@8.2.1(@types/node@22.19.19)(esbuild@0.28.1)(terser@5.48.0)(yaml@2.9.0))
 
   packages/ckeditor5-dev-stale-bot:
     dependencies:
@@ -343,7 +343,7 @@ importers:
     devDependencies:
       vitest:
         specifier: ^4.1.2
-        version: 4.1.7(@types/node@22.19.19)(@vitest/coverage-v8@4.1.7)(vite@8.1.0(@types/node@22.19.19)(esbuild@0.28.1)(terser@5.48.0)(yaml@2.9.0))
+        version: 4.1.7(@types/node@22.19.19)(@vitest/coverage-v8@4.1.7)(vite@8.2.1(@types/node@22.19.19)(esbuild@0.28.1)(terser@5.48.0)(yaml@2.9.0))
 
   packages/ckeditor5-dev-translations:
     dependencies:
@@ -371,7 +371,7 @@ importers:
     devDependencies:
       vitest:
         specifier: ^4.1.2
-        version: 4.1.7(@types/node@22.19.19)(@vitest/coverage-v8@4.1.7)(vite@8.1.0(@types/node@22.19.19)(esbuild@0.28.1)(terser@5.48.0)(yaml@2.9.0))
+        version: 4.1.7(@types/node@22.19.19)(@vitest/coverage-v8@4.1.7)(vite@8.2.1(@types/node@22.19.19)(esbuild@0.28.1)(terser@5.48.0)(yaml@2.9.0))
 
   packages/ckeditor5-dev-utils:
     dependencies:
@@ -420,10 +420,10 @@ importers:
         version: 5.0.3
       rolldown:
         specifier: ^1.1.2
-        version: 1.1.2
+        version: 1.2.3
       vitest:
         specifier: ^4.1.2
-        version: 4.1.7(@types/node@22.19.19)(@vitest/coverage-v8@4.1.7)(vite@8.1.0(@types/node@22.19.19)(esbuild@0.28.1)(terser@5.48.0)(yaml@2.9.0))
+        version: 4.1.7(@types/node@22.19.19)(@vitest/coverage-v8@4.1.7)(vite@8.2.1(@types/node@22.19.19)(esbuild@0.28.1)(terser@5.48.0)(yaml@2.9.0))
 
   packages/ckeditor5-dev-web-crawler:
     dependencies:
@@ -439,13 +439,13 @@ importers:
         version: 4.1.7(vitest@4.1.7)
       rolldown:
         specifier: ^1.1.2
-        version: 1.1.2
+        version: 1.2.3
       upath:
         specifier: ^2.0.1
         version: 2.0.1
       vitest:
         specifier: ^4.1.2
-        version: 4.1.7(@types/node@22.19.19)(@vitest/coverage-v8@4.1.7)(vite@8.1.0(@types/node@22.19.19)(esbuild@0.28.1)(terser@5.48.0)(yaml@2.9.0))
+        version: 4.1.7(@types/node@22.19.19)(@vitest/coverage-v8@4.1.7)(vite@8.2.1(@types/node@22.19.19)(esbuild@0.28.1)(terser@5.48.0)(yaml@2.9.0))
 
   packages/typedoc-plugins:
     dependencies:
@@ -458,7 +458,7 @@ importers:
         version: 13.0.6
       rolldown:
         specifier: ^1.1.2
-        version: 1.1.2
+        version: 1.2.3
       typedoc:
         specifier: ^0.28.20
         version: 0.28.20(typescript@5.5.4)
@@ -467,7 +467,7 @@ importers:
         version: 0.7.3(typedoc@0.28.20(typescript@5.5.4))
       vitest:
         specifier: ^4.1.2
-        version: 4.1.7(@types/node@22.19.19)(@vitest/coverage-v8@4.1.7)(vite@8.1.0(@types/node@22.19.19)(esbuild@0.28.1)(terser@5.48.0)(yaml@2.9.0))
+        version: 4.1.7(@types/node@22.19.19)(@vitest/coverage-v8@4.1.7)(vite@8.2.1(@types/node@22.19.19)(esbuild@0.28.1)(terser@5.48.0)(yaml@2.9.0))
 
 packages:
 
@@ -973,12 +973,6 @@ packages:
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
 
-  '@napi-rs/wasm-runtime@1.1.5':
-    resolution: {integrity: sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==}
-    peerDependencies:
-      '@emnapi/core': ^1.7.1
-      '@emnapi/runtime': ^1.7.1
-
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -1169,8 +1163,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@oxc-project/types@0.137.0':
-    resolution: {integrity: sha512-WT+Gb24i8hmvo85AIv2oEYouEXkRlKAlT9WaCa3TfLgNCN+GhrJOGZuIlMouAh38Qe4QOx26eUOVsq70qXrywA==}
+  '@oxc-project/types@0.143.0':
+    resolution: {integrity: sha512-u6JZdLBTLotrNC9Vd6vPssINdzcCzleKAH6EJKImQb7GtYvX5keN2dxkoK44stCc4tffE6QQRtZTXVSzsLUlWA==}
 
   '@oxc-project/types@0.72.3':
     resolution: {integrity: sha512-CfAC4wrmMkUoISpQkFAIfMVvlPfQV3xg7ZlcqPXPOIMQhdKIId44G8W0mCPgtpWdFFAyJ+SFtiM+9vbyCkoVng==}
@@ -1188,97 +1182,92 @@ packages:
       yauzl:
         optional: true
 
-  '@rolldown/binding-android-arm64@1.1.2':
-    resolution: {integrity: sha512-2cZ+7xRS+DBcuJBJKnfzsbleumJhBqSlJVpuzHC0nTqfd3QQ7Vx2/x5YR/D7cBamKSeWplwo82Fn9lqYUDEMfA==}
+  '@rolldown/binding-android-arm64@1.2.3':
+    resolution: {integrity: sha512-zrJtHDcaZJ1Fp7xf4hNl+7seH9Cn/N5TwLYkhgXREtBwAd/jaqW3uqeHxpDugJLVICWg4eW44kOQEGJ1r6jCGw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@rolldown/binding-darwin-arm64@1.1.2':
-    resolution: {integrity: sha512-RkPMJnygxsgOYdkfqgpwY0/Fzm8d0VQe6HGU2/B00Xa9eqdLbrII+DOKAodbJAn3ZL1AJxGHkZRPYazgGY6Ljw==}
+  '@rolldown/binding-darwin-arm64@1.2.3':
+    resolution: {integrity: sha512-ieIiibVCp0tX7TLu2cafoNPv8wJyYi01ekXpbf8q2j7F4rGAhhXb/eQh7ge9DRBY78GwmRQtvjZDux7EDbA8kA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-x64@1.1.2':
-    resolution: {integrity: sha512-Uiczh6vFhwyfd7WNe7Q7mCA4KxAiLdz7jPE/WGizfRpIieoyFuNVMmM8HqZ9HwudTkY6/AeMQwlNJ9NJijguWw==}
+  '@rolldown/binding-darwin-x64@1.2.3':
+    resolution: {integrity: sha512-Zh9tCon19eDXJoihx0rqKhMUlMYqzwj3aPsSuHmI4RWZh62dWUL+DJN4C5YQya5TcQBJU/Fe8+rY0jhXTQITqA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@rolldown/binding-freebsd-x64@1.1.2':
-    resolution: {integrity: sha512-+TpdtTRgHiJFjCVFbw311SuLk3KfytPOQQn+VlAEv+gBxYPtL7E6JS9e/tk+8CwxhIZvemJKo4rTKgfWNsKkkA==}
+  '@rolldown/binding-freebsd-x64@1.2.3':
+    resolution: {integrity: sha512-nGbJWewA1wrXXZiQhjAT5rhibGfns5ZNkDVqxsO6zJ3f3YvpoDNNmGMSbbhLuXKjNScaBJVOAboztAWVespQMg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.1.2':
-    resolution: {integrity: sha512-4lv1/tkmi7ueIVHnyreaOeUpiZP26BH9rRy6hoYfR9310A2B9nUEVRDvBx69vx64Nr3eTPPRkyciqJJs+j9Jmw==}
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.3':
+    resolution: {integrity: sha512-QNniJr5Kml0kDEB98jiDOJjXNroxIIi0IXIbdYzY26Xt1pVbeP62+KnoIZLwirOymX/0jDk/2gI/bNUv7A7OIw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-gnu@1.1.2':
-    resolution: {integrity: sha512-gBSUVO0eaWgw1JMjK3gB8BMlX2Mk148s2lTiVT3e9vjVxbl7UDfMWWY8CfIaaqiXuM9fVTMxIpUz6CAo/B6Vlw==}
+  '@rolldown/binding-linux-arm64-gnu@1.2.3':
+    resolution: {integrity: sha512-TkqEAcmmvH3I/q4114NB4RVt6241Dao48pF45uLcFGrwAaIn0iITgTAKP/dLjbN0R4buJjGb91+UHSoFmpgIWw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-arm64-musl@1.1.2':
-    resolution: {integrity: sha512-LjQP/iZLBu8o8PjIfk4x3At0/mT6h282pvz8Z5LAyhGbu/kDezyO7ea62rF5uoqmgnIYqbN/MqJ3Si3Aymi7xQ==}
+  '@rolldown/binding-linux-arm64-musl@1.2.3':
+    resolution: {integrity: sha512-NHqjnxpsndf4MPymxteFAWHHfkTL8HjWh1KB7z23ofZ6QO2euONuxDXjat69dKZRALnGypg8k8SsK8vZJoXv1Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-linux-ppc64-gnu@1.1.2':
-    resolution: {integrity: sha512-X/7bVLWelEsbyWDUSXt7zVsTniLLPIY2n1rH58qr78l9i7MNbbxBWD8gI2vRfBWf4NUXJCUuQnfZDsp32LqsfQ==}
+  '@rolldown/binding-linux-ppc64-gnu@1.2.3':
+    resolution: {integrity: sha512-6tbrbwfz5GB9DQ4Jwo6hy9v+vR31xZlvzZ6n5Xut6Hhx5PvrA9q/HsK8KMaYQp063iqZGXwNvZtYNLD7EM/x0w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-s390x-gnu@1.1.2':
-    resolution: {integrity: sha512-gb6dYKW/1KDorGXyy48glEBJs/sxVSC5pcVrox/pFGV4mvwSFeg2sK5L2tRkVsVlh7kueqOgg4GEcuipJcGuKg==}
+  '@rolldown/binding-linux-s390x-gnu@1.2.3':
+    resolution: {integrity: sha512-oyuXxXmoZHjXC917IAPFAAv4wWAa0cM9afk8nx1+9/jNNOX1uPf8yDA6p7G0RypOfw/X0PQt5IfoquY1um+zSg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-gnu@1.1.2':
-    resolution: {integrity: sha512-JY4w85pU3iAiJVMh5nuk4/Mh9GjMsupe8MrIN53rwxAZW64GKrWeJBuN6SxQg9QTU5uB1cxyhDzW8jqRn1EABw==}
+  '@rolldown/binding-linux-x64-gnu@1.2.3':
+    resolution: {integrity: sha512-TytMwF2KVGqP2tgd0I1OY0PAv78dZRAYcF5ssDzjM34SUXCED3uXvSd5+lHoC0bTD6eEdFz7LdQNCO1y0oVk9w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-musl@1.1.2':
-    resolution: {integrity: sha512-xvpA7o5KCYLB0Rwscmuylb1/zHHSUx4g4xilm4prC5jP76pEUlzBmMbgpbh7bVDbId4NcfT96gN5i6mE6UDaiw==}
+  '@rolldown/binding-linux-x64-musl@1.2.3':
+    resolution: {integrity: sha512-/E9m3qstrJFVPoULV25mVQblSNExY2+kBsYe4sy0Tn0yOOgJ8wZbZt3KnRbF/XeU2Gl1STKUQnDNTqhIE5MD4A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-openharmony-arm64@1.1.2':
-    resolution: {integrity: sha512-p/ts6KBLjuk49Bp21XH77poQGt02iNz7ChgHep7tudPOaLinR/De/RHdxF8w8Yj4r/bF/bqXwH6PZrB2sA+Nvw==}
+  '@rolldown/binding-openharmony-arm64@1.2.3':
+    resolution: {integrity: sha512-Kr0OcsoQI816i6HOl3vFHpd1K0eZyh76zgfj4c1nTyaTsd5r2Mj1lwM4R90y/qaCfmTn9eHy0SKwi98eitRxug==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rolldown/binding-wasm32-wasi@1.1.2':
-    resolution: {integrity: sha512-VMu/wmrZ9hJzYlRhbw7jK5PODlugyKZ5mOdX78+lS8OvuFkWNQdz1pFLrI2p3P0pjXOmUZ7B48o5VnMH9QOGtg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [wasm32]
-
-  '@rolldown/binding-win32-arm64-msvc@1.1.2':
-    resolution: {integrity: sha512-xtUJqs8qEkuSviS0n1tsohaPuz3a1SPhZywOji4Oo+sgrJs8daEDMZ0QtqL0OS7dx8PoVpg2J/ZZycPY5I2+Zg==}
+  '@rolldown/binding-win32-arm64-msvc@1.2.3':
+    resolution: {integrity: sha512-hOtMwTqnME+/gJcH/PCZ0wn0zPUjiWOgkHpxbSJpfGKMezHltx1S7/k1SitzVa7Ww2cqrDDaFbZEhcJZO8o+Jw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@rolldown/binding-win32-x64-msvc@1.1.2':
-    resolution: {integrity: sha512-85YiLQqjUKgSO/Zjnf9e0XIn5Ymrh1fLDWBeAkZqpuBR/3R8TpfoHXuyblqyQrftSSgWO9qpcHN8mkyKsLraoA==}
+  '@rolldown/binding-win32-x64-msvc@1.2.3':
+    resolution: {integrity: sha512-ekcqMMkI2PlhYnfzQnB/cEdYUVVJViWvoUyLrbzgDoi3Snfc1mVBwdnc306ufA5ejy8JSPjT2RlW1nQSjW7efg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -3142,8 +3131,8 @@ packages:
     resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
     engines: {node: '>=8.6'}
 
-  picomatch@4.0.4:
-    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+  picomatch@4.0.5:
+    resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
 
   pkg-types@1.3.1:
@@ -3254,8 +3243,8 @@ packages:
     resolution: {integrity: sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==}
     engines: {node: '>=8.0'}
 
-  rolldown@1.1.2:
-    resolution: {integrity: sha512-x0CrQQqCXWGeI8dTvFfN/Dnv3yMKT9hv5jFjlOreKAx9wqLq9wz7VvLLHyaAXC90/CpggTu9SisSbsJJTPSjNQ==}
+  rolldown@1.2.3:
+    resolution: {integrity: sha512-rn9wpmxplLf7NLNyCk9FyWh3FM43DbY8jOzCdEPzH7uflhTftRbCEpqi6Ly2osgoU8OwObtmavMbWLaWy4LX7A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -3585,13 +3574,13 @@ packages:
     resolution: {integrity: sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
-  vite@8.1.0:
-    resolution: {integrity: sha512-BuJcQK/56NQTWDGn4ABea3q4SSBdNPWwNZKTkkUpcMPnLoquSYH8llRtSUIgoL1KSCpHt5eghLShn50mH36y7Q==}
+  vite@8.2.1:
+    resolution: {integrity: sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
       '@types/node': ^20.19.0 || >=22.12.0
-      '@vitejs/devtools': ^0.3.0
+      '@vitejs/devtools': ^0.4.0
       esbuild: ^0.27.0 || ^0.28.0
       jiti: '>=1.21.0'
       less: ^4.0.0
@@ -4218,13 +4207,6 @@ snapshots:
       '@tybys/wasm-util': 0.10.2
     optional: true
 
-  '@napi-rs/wasm-runtime@1.1.5(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
-    dependencies:
-      '@emnapi/core': 1.11.1
-      '@emnapi/runtime': 1.11.1
-      '@tybys/wasm-util': 0.10.2
-    optional: true
-
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -4400,7 +4382,7 @@ snapshots:
   '@oxc-parser/binding-win32-x64-msvc@0.72.3':
     optional: true
 
-  '@oxc-project/types@0.137.0': {}
+  '@oxc-project/types@0.143.0': {}
 
   '@oxc-project/types@0.72.3': {}
 
@@ -4411,53 +4393,46 @@ snapshots:
     optionalDependencies:
       yauzl: 2.10.0
 
-  '@rolldown/binding-android-arm64@1.1.2':
+  '@rolldown/binding-android-arm64@1.2.3':
     optional: true
 
-  '@rolldown/binding-darwin-arm64@1.1.2':
+  '@rolldown/binding-darwin-arm64@1.2.3':
     optional: true
 
-  '@rolldown/binding-darwin-x64@1.1.2':
+  '@rolldown/binding-darwin-x64@1.2.3':
     optional: true
 
-  '@rolldown/binding-freebsd-x64@1.1.2':
+  '@rolldown/binding-freebsd-x64@1.2.3':
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.1.2':
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.3':
     optional: true
 
-  '@rolldown/binding-linux-arm64-gnu@1.1.2':
+  '@rolldown/binding-linux-arm64-gnu@1.2.3':
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@1.1.2':
+  '@rolldown/binding-linux-arm64-musl@1.2.3':
     optional: true
 
-  '@rolldown/binding-linux-ppc64-gnu@1.1.2':
+  '@rolldown/binding-linux-ppc64-gnu@1.2.3':
     optional: true
 
-  '@rolldown/binding-linux-s390x-gnu@1.1.2':
+  '@rolldown/binding-linux-s390x-gnu@1.2.3':
     optional: true
 
-  '@rolldown/binding-linux-x64-gnu@1.1.2':
+  '@rolldown/binding-linux-x64-gnu@1.2.3':
     optional: true
 
-  '@rolldown/binding-linux-x64-musl@1.1.2':
+  '@rolldown/binding-linux-x64-musl@1.2.3':
     optional: true
 
-  '@rolldown/binding-openharmony-arm64@1.1.2':
+  '@rolldown/binding-openharmony-arm64@1.2.3':
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@1.1.2':
-    dependencies:
-      '@emnapi/core': 1.11.1
-      '@emnapi/runtime': 1.11.1
-      '@napi-rs/wasm-runtime': 1.1.5(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+  '@rolldown/binding-win32-arm64-msvc@1.2.3':
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@1.1.2':
-    optional: true
-
-  '@rolldown/binding-win32-x64-msvc@1.1.2':
+  '@rolldown/binding-win32-x64-msvc@1.2.3':
     optional: true
 
   '@rolldown/pluginutils@1.0.1': {}
@@ -4466,7 +4441,7 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.9
       estree-walker: 2.0.2
-      picomatch: 4.0.4
+      picomatch: 4.0.5
     optionalDependencies:
       rollup: 4.60.4
 
@@ -4646,7 +4621,7 @@ snapshots:
       eslint-visitor-keys: 4.2.1
       espree: 10.4.0
       estraverse: 5.3.0
-      picomatch: 4.0.4
+      picomatch: 4.0.5
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -4847,7 +4822,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.7(@types/node@22.19.19)(@vitest/coverage-v8@4.1.7)(vite@8.1.0(@types/node@22.19.19)(esbuild@0.28.1)(terser@5.48.0)(yaml@2.9.0))
+      vitest: 4.1.7(@types/node@22.19.19)(@vitest/coverage-v8@4.1.7)(vite@8.2.1(@types/node@22.19.19)(esbuild@0.28.1)(terser@5.48.0)(yaml@2.9.0))
 
   '@vitest/eslint-plugin@1.6.24(@typescript-eslint/eslint-plugin@8.60.0(@typescript-eslint/parser@8.60.0(eslint@10.7.0)(typescript@5.5.4))(eslint@10.7.0)(typescript@5.5.4))(eslint@10.7.0)(typescript@5.5.4)(vitest@4.1.7)':
     dependencies:
@@ -4857,7 +4832,7 @@ snapshots:
     optionalDependencies:
       '@typescript-eslint/eslint-plugin': 8.60.0(@typescript-eslint/parser@8.60.0(eslint@10.7.0)(typescript@5.5.4))(eslint@10.7.0)(typescript@5.5.4)
       typescript: 5.5.4
-      vitest: 4.1.7(@types/node@22.19.19)(@vitest/coverage-v8@4.1.7)(vite@8.1.0(@types/node@22.19.19)(esbuild@0.28.1)(terser@5.48.0)(yaml@2.9.0))
+      vitest: 4.1.7(@types/node@22.19.19)(@vitest/coverage-v8@4.1.7)(vite@8.2.1(@types/node@22.19.19)(esbuild@0.28.1)(terser@5.48.0)(yaml@2.9.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -4870,13 +4845,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.7(vite@8.1.0(@types/node@22.19.19)(esbuild@0.28.1)(terser@5.48.0)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.7(vite@8.2.1(@types/node@22.19.19)(esbuild@0.28.1)(terser@5.48.0)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.7
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.1.0(@types/node@22.19.19)(esbuild@0.28.1)(terser@5.48.0)(yaml@2.9.0)
+      vite: 8.2.1(@types/node@22.19.19)(esbuild@0.28.1)(terser@5.48.0)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.1.7':
     dependencies:
@@ -5466,9 +5441,9 @@ snapshots:
       pend: 1.2.0
     optional: true
 
-  fdir@6.5.0(picomatch@4.0.4):
+  fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
-      picomatch: 4.0.4
+      picomatch: 4.0.5
 
   file-entry-cache@8.0.0:
     dependencies:
@@ -5864,7 +5839,7 @@ snapshots:
     dependencies:
       commander: 14.0.3
       listr2: 9.0.5
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       string-argv: 0.3.2
       tinyexec: 1.2.2
       yaml: 2.9.0
@@ -6577,7 +6552,7 @@ snapshots:
 
   picomatch@2.3.2: {}
 
-  picomatch@4.0.4: {}
+  picomatch@4.0.5: {}
 
   pkg-types@1.3.1:
     dependencies:
@@ -6706,26 +6681,25 @@ snapshots:
       semver-compare: 1.0.0
       sprintf-js: 1.1.3
 
-  rolldown@1.1.2:
+  rolldown@1.2.3:
     dependencies:
-      '@oxc-project/types': 0.137.0
+      '@oxc-project/types': 0.143.0
       '@rolldown/pluginutils': 1.0.1
     optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.1.2
-      '@rolldown/binding-darwin-arm64': 1.1.2
-      '@rolldown/binding-darwin-x64': 1.1.2
-      '@rolldown/binding-freebsd-x64': 1.1.2
-      '@rolldown/binding-linux-arm-gnueabihf': 1.1.2
-      '@rolldown/binding-linux-arm64-gnu': 1.1.2
-      '@rolldown/binding-linux-arm64-musl': 1.1.2
-      '@rolldown/binding-linux-ppc64-gnu': 1.1.2
-      '@rolldown/binding-linux-s390x-gnu': 1.1.2
-      '@rolldown/binding-linux-x64-gnu': 1.1.2
-      '@rolldown/binding-linux-x64-musl': 1.1.2
-      '@rolldown/binding-openharmony-arm64': 1.1.2
-      '@rolldown/binding-wasm32-wasi': 1.1.2
-      '@rolldown/binding-win32-arm64-msvc': 1.1.2
-      '@rolldown/binding-win32-x64-msvc': 1.1.2
+      '@rolldown/binding-android-arm64': 1.2.3
+      '@rolldown/binding-darwin-arm64': 1.2.3
+      '@rolldown/binding-darwin-x64': 1.2.3
+      '@rolldown/binding-freebsd-x64': 1.2.3
+      '@rolldown/binding-linux-arm-gnueabihf': 1.2.3
+      '@rolldown/binding-linux-arm64-gnu': 1.2.3
+      '@rolldown/binding-linux-arm64-musl': 1.2.3
+      '@rolldown/binding-linux-ppc64-gnu': 1.2.3
+      '@rolldown/binding-linux-s390x-gnu': 1.2.3
+      '@rolldown/binding-linux-x64-gnu': 1.2.3
+      '@rolldown/binding-linux-x64-musl': 1.2.3
+      '@rolldown/binding-openharmony-arm64': 1.2.3
+      '@rolldown/binding-win32-arm64-msvc': 1.2.3
+      '@rolldown/binding-win32-x64-msvc': 1.2.3
 
   rollup@4.60.4:
     dependencies:
@@ -6964,8 +6938,8 @@ snapshots:
 
   tinyglobby@0.2.17:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
 
   tinyrainbow@3.1.0: {}
 
@@ -7061,7 +7035,7 @@ snapshots:
     dependencies:
       '@jridgewell/remapping': 2.3.5
       acorn: 8.16.0
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       webpack-virtual-modules: 0.6.2
 
   upath@2.0.1: {}
@@ -7076,12 +7050,12 @@ snapshots:
 
   validate-npm-package-name@7.0.2: {}
 
-  vite@8.1.0(@types/node@22.19.19)(esbuild@0.28.1)(terser@5.48.0)(yaml@2.9.0):
+  vite@8.2.1(@types/node@22.19.19)(esbuild@0.28.1)(terser@5.48.0)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.33.0
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       postcss: 8.5.23
-      rolldown: 1.1.2
+      rolldown: 1.2.3
       tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 22.19.19
@@ -7090,10 +7064,10 @@ snapshots:
       terser: 5.48.0
       yaml: 2.9.0
 
-  vitest@4.1.7(@types/node@22.19.19)(@vitest/coverage-v8@4.1.7)(vite@8.1.0(@types/node@22.19.19)(esbuild@0.28.1)(terser@5.48.0)(yaml@2.9.0)):
+  vitest@4.1.7(@types/node@22.19.19)(@vitest/coverage-v8@4.1.7)(vite@8.2.1(@types/node@22.19.19)(esbuild@0.28.1)(terser@5.48.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.7
-      '@vitest/mocker': 4.1.7(vite@8.1.0(@types/node@22.19.19)(esbuild@0.28.1)(terser@5.48.0)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.7(vite@8.2.1(@types/node@22.19.19)(esbuild@0.28.1)(terser@5.48.0)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.7
       '@vitest/runner': 4.1.7
       '@vitest/snapshot': 4.1.7
@@ -7104,13 +7078,13 @@ snapshots:
       magic-string: 0.30.21
       obug: 2.1.1
       pathe: 2.0.3
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       std-env: 4.1.0
       tinybench: 2.9.0
       tinyexec: 1.2.2
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 8.1.0(@types/node@22.19.19)(esbuild@0.28.1)(terser@5.48.0)(yaml@2.9.0)
+      vite: 8.2.1(@types/node@22.19.19)(esbuild@0.28.1)(terser@5.48.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.19.19


### PR DESCRIPTION
### 🚀 Summary

Add TypeScript translation loading to manual tests, selected through the `language` option passed to the `manual-tests-plugin`. Preserve CSS HMR while showing the existing refresh prompt for translation and other JavaScript changes under Vite 8.2.

---

### 📌 Related issues

* https://github.com/ckeditor/ckeditor5-internal/issues/4538

---

### 💡 Additional information

This PR is stacked on #1459 and should be reviewed after it.
