### PR TITLE
Fix CSS import order in manual tests

### DIFF
--- a/.changelog/20260819144011_ck_20222_manual_test_css_order.md
+++ b/.changelog/20260819144011_ck_20222_manual_test_css_order.md
@@ -1,0 +1,9 @@
+---
+type: Fix
+scope:
+  - ckeditor5-dev-manual-server
+closes:
+  - ckeditor/ckeditor5#20222
+---
+
+The manual test server now preserves CSS import order when bundled dev splits styles across chunks.

--- a/.changelog/20260819144011_ck_20222_manual_test_css_order.md
+++ b/.changelog/20260819144011_ck_20222_manual_test_css_order.md
@@ -2,8 +2,6 @@
 type: Fix
 scope:
   - ckeditor5-dev-manual-server
-closes:
-  - ckeditor/ckeditor5#20222
 ---
 
 The manual test server now preserves CSS import order when bundled dev splits styles across chunks.

--- a/packages/ckeditor5-dev-manual-server/src/manual-test-plugin/plugin.ts
+++ b/packages/ckeditor5-dev-manual-server/src/manual-test-plugin/plugin.ts
@@ -96,7 +96,15 @@ export function manualTestsPlugin( options: ManualTestsPluginOptions ): Plugin {
 			workspaceRoot = resolve( config.root || process.cwd() );
 
 			return {
-				input: getManualBuildInputs()
+				input: getManualBuildInputs(),
+				build: {
+					rolldownOptions: {
+						output: {
+							// Keep CSS side effects in source order when bundled dev splits them across chunks.
+							strictExecutionOrder: true
+						}
+					}
+				}
 			};
 		},
 

--- a/packages/ckeditor5-dev-manual-server/tests/manual-test-plugin/plugin.ts
+++ b/packages/ckeditor5-dev-manual-server/tests/manual-test-plugin/plugin.ts
@@ -84,6 +84,13 @@ describe( 'manualTestsPlugin()', () => {
 		expect( input ).not.to.include( join( workspaceRoot, 'packages/ckeditor5-bar/manual/bar.manual.html' ) );
 	} );
 
+	it( 'preserves module execution order when serving manual tests', async () => {
+		server = await createManualTestServer( { paths: [] } );
+		const output = server.config.build.rolldownOptions.output as { strictExecutionOrder: boolean };
+
+		expect( output.strictExecutionOrder ).to.be.true;
+	} );
+
 	it( 'exposes entries collected from provided package root globs', async () => {
 		await Promise.all( [
 			createFile( workspaceRoot, 'packages/ckeditor5-foo/manual/foo.manual.html' ),


### PR DESCRIPTION
### 🚀 Summary

Preserve source module execution order in the manual test server so filtering its input pages does not change the editor CSS cascade.

---

### 📌 Related issues

* Closes https://github.com/ckeditor/ckeditor5-commercial/issues/11385

---

### 💡 Additional information

Uses Rolldown's built-in `strictExecutionOrder` option. CSS HMR was verified to update the existing style element without changing its cascade position or reloading the page.