### PR TITLE
Preserve root workspace dependencies during releases

### DIFF
--- a/.changelog/20260820130800_update_lockfile.md
+++ b/.changelog/20260820130800_update_lockfile.md
@@ -1,0 +1,7 @@
+---
+type: Fix
+scope:
+  - ckeditor5-dev-release-tools
+---
+
+The `updateDependencies()` release helper now allows excluding the package in the working directory.

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "type": "module",
   "devDependencies": {
-    "@ckeditor/ckeditor5-dev-changelog": "^61.0.0",
+    "@ckeditor/ckeditor5-dev-changelog": "workspace:*",
     "@inquirer/prompts": "^7.10.1",
     "@listr2/prompt-adapter-inquirer": "^2.0.22",
     "@vitest/coverage-v8": "^4.1.2",

--- a/packages/ckeditor5-dev-release-tools/lib/tasks/updatedependencies.js
+++ b/packages/ckeditor5-dev-release-tools/lib/tasks/updatedependencies.js
@@ -26,6 +26,7 @@ const { normalizeTrim } = upath;
  * for a dependency. It receives a package name as an argument and should return a boolean value.
  * @param {UpdateDependenciesPackagesDirectoryFilter|null} [options.packagesDirectoryFilter=null] An optional callback allowing
  * filtering out directories/packages that should not be touched by the task.
+ * @param {boolean} [options.includeCwd=true] Whether to update dependencies in the package located directly in `options.cwd`.
  * @param {string} [options.packagesDirectory] Relative path to a location of packages to update their dependencies. If not specified,
  * only the root package is checked.
  * @param {string} [options.cwd=process.cwd()] Current working directory from which all paths will be resolved.
@@ -37,6 +38,7 @@ export default async function updateDependencies( options ) {
 		packagesDirectory,
 		shouldUpdateVersionCallback,
 		packagesDirectoryFilter = null,
+		includeCwd = true,
 		cwd = process.cwd()
 	} = options;
 
@@ -45,7 +47,7 @@ export default async function updateDependencies( options ) {
 		packagesDirectory ? normalizeTrim( packagesDirectory ) : null,
 		{
 			includePackageJson: true,
-			includeCwd: true,
+			includeCwd,
 			packagesDirectoryFilter
 		}
 	);

--- a/packages/ckeditor5-dev-release-tools/tests/tasks/updatedependencies.js
+++ b/packages/ckeditor5-dev-release-tools/tests/tasks/updatedependencies.js
@@ -69,6 +69,18 @@ describe( 'updateDependencies()', () => {
 			);
 		} );
 
+		it( 'should not include a package included in the "cwd" when `includeCwd` is false', async () => {
+			await updateDependencies( { includeCwd: false } );
+
+			expect( vi.mocked( workspaces.findPathsToPackages ) ).toHaveBeenCalledExactlyOnceWith(
+				expect.anything(),
+				null,
+				expect.objectContaining( {
+					includeCwd: false
+				} )
+			);
+		} );
+
 		it( 'should use the `packagesDirectory` option for searching for packages in `cwd`', () => {
 			updateDependencies( {
 				packagesDirectory: 'packages'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,7 +24,7 @@ importers:
   .:
     devDependencies:
       '@ckeditor/ckeditor5-dev-changelog':
-        specifier: workspace:*
+        specifier: ^61.0.0
         version: link:packages/ckeditor5-dev-changelog
       '@inquirer/prompts':
         specifier: ^7.10.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,7 +24,7 @@ importers:
   .:
     devDependencies:
       '@ckeditor/ckeditor5-dev-changelog':
-        specifier: ^61.0.0
+        specifier: workspace:*
         version: link:packages/ckeditor5-dev-changelog
       '@inquirer/prompts':
         specifier: ^7.10.1

--- a/scripts-tests/preparepackages.mjs
+++ b/scripts-tests/preparepackages.mjs
@@ -6,6 +6,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { Listr } from 'listr2';
 import fs from 'fs-extra';
+import * as releaseTools from '@ckeditor/ckeditor5-dev-release-tools';
 
 vi.mock( './utils/parsearguments.js' );
 vi.mock( '@ckeditor/ckeditor5-dev-release-tools' );
@@ -59,6 +60,22 @@ describe( 'scripts/preparepackages', () => {
 			} catch ( err ) {
 				expect( err ).toEqual( 'Release directory is empty, aborting.' );
 			}
+		} );
+	} );
+
+	describe( 'Updating dependencies.', () => {
+		it( 'does not update dependencies in the root package', async () => {
+			const task = listrTasks.find( ( { title } ) => title === 'Updating dependencies.' ).task;
+
+			expect( task ).toBeInstanceOf( Function );
+
+			await task();
+
+			expect( vi.mocked( releaseTools.updateDependencies ) ).toHaveBeenCalledExactlyOnceWith(
+				expect.objectContaining( {
+					includeCwd: false
+				} )
+			);
 		} );
 	} );
 } );

--- a/scripts/preparepackages.js
+++ b/scripts/preparepackages.js
@@ -125,6 +125,7 @@ const tasks = new Listr( [
 			return releaseTools.updateDependencies( {
 				version: '^' + latestVersion,
 				packagesDirectory: RELEASE_DIRECTORY,
+				includeCwd: false,
 				shouldUpdateVersionCallback: packageName => {
 					return CKEDITOR5_DEV_PACKAGES.includes( packageName.split( '/' )[ 1 ] );
 				}


### PR DESCRIPTION
### 🚀 Summary

Fix the release preparation flow so that it converts workspace dependencies only in package copies under `release/*`, while preserving `workspace:*` dependencies in the repository root.

`updateDependencies()` previously always included `cwd/package.json`, even when `packagesDirectory` pointed to `release`. As a result, the v61 release changed the root `@ckeditor/ckeditor5-dev-changelog` dependency from `workspace:*` to `^61.0.0` without regenerating the lockfile. Updating only the lockfile would hide that release-script issue and would violate the syncpack rule requiring local packages to use the workspace protocol.

This PR:

- adds an optional `includeCwd` setting to `updateDependencies()`, defaulting to `true` for backward compatibility;
- sets `includeCwd: false` in the ckeditor5-dev release flow;
- restores the root manifest and lockfile specifier to `workspace:*`;
- adds regression tests and a changelog entry.

The release copies are still converted from `workspace:*` to the released version range before publication. The root package version is also still updated by the separate `updateVersions()` step.

---

### 📌 Related issues

* Closes https://github.com/ckeditor/ckeditor5-commercial/issues/11395

---

### 💡 Additional information

Consumer impact was checked in both `ckeditor/ckeditor5` and `ckeditor/ckeditor5-commercial`. Their release scripts omit `includeCwd`, so the default value preserves their existing behavior. Their root manifests also contain no eligible local CKEditor package dependency that would be affected by this option. No changes are required in either repository.