### PR TITLE
Verify GitHub token permissions before releases

### DIFF
--- a/.changelog/20260818172448_ck_20214_verify_github_token.md
+++ b/.changelog/20260818172448_ck_20214_verify_github_token.md
@@ -1,0 +1,7 @@
+---
+type: Fix
+scope:
+  - ckeditor5-dev-release-tools
+---
+
+The GitHub token used by the release workflow is now verified against the target repository instead of being required to contain 40 characters.

--- a/packages/ckeditor5-dev-release-tools/lib/index.js
+++ b/packages/ckeditor5-dev-release-tools/lib/index.js
@@ -34,6 +34,7 @@ export { default as executeInParallel } from './utils/executeinparallel.js';
 export { default as validateRepositoryToRelease } from './utils/validaterepositorytorelease.js';
 export { default as getNpmTagFromVersion } from './utils/getnpmtagfromversion.js';
 export { default as provideToken } from './utils/providetoken.js';
+export { default as validateGithubToken } from './utils/validategithubtoken.js';
 
 // Backwards compatibility for the old API.
 export const checkVersionAvailability = ( ...args ) => {

--- a/packages/ckeditor5-dev-release-tools/lib/utils/providetoken.js
+++ b/packages/ckeditor5-dev-release-tools/lib/utils/providetoken.js
@@ -4,23 +4,32 @@
  */
 
 import inquirer from 'inquirer';
+import validateGithubToken from './validategithubtoken.js';
 
 /**
  * Asks a user for providing the GitHub token.
  *
+ * @param {object} [options]
+ * @param {string} [options.cwd=process.cwd()] Current working directory from which the repository will be resolved.
  * @returns {Promise.<string>}
  */
-export default async function provideToken() {
+export default async function provideToken( options ) {
 	const tokenQuestion = {
 		type: 'password',
 		name: 'token',
 		message: 'Provide the GitHub token:',
-		validate( input ) {
-			return input.length === 40 ? true : 'Please provide a valid token.';
+		async validate( input ) {
+			try {
+				await validateGithubToken( input, options );
+
+				return true;
+			} catch ( error ) {
+				return error.message;
+			}
 		}
 	};
 
 	const { token } = await inquirer.prompt( [ tokenQuestion ] );
 
-	return token;
+	return token.trim();
 }

--- a/packages/ckeditor5-dev-release-tools/lib/utils/providetoken.js
+++ b/packages/ckeditor5-dev-release-tools/lib/utils/providetoken.js
@@ -13,14 +13,14 @@ import validateGithubToken from './validategithubtoken.js';
  * @param {string} [options.cwd=process.cwd()] Current working directory from which the repository will be resolved.
  * @returns {Promise.<string>}
  */
-export default async function provideToken( options ) {
+export default async function provideToken( { cwd = process.cwd() } = {} ) {
 	const tokenQuestion = {
 		type: 'password',
 		name: 'token',
 		message: 'Provide the GitHub token:',
 		async validate( input ) {
 			try {
-				await validateGithubToken( input, options );
+				await validateGithubToken( input, { cwd } );
 
 				return true;
 			} catch ( error ) {

--- a/packages/ckeditor5-dev-release-tools/lib/utils/validategithubtoken.js
+++ b/packages/ckeditor5-dev-release-tools/lib/utils/validategithubtoken.js
@@ -1,0 +1,72 @@
+/**
+ * @license Copyright (c) 2003-2026, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+import { Octokit } from '@octokit/rest';
+import { workspaces } from '@ckeditor/ckeditor5-dev-utils';
+
+const VALIDATION_TAG_NAME = 'ckeditor5-dev-release-tools-token-validation';
+
+/**
+ * Verifies that a GitHub token can create a release in the current repository.
+ *
+ * @param {string} token Token used to authenticate with GitHub.
+ * @param {object} [options]
+ * @param {string} [options.cwd=process.cwd()] Current working directory from which the repository will be resolved.
+ * @returns {Promise.<string>} The normalized token.
+ */
+export default async function validateGithubToken( token, { cwd = process.cwd() } = {} ) {
+	const normalizedToken = token.trim();
+
+	if ( !normalizedToken ) {
+		throw new Error( 'The token cannot be empty.' );
+	}
+
+	const repositoryUrl = workspaces.getRepositoryUrl( cwd );
+	const [ repositoryName, repositoryOwner ] = repositoryUrl.split( '/' ).reverse();
+	const repository = `${ repositoryOwner }/${ repositoryName }`;
+	const github = new Octokit( { auth: normalizedToken } );
+
+	let repositoryDetails;
+
+	try {
+		repositoryDetails = await github.repos.get( {
+			owner: repositoryOwner,
+			repo: repositoryName
+		} );
+	} catch ( error ) {
+		throw createValidationError( error, repository );
+	}
+
+	try {
+		// This endpoint only computes and returns proposed release notes. It does not persist a release, tag, or any other data.
+		// See: https://docs.github.com/en/rest/releases/releases#generate-release-notes-content-for-a-release
+		await github.repos.generateReleaseNotes( {
+			owner: repositoryOwner,
+			repo: repositoryName,
+			tag_name: VALIDATION_TAG_NAME,
+			target_commitish: repositoryDetails.data.default_branch
+		} );
+	} catch ( error ) {
+		throw createValidationError( error, repository );
+	}
+
+	return normalizedToken;
+}
+
+/**
+ * @param {Error & { status?: number, response?: { data?: { message?: string } } }} error
+ * @param {string} repository
+ * @returns {Error}
+ */
+function createValidationError( error, repository ) {
+	const githubMessage = error.response?.data?.message || error.message;
+
+	if ( error.status ) {
+		return new Error( `GitHub API request for the "${ repository }" repository failed ` +
+			`with HTTP ${ error.status }: ${ githubMessage }` );
+	}
+
+	return new Error( `Could not verify the token for the "${ repository }" repository: ${ githubMessage }` );
+}

--- a/packages/ckeditor5-dev-release-tools/lib/utils/validategithubtoken.js
+++ b/packages/ckeditor5-dev-release-tools/lib/utils/validategithubtoken.js
@@ -12,11 +12,11 @@ const VALIDATION_TAG_NAME = 'ckeditor5-dev-release-tools-token-validation';
  * Verifies that a GitHub token can create a release in the current repository.
  *
  * @param {string} token Token used to authenticate with GitHub.
- * @param {object} [options]
- * @param {string} [options.cwd=process.cwd()] Current working directory from which the repository will be resolved.
+ * @param {object} options
+ * @param {string} options.cwd=process.cwd() Current working directory from which the repository will be resolved.
  * @returns {Promise.<string>} The normalized token.
  */
-export default async function validateGithubToken( token, { cwd = process.cwd() } = {} ) {
+export default async function validateGithubToken( token, { cwd } ) {
 	const normalizedToken = token.trim();
 
 	if ( !normalizedToken ) {

--- a/packages/ckeditor5-dev-release-tools/tests/index.js
+++ b/packages/ckeditor5-dev-release-tools/tests/index.js
@@ -34,6 +34,7 @@ import executeInParallel from '../lib/utils/executeinparallel.js';
 import validateRepositoryToRelease from '../lib/utils/validaterepositorytorelease.js';
 import getNpmTagFromVersion from '../lib/utils/getnpmtagfromversion.js';
 import provideToken from '../lib/utils/providetoken.js';
+import validateGithubToken from '../lib/utils/validategithubtoken.js';
 
 import * as index from '../lib/index.js';
 
@@ -53,6 +54,7 @@ vi.mock( '../lib/utils/changelog' );
 vi.mock( '../lib/utils/executeinparallel' );
 vi.mock( '../lib/utils/validaterepositorytorelease' );
 vi.mock( '../lib/utils/providetoken' );
+vi.mock( '../lib/utils/validategithubtoken' );
 
 describe( 'dev-release-tools/index', () => {
 	describe( 'updateDependencies()', () => {
@@ -241,6 +243,13 @@ describe( 'dev-release-tools/index', () => {
 		it( 'should be a function', () => {
 			expect( provideToken ).to.be.a( 'function' );
 			expect( index.provideToken ).to.equal( provideToken );
+		} );
+	} );
+
+	describe( 'validateGithubToken()', () => {
+		it( 'should be a function', () => {
+			expect( validateGithubToken ).to.be.a( 'function' );
+			expect( index.validateGithubToken ).to.equal( validateGithubToken );
 		} );
 	} );
 

--- a/packages/ckeditor5-dev-release-tools/tests/utils/providetoken.js
+++ b/packages/ckeditor5-dev-release-tools/tests/utils/providetoken.js
@@ -52,6 +52,18 @@ describe( 'provideToken()', () => {
 		expect( validateGithubToken ).toHaveBeenCalledExactlyOnceWith( 'github-token', { cwd: '/workspace' } );
 	} );
 
+	it( 'uses the current working directory by default', async () => {
+		await provideToken();
+
+		const [ firstCall ] = vi.mocked( inquirer ).prompt.mock.calls;
+		const [ firstArgument ] = firstCall;
+		const [ firstQuestion ] = firstArgument;
+
+		await firstQuestion.validate( 'github-token' );
+
+		expect( validateGithubToken ).toHaveBeenCalledExactlyOnceWith( 'github-token', { cwd: process.cwd() } );
+	} );
+
 	it( 'shows a validation error returned by GitHub', async () => {
 		vi.mocked( validateGithubToken ).mockRejectedValue( new Error( 'GitHub API request failed with HTTP 401: Bad credentials' ) );
 

--- a/packages/ckeditor5-dev-release-tools/tests/utils/providetoken.js
+++ b/packages/ckeditor5-dev-release-tools/tests/utils/providetoken.js
@@ -6,12 +6,15 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import inquirer from 'inquirer';
 import provideToken from '../../lib/utils/providetoken.js';
+import validateGithubToken from '../../lib/utils/validategithubtoken.js';
 
 vi.mock( 'inquirer' );
+vi.mock( '../../lib/utils/validategithubtoken.js' );
 
 describe( 'provideToken()', () => {
 	beforeEach( () => {
-		vi.mocked( inquirer ).prompt.mockResolvedValue( { token: 'MyPassword' } );
+		vi.mocked( inquirer ).prompt.mockResolvedValue( { token: '  MyPassword  ' } );
+		vi.mocked( validateGithubToken ).mockResolvedValue( 'MyPassword' );
 	} );
 
 	it( 'user is able to provide the token', async () => {
@@ -28,8 +31,8 @@ describe( 'provideToken()', () => {
 		);
 	} );
 
-	it( 'token must contain 40 characters', async () => {
-		await provideToken();
+	it( 'validates the token using GitHub', async () => {
+		await provideToken( { cwd: '/workspace' } );
 
 		expect( vi.mocked( inquirer ).prompt ).toHaveBeenCalledExactlyOnceWith(
 			expect.arrayContaining( [
@@ -44,7 +47,21 @@ describe( 'provideToken()', () => {
 		const [ firstQuestion ] = firstArgument;
 		const { validate } = firstQuestion;
 
-		expect( validate( 'abc' ) ).to.equal( 'Please provide a valid token.' );
-		expect( validate( 'a'.repeat( 40 ) ) ).to.equal( true );
+		await expect( validate( 'github-token' ) ).resolves.toBe( true );
+
+		expect( validateGithubToken ).toHaveBeenCalledExactlyOnceWith( 'github-token', { cwd: '/workspace' } );
+	} );
+
+	it( 'shows a validation error returned by GitHub', async () => {
+		vi.mocked( validateGithubToken ).mockRejectedValue( new Error( 'GitHub API request failed with HTTP 401: Bad credentials' ) );
+
+		await provideToken();
+
+		const [ firstCall ] = vi.mocked( inquirer ).prompt.mock.calls;
+		const [ firstArgument ] = firstCall;
+		const [ firstQuestion ] = firstArgument;
+
+		await expect( firstQuestion.validate( 'github-token' ) )
+			.resolves.toBe( 'GitHub API request failed with HTTP 401: Bad credentials' );
 	} );
 } );

--- a/packages/ckeditor5-dev-release-tools/tests/utils/validategithubtoken.js
+++ b/packages/ckeditor5-dev-release-tools/tests/utils/validategithubtoken.js
@@ -56,7 +56,7 @@ describe( 'validateGithubToken()', () => {
 	} );
 
 	it( 'rejects an empty token without calling GitHub', async () => {
-		await expect( validateGithubToken( '   ' ) ).rejects.toThrow( 'The token cannot be empty.' );
+		await expect( validateGithubToken( '   ', { cwd: '/workspace' } ) ).rejects.toThrow( 'The token cannot be empty.' );
 
 		expect( stubs.constructor ).not.toHaveBeenCalled();
 	} );
@@ -71,7 +71,7 @@ describe( 'validateGithubToken()', () => {
 			}
 		} );
 
-		await expect( validateGithubToken( 'github-token' ) )
+		await expect( validateGithubToken( 'github-token', { cwd: '/workspace' } ) )
 			.rejects.toThrow(
 				'GitHub API request for the "ckeditor/ckeditor5-dev" repository failed with HTTP 401: Bad credentials'
 			);
@@ -87,7 +87,7 @@ describe( 'validateGithubToken()', () => {
 			}
 		} );
 
-		await expect( validateGithubToken( 'github-token' ) )
+		await expect( validateGithubToken( 'github-token', { cwd: '/workspace' } ) )
 			.rejects.toThrow(
 				'GitHub API request for the "ckeditor/ckeditor5-dev" repository failed with HTTP 404: Not Found'
 			);
@@ -103,7 +103,7 @@ describe( 'validateGithubToken()', () => {
 			}
 		} );
 
-		await expect( validateGithubToken( 'github-token' ) )
+		await expect( validateGithubToken( 'github-token', { cwd: '/workspace' } ) )
 			.rejects.toThrow(
 				'GitHub API request for the "ckeditor/ckeditor5-dev" repository failed with HTTP 403: ' +
 				'Resource not accessible by personal access token'
@@ -113,7 +113,7 @@ describe( 'validateGithubToken()', () => {
 	it( 'reports unexpected errors returned by GitHub', async () => {
 		stubs.getRepository.mockRejectedValue( new Error( 'Network unavailable.' ) );
 
-		await expect( validateGithubToken( 'github-token' ) )
+		await expect( validateGithubToken( 'github-token', { cwd: '/workspace' } ) )
 			.rejects.toThrow(
 				'Could not verify the token for the "ckeditor/ckeditor5-dev" repository: Network unavailable.'
 			);

--- a/packages/ckeditor5-dev-release-tools/tests/utils/validategithubtoken.js
+++ b/packages/ckeditor5-dev-release-tools/tests/utils/validategithubtoken.js
@@ -1,0 +1,121 @@
+/**
+ * @license Copyright (c) 2003-2026, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+import { workspaces } from '@ckeditor/ckeditor5-dev-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import validateGithubToken from '../../lib/utils/validategithubtoken.js';
+
+const stubs = vi.hoisted( () => ( {
+	constructor: vi.fn(),
+	getRepository: vi.fn(),
+	generateReleaseNotes: vi.fn()
+} ) );
+
+vi.mock( '@ckeditor/ckeditor5-dev-utils' );
+vi.mock( '@octokit/rest', () => ( {
+	Octokit: class {
+		constructor( ...args ) {
+			stubs.constructor( ...args );
+
+			this.repos = {
+				get: stubs.getRepository,
+				generateReleaseNotes: stubs.generateReleaseNotes
+			};
+		}
+	}
+} ) );
+
+describe( 'validateGithubToken()', () => {
+	beforeEach( () => {
+		vi.mocked( workspaces.getRepositoryUrl ).mockReturnValue( 'https://github.com/ckeditor/ckeditor5-dev' );
+		stubs.getRepository.mockResolvedValue( {
+			data: {
+				default_branch: 'master'
+			}
+		} );
+		stubs.generateReleaseNotes.mockResolvedValue();
+	} );
+
+	it( 'returns a normalized token that can generate release notes', async () => {
+		await expect( validateGithubToken( '  github-token  ', { cwd: '/workspace' } ) ).resolves.toBe( 'github-token' );
+
+		expect( workspaces.getRepositoryUrl ).toHaveBeenCalledExactlyOnceWith( '/workspace' );
+		expect( stubs.constructor ).toHaveBeenCalledExactlyOnceWith( { auth: 'github-token' } );
+		expect( stubs.getRepository ).toHaveBeenCalledExactlyOnceWith( {
+			owner: 'ckeditor',
+			repo: 'ckeditor5-dev'
+		} );
+		expect( stubs.generateReleaseNotes ).toHaveBeenCalledExactlyOnceWith( {
+			owner: 'ckeditor',
+			repo: 'ckeditor5-dev',
+			tag_name: 'ckeditor5-dev-release-tools-token-validation',
+			target_commitish: 'master'
+		} );
+	} );
+
+	it( 'rejects an empty token without calling GitHub', async () => {
+		await expect( validateGithubToken( '   ' ) ).rejects.toThrow( 'The token cannot be empty.' );
+
+		expect( stubs.constructor ).not.toHaveBeenCalled();
+	} );
+
+	it( 'rejects an invalid or expired token', async () => {
+		stubs.getRepository.mockRejectedValue( {
+			status: 401,
+			response: {
+				data: {
+					message: 'Bad credentials'
+				}
+			}
+		} );
+
+		await expect( validateGithubToken( 'github-token' ) )
+			.rejects.toThrow(
+				'GitHub API request for the "ckeditor/ckeditor5-dev" repository failed with HTTP 401: Bad credentials'
+			);
+	} );
+
+	it( 'rejects a token that cannot access the repository', async () => {
+		stubs.getRepository.mockRejectedValue( {
+			status: 404,
+			response: {
+				data: {
+					message: 'Not Found'
+				}
+			}
+		} );
+
+		await expect( validateGithubToken( 'github-token' ) )
+			.rejects.toThrow(
+				'GitHub API request for the "ckeditor/ckeditor5-dev" repository failed with HTTP 404: Not Found'
+			);
+	} );
+
+	it( 'rejects a token without write access to the repository', async () => {
+		stubs.generateReleaseNotes.mockRejectedValue( {
+			status: 403,
+			response: {
+				data: {
+					message: 'Resource not accessible by personal access token'
+				}
+			}
+		} );
+
+		await expect( validateGithubToken( 'github-token' ) )
+			.rejects.toThrow(
+				'GitHub API request for the "ckeditor/ckeditor5-dev" repository failed with HTTP 403: ' +
+				'Resource not accessible by personal access token'
+			);
+	} );
+
+	it( 'reports unexpected errors returned by GitHub', async () => {
+		stubs.getRepository.mockRejectedValue( new Error( 'Network unavailable.' ) );
+
+		await expect( validateGithubToken( 'github-token' ) )
+			.rejects.toThrow(
+				'Could not verify the token for the "ckeditor/ckeditor5-dev" repository: Network unavailable.'
+			);
+	} );
+} );

--- a/scripts-tests/publishpackages.mjs
+++ b/scripts-tests/publishpackages.mjs
@@ -32,7 +32,7 @@ describe( 'scripts/publishpackages', () => {
 	} );
 
 	it( 'validates the GitHub token before running release tasks', () => {
-		expect( releaseTools.validateGithubToken ).toHaveBeenCalledExactlyOnceWith( 'github-token' );
+		expect( releaseTools.validateGithubToken ).toHaveBeenCalledExactlyOnceWith( 'github-token', { cwd: process.cwd() } );
 	} );
 
 	describe( 'Publishing packages.', () => {

--- a/scripts-tests/publishpackages.mjs
+++ b/scripts-tests/publishpackages.mjs
@@ -24,10 +24,15 @@ describe( 'scripts/publishpackages', () => {
 		vi.mocked( releaseTools.getLastFromChangelog ).mockReturnValue( '1.0.0' );
 		vi.mocked( releaseTools.getChangesForVersion ).mockReturnValue( 'Changes.' );
 		vi.mocked( releaseTools.getNpmTagFromVersion ).mockReturnValue( 'latest' );
+		vi.mocked( releaseTools.validateGithubToken ).mockResolvedValue( 'github-token' );
 
 		await import( '../scripts/publishpackages.js' );
 
 		listrTasks = vi.mocked( Listr ).mock.calls[ 0 ][ 0 ];
+	} );
+
+	it( 'validates the GitHub token before running release tasks', () => {
+		expect( releaseTools.validateGithubToken ).toHaveBeenCalledExactlyOnceWith( 'github-token' );
 	} );
 
 	describe( 'Publishing packages.', () => {

--- a/scripts/publishpackages.js
+++ b/scripts/publishpackages.js
@@ -81,7 +81,7 @@ tasks.run()
  */
 async function getGitHubToken() {
 	if ( process.env.CKE5_RELEASE_TOKEN ) {
-		return process.env.CKE5_RELEASE_TOKEN;
+		return releaseTools.validateGithubToken( process.env.CKE5_RELEASE_TOKEN );
 	}
 
 	return releaseTools.provideToken();

--- a/scripts/publishpackages.js
+++ b/scripts/publishpackages.js
@@ -81,7 +81,7 @@ tasks.run()
  */
 async function getGitHubToken() {
 	if ( process.env.CKE5_RELEASE_TOKEN ) {
-		return releaseTools.validateGithubToken( process.env.CKE5_RELEASE_TOKEN );
+		return releaseTools.validateGithubToken( process.env.CKE5_RELEASE_TOKEN, { cwd: process.cwd() } );
 	}
 
 	return releaseTools.provideToken();


### PR DESCRIPTION
### 🚀 Summary

Replaces GitHub token length validation with an API preflight against the target repository. Both prompted and environment-provided tokens are checked for repository access and `Contents: write` permission before release tasks begin.

---

### 📌 Related issues

* Closes https://github.com/ckeditor/ckeditor5/issues/20214

---

### 💡 Additional information

The write-permission probe uses GitHub’s generate-release-notes endpoint, which computes and returns proposed notes without persisting a release, tag, or other repository data. The validator was also exercised successfully in CI in [#1467](https://github.com/ckeditor/ckeditor5-dev/pull/1467).